### PR TITLE
Add shared-storage cluster mode with S3 read replicas

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -829,6 +829,92 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         }
     }
 
+    @Override
+    public void publishReplicaCheckpointLsn(String tableSpaceUUID, String nodeId, LogSequenceNumber lsn) throws MetadataStorageManagerException {
+        try {
+            // Ensure parent persistent znode exists (the leader's checkpoint znode)
+            String parentPath = checkpointsPath + "/" + tableSpaceUUID;
+            try {
+                ensureZooKeeper().create(checkpointsPath, new byte[0],
+                        ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } catch (KeeperException.NodeExistsException e) {
+                // ignore
+            }
+            try {
+                ensureZooKeeper().create(parentPath, new byte[0],
+                        ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } catch (KeeperException.NodeExistsException e) {
+                // ignore
+            }
+            // Now create/update the ephemeral replica node
+            String replicaPath = parentPath + "/" + nodeId;
+            byte[] data = serializeLsn(lsn);
+            try {
+                ensureZooKeeper().setData(replicaPath, data, -1);
+            } catch (KeeperException.NoNodeException notExists) {
+                try {
+                    ensureZooKeeper().create(replicaPath, data,
+                            ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                } catch (KeeperException.NodeExistsException exists) {
+                    // race: session came back and reclaimed, just set
+                    ensureZooKeeper().setData(replicaPath, data, -1);
+                }
+            }
+            LOGGER.log(Level.FINE, "Published replica checkpoint LSN {0} for {1}/{2}",
+                    new Object[]{lsn, tableSpaceUUID, nodeId});
+        } catch (InterruptedException | KeeperException | IOException err) {
+            handleSessionExpiredError(err);
+            throw new MetadataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void unregisterReplicaCheckpointLsn(String tableSpaceUUID, String nodeId) throws MetadataStorageManagerException {
+        try {
+            String replicaPath = checkpointsPath + "/" + tableSpaceUUID + "/" + nodeId;
+            try {
+                ensureZooKeeper().delete(replicaPath, -1);
+            } catch (KeeperException.NoNodeException notExists) {
+                // already gone
+            }
+        } catch (InterruptedException | KeeperException | IOException err) {
+            handleSessionExpiredError(err);
+            throw new MetadataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public LogSequenceNumber getMinReplicaCheckpointLsn(String tableSpaceUUID) throws MetadataStorageManagerException {
+        try {
+            String parentPath = checkpointsPath + "/" + tableSpaceUUID;
+            List<String> children;
+            try {
+                children = ensureZooKeeper().getChildren(parentPath, false);
+            } catch (KeeperException.NoNodeException notExists) {
+                return null;
+            }
+            if (children.isEmpty()) {
+                return null;
+            }
+            LogSequenceNumber min = null;
+            for (String child : children) {
+                try {
+                    byte[] data = ensureZooKeeper().getData(parentPath + "/" + child, false, new Stat());
+                    LogSequenceNumber lsn = deserializeLsn(data);
+                    if (min == null || min.after(lsn)) {
+                        min = lsn;
+                    }
+                } catch (KeeperException.NoNodeException disappeared) {
+                    // replica disconnected mid-query, skip
+                }
+            }
+            return min;
+        } catch (InterruptedException | KeeperException | IOException err) {
+            handleSessionExpiredError(err);
+            throw new MetadataStorageManagerException(err);
+        }
+    }
+
     private void installCheckpointWatch(String tableSpaceUUID, String path) throws KeeperException, InterruptedException, IOException {
         Watcher watcher = (WatchedEvent event) -> {
             if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -21,6 +21,7 @@ package herddb.cluster;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.log.LogNotAvailableException;
+import herddb.log.LogSequenceNumber;
 import herddb.metadata.MetadataStorageManager;
 import herddb.metadata.MetadataStorageManagerException;
 import herddb.model.DDLException;
@@ -35,8 +36,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.zookeeper.CreateMode;
@@ -66,7 +69,11 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
     private final String nodesPath;
     private final String indexingServicesPath;
     private final String fileServersPath;
+    private final String checkpointsPath;
     private volatile boolean started;
+
+    // Checkpoint LSN watchers for shared-storage read replicas
+    private final ConcurrentHashMap<String, Consumer<LogSequenceNumber>> checkpointWatchers = new ConcurrentHashMap<>();
 
     // For re-registration after session expiry
     private volatile String registeredIndexingServiceId;
@@ -188,6 +195,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         this.nodesPath = basePath + "/nodes";
         this.indexingServicesPath = basePath + "/indexingServices";
         this.fileServersPath = basePath + "/fileServers";
+        this.checkpointsPath = basePath + "/checkpoints"; // checkpoints/TABLESPACEUUID
     }
 
     @Override
@@ -723,6 +731,129 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
             handleSessionExpiredError(err);
             throw new MetadataStorageManagerException(err);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Checkpoint LSN notification for shared-storage read replicas
+    // -------------------------------------------------------------------------
+
+    private static byte[] serializeLsn(LogSequenceNumber lsn) {
+        // Simple format: "ledgerId:offset" as UTF-8
+        return (lsn.ledgerId + ":" + lsn.offset).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static LogSequenceNumber deserializeLsn(byte[] data) {
+        if (data == null || data.length == 0) {
+            return LogSequenceNumber.START_OF_TIME;
+        }
+        String s = new String(data, StandardCharsets.UTF_8);
+        String[] parts = s.split(":");
+        if (parts.length != 2) {
+            return LogSequenceNumber.START_OF_TIME;
+        }
+        try {
+            return new LogSequenceNumber(Long.parseLong(parts[0]), Long.parseLong(parts[1]));
+        } catch (NumberFormatException e) {
+            return LogSequenceNumber.START_OF_TIME;
+        }
+    }
+
+    @Override
+    public void publishCheckpointLsn(String tableSpaceUUID, LogSequenceNumber lsn) throws MetadataStorageManagerException {
+        try {
+            String path = checkpointsPath + "/" + tableSpaceUUID;
+            byte[] data = serializeLsn(lsn);
+            try {
+                ensureZooKeeper().setData(path, data, -1);
+            } catch (KeeperException.NoNodeException notExists) {
+                try {
+                    ensureZooKeeper().create(checkpointsPath, new byte[0],
+                            ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                } catch (KeeperException.NodeExistsException existsRoot) {
+                    // ignore
+                }
+                try {
+                    ensureZooKeeper().create(path, data,
+                            ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                } catch (KeeperException.NodeExistsException exists) {
+                    // race: another node created it, just set
+                    ensureZooKeeper().setData(path, data, -1);
+                }
+            }
+            LOGGER.log(Level.FINE, "Published checkpoint LSN {0} for tablespace {1}",
+                    new Object[]{lsn, tableSpaceUUID});
+        } catch (InterruptedException | KeeperException | IOException err) {
+            handleSessionExpiredError(err);
+            throw new MetadataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public LogSequenceNumber getCheckpointLsn(String tableSpaceUUID) throws MetadataStorageManagerException {
+        try {
+            String path = checkpointsPath + "/" + tableSpaceUUID;
+            Stat stat = new Stat();
+            byte[] data = ensureZooKeeper().getData(path, false, stat);
+            return deserializeLsn(data);
+        } catch (KeeperException.NoNodeException notExists) {
+            return LogSequenceNumber.START_OF_TIME;
+        } catch (InterruptedException | KeeperException | IOException err) {
+            handleSessionExpiredError(err);
+            throw new MetadataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void watchCheckpointLsn(String tableSpaceUUID, Consumer<LogSequenceNumber> callback) throws MetadataStorageManagerException {
+        checkpointWatchers.put(tableSpaceUUID, callback);
+        try {
+            String path = checkpointsPath + "/" + tableSpaceUUID;
+            // Ensure parent and node exist
+            try {
+                ensureZooKeeper().create(checkpointsPath, new byte[0],
+                        ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } catch (KeeperException.NodeExistsException e) {
+                // ignore
+            }
+            try {
+                ensureZooKeeper().create(path, new byte[0],
+                        ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } catch (KeeperException.NodeExistsException e) {
+                // ignore
+            }
+            // Set the watch
+            installCheckpointWatch(tableSpaceUUID, path);
+        } catch (InterruptedException | KeeperException | IOException err) {
+            handleSessionExpiredError(err);
+            throw new MetadataStorageManagerException(err);
+        }
+    }
+
+    private void installCheckpointWatch(String tableSpaceUUID, String path) throws KeeperException, InterruptedException, IOException {
+        Watcher watcher = (WatchedEvent event) -> {
+            if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {
+                Consumer<LogSequenceNumber> cb = checkpointWatchers.get(tableSpaceUUID);
+                if (cb != null) {
+                    try {
+                        Stat stat = new Stat();
+                        byte[] data = ensureZooKeeper().getData(path, false, stat);
+                        LogSequenceNumber lsn = deserializeLsn(data);
+                        // Re-install the watch before calling the callback
+                        installCheckpointWatch(tableSpaceUUID, path);
+                        cb.accept(lsn);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "Error processing checkpoint watch for " + tableSpaceUUID, e);
+                        // Try to re-install the watch
+                        try {
+                            installCheckpointWatch(tableSpaceUUID, path);
+                        } catch (Exception reInstallError) {
+                            LOGGER.log(Level.SEVERE, "Failed to re-install checkpoint watch for " + tableSpaceUUID, reInstallError);
+                        }
+                    }
+                }
+            }
+        };
+        ensureZooKeeper().getData(path, watcher, null);
     }
 
 }

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -146,6 +146,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     private String serverToServerUsername = ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT;
     private String serverToServerPassword = ClientConfiguration.PROPERTY_CLIENT_PASSWORD_DEFAULT;
     private boolean errorIfNotLeader = true;
+    private boolean readOnlyReplica = false;
     private final ServerConfiguration serverConfiguration;
     private final String mode;
     private ConnectionsInfoProvider connectionsInfoProvider;
@@ -334,6 +335,14 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     public void setErrorIfNotLeader(boolean errorIfNotLeader) {
         this.errorIfNotLeader = errorIfNotLeader;
+    }
+
+    public boolean isReadOnlyReplica() {
+        return readOnlyReplica;
+    }
+
+    public void setReadOnlyReplica(boolean readOnlyReplica) {
+        this.readOnlyReplica = readOnlyReplica;
     }
 
     public MetadataStorageManager getMetadataStorageManager() {
@@ -781,6 +790,14 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         }
         if (errorIfNotLeader && !manager.isLeader() && !statement.getAllowExecutionFromFollower()) {
             return Futures.exception(new NotLeaderException("node " + nodeId + " is not leader for tableSpace " + tableSpace));
+        }
+        // In shared-storage read-replica mode, reject non-read statements on non-leader nodes
+        if (readOnlyReplica && !manager.isLeader()) {
+            if (!(statement instanceof GetStatement) && !(statement instanceof ScanStatement)) {
+                return Futures.exception(new NotLeaderException(
+                        "This is a read-only replica. Write operations must go to the leader. "
+                        + "node " + nodeId + " is not leader for tableSpace " + tableSpace));
+            }
         }
         CompletableFuture<StatementExecutionResult> res = manager.executeStatementAsync(statement, context, transactionContext);
         if (statement instanceof DDLStatement) {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1393,6 +1393,10 @@ public class TableSpaceManager {
                         ServerConfiguration.PROPERTY_REPLICA_CHECKPOINT_POLL_INTERVAL,
                         ServerConfiguration.PROPERTY_REPLICA_CHECKPOINT_POLL_INTERVAL_DEFAULT);
 
+                // Publish initial replica LSN (may be START_OF_TIME if no checkpoint seen yet)
+                // so the leader knows this replica exists and won't prematurely delete pages.
+                publishReplicaCheckpointLsn(actualLogSequenceNumber);
+
                 // Set up ZK watch for checkpoint notifications
                 try {
                     metadataStorageManager.watchCheckpointLsn(tableSpaceUUID, (lsn) -> {
@@ -1432,6 +1436,9 @@ public class TableSpaceManager {
                             LOGGER.log(Level.INFO, "Refreshing {0} from checkpoint {1} (current: {2})",
                                     new Object[]{tableSpaceName, newLsn, actualLogSequenceNumber});
                             refreshFromCheckpoint(newLsn);
+                            // Advertise the replica's new position so the leader can
+                            // release pages that became stale at or before newLsn.
+                            publishReplicaCheckpointLsn(newLsn);
                         }
                     } catch (Exception err) {
                         LOGGER.log(Level.WARNING, "Error refreshing from checkpoint for " + tableSpaceName, err);
@@ -1441,7 +1448,24 @@ public class TableSpaceManager {
                 LOGGER.log(Level.SEVERE, "checkpoint follower error " + tableSpaceName, t);
                 setFailed();
             } finally {
+                try {
+                    metadataStorageManager.unregisterReplicaCheckpointLsn(tableSpaceUUID, nodeId);
+                } catch (Exception ignore) {
+                    // best-effort cleanup; ZK ephemeral znode will be removed on session close anyway
+                }
                 running.countDown();
+            }
+        }
+
+        private void publishReplicaCheckpointLsn(LogSequenceNumber lsn) {
+            if (lsn == null) {
+                lsn = LogSequenceNumber.START_OF_TIME;
+            }
+            try {
+                metadataStorageManager.publishReplicaCheckpointLsn(tableSpaceUUID, nodeId, lsn);
+            } catch (Exception err) {
+                LOGGER.log(Level.WARNING, "Failed to publish replica checkpoint LSN " + lsn
+                        + " for " + tableSpaceName, err);
             }
         }
 

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -189,6 +189,7 @@ public class TableSpaceManager {
     private final AtomicLong newTransactionId = new AtomicLong();
     private final DBManager dbmanager;
     private volatile FollowerThread followerThread;
+    private volatile CheckpointFollowerThread checkpointFollowerThread;
     private final ExecutorService callbacksExecutor;
     private final boolean virtual;
 
@@ -433,7 +434,12 @@ public class TableSpaceManager {
             }
         });
 
-        if (LogSequenceNumber.START_OF_TIME.equals(logSequenceNumber)
+        if (dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)) {
+            // In shared-storage mode, replicas get their state from S3 checkpoints.
+            // No WAL replay needed — the CheckpointFollowerThread will handle updates.
+            LOGGER.log(Level.INFO, "{0} shared-storage mode: skipping WAL recovery for {1}, state loaded from checkpoint at {2}",
+                    new Object[]{nodeId, tableSpaceName, logSequenceNumber});
+        } else if (LogSequenceNumber.START_OF_TIME.equals(logSequenceNumber)
                 && dbmanager.getServerConfiguration().getBoolean(ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT, ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT_DEFAULT)) {
             LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is forced (" + ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT + "=true) for tableSpace " + tableSpaceName);
             downloadTableSpaceData();
@@ -448,7 +454,8 @@ public class TableSpaceManager {
             }
         }
         recoveryInProgress = false;
-        if (!LogSequenceNumber.START_OF_TIME.equals(actualLogSequenceNumber)) {
+        if (!dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)
+                && !LogSequenceNumber.START_OF_TIME.equals(actualLogSequenceNumber)) {
             LOGGER.log(Level.INFO, "Recovery finished for {0} seqNum {1}", new Object[]{tableSpaceName, actualLogSequenceNumber});
             checkpoint(false, false, false);
         }
@@ -1346,10 +1353,222 @@ public class TableSpaceManager {
     private void startAsFollower() throws DataStorageManagerException, LogNotAvailableException {
         if (dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER)) {
             // in diskless cluster mode there is no need to really 'follow' the leader
+        } else if (dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)) {
+            // shared-storage mode: follow checkpoints from S3 via ZK watches
+            checkpointFollowerThread = new CheckpointFollowerThread();
+            dbmanager.submit(checkpointFollowerThread);
         } else {
             followerThread = new FollowerThread();
             dbmanager.submit(followerThread);
         }
+    }
+
+    /**
+     * Follower thread for shared-storage mode. Instead of replaying WAL entries,
+     * it watches ZooKeeper for checkpoint LSN updates and loads the new checkpoint
+     * state from S3.
+     */
+    private class CheckpointFollowerThread implements Runnable {
+
+        private volatile CountDownLatch running = new CountDownLatch(1);
+        private final Object notifyLock = new Object();
+        private volatile boolean notified = false;
+
+        @Override
+        public String toString() {
+            return "CheckpointFollowerThread{" + tableSpaceName + '}';
+        }
+
+        void notifyCheckpointAvailable() {
+            synchronized (notifyLock) {
+                notified = true;
+                notifyLock.notifyAll();
+            }
+        }
+
+        @Override
+        public void run() {
+            try {
+                long pollInterval = dbmanager.getServerConfiguration().getLong(
+                        ServerConfiguration.PROPERTY_REPLICA_CHECKPOINT_POLL_INTERVAL,
+                        ServerConfiguration.PROPERTY_REPLICA_CHECKPOINT_POLL_INTERVAL_DEFAULT);
+
+                // Set up ZK watch for checkpoint notifications
+                try {
+                    metadataStorageManager.watchCheckpointLsn(tableSpaceUUID, (lsn) -> {
+                        LOGGER.log(Level.INFO, "Checkpoint notification for {0}: {1}", new Object[]{tableSpaceName, lsn});
+                        notifyCheckpointAvailable();
+                    });
+                } catch (MetadataStorageManagerException err) {
+                    LOGGER.log(Level.WARNING, "Failed to set up checkpoint watch for " + tableSpaceName
+                            + ", will rely on polling", err);
+                }
+
+                while (!isLeader() && !closed) {
+                    // Wait for notification or poll interval
+                    synchronized (notifyLock) {
+                        if (!notified) {
+                            try {
+                                notifyLock.wait(pollInterval);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
+                        }
+                        notified = false;
+                    }
+
+                    if (isLeader() || closed) {
+                        break;
+                    }
+
+                    // Check for a new checkpoint
+                    try {
+                        LogSequenceNumber newLsn = metadataStorageManager.getCheckpointLsn(tableSpaceUUID);
+                        if (newLsn != null && !newLsn.isStartOfTime()
+                                && (actualLogSequenceNumber == null
+                                    || actualLogSequenceNumber.isStartOfTime()
+                                    || newLsn.after(actualLogSequenceNumber))) {
+                            LOGGER.log(Level.INFO, "Refreshing {0} from checkpoint {1} (current: {2})",
+                                    new Object[]{tableSpaceName, newLsn, actualLogSequenceNumber});
+                            refreshFromCheckpoint(newLsn);
+                        }
+                    } catch (Exception err) {
+                        LOGGER.log(Level.WARNING, "Error refreshing from checkpoint for " + tableSpaceName, err);
+                    }
+                }
+            } catch (Throwable t) {
+                LOGGER.log(Level.SEVERE, "checkpoint follower error " + tableSpaceName, t);
+                setFailed();
+            } finally {
+                running.countDown();
+            }
+        }
+
+        void waitForStop() throws InterruptedException {
+            LOGGER.log(Level.INFO, "Waiting for CheckpointFollowerThread of {0} to stop", tableSpaceName);
+            running.await();
+            LOGGER.log(Level.INFO, "CheckpointFollowerThread of {0} stopped", tableSpaceName);
+        }
+    }
+
+    /**
+     * Atomically switches the replica's in-memory state to a new checkpoint from S3.
+     * <p>
+     * This method:
+     * 1. Reads new metadata from S3 (outside the lock)
+     * 2. Acquires the write lock to block queries
+     * 3. Disposes old tables/indexes, boots new ones from checkpoint
+     * 4. Updates actualLogSequenceNumber
+     * 5. Releases the write lock
+     */
+    void refreshFromCheckpoint(LogSequenceNumber newLsn)
+            throws DataStorageManagerException, MetadataStorageManagerException {
+        long _start = System.currentTimeMillis();
+
+        // Phase 1: Read new metadata from S3 (outside lock)
+        List<Table> newTables = dataStorageManager.loadTables(newLsn, tableSpaceUUID);
+        List<Index> newIndexes = dataStorageManager.loadIndexes(newLsn, tableSpaceUUID);
+
+        // Phase 2: Acquire write lock and swap state
+        long switchTimeout = dbmanager.getServerConfiguration().getLong(
+                ServerConfiguration.PROPERTY_REPLICA_CHECKPOINT_SWITCH_TIMEOUT,
+                ServerConfiguration.PROPERTY_REPLICA_CHECKPOINT_SWITCH_TIMEOUT_DEFAULT);
+
+        long lockStamp = acquireWriteLock("refreshFromCheckpoint");
+        try {
+            // Build sets of current and new table names
+            Set<String> currentTableNames = new HashSet<>();
+            for (AbstractTableManager tm : tables.values()) {
+                if (!tm.isSystemTable()) {
+                    currentTableNames.add(tm.getTable().name);
+                }
+            }
+            Set<String> newTableNames = new HashSet<>();
+            for (Table t : newTables) {
+                newTableNames.add(t.name);
+            }
+
+            // Dispose tables that no longer exist
+            for (String tableName : currentTableNames) {
+                if (!newTableNames.contains(tableName)) {
+                    AbstractTableManager tm = tables.get(tableName);
+                    if (tm != null) {
+                        LOGGER.log(Level.INFO, "refreshFromCheckpoint: dropping table {0}.{1}",
+                                new Object[]{tableSpaceName, tableName});
+                        // Close the table manager (but don't drop remote data — we don't own it)
+                        tm.close();
+                        tables.remove(tableName);
+                        // Remove associated indexes
+                        Map<String, AbstractIndexManager> tableIndexes = indexesByTable.remove(tableName);
+                        if (tableIndexes != null) {
+                            for (AbstractIndexManager idx : tableIndexes.values()) {
+                                idx.close();
+                                indexes.remove(idx.getIndex().name);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Close all existing non-system table managers (they'll be re-booted fresh)
+            for (String tableName : new ArrayList<>(currentTableNames)) {
+                if (newTableNames.contains(tableName)) {
+                    AbstractTableManager tm = tables.get(tableName);
+                    if (tm != null) {
+                        tm.close();
+                        tables.remove(tableName);
+                    }
+                }
+            }
+
+            // Close all existing non-system index managers
+            for (AbstractIndexManager idx : new ArrayList<>(indexes.values())) {
+                idx.close();
+                indexes.remove(idx.getIndex().name);
+            }
+            indexesByTable.clear();
+
+            // Boot all tables fresh from the new checkpoint
+            for (Table table : newTables) {
+                try {
+                    TableManager tableManager = new TableManager(
+                            table, log, dbmanager.getMemoryManager(), dataStorageManager, this, tableSpaceUUID, 0);
+                    tables.put(table.name, tableManager);
+                    tableManager.start(false);
+                    LOGGER.log(Level.FINE, "refreshFromCheckpoint: booted table {0}.{1}",
+                            new Object[]{tableSpaceName, table.name});
+                } catch (Exception err) {
+                    LOGGER.log(Level.SEVERE, "refreshFromCheckpoint: failed to boot table " + table.name, err);
+                }
+            }
+
+            // Boot all indexes fresh from the new checkpoint
+            for (Index index : newIndexes) {
+                AbstractTableManager tableManager = tables.get(index.table);
+                if (tableManager != null) {
+                    try {
+                        bootIndex(index, tableManager, false, 0, false, false);
+                        LOGGER.log(Level.FINE, "refreshFromCheckpoint: booted index {0}.{1}.{2}",
+                                new Object[]{tableSpaceName, index.table, index.name});
+                    } catch (Exception err) {
+                        LOGGER.log(Level.SEVERE, "refreshFromCheckpoint: failed to boot index " + index.name, err);
+                    }
+                }
+            }
+
+            // Update the tablespace LSN
+            actualLogSequenceNumber = newLsn;
+
+            dbmanager.getPlanner().clearCache();
+
+        } finally {
+            releaseWriteLock(lockStamp, "refreshFromCheckpoint");
+        }
+
+        long _stop = System.currentTimeMillis();
+        LOGGER.log(Level.INFO, "refreshFromCheckpoint for {0} completed at {1}, took {2} ms",
+                new Object[]{tableSpaceName, newLsn, (_stop - _start)});
     }
 
     private void startAsLeader(int expectedReplicaCount) throws DataStorageManagerException, DDLException, LogNotAvailableException {
@@ -2061,6 +2280,15 @@ public class TableSpaceManager {
                 LOGGER.log(Level.SEVERE, "Cannot wait for FollowerThread to stop", err);
             }
         }
+        if (checkpointFollowerThread != null) {
+            checkpointFollowerThread.notifyCheckpointAvailable(); // wake it up so it sees closed=true
+            try {
+                checkpointFollowerThread.waitForStop();
+            } catch (InterruptedException err) {
+                Thread.currentThread().interrupt();
+                LOGGER.log(Level.SEVERE, "Cannot wait for CheckpointFollowerThread to stop", err);
+            }
+        }
         if (!virtual) {
             long lockStamp = acquireWriteLock("closeTablespace");
             try {
@@ -2204,6 +2432,8 @@ public class TableSpaceManager {
                     actions.addAll(dataStorageManager.writeCheckpointSequenceNumber(tableSpaceUUID, logSequenceNumber));
                     if (leader) {
                         log.dropOldLedgers(logSequenceNumber);
+                        // Notify shared-storage read replicas of the new checkpoint
+                        publishCheckpointLsnToMetadata(logSequenceNumber);
                     }
                     _logSequenceNumber = log.getLastSequenceNumber();
                 } catch (DataStorageManagerException | LogNotAvailableException ex) {
@@ -2293,6 +2523,8 @@ public class TableSpaceManager {
                     /* Indexes checkpoint is handled by TableManagers */
                     if (leader) {
                         log.dropOldLedgers(logSequenceNumber);
+                        // Notify shared-storage read replicas of the new checkpoint
+                        publishCheckpointLsnToMetadata(logSequenceNumber);
                     }
 
                     _logSequenceNumber = log.getLastSequenceNumber();
@@ -2314,6 +2546,14 @@ public class TableSpaceManager {
             LOGGER.log(Level.INFO, "{0} checkpoint finish {1} started ad {2}, finished at {3}, total time {4} ms",
                     new Object[]{nodeId, tableSpaceName, logSequenceNumber, _logSequenceNumber, Long.toString(_stop - _start)});
             checkpointTimeStats.registerSuccessfulEvent(_stop, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void publishCheckpointLsnToMetadata(LogSequenceNumber logSequenceNumber) {
+        try {
+            metadataStorageManager.publishCheckpointLsn(tableSpaceUUID, logSequenceNumber);
+        } catch (Exception err) {
+            LOGGER.log(Level.WARNING, "Failed to publish checkpoint LSN to metadata for " + tableSpaceName, err);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
@@ -221,6 +221,34 @@ public abstract class MetadataStorageManager implements AutoCloseable {
         // no-op for non-ZK implementations
     }
 
+    /**
+     * A replica publishes its current applied checkpoint LSN. The leader reads this to
+     * determine when it is safe to delete stale pages from remote storage.
+     * <p>
+     * Implementations should use an ephemeral mechanism (e.g., ephemeral znode in ZK) so
+     * that the entry is automatically removed when the replica disconnects/crashes.
+     */
+    public void publishReplicaCheckpointLsn(String tableSpaceUUID, String nodeId, LogSequenceNumber lsn) throws MetadataStorageManagerException {
+        // no-op for non-ZK implementations
+    }
+
+    /**
+     * Removes the replica's published checkpoint LSN (called on clean shutdown).
+     */
+    public void unregisterReplicaCheckpointLsn(String tableSpaceUUID, String nodeId) throws MetadataStorageManagerException {
+        // no-op for non-ZK implementations
+    }
+
+    /**
+     * Returns the minimum checkpoint LSN across all currently-registered replicas for
+     * the given tablespace. Returns {@code null} if no replicas are registered.
+     * <p>
+     * The leader uses this to decide whether it is safe to delete stale remote pages.
+     */
+    public LogSequenceNumber getMinReplicaCheckpointLsn(String tableSpaceUUID) throws MetadataStorageManagerException {
+        return null;
+    }
+
     public String generateNewNodeId(ServerConfiguration config) throws MetadataStorageManagerException {
         List<NodeMetadata> actualNodes = listNodes();
         NodeIdGenerator generator = new NodeIdGenerator();

--- a/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
@@ -20,6 +20,7 @@
 
 package herddb.metadata;
 
+import herddb.log.LogSequenceNumber;
 import herddb.model.DDLException;
 import herddb.model.InvalidTableException;
 import herddb.model.NodeMetadata;
@@ -30,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 /**
  * Store of all metadata of the system: definition of tables, tablesets, available nodes
@@ -187,6 +189,36 @@ public abstract class MetadataStorageManager implements AutoCloseable {
 
     public void clear() throws MetadataStorageManagerException {
 
+    }
+
+    // -------------------------------------------------------------------------
+    // Checkpoint LSN notification for shared-storage read replicas
+    // -------------------------------------------------------------------------
+
+    /**
+     * Publishes the latest checkpoint LSN for a tablespace so that read replicas
+     * can be notified of new checkpoints. Default implementation is a no-op.
+     */
+    public void publishCheckpointLsn(String tableSpaceUUID, LogSequenceNumber lsn) throws MetadataStorageManagerException {
+        // no-op for non-ZK implementations
+    }
+
+    /**
+     * Reads the latest published checkpoint LSN for a tablespace.
+     *
+     * @return the latest LSN, or {@link LogSequenceNumber#START_OF_TIME} if none published
+     */
+    public LogSequenceNumber getCheckpointLsn(String tableSpaceUUID) throws MetadataStorageManagerException {
+        return LogSequenceNumber.START_OF_TIME;
+    }
+
+    /**
+     * Sets a watch on checkpoint LSN changes for the given tablespace.
+     * The callback is invoked each time the leader publishes a new checkpoint LSN.
+     * The watch is persistent and re-registers automatically.
+     */
+    public void watchCheckpointLsn(String tableSpaceUUID, Consumer<LogSequenceNumber> callback) throws MetadataStorageManagerException {
+        // no-op for non-ZK implementations
     }
 
     public String generateNewNodeId(ServerConfiguration config) throws MetadataStorageManagerException {

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -428,6 +428,30 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                         Object metaMgr = metaMgrClass.getConstructor(clientClass).newInstance(client);
                         storageClass.getMethod("setSharedCheckpointMetadataManager", metaMgrClass)
                                 .invoke(dsm, metaMgr);
+
+                        // Enable deferred page deletion so replicas can safely consume old pages.
+                        long minRetentionMillis = configuration.getLong(
+                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS,
+                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS_DEFAULT);
+                        long maxRetentionMillis = configuration.getLong(
+                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS,
+                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS_DEFAULT);
+                        final MetadataStorageManager msm = metadataStorageManager;
+                        java.util.function.Function<String, herddb.log.LogSequenceNumber> supplier = tableSpaceUuid -> {
+                            try {
+                                return msm.getMinReplicaCheckpointLsn(tableSpaceUuid);
+                            } catch (Exception e) {
+                                LOGGER.log(Level.WARNING,
+                                        "Failed to read min replica LSN from metadata for " + tableSpaceUuid, e);
+                                return null;
+                            }
+                        };
+                        storageClass.getMethod("setRetentionPolicy",
+                                java.util.function.Function.class, long.class, long.class)
+                                .invoke(dsm, supplier, minRetentionMillis, maxRetentionMillis);
+                        LOGGER.log(Level.INFO,
+                                "Replica-aware page retention enabled: min={0}ms, max={1}ms",
+                                new Object[]{minRetentionMillis, maxRetentionMillis});
                     }
 
                     return (DataStorageManager) dsm;

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -242,7 +242,13 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         this.manager.setAbandonedTransactionsTimeout(configuration.getLong(ServerConfiguration.PROPERTY_ABANDONED_TRANSACTIONS_TIMEOUT, ServerConfiguration.PROPERTY_ABANDONED_TRANSACTIONS_TIMEOUT_DEFAULT));
 
         boolean enforeLeadership = configuration.getBoolean(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP_DEFAULT);
-        this.manager.setErrorIfNotLeader(enforeLeadership);
+        if (mode.equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)) {
+            // shared-storage replicas allow reads from followers but reject writes
+            this.manager.setErrorIfNotLeader(false);
+            this.manager.setReadOnlyReplica(true);
+        } else {
+            this.manager.setErrorIfNotLeader(enforeLeadership);
+        }
 
         this.networkServer = buildChannelAcceptor();
         this.networkServer.setAcceptor(this);
@@ -316,6 +322,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 return new FileMetadataStorageManager(metadataDirectory);
             case ServerConfiguration.PROPERTY_MODE_CLUSTER:
             case ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER:
+            case ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE:
                 return new ZookeeperMetadataStorageManager(configuration.getString(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS_DEFAULT),
                         configuration.getInt(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT_DEFAULT),
                         configuration.getString(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, ServerConfiguration.PROPERTY_ZOOKEEPER_PATH_DEFAULT));
@@ -325,6 +332,10 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
     }
 
     private DataStorageManager buildDataStorageManager(String nodeId) {
+        // shared-storage mode forces remote storage
+        if (mode.equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)) {
+            return buildSharedStorageDataManager(nodeId);
+        }
         String defaultStorageMode = mode.equals(ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER)
                 ? ServerConfiguration.PROPERTY_STORAGE_MODE_BOOKKEEPER
                 : ServerConfiguration.PROPERTY_STORAGE_MODE_LOCAL;
@@ -405,7 +416,21 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                     }
                     Class<?> storageClass = Class.forName("herddb.remote.RemoteFileDataStorageManager");
                     Constructor<?> ctor = storageClass.getConstructor(Path.class, Path.class, int.class, clientClass);
-                    return (DataStorageManager) ctor.newInstance(dataDirectory, tmpDirectory, diskswapThreshold, client);
+                    Object dsm = ctor.newInstance(dataDirectory, tmpDirectory, diskswapThreshold, client);
+
+                    // Optionally enable checkpoint metadata publication to S3 for read replicas
+                    boolean publishToRemote = configuration.getBoolean(
+                            ServerConfiguration.PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE,
+                            ServerConfiguration.PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE_DEFAULT);
+                    if (publishToRemote) {
+                        LOGGER.log(Level.INFO, "Checkpoint metadata publication to remote storage enabled");
+                        Class<?> metaMgrClass = Class.forName("herddb.remote.SharedCheckpointMetadataManager");
+                        Object metaMgr = metaMgrClass.getConstructor(clientClass).newInstance(client);
+                        storageClass.getMethod("setSharedCheckpointMetadataManager", metaMgrClass)
+                                .invoke(dsm, metaMgr);
+                    }
+
+                    return (DataStorageManager) dsm;
                 } catch (ReflectiveOperationException e) {
                     throw new RuntimeException("Cannot create RemoteFileDataStorageManager. "
                             + "Ensure herddb-remote-file-service is on the classpath.", e);
@@ -413,6 +438,69 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
             }
             default:
                 throw new RuntimeException("invalid " + ServerConfiguration.PROPERTY_STORAGE_MODE + "=" + storageMode);
+        }
+    }
+
+    private DataStorageManager buildSharedStorageDataManager(String nodeId) {
+        int diskswapThreshold = configuration.getInt(ServerConfiguration.PROPERTY_DISK_SWAP_MAX_RECORDS, ServerConfiguration.PROPERTY_DISK_SWAP_MAX_RECORDS_DEFAULT);
+        String remoteServersConfig = configuration.getString(ServerConfiguration.PROPERTY_REMOTE_FILE_SERVERS, ServerConfiguration.PROPERTY_REMOTE_FILE_SERVERS_DEFAULT);
+        List<String> servers;
+        boolean useZKDiscovery = false;
+        if (!remoteServersConfig.isEmpty()) {
+            servers = Arrays.asList(remoteServersConfig.split(","));
+            LOGGER.log(Level.INFO, "Shared-storage remote file services (static): {0}", servers);
+        } else {
+            try {
+                servers = metadataStorageManager.listFileServers();
+                useZKDiscovery = true;
+                LOGGER.log(Level.INFO, "Shared-storage remote file services (ZK discovery): {0}", servers);
+            } catch (Exception e) {
+                servers = Collections.emptyList();
+                LOGGER.log(Level.WARNING, "Failed to discover remote file servers via ZK for shared-storage", e);
+            }
+        }
+        Map<String, Object> clientConfig = new HashMap<>();
+        clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_TIMEOUT,
+                configuration.getLong(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_TIMEOUT,
+                        ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_TIMEOUT_DEFAULT));
+        clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
+                configuration.getInt(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
+                        ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT));
+        try {
+            Class<?> clientClass = Class.forName("herddb.remote.RemoteFileServiceClient");
+            Object client = clientClass.getConstructor(List.class, Map.class).newInstance(servers, clientConfig);
+            // Set up ZK-based discovery listener if applicable
+            if (useZKDiscovery && client instanceof DynamicServiceClient) {
+                DynamicServiceClient dynamicClient = (DynamicServiceClient) client;
+                metadataStorageManager.addServiceDiscoveryListener(
+                        new herddb.metadata.ServiceDiscoveryListener() {
+                            @Override
+                            public void onIndexingServicesChanged(List<String> currentAddresses) {
+                            }
+                            @Override
+                            public void onFileServersChanged(List<String> currentAddresses) {
+                                LOGGER.log(Level.INFO, "Remote file servers changed via ZK (shared-storage): {0}",
+                                        currentAddresses);
+                                dynamicClient.updateServers(currentAddresses);
+                            }
+                        });
+            }
+            // Create SharedCheckpointMetadataManager + ReadReplicaDataStorageManager
+            // wrapped in PromotableRemoteFileDataStorageManager for failover support
+            Class<?> metaMgrClass = Class.forName("herddb.remote.SharedCheckpointMetadataManager");
+            Object metaMgr = metaMgrClass.getConstructor(clientClass).newInstance(client);
+            Class<?> readReplicaClass = Class.forName("herddb.remote.ReadReplicaDataStorageManager");
+            Constructor<?> readReplicaCtor = readReplicaClass.getConstructor(clientClass, metaMgrClass, Path.class, int.class);
+            Object readReplica = readReplicaCtor.newInstance(client, metaMgr, tmpDirectory, diskswapThreshold);
+
+            Class<?> promotableClass = Class.forName("herddb.remote.PromotableRemoteFileDataStorageManager");
+            Constructor<?> promotableCtor = promotableClass.getConstructor(
+                    readReplicaClass, clientClass, metaMgrClass, Path.class, Path.class, int.class);
+            return (DataStorageManager) promotableCtor.newInstance(
+                    readReplica, client, metaMgr, dataDirectory, tmpDirectory, diskswapThreshold);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Cannot create PromotableRemoteFileDataStorageManager. "
+                    + "Ensure herddb-remote-file-service is on the classpath.", e);
         }
     }
 
@@ -435,6 +523,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 );
             case ServerConfiguration.PROPERTY_MODE_CLUSTER:
             case ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER:
+            case ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE:
                 BookkeeperCommitLogManager bkmanager = new BookkeeperCommitLogManager((ZookeeperMetadataStorageManager) this.metadataStorageManager, configuration, statsLogger);
                 bkmanager.setAckQuorumSize(configuration.getInt(ServerConfiguration.PROPERTY_BOOKKEEPER_ACKQUORUMSIZE, ServerConfiguration.PROPERTY_BOOKKEEPER_ACKQUORUMSIZE_DEFAULT));
                 bkmanager.setEnsemble(configuration.getInt(ServerConfiguration.PROPERTY_BOOKKEEPER_ENSEMBLE, ServerConfiguration.PROPERTY_BOOKKEEPER_ENSEMBLE_DEFAULT));
@@ -468,6 +557,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
             case ServerConfiguration.PROPERTY_MODE_STANDALONE:
             case ServerConfiguration.PROPERTY_MODE_CLUSTER:
             case ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER:
+            case ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE:
                 return new LocalNodeIdManager(dataDirectory);
             default:
                 throw new RuntimeException();

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -91,6 +91,25 @@ public final class ServerConfiguration {
     public static final String PROPERTY_REPLICA_CHECKPOINT_SWITCH_TIMEOUT = "replica.checkpoint.switch.timeout.seconds";
     public static final long PROPERTY_REPLICA_CHECKPOINT_SWITCH_TIMEOUT_DEFAULT = 60;
 
+    /**
+     * Minimum time (milliseconds) that pages stale-at-checkpoint-K must be retained on
+     * remote storage before they can be deleted, even if no replicas are tracked or all
+     * replicas have advanced past K. Acts as a safety grace period so that in-flight
+     * replica queries always see complete pages. Also used as the upper bound when a
+     * replica is stuck or dead.
+     */
+    public static final String PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS = "server.checkpoint.replica.retention.min.millis";
+    public static final long PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS_DEFAULT = 5L * 60L * 1000L; // 5 minutes
+
+    /**
+     * Maximum time (milliseconds) to retain stale pages on remote storage. If this is
+     * exceeded, pages are deleted even if some replica is still behind — at which point
+     * that replica will hit DataPageDoesNotExistException and must re-bootstrap from the
+     * latest checkpoint. Set to 0 to retain forever (dangerous).
+     */
+    public static final String PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS = "server.checkpoint.replica.retention.max.millis";
+    public static final long PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS_DEFAULT = 2L * 60L * 60L * 1000L; // 2 hours
+
     public static final String PROPERTY_BASEDIR = "server.base.dir";
     public static final String PROPERTY_BASEDIR_DEFAULT = "dbdata";
     public static final String PROPERTY_DATADIR = "server.data.dir";

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -55,6 +55,7 @@ public final class ServerConfiguration {
     public static final String PROPERTY_MODE_STANDALONE = "standalone";
     public static final String PROPERTY_MODE_CLUSTER = "cluster";
     public static final String PROPERTY_MODE_DISKLESSCLUSTER = "diskless-cluster";
+    public static final String PROPERTY_MODE_SHARED_STORAGE = "shared-storage";
 
     public static final String PROPERTY_STORAGE_MODE = "server.storage.mode";
     public static final String PROPERTY_STORAGE_MODE_LOCAL = "local";
@@ -69,6 +70,26 @@ public final class ServerConfiguration {
 
     public static final String PROPERTY_REMOTE_FILE_CLIENT_RETRIES = "remote.file.client.retries";
     public static final int PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT = 10;
+
+    /**
+     * When true, the leader publishes checkpoint metadata to remote storage (S3)
+     * so that shared-storage read replicas can consume it.
+     */
+    public static final String PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE = "server.checkpoint.publish.to.remote";
+    public static final boolean PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE_DEFAULT = false;
+
+    /**
+     * Safety-net poll interval (ms) for shared-storage replicas to check for new checkpoints,
+     * in case ZooKeeper watch notifications are missed.
+     */
+    public static final String PROPERTY_REPLICA_CHECKPOINT_POLL_INTERVAL = "replica.checkpoint.poll.interval.ms";
+    public static final long PROPERTY_REPLICA_CHECKPOINT_POLL_INTERVAL_DEFAULT = 30000; // 30 seconds
+
+    /**
+     * Timeout (seconds) for acquiring the write lock during checkpoint view switch on replicas.
+     */
+    public static final String PROPERTY_REPLICA_CHECKPOINT_SWITCH_TIMEOUT = "replica.checkpoint.switch.timeout.seconds";
+    public static final long PROPERTY_REPLICA_CHECKPOINT_SWITCH_TIMEOUT_DEFAULT = 60;
 
     public static final String PROPERTY_BASEDIR = "server.base.dir";
     public static final String PROPERTY_BASEDIR_DEFAULT = "dbdata";

--- a/herddb-core/src/test/java/herddb/cluster/ZkReplicaCheckpointLsnTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ZkReplicaCheckpointLsnTest.java
@@ -1,0 +1,153 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.cluster;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import herddb.log.LogSequenceNumber;
+import herddb.utils.ZKTestEnv;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * ZooKeeper-backed tests for the replica-checkpoint-LSN tracking API used by the
+ * shared-storage retention logic.
+ */
+public class ZkReplicaCheckpointLsnTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+    private static final String TS = "ts-uuid-1";
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookieAndInitCluster();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    /** No replicas registered → null. */
+    @Test
+    public void noReplicas_minIsNull() throws Exception {
+        try (ZookeeperMetadataStorageManager m = newManager()) {
+            m.start();
+            assertNull(m.getMinReplicaCheckpointLsn(TS));
+        }
+    }
+
+    /** Single replica: min is its own LSN. Updating re-publishes the same znode. */
+    @Test
+    public void singleReplica_publishAndRead() throws Exception {
+        try (ZookeeperMetadataStorageManager m = newManager()) {
+            m.start();
+            LogSequenceNumber a = new LogSequenceNumber(3, 100);
+            m.publishReplicaCheckpointLsn(TS, "nodeA", a);
+            assertEquals(a, m.getMinReplicaCheckpointLsn(TS));
+
+            LogSequenceNumber b = new LogSequenceNumber(3, 500);
+            m.publishReplicaCheckpointLsn(TS, "nodeA", b);
+            assertEquals(b, m.getMinReplicaCheckpointLsn(TS));
+        }
+    }
+
+    /** Two replicas: min is the smaller. */
+    @Test
+    public void twoReplicas_minIsSmallest() throws Exception {
+        try (ZookeeperMetadataStorageManager m = newManager()) {
+            m.start();
+            m.publishReplicaCheckpointLsn(TS, "fast", new LogSequenceNumber(5, 200));
+            m.publishReplicaCheckpointLsn(TS, "slow", new LogSequenceNumber(3, 50));
+            assertEquals(new LogSequenceNumber(3, 50), m.getMinReplicaCheckpointLsn(TS));
+        }
+    }
+
+    /** Explicit unregister removes the replica from the min computation. */
+    @Test
+    public void unregister_dropsReplica() throws Exception {
+        try (ZookeeperMetadataStorageManager m = newManager()) {
+            m.start();
+            m.publishReplicaCheckpointLsn(TS, "fast", new LogSequenceNumber(5, 200));
+            m.publishReplicaCheckpointLsn(TS, "slow", new LogSequenceNumber(3, 50));
+            m.unregisterReplicaCheckpointLsn(TS, "slow");
+            assertEquals("only fast remains",
+                    new LogSequenceNumber(5, 200), m.getMinReplicaCheckpointLsn(TS));
+
+            m.unregisterReplicaCheckpointLsn(TS, "fast");
+            assertNull(m.getMinReplicaCheckpointLsn(TS));
+        }
+    }
+
+    /**
+     * Replica znodes are ephemeral: when a replica's ZK session closes, its entry
+     * auto-disappears so the leader no longer waits for it.
+     */
+    @Test
+    public void ephemeralReplica_sessionCloseRemoves() throws Exception {
+        try (ZookeeperMetadataStorageManager leader = newManager()) {
+            leader.start();
+
+            // Use a separate ZK client session for the "replica"
+            try (ZookeeperMetadataStorageManager replica = newManager()) {
+                replica.start();
+                replica.publishReplicaCheckpointLsn(TS, "nodeR", new LogSequenceNumber(4, 7));
+                assertNotNull(leader.getMinReplicaCheckpointLsn(TS));
+                assertEquals(new LogSequenceNumber(4, 7), leader.getMinReplicaCheckpointLsn(TS));
+            } // replica closes session -> ephemeral znode goes away
+
+            // Wait a short moment for ZK to clean up
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (leader.getMinReplicaCheckpointLsn(TS) != null
+                    && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50);
+            }
+            assertNull("ephemeral znode removed after session close",
+                    leader.getMinReplicaCheckpointLsn(TS));
+        }
+    }
+
+    /**
+     * Unknown tablespace → null.
+     */
+    @Test
+    public void unknownTablespace_returnsNull() throws Exception {
+        try (ZookeeperMetadataStorageManager m = newManager()) {
+            m.start();
+            assertNull(m.getMinReplicaCheckpointLsn("nonexistent-uuid"));
+        }
+    }
+
+    private ZookeeperMetadataStorageManager newManager() {
+        return new ZookeeperMetadataStorageManager(
+                testEnv.getAddress(), testEnv.getTimeout(), testEnv.getPath());
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
@@ -1,0 +1,277 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.core.RecordSetFactory;
+import herddb.index.KeyToPageIndex;
+import herddb.log.LogSequenceNumber;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.model.Transaction;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.FullTableScanConsumer;
+import herddb.storage.IndexStatus;
+import herddb.storage.TableStatus;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * DataStorageManager that starts in read-only mode (delegating to {@link ReadReplicaDataStorageManager})
+ * and can be promoted to writable mode (delegating to {@link RemoteFileDataStorageManager}) when
+ * a shared-storage replica becomes leader.
+ * <p>
+ * On promotion, the current checkpoint metadata from S3 is written to local disk to bootstrap
+ * the {@link RemoteFileDataStorageManager}'s local metadata manager.
+ *
+ * @author enrico.olivelli
+ */
+public class PromotableRemoteFileDataStorageManager extends DataStorageManager {
+
+    private static final Logger LOGGER = Logger.getLogger(PromotableRemoteFileDataStorageManager.class.getName());
+
+    private final ReadReplicaDataStorageManager readOnlyDelegate;
+    private final RemoteFileServiceClient client;
+    private final SharedCheckpointMetadataManager metadataManager;
+    private final Path dataDirectory;
+    private final Path tmpDirectory;
+    private final int swapThreshold;
+
+    private volatile DataStorageManager activeDelegate;
+    private volatile boolean promoted = false;
+
+    public PromotableRemoteFileDataStorageManager(
+            ReadReplicaDataStorageManager readOnlyDelegate,
+            RemoteFileServiceClient client,
+            SharedCheckpointMetadataManager metadataManager,
+            Path dataDirectory,
+            Path tmpDirectory,
+            int swapThreshold) {
+        this.readOnlyDelegate = readOnlyDelegate;
+        this.client = client;
+        this.metadataManager = metadataManager;
+        this.dataDirectory = dataDirectory;
+        this.tmpDirectory = tmpDirectory;
+        this.swapThreshold = swapThreshold;
+        this.activeDelegate = readOnlyDelegate;
+    }
+
+    /**
+     * Promotes this storage manager from read-only to writable mode.
+     * Creates a {@link RemoteFileDataStorageManager} backed by the same
+     * {@link RemoteFileServiceClient} and enables it for writes.
+     */
+    public synchronized void promoteToWritable() throws DataStorageManagerException {
+        if (promoted) {
+            return;
+        }
+        LOGGER.log(Level.INFO, "Promoting storage manager to writable mode");
+
+        RemoteFileDataStorageManager writableDelegate = new RemoteFileDataStorageManager(
+                dataDirectory, tmpDirectory, swapThreshold, client);
+        writableDelegate.setSharedCheckpointMetadataManager(metadataManager);
+        writableDelegate.start();
+
+        this.activeDelegate = writableDelegate;
+        this.promoted = true;
+        LOGGER.log(Level.INFO, "Storage manager promoted to writable mode");
+    }
+
+    public boolean isPromoted() {
+        return promoted;
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void start() throws DataStorageManagerException {
+        activeDelegate.start();
+    }
+
+    @Override
+    public void close() throws DataStorageManagerException {
+        activeDelegate.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // All operations delegated to activeDelegate
+    // -------------------------------------------------------------------------
+
+    @Override
+    public List<Record> readPage(String tableSpace, String uuid, Long pageId) throws DataStorageManagerException {
+        return activeDelegate.readPage(tableSpace, uuid, pageId);
+    }
+
+    @Override
+    public <X> X readIndexPage(String tableSpace, String uuid, Long pageId, DataReader<X> reader) throws DataStorageManagerException {
+        return activeDelegate.readIndexPage(tableSpace, uuid, pageId, reader);
+    }
+
+    @Override
+    public void writePage(String tableSpace, String uuid, long pageId, Collection<Record> newPage) throws DataStorageManagerException {
+        activeDelegate.writePage(tableSpace, uuid, pageId, newPage);
+    }
+
+    @Override
+    public void writeIndexPage(String tableSpace, String uuid, long pageId, DataWriter writer) {
+        activeDelegate.writeIndexPage(tableSpace, uuid, pageId, writer);
+    }
+
+    @Override
+    public void fullTableScan(String tableSpace, String uuid, FullTableScanConsumer consumer) throws DataStorageManagerException {
+        activeDelegate.fullTableScan(tableSpace, uuid, consumer);
+    }
+
+    @Override
+    public void fullTableScan(String tableSpace, String uuid, LogSequenceNumber sequenceNumber, FullTableScanConsumer consumer) throws DataStorageManagerException {
+        activeDelegate.fullTableScan(tableSpace, uuid, sequenceNumber, consumer);
+    }
+
+    @Override
+    public List<PostCheckpointAction> tableCheckpoint(String tableSpace, String uuid, TableStatus tableStatus, boolean pin) throws DataStorageManagerException {
+        return activeDelegate.tableCheckpoint(tableSpace, uuid, tableStatus, pin);
+    }
+
+    @Override
+    public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String uuid, IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
+        return activeDelegate.indexCheckpoint(tableSpace, uuid, indexStatus, pin);
+    }
+
+    @Override
+    public int getActualNumberOfPages(String tableSpace, String uuid) throws DataStorageManagerException {
+        return activeDelegate.getActualNumberOfPages(tableSpace, uuid);
+    }
+
+    @Override
+    public TableStatus getLatestTableStatus(String tableSpace, String uuid) throws DataStorageManagerException {
+        return activeDelegate.getLatestTableStatus(tableSpace, uuid);
+    }
+
+    @Override
+    public TableStatus getTableStatus(String tableSpace, String uuid, LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+        return activeDelegate.getTableStatus(tableSpace, uuid, sequenceNumber);
+    }
+
+    @Override
+    public IndexStatus getIndexStatus(String tableSpace, String uuid, LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+        return activeDelegate.getIndexStatus(tableSpace, uuid, sequenceNumber);
+    }
+
+    @Override
+    public void initTablespace(String tableSpace) throws DataStorageManagerException {
+        activeDelegate.initTablespace(tableSpace);
+    }
+
+    @Override
+    public void initTable(String tableSpace, String uuid) throws DataStorageManagerException {
+        activeDelegate.initTable(tableSpace, uuid);
+    }
+
+    @Override
+    public void initIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        activeDelegate.initIndex(tableSpace, uuid);
+    }
+
+    @Override
+    public List<Table> loadTables(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
+        return activeDelegate.loadTables(sequenceNumber, tableSpace);
+    }
+
+    @Override
+    public List<Index> loadIndexes(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
+        return activeDelegate.loadIndexes(sequenceNumber, tableSpace);
+    }
+
+    @Override
+    public void loadTransactions(LogSequenceNumber sequenceNumber, String tableSpace, Consumer<Transaction> consumer) throws DataStorageManagerException {
+        activeDelegate.loadTransactions(sequenceNumber, tableSpace, consumer);
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeTables(String tableSpace, LogSequenceNumber sequenceNumber, List<Table> tables, List<Index> indexlist, boolean prepareActions) throws DataStorageManagerException {
+        return activeDelegate.writeTables(tableSpace, sequenceNumber, tables, indexlist, prepareActions);
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeCheckpointSequenceNumber(String tableSpace, LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+        return activeDelegate.writeCheckpointSequenceNumber(tableSpace, sequenceNumber);
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeTransactionsAtCheckpoint(String tableSpace, LogSequenceNumber sequenceNumber, Collection<Transaction> transactions) throws DataStorageManagerException {
+        return activeDelegate.writeTransactionsAtCheckpoint(tableSpace, sequenceNumber, transactions);
+    }
+
+    @Override
+    public LogSequenceNumber getLastcheckpointSequenceNumber(String tableSpace) throws DataStorageManagerException {
+        return activeDelegate.getLastcheckpointSequenceNumber(tableSpace);
+    }
+
+    @Override
+    public void dropTable(String tableSpace, String uuid) throws DataStorageManagerException {
+        activeDelegate.dropTable(tableSpace, uuid);
+    }
+
+    @Override
+    public void dropIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        activeDelegate.dropIndex(tableSpace, uuid);
+    }
+
+    @Override
+    public void truncateIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        activeDelegate.truncateIndex(tableSpace, uuid);
+    }
+
+    @Override
+    public void eraseTablespaceData(String tableSpace) throws DataStorageManagerException {
+        activeDelegate.eraseTablespaceData(tableSpace);
+    }
+
+    @Override
+    public KeyToPageIndex createKeyToPageMap(String tableSpace, String uuid, MemoryManager memoryManager) throws DataStorageManagerException {
+        return activeDelegate.createKeyToPageMap(tableSpace, uuid, memoryManager);
+    }
+
+    @Override
+    public void releaseKeyToPageMap(String tableSpace, String uuid, KeyToPageIndex index) {
+        activeDelegate.releaseKeyToPageMap(tableSpace, uuid, index);
+    }
+
+    @Override
+    public RecordSetFactory createRecordSetFactory() {
+        return activeDelegate.createRecordSetFactory();
+    }
+
+    @Override
+    public void cleanupAfterTableBoot(String tableSpace, String uuid, Set<Long> activePagesAtBoot) throws DataStorageManagerException {
+        activeDelegate.cleanupAfterTableBoot(tableSpace, uuid, activePagesAtBoot);
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
@@ -39,19 +39,13 @@ import herddb.storage.IndexStatus;
 import herddb.storage.TableStatus;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.Bytes;
-import herddb.utils.ExtendedDataOutputStream;
-import herddb.utils.VisibleByteArrayOutputStream;
-import herddb.utils.XXHash64Utils;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
@@ -1,0 +1,378 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.core.RecordSetFactory;
+import herddb.file.FileRecordSetFactory;
+import herddb.index.KeyToPageIndex;
+import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.log.LogSequenceNumber;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.model.Transaction;
+import herddb.storage.DataPageDoesNotExistException;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.FullTableScanConsumer;
+import herddb.storage.IndexStatus;
+import herddb.storage.TableStatus;
+import herddb.utils.ByteArrayCursor;
+import herddb.utils.Bytes;
+import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.VisibleByteArrayOutputStream;
+import herddb.utils.XXHash64Utils;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Read-only DataStorageManager for shared-storage read replicas.
+ * <p>
+ * Reads both data/index pages AND metadata (TableStatus, table definitions, etc.)
+ * from remote storage (S3 via RemoteFileServiceClient). All write operations throw
+ * {@link UnsupportedOperationException}.
+ * <p>
+ * This storage manager has NO local disk dependency for metadata. Pages are read on-demand
+ * from S3, and the CachingObjectStorage on the file server provides local caching.
+ *
+ * @author enrico.olivelli
+ */
+public class ReadReplicaDataStorageManager extends DataStorageManager {
+
+    private static final Logger LOGGER = Logger.getLogger(ReadReplicaDataStorageManager.class.getName());
+
+    private final RemoteFileServiceClient client;
+    private final SharedCheckpointMetadataManager metadataManager;
+    private final Path tmpDir;
+    private final int swapThreshold;
+
+    public ReadReplicaDataStorageManager(
+            RemoteFileServiceClient client,
+            SharedCheckpointMetadataManager metadataManager,
+            Path tmpDir,
+            int swapThreshold) {
+        this.client = client;
+        this.metadataManager = metadataManager;
+        this.tmpDir = tmpDir;
+        this.swapThreshold = swapThreshold;
+    }
+
+    // -------------------------------------------------------------------------
+    // Remote page paths (same convention as RemoteFileDataStorageManager)
+    // -------------------------------------------------------------------------
+
+    private static String remoteDataPagePath(String tableSpace, String uuid, long pageId) {
+        return tableSpace + "/" + uuid + "/data/" + pageId + ".page";
+    }
+
+    private static String remoteIndexPagePath(String tableSpace, String uuid, long pageId) {
+        return tableSpace + "/" + uuid + "/index/" + pageId + ".page";
+    }
+
+    // -------------------------------------------------------------------------
+    // Page deserialization (matches FileDataStorageManager format)
+    // -------------------------------------------------------------------------
+
+    private static List<Record> deserializeDataPage(byte[] data) throws IOException, DataStorageManagerException {
+        try (ByteArrayCursor dataIn = ByteArrayCursor.wrap(data)) {
+            long version = dataIn.readVLong();
+            long flags = dataIn.readVLong();
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted remote data page");
+            }
+            int numRecords = dataIn.readInt();
+            List<Record> result = new ArrayList<>(numRecords);
+            for (int i = 0; i < numRecords; i++) {
+                Bytes key = dataIn.readBytesNoCopy();
+                Bytes value = dataIn.readBytesNoCopy();
+                result.add(new Record(key, value));
+            }
+            return result;
+        }
+    }
+
+    private static <X> X deserializeIndexPage(byte[] data, DataReader<X> reader)
+            throws IOException, DataStorageManagerException {
+        try (ByteArrayCursor dataIn = ByteArrayCursor.wrap(data)) {
+            long version = dataIn.readVLong();
+            long flags = dataIn.readVLong();
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted remote index page");
+            }
+            return reader.read(dataIn);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void start() throws DataStorageManagerException {
+        // nothing to start — no local state
+    }
+
+    @Override
+    public void close() throws DataStorageManagerException {
+        // nothing to close
+    }
+
+    // -------------------------------------------------------------------------
+    // Read operations — delegated to remote storage
+    // -------------------------------------------------------------------------
+
+    @Override
+    public List<Record> readPage(String tableSpace, String uuid, Long pageId)
+            throws DataStorageManagerException {
+        String path = remoteDataPagePath(tableSpace, uuid, pageId);
+        byte[] data = client.readFile(path);
+        if (data == null) {
+            throw new DataPageDoesNotExistException(
+                    "No such remote page: " + tableSpace + "_" + uuid + "." + pageId);
+        }
+        try {
+            return deserializeDataPage(data);
+        } catch (IOException e) {
+            throw new DataStorageManagerException("Error reading remote data page: " + path, e);
+        }
+    }
+
+    @Override
+    public <X> X readIndexPage(String tableSpace, String uuid, Long pageId, DataReader<X> reader)
+            throws DataStorageManagerException {
+        String path = remoteIndexPagePath(tableSpace, uuid, pageId);
+        byte[] data = client.readFile(path);
+        if (data == null) {
+            throw new DataStorageManagerException(
+                    "No such remote index page: " + tableSpace + "_" + uuid + "." + pageId);
+        }
+        try {
+            return deserializeIndexPage(data, reader);
+        } catch (IOException e) {
+            throw new DataStorageManagerException("Error reading remote index page: " + path, e);
+        }
+    }
+
+    @Override
+    public void fullTableScan(String tableSpace, String uuid, FullTableScanConsumer consumer)
+            throws DataStorageManagerException {
+        TableStatus status = getLatestTableStatus(tableSpace, uuid);
+        doFullTableScan(tableSpace, uuid, status, consumer);
+    }
+
+    @Override
+    public void fullTableScan(String tableSpace, String uuid, LogSequenceNumber sequenceNumber,
+            FullTableScanConsumer consumer) throws DataStorageManagerException {
+        TableStatus status = getTableStatus(tableSpace, uuid, sequenceNumber);
+        doFullTableScan(tableSpace, uuid, status, consumer);
+    }
+
+    private void doFullTableScan(String tableSpace, String uuid, TableStatus status,
+            FullTableScanConsumer consumer) throws DataStorageManagerException {
+        consumer.acceptTableStatus(status);
+        List<Long> activePages = new ArrayList<>(status.activePages.keySet());
+        activePages.sort(null);
+        for (long pageId : activePages) {
+            List<Record> records = readPage(tableSpace, uuid, pageId);
+            consumer.acceptPage(pageId, records);
+        }
+        consumer.endTable();
+    }
+
+    // -------------------------------------------------------------------------
+    // Metadata — read from shared checkpoint metadata on S3
+    // -------------------------------------------------------------------------
+
+    @Override
+    public LogSequenceNumber getLastcheckpointSequenceNumber(String tableSpace)
+            throws DataStorageManagerException {
+        return metadataManager.readCheckpointLsn(tableSpace);
+    }
+
+    @Override
+    public List<Table> loadTables(LogSequenceNumber sequenceNumber, String tableSpace)
+            throws DataStorageManagerException {
+        return metadataManager.readTableDefinitions(tableSpace, sequenceNumber);
+    }
+
+    @Override
+    public List<Index> loadIndexes(LogSequenceNumber sequenceNumber, String tableSpace)
+            throws DataStorageManagerException {
+        return metadataManager.readIndexDefinitions(tableSpace, sequenceNumber);
+    }
+
+    @Override
+    public void loadTransactions(LogSequenceNumber sequenceNumber, String tableSpace,
+            Consumer<Transaction> consumer) throws DataStorageManagerException {
+        metadataManager.readTransactions(tableSpace, sequenceNumber, consumer);
+    }
+
+    @Override
+    public TableStatus getLatestTableStatus(String tableSpace, String uuid)
+            throws DataStorageManagerException {
+        LogSequenceNumber lsn = getLastcheckpointSequenceNumber(tableSpace);
+        return metadataManager.readTableStatus(tableSpace, uuid, lsn);
+    }
+
+    @Override
+    public TableStatus getTableStatus(String tableSpace, String uuid, LogSequenceNumber sequenceNumber)
+            throws DataStorageManagerException {
+        return metadataManager.readTableStatus(tableSpace, uuid, sequenceNumber);
+    }
+
+    @Override
+    public IndexStatus getIndexStatus(String tableSpace, String uuid, LogSequenceNumber sequenceNumber)
+            throws DataStorageManagerException {
+        return metadataManager.readIndexStatus(tableSpace, uuid, sequenceNumber);
+    }
+
+    @Override
+    public int getActualNumberOfPages(String tableSpace, String uuid)
+            throws DataStorageManagerException {
+        TableStatus status = getLatestTableStatus(tableSpace, uuid);
+        return status.activePages.size();
+    }
+
+    // -------------------------------------------------------------------------
+    // Init / no-op (replicas don't create structures)
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void initTablespace(String tableSpace) throws DataStorageManagerException {
+        // no-op on read replica
+    }
+
+    @Override
+    public void initTable(String tableSpace, String uuid) throws DataStorageManagerException {
+        // no-op on read replica
+    }
+
+    @Override
+    public void initIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        // no-op on read replica
+    }
+
+    @Override
+    public void cleanupAfterTableBoot(String tableSpace, String uuid, Set<Long> activePagesAtBoot)
+            throws DataStorageManagerException {
+        // no-op on read replica — we don't own the pages
+    }
+
+    // -------------------------------------------------------------------------
+    // Index and record set factory
+    // -------------------------------------------------------------------------
+
+    @Override
+    public KeyToPageIndex createKeyToPageMap(String tableSpace, String uuid,
+            MemoryManager memoryManager) throws DataStorageManagerException {
+        return new BLinkKeyToPageIndex(tableSpace, uuid, memoryManager, this);
+    }
+
+    @Override
+    public void releaseKeyToPageMap(String tableSpace, String uuid, KeyToPageIndex index) {
+        if (index != null) {
+            index.close();
+        }
+    }
+
+    @Override
+    public RecordSetFactory createRecordSetFactory() {
+        return new FileRecordSetFactory(tmpDir, swapThreshold);
+    }
+
+    // -------------------------------------------------------------------------
+    // Write operations — all rejected on read replicas
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void writePage(String tableSpace, String uuid, long pageId, Collection<Record> newPage)
+            throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support write operations");
+    }
+
+    @Override
+    public void writeIndexPage(String tableSpace, String uuid, long pageId, DataWriter writer) {
+        throw new UnsupportedOperationException("Read replica does not support write operations");
+    }
+
+    @Override
+    public List<PostCheckpointAction> tableCheckpoint(String tableSpace, String uuid,
+            TableStatus tableStatus, boolean pin) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support checkpoint operations");
+    }
+
+    @Override
+    public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String uuid,
+            IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support checkpoint operations");
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeTables(String tableSpace,
+            LogSequenceNumber sequenceNumber, List<Table> tables, List<Index> indexlist,
+            boolean prepareActions) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support write operations");
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeCheckpointSequenceNumber(String tableSpace,
+            LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support write operations");
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeTransactionsAtCheckpoint(String tableSpace,
+            LogSequenceNumber sequenceNumber, Collection<Transaction> transactions)
+            throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support write operations");
+    }
+
+    @Override
+    public void dropTable(String tableSpace, String uuid) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support drop operations");
+    }
+
+    @Override
+    public void dropIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support drop operations");
+    }
+
+    @Override
+    public void truncateIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support truncate operations");
+    }
+
+    @Override
+    public void eraseTablespaceData(String tableSpace) throws DataStorageManagerException {
+        throw new UnsupportedOperationException("Read replica does not support erase operations");
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -74,6 +74,13 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
     private final int swapThreshold;
 
     /**
+     * When set, checkpoint metadata (TableStatus, IndexStatus, table/index definitions,
+     * checkpoint LSN) is also published to remote storage so that shared-storage read
+     * replicas can consume it.
+     */
+    private volatile SharedCheckpointMetadataManager sharedCheckpointMetadataManager;
+
+    /**
      * Tracks the set of active data page IDs as of the last successful tableCheckpoint per
      * "{tableSpace}/{uuid}" key. Used to compute the stale-page diff without a full remote listFiles.
      * Populated on the first checkpoint after boot (via listFiles fallback); subsequent checkpoints
@@ -96,6 +103,13 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
                 localMetadataDir, tmpDir, swapThreshold,
                 false, false, false, false, false,
                 new NullStatsLogger());
+    }
+
+    /**
+     * Enables publication of checkpoint metadata to remote storage for shared-storage read replicas.
+     */
+    public void setSharedCheckpointMetadataManager(SharedCheckpointMetadataManager manager) {
+        this.sharedCheckpointMetadataManager = manager;
     }
 
     // -------------------------------------------------------------------------
@@ -351,6 +365,13 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
             }
         }
         lastCheckpointedDataPages.put(key, new HashSet<>(currentActivePages));
+
+        // Publish to shared storage for read replicas
+        SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
+        if (shared != null) {
+            shared.writeTableStatus(tableSpace, uuid, tableStatus);
+        }
+
         return result;
     }
 
@@ -395,6 +416,13 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
             }
         }
         lastCheckpointedIndexPages.put(key, new HashSet<>(currentActivePages));
+
+        // Publish to shared storage for read replicas
+        SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
+        if (shared != null) {
+            shared.writeIndexStatus(tableSpace, uuid, indexStatus);
+        }
+
         return result;
     }
 
@@ -529,20 +557,49 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
     public Collection<PostCheckpointAction> writeTables(String tableSpace,
             LogSequenceNumber sequenceNumber, List<Table> tables, List<Index> indexlist,
             boolean prepareActions) throws DataStorageManagerException {
-        return localMetadataManager.writeTables(tableSpace, sequenceNumber, tables, indexlist, prepareActions);
+        Collection<PostCheckpointAction> result =
+                localMetadataManager.writeTables(tableSpace, sequenceNumber, tables, indexlist, prepareActions);
+
+        // Publish to shared storage for read replicas
+        SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
+        if (shared != null) {
+            shared.writeTableDefinitions(tableSpace, sequenceNumber, tables);
+            shared.writeIndexDefinitions(tableSpace, sequenceNumber, indexlist);
+        }
+
+        return result;
     }
 
     @Override
     public Collection<PostCheckpointAction> writeCheckpointSequenceNumber(String tableSpace,
             LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
-        return localMetadataManager.writeCheckpointSequenceNumber(tableSpace, sequenceNumber);
+        Collection<PostCheckpointAction> result =
+                localMetadataManager.writeCheckpointSequenceNumber(tableSpace, sequenceNumber);
+
+        // Publish to shared storage for read replicas — this is written LAST,
+        // acting as the atomic commit marker for the checkpoint metadata
+        SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
+        if (shared != null) {
+            shared.writeCheckpointLsn(tableSpace, sequenceNumber);
+        }
+
+        return result;
     }
 
     @Override
     public Collection<PostCheckpointAction> writeTransactionsAtCheckpoint(String tableSpace,
             LogSequenceNumber sequenceNumber, Collection<Transaction> transactions)
             throws DataStorageManagerException {
-        return localMetadataManager.writeTransactionsAtCheckpoint(tableSpace, sequenceNumber, transactions);
+        Collection<PostCheckpointAction> result =
+                localMetadataManager.writeTransactionsAtCheckpoint(tableSpace, sequenceNumber, transactions);
+
+        // Publish to shared storage for read replicas
+        SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
+        if (shared != null) {
+            shared.writeTransactions(tableSpace, sequenceNumber, transactions);
+        }
+
+        return result;
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -47,13 +47,16 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -93,6 +96,28 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
      */
     private final ConcurrentHashMap<String, Set<Long>> lastCheckpointedIndexPages = new ConcurrentHashMap<>();
 
+    /**
+     * Deferred page deletions keyed by "{tableSpace}/{uuid}". Each entry records pages
+     * that became stale at a specific checkpoint LSN and are waiting until it is safe to
+     * actually delete them from remote storage. Populated only when retention is enabled.
+     */
+    private final ConcurrentHashMap<String, List<PendingDeletion>> pendingDataDeletions = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, List<PendingDeletion>> pendingIndexDeletions = new ConcurrentHashMap<>();
+
+    /**
+     * When retention is enabled, page deletions are deferred according to the following rules:
+     * <ul>
+     *   <li>wait at least {@link #minRetentionMillis} after a page became stale (safety grace)</li>
+     *   <li>delete when the min replica LSN (from {@link #minReplicaLsnSupplier}) has advanced
+     *       past the page's stale-LSN</li>
+     *   <li>force-delete after {@link #maxRetentionMillis} even if replicas are behind (safety cap)</li>
+     * </ul>
+     */
+    private volatile boolean retentionEnabled = false;
+    private volatile Function<String, LogSequenceNumber> minReplicaLsnSupplier = ts -> null;
+    private volatile long minRetentionMillis = 0L;
+    private volatile long maxRetentionMillis = Long.MAX_VALUE;
+
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client) {
@@ -110,6 +135,112 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
      */
     public void setSharedCheckpointMetadataManager(SharedCheckpointMetadataManager manager) {
         this.sharedCheckpointMetadataManager = manager;
+    }
+
+    /**
+     * Enables deferred page deletion so that shared-storage read replicas can safely consume
+     * pages from old checkpoints. See the class-level documentation for the retention model.
+     *
+     * @param minReplicaLsnSupplier given a tableSpace UUID, returns the minimum checkpoint LSN
+     *        across all currently-registered replicas, or {@code null} if no replicas are tracked
+     * @param minRetentionMillis minimum grace period before a page can be deleted, even if all
+     *        replicas have advanced past its stale-LSN
+     * @param maxRetentionMillis maximum time a page can be retained; after this, it is force-deleted
+     *        even if some replicas are still behind (they will need to re-bootstrap)
+     */
+    public void setRetentionPolicy(
+            Function<String, LogSequenceNumber> minReplicaLsnSupplier,
+            long minRetentionMillis,
+            long maxRetentionMillis) {
+        this.minReplicaLsnSupplier = minReplicaLsnSupplier != null ? minReplicaLsnSupplier : ts -> null;
+        this.minRetentionMillis = Math.max(0, minRetentionMillis);
+        this.maxRetentionMillis = maxRetentionMillis <= 0 ? Long.MAX_VALUE : maxRetentionMillis;
+        this.retentionEnabled = true;
+        LOGGER.log(Level.INFO,
+                "Deferred page deletion enabled: minRetention={0}ms, maxRetention={1}ms",
+                new Object[]{this.minRetentionMillis, this.maxRetentionMillis});
+    }
+
+    // visible for testing
+    long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+
+    // visible for testing
+    int pendingDataDeletionCount(String tableSpace, String uuid) {
+        List<PendingDeletion> pending = pendingDataDeletions.get(tableSpace + "/" + uuid);
+        return pending == null ? 0 : pending.size();
+    }
+
+    // visible for testing
+    int pendingIndexDeletionCount(String tableSpace, String uuid) {
+        List<PendingDeletion> pending = pendingIndexDeletions.get(tableSpace + "/" + uuid);
+        return pending == null ? 0 : pending.size();
+    }
+
+    private static final class PendingDeletion {
+        final LogSequenceNumber staleAt;
+        final long scheduledAtMillis;
+        final String remotePath;
+        final String description;
+        final String tableSpace;
+        final String uuid;
+
+        PendingDeletion(LogSequenceNumber staleAt, long scheduledAtMillis, String remotePath,
+                        String description, String tableSpace, String uuid) {
+            this.staleAt = staleAt;
+            this.scheduledAtMillis = scheduledAtMillis;
+            this.remotePath = remotePath;
+            this.description = description;
+            this.tableSpace = tableSpace;
+            this.uuid = uuid;
+        }
+    }
+
+    /**
+     * Evaluates pending deletions for a table/index and returns the subset that is safe to
+     * execute now. Safe deletions are removed from the pending list.
+     */
+    private List<PostCheckpointAction> promotePendingDeletions(
+            ConcurrentHashMap<String, List<PendingDeletion>> store, String key, String tableSpace) {
+        List<PendingDeletion> pending = store.get(key);
+        if (pending == null || pending.isEmpty()) {
+            return Collections.emptyList();
+        }
+        LogSequenceNumber minReplicaLsn = null;
+        try {
+            minReplicaLsn = minReplicaLsnSupplier.apply(tableSpace);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to query min replica LSN for " + tableSpace
+                    + "; retaining pages conservatively", e);
+        }
+        long now = currentTimeMillis();
+        List<PostCheckpointAction> toRun = new ArrayList<>();
+        synchronized (pending) {
+            Iterator<PendingDeletion> it = pending.iterator();
+            while (it.hasNext()) {
+                PendingDeletion pd = it.next();
+                long ageMs = now - pd.scheduledAtMillis;
+                boolean minGracePassed = ageMs >= minRetentionMillis;
+                // A replica at LSN L does not reference pages that became stale at LSN pd.staleAt
+                // when L >= pd.staleAt. after() is strictly-after, so we check !pd.staleAt.after(L).
+                boolean replicasAdvanced = minReplicaLsn != null
+                        && !pd.staleAt.after(minReplicaLsn);
+                boolean forceByMaxAge = ageMs >= maxRetentionMillis;
+                boolean safe = (minGracePassed && replicasAdvanced) || forceByMaxAge;
+                if (safe) {
+                    toRun.add(new RemoteDeletePageAction(pd.tableSpace, pd.uuid, pd.description,
+                            pd.remotePath, client));
+                    it.remove();
+                    if (forceByMaxAge && !replicasAdvanced) {
+                        LOGGER.log(Level.WARNING,
+                                "Force-deleting page {0} after {1}ms (min replica LSN: {2}, stale at: {3})",
+                                new Object[]{pd.remotePath, ageMs, minReplicaLsn, pd.staleAt});
+                    }
+                }
+            }
+        }
+        return toRun;
     }
 
     // -------------------------------------------------------------------------
@@ -337,15 +468,16 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
         String key = tableSpace + "/" + uuid;
 
         Set<Long> previousActivePages = lastCheckpointedDataPages.get(key);
+        List<long[]> newlyStale = new ArrayList<>(); // [pageId] or [-1] when only path is known
+        List<String> newlyStalePaths = new ArrayList<>();
         if (previousActivePages != null) {
             // Fast path: diff against the previous checkpoint — no remote listing needed
             for (Long pageId : previousActivePages) {
                 if (!pins.containsKey(pageId)
                         && !currentActivePages.contains(pageId)
                         && pageId < maxPageId) {
-                    result.add(new RemoteDeletePageAction(tableSpace, uuid,
-                            "delete remote page " + pageId,
-                            remoteDataPagePath(tableSpace, uuid, pageId), client));
+                    newlyStale.add(new long[]{pageId});
+                    newlyStalePaths.add(remoteDataPagePath(tableSpace, uuid, pageId));
                 }
             }
         } else {
@@ -359,12 +491,31 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
                         && !pins.containsKey(pageId)
                         && !currentActivePages.contains(pageId)
                         && pageId < maxPageId) {
-                    result.add(new RemoteDeletePageAction(tableSpace, uuid,
-                            "delete remote page " + pageId, remotePath, client));
+                    newlyStale.add(new long[]{pageId});
+                    newlyStalePaths.add(remotePath);
                 }
             }
         }
         lastCheckpointedDataPages.put(key, new HashSet<>(currentActivePages));
+
+        // Emit data-page deletion actions: either deferred (with retention) or immediate
+        if (retentionEnabled) {
+            long now = currentTimeMillis();
+            List<PendingDeletion> bucket = pendingDataDeletions.computeIfAbsent(key,
+                    k -> Collections.synchronizedList(new ArrayList<>()));
+            for (int i = 0; i < newlyStale.size(); i++) {
+                long pageId = newlyStale.get(i)[0];
+                bucket.add(new PendingDeletion(tableStatus.sequenceNumber, now, newlyStalePaths.get(i),
+                        "delete remote page " + pageId, tableSpace, uuid));
+            }
+            result.addAll(promotePendingDeletions(pendingDataDeletions, key, tableSpace));
+        } else {
+            for (int i = 0; i < newlyStale.size(); i++) {
+                long pageId = newlyStale.get(i)[0];
+                result.add(new RemoteDeletePageAction(tableSpace, uuid,
+                        "delete remote page " + pageId, newlyStalePaths.get(i), client));
+            }
+        }
 
         // Publish to shared storage for read replicas
         SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
@@ -388,15 +539,16 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
         String key = tableSpace + "/" + uuid;
 
         Set<Long> previousActivePages = lastCheckpointedIndexPages.get(key);
+        List<long[]> newlyStale = new ArrayList<>();
+        List<String> newlyStalePaths = new ArrayList<>();
         if (previousActivePages != null) {
             // Fast path: diff against the previous checkpoint — no remote listing needed
             for (Long pageId : previousActivePages) {
                 if (!pins.containsKey(pageId)
                         && !currentActivePages.contains(pageId)
                         && pageId < maxPageId) {
-                    result.add(new RemoteDeletePageAction(tableSpace, uuid,
-                            "delete remote index page " + pageId,
-                            remoteIndexPagePath(tableSpace, uuid, pageId), client));
+                    newlyStale.add(new long[]{pageId});
+                    newlyStalePaths.add(remoteIndexPagePath(tableSpace, uuid, pageId));
                 }
             }
         } else {
@@ -410,12 +562,31 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
                         && !pins.containsKey(pageId)
                         && !currentActivePages.contains(pageId)
                         && pageId < maxPageId) {
-                    result.add(new RemoteDeletePageAction(tableSpace, uuid,
-                            "delete remote index page " + pageId, remotePath, client));
+                    newlyStale.add(new long[]{pageId});
+                    newlyStalePaths.add(remotePath);
                 }
             }
         }
         lastCheckpointedIndexPages.put(key, new HashSet<>(currentActivePages));
+
+        // Emit index-page deletion actions: either deferred (with retention) or immediate
+        if (retentionEnabled) {
+            long now = currentTimeMillis();
+            List<PendingDeletion> bucket = pendingIndexDeletions.computeIfAbsent(key,
+                    k -> Collections.synchronizedList(new ArrayList<>()));
+            for (int i = 0; i < newlyStale.size(); i++) {
+                long pageId = newlyStale.get(i)[0];
+                bucket.add(new PendingDeletion(indexStatus.sequenceNumber, now, newlyStalePaths.get(i),
+                        "delete remote index page " + pageId, tableSpace, uuid));
+            }
+            result.addAll(promotePendingDeletions(pendingIndexDeletions, key, tableSpace));
+        } else {
+            for (int i = 0; i < newlyStale.size(); i++) {
+                long pageId = newlyStale.get(i)[0];
+                result.add(new RemoteDeletePageAction(tableSpace, uuid,
+                        "delete remote index page " + pageId, newlyStalePaths.get(i), client));
+            }
+        }
 
         // Publish to shared storage for read replicas
         SharedCheckpointMetadataManager shared = this.sharedCheckpointMetadataManager;
@@ -467,21 +638,27 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
     public void dropTable(String tableSpace, String uuid) throws DataStorageManagerException {
         localMetadataManager.dropTable(tableSpace, uuid);
         client.deleteByPrefix(remoteDataPrefix(tableSpace, uuid));
-        lastCheckpointedDataPages.remove(tableSpace + "/" + uuid);
+        String key = tableSpace + "/" + uuid;
+        lastCheckpointedDataPages.remove(key);
+        pendingDataDeletions.remove(key);
     }
 
     @Override
     public void dropIndex(String tableSpace, String uuid) throws DataStorageManagerException {
         localMetadataManager.dropIndex(tableSpace, uuid);
         client.deleteByPrefix(remoteIndexPrefix(tableSpace, uuid));
-        lastCheckpointedIndexPages.remove(tableSpace + "/" + uuid);
+        String key = tableSpace + "/" + uuid;
+        lastCheckpointedIndexPages.remove(key);
+        pendingIndexDeletions.remove(key);
     }
 
     @Override
     public void truncateIndex(String tableSpace, String uuid) throws DataStorageManagerException {
         localMetadataManager.truncateIndex(tableSpace, uuid);
         client.deleteByPrefix(remoteIndexPrefix(tableSpace, uuid));
-        lastCheckpointedIndexPages.remove(tableSpace + "/" + uuid);
+        String key = tableSpace + "/" + uuid;
+        lastCheckpointedIndexPages.remove(key);
+        pendingIndexDeletions.remove(key);
     }
 
     @Override
@@ -491,6 +668,8 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
         String prefix = tableSpace + "/";
         lastCheckpointedDataPages.keySet().removeIf(k -> k.startsWith(prefix));
         lastCheckpointedIndexPages.keySet().removeIf(k -> k.startsWith(prefix));
+        pendingDataDeletions.keySet().removeIf(k -> k.startsWith(prefix));
+        pendingIndexDeletions.keySet().removeIf(k -> k.startsWith(prefix));
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SharedCheckpointMetadataManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SharedCheckpointMetadataManager.java
@@ -36,7 +36,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SharedCheckpointMetadataManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SharedCheckpointMetadataManager.java
@@ -1,0 +1,511 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import herddb.log.LogSequenceNumber;
+import herddb.model.Index;
+import herddb.model.Table;
+import herddb.model.Transaction;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.IndexStatus;
+import herddb.storage.TableStatus;
+import herddb.utils.ExtendedDataInputStream;
+import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.SimpleByteArrayInputStream;
+import herddb.utils.VisibleByteArrayOutputStream;
+import herddb.utils.XXHash64Utils;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Manages checkpoint metadata on remote storage (S3 via RemoteFileServiceClient).
+ * <p>
+ * The leader publishes checkpoint metadata here so that shared-storage read replicas
+ * can discover and load consistent checkpoint snapshots without local disk or WAL replay.
+ * <p>
+ * Metadata is organized under a {@code _metadata/} prefix to avoid collisions with data pages:
+ * <ul>
+ *   <li>{@code {tableSpace}/_metadata/latest.checkpoint} - latest checkpoint LSN (binary)</li>
+ *   <li>{@code {tableSpace}/_metadata/tables.{ledgerId}.{offset}.tablesmetadata} - table definitions</li>
+ *   <li>{@code {tableSpace}/_metadata/indexes.{ledgerId}.{offset}.tablesmetadata} - index definitions</li>
+ *   <li>{@code {tableSpace}/_metadata/transactions.{ledgerId}.{offset}.tx} - transactions</li>
+ *   <li>{@code {tableSpace}/_metadata/{uuid}.{ledgerId}.{offset}.tablestatus} - table status</li>
+ *   <li>{@code {tableSpace}/_metadata/{uuid}.{ledgerId}.{offset}.indexstatus} - index status</li>
+ * </ul>
+ *
+ * @author enrico.olivelli
+ */
+public class SharedCheckpointMetadataManager {
+
+    private static final Logger LOGGER = Logger.getLogger(SharedCheckpointMetadataManager.class.getName());
+
+    private final RemoteFileServiceClient client;
+
+    public SharedCheckpointMetadataManager(RemoteFileServiceClient client) {
+        this.client = client;
+    }
+
+    // -------------------------------------------------------------------------
+    // Path helpers
+    // -------------------------------------------------------------------------
+
+    private static String latestCheckpointPath(String tableSpace) {
+        return tableSpace + "/_metadata/latest.checkpoint";
+    }
+
+    private static String tablesMetadataPath(String tableSpace, LogSequenceNumber lsn) {
+        return tableSpace + "/_metadata/tables." + lsn.ledgerId + "." + lsn.offset + ".tablesmetadata";
+    }
+
+    private static String indexesMetadataPath(String tableSpace, LogSequenceNumber lsn) {
+        return tableSpace + "/_metadata/indexes." + lsn.ledgerId + "." + lsn.offset + ".tablesmetadata";
+    }
+
+    private static String transactionsPath(String tableSpace, LogSequenceNumber lsn) {
+        return tableSpace + "/_metadata/transactions." + lsn.ledgerId + "." + lsn.offset + ".tx";
+    }
+
+    private static String tableStatusPath(String tableSpace, String tableUuid, LogSequenceNumber lsn) {
+        return tableSpace + "/_metadata/" + tableUuid + "." + lsn.ledgerId + "." + lsn.offset + ".tablestatus";
+    }
+
+    private static String indexStatusPath(String tableSpace, String indexUuid, LogSequenceNumber lsn) {
+        return tableSpace + "/_metadata/" + indexUuid + "." + lsn.ledgerId + "." + lsn.offset + ".indexstatus";
+    }
+
+    private static String metadataPrefix(String tableSpace) {
+        return tableSpace + "/_metadata/";
+    }
+
+    // -------------------------------------------------------------------------
+    // Write methods (used by leader)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Publishes table definitions to remote storage.
+     */
+    public void writeTableDefinitions(String tableSpace, LogSequenceNumber lsn,
+                                      List<Table> tables) throws DataStorageManagerException {
+        String path = tablesMetadataPath(tableSpace, lsn);
+        try {
+            VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+            try (ExtendedDataOutputStream dout = new ExtendedDataOutputStream(bos)) {
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(lsn.ledgerId);
+                dout.writeZLong(lsn.offset);
+                dout.writeInt(tables.size());
+                for (Table t : tables) {
+                    byte[] tableSerialized = t.serialize();
+                    dout.writeArray(tableSerialized);
+                }
+            }
+            client.writeFile(path, bos.toByteArray());
+            LOGGER.log(Level.FINE, "Published table definitions for {0} at {1}", new Object[]{tableSpace, lsn});
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to write table definitions to " + path, err);
+        }
+    }
+
+    /**
+     * Publishes index definitions to remote storage.
+     */
+    public void writeIndexDefinitions(String tableSpace, LogSequenceNumber lsn,
+                                      List<Index> indexes) throws DataStorageManagerException {
+        String path = indexesMetadataPath(tableSpace, lsn);
+        try {
+            VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+            try (ExtendedDataOutputStream dout = new ExtendedDataOutputStream(bos)) {
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(lsn.ledgerId);
+                dout.writeZLong(lsn.offset);
+                dout.writeInt(indexes != null ? indexes.size() : 0);
+                if (indexes != null) {
+                    for (Index idx : indexes) {
+                        byte[] indexSerialized = idx.serialize();
+                        dout.writeArray(indexSerialized);
+                    }
+                }
+            }
+            client.writeFile(path, bos.toByteArray());
+            LOGGER.log(Level.FINE, "Published index definitions for {0} at {1}", new Object[]{tableSpace, lsn});
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to write index definitions to " + path, err);
+        }
+    }
+
+    /**
+     * Publishes a table's checkpoint status to remote storage.
+     */
+    public void writeTableStatus(String tableSpace, String tableUuid,
+                                 TableStatus tableStatus) throws DataStorageManagerException {
+        LogSequenceNumber lsn = tableStatus.sequenceNumber;
+        String path = tableStatusPath(tableSpace, tableUuid, lsn);
+        try {
+            VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+            XXHash64Utils.HashingOutputStream hashOut = new XXHash64Utils.HashingOutputStream(bos);
+            try (ExtendedDataOutputStream dout = new ExtendedDataOutputStream(hashOut)) {
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags
+                tableStatus.serialize(dout);
+                dout.writeLong(hashOut.hash());
+            }
+            client.writeFile(path, bos.toByteArray());
+            LOGGER.log(Level.FINE, "Published table status for {0}/{1} at {2}",
+                    new Object[]{tableSpace, tableUuid, lsn});
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to write table status to " + path, err);
+        }
+    }
+
+    /**
+     * Publishes an index's checkpoint status to remote storage.
+     */
+    public void writeIndexStatus(String tableSpace, String indexUuid,
+                                 IndexStatus indexStatus) throws DataStorageManagerException {
+        LogSequenceNumber lsn = indexStatus.sequenceNumber;
+        String path = indexStatusPath(tableSpace, indexUuid, lsn);
+        try {
+            VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+            XXHash64Utils.HashingOutputStream hashOut = new XXHash64Utils.HashingOutputStream(bos);
+            try (ExtendedDataOutputStream dout = new ExtendedDataOutputStream(hashOut)) {
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags
+                indexStatus.serialize(dout);
+                dout.writeLong(hashOut.hash());
+            }
+            client.writeFile(path, bos.toByteArray());
+            LOGGER.log(Level.FINE, "Published index status for {0}/{1} at {2}",
+                    new Object[]{tableSpace, indexUuid, lsn});
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to write index status to " + path, err);
+        }
+    }
+
+    /**
+     * Publishes transaction state to remote storage.
+     */
+    public void writeTransactions(String tableSpace, LogSequenceNumber lsn,
+                                  Collection<Transaction> transactions) throws DataStorageManagerException {
+        String path = transactionsPath(tableSpace, lsn);
+        try {
+            VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+            try (ExtendedDataOutputStream dout = new ExtendedDataOutputStream(bos)) {
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(lsn.ledgerId);
+                dout.writeZLong(lsn.offset);
+                dout.writeInt(transactions.size());
+                for (Transaction t : transactions) {
+                    t.serialize(dout);
+                }
+            }
+            client.writeFile(path, bos.toByteArray());
+            LOGGER.log(Level.FINE, "Published transactions for {0} at {1}", new Object[]{tableSpace, lsn});
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to write transactions to " + path, err);
+        }
+    }
+
+    /**
+     * Writes the latest checkpoint LSN marker. This must be called LAST, after all other
+     * metadata files for the checkpoint have been written. It acts as an atomic commit
+     * marker — replicas only read checkpoints whose latest marker is present.
+     */
+    public void writeCheckpointLsn(String tableSpace, LogSequenceNumber lsn) throws DataStorageManagerException {
+        String path = latestCheckpointPath(tableSpace);
+        try {
+            VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+            try (ExtendedDataOutputStream dout = new ExtendedDataOutputStream(bos)) {
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(lsn.ledgerId);
+                dout.writeZLong(lsn.offset);
+            }
+            client.writeFile(path, bos.toByteArray());
+            LOGGER.log(Level.INFO, "Published checkpoint LSN for {0}: {1}", new Object[]{tableSpace, lsn});
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to write checkpoint LSN to " + path, err);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Read methods (used by replicas)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads the latest checkpoint LSN from remote storage.
+     *
+     * @return the latest LSN, or {@link LogSequenceNumber#START_OF_TIME} if no checkpoint exists yet
+     */
+    public LogSequenceNumber readCheckpointLsn(String tableSpace) throws DataStorageManagerException {
+        String path = latestCheckpointPath(tableSpace);
+        try {
+            byte[] data = client.readFile(path);
+            if (data == null) {
+                return LogSequenceNumber.START_OF_TIME;
+            }
+            try (InputStream in = new SimpleByteArrayInputStream(data);
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(in)) {
+                long version = din.readVLong();
+                long flags = din.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted checkpoint LSN file at " + path);
+                }
+                String readTableSpace = din.readUTF();
+                long ledgerId = din.readZLong();
+                long offset = din.readZLong();
+                return new LogSequenceNumber(ledgerId, offset);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to read checkpoint LSN from " + path, err);
+        }
+    }
+
+    /**
+     * Reads table definitions from a specific checkpoint.
+     */
+    public List<Table> readTableDefinitions(String tableSpace, LogSequenceNumber lsn) throws DataStorageManagerException {
+        String path = tablesMetadataPath(tableSpace, lsn);
+        try {
+            byte[] data = client.readFile(path);
+            if (data == null) {
+                if (lsn.isStartOfTime()) {
+                    return Collections.emptyList();
+                }
+                throw new DataStorageManagerException("Table definitions not found at " + path);
+            }
+            try (InputStream in = new BufferedInputStream(new ByteArrayInputStream(data));
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(in)) {
+                long version = din.readVLong();
+                long flags = din.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted table list file at " + path);
+                }
+                String readName = din.readUTF();
+                long ledgerId = din.readZLong();
+                long offset = din.readZLong();
+                int numTables = din.readInt();
+                List<Table> res = new ArrayList<>();
+                for (int i = 0; i < numTables; i++) {
+                    byte[] tableData = din.readArray();
+                    Table table = Table.deserialize(tableData);
+                    res.add(table);
+                }
+                return Collections.unmodifiableList(res);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to read table definitions from " + path, err);
+        }
+    }
+
+    /**
+     * Reads index definitions from a specific checkpoint.
+     */
+    public List<Index> readIndexDefinitions(String tableSpace, LogSequenceNumber lsn) throws DataStorageManagerException {
+        String path = indexesMetadataPath(tableSpace, lsn);
+        try {
+            byte[] data = client.readFile(path);
+            if (data == null) {
+                if (lsn.isStartOfTime()) {
+                    return Collections.emptyList();
+                }
+                throw new DataStorageManagerException("Index definitions not found at " + path);
+            }
+            try (InputStream in = new BufferedInputStream(new ByteArrayInputStream(data));
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(in)) {
+                long version = din.readVLong();
+                long flags = din.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted index list file at " + path);
+                }
+                String readName = din.readUTF();
+                long ledgerId = din.readZLong();
+                long offset = din.readZLong();
+                int numIndexes = din.readInt();
+                List<Index> res = new ArrayList<>();
+                for (int i = 0; i < numIndexes; i++) {
+                    byte[] indexData = din.readArray();
+                    Index index = Index.deserialize(indexData);
+                    res.add(index);
+                }
+                return Collections.unmodifiableList(res);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to read index definitions from " + path, err);
+        }
+    }
+
+    /**
+     * Reads a table's checkpoint status from remote storage.
+     */
+    public TableStatus readTableStatus(String tableSpace, String tableUuid,
+                                       LogSequenceNumber lsn) throws DataStorageManagerException {
+        String path = tableStatusPath(tableSpace, tableUuid, lsn);
+        try {
+            byte[] data = client.readFile(path);
+            if (data == null) {
+                return TableStatus.buildTableStatusForNewCreatedTable(tableUuid);
+            }
+            XXHash64Utils.verifyBlockWithFooter(data, 0, data.length);
+            try (InputStream in = new SimpleByteArrayInputStream(data);
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(in)) {
+                long version = din.readVLong();
+                long flags = din.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted table status file at " + path);
+                }
+                return TableStatus.deserialize(din);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to read table status from " + path, err);
+        }
+    }
+
+    /**
+     * Reads an index's checkpoint status from remote storage.
+     */
+    public IndexStatus readIndexStatus(String tableSpace, String indexUuid,
+                                       LogSequenceNumber lsn) throws DataStorageManagerException {
+        String path = indexStatusPath(tableSpace, indexUuid, lsn);
+        try {
+            byte[] data = client.readFile(path);
+            if (data == null) {
+                return null;
+            }
+            XXHash64Utils.verifyBlockWithFooter(data, 0, data.length);
+            try (InputStream in = new SimpleByteArrayInputStream(data);
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(in)) {
+                long version = din.readVLong();
+                long flags = din.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted index status file at " + path);
+                }
+                return IndexStatus.deserialize(din);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to read index status from " + path, err);
+        }
+    }
+
+    /**
+     * Reads transactions from a specific checkpoint.
+     */
+    public void readTransactions(String tableSpace, LogSequenceNumber lsn,
+                                 Consumer<Transaction> consumer) throws DataStorageManagerException {
+        String path = transactionsPath(tableSpace, lsn);
+        try {
+            byte[] data = client.readFile(path);
+            if (data == null) {
+                return; // no transactions file
+            }
+            try (InputStream in = new BufferedInputStream(new ByteArrayInputStream(data));
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(in)) {
+                long version = din.readVLong();
+                long flags = din.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted transactions file at " + path);
+                }
+                String readName = din.readUTF();
+                long ledgerId = din.readZLong();
+                long offset = din.readZLong();
+                int numTransactions = din.readInt();
+                for (int i = 0; i < numTransactions; i++) {
+                    Transaction tx = Transaction.deserialize(tableSpace, din);
+                    consumer.accept(tx);
+                }
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException("Failed to read transactions from " + path, err);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cleanup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Deletes old checkpoint metadata files, retaining only those at or after
+     * the specified LSN.
+     */
+    public void cleanupOldMetadata(String tableSpace, LogSequenceNumber retainLsn) throws DataStorageManagerException {
+        String prefix = metadataPrefix(tableSpace);
+        try {
+            List<String> files = client.listFiles(prefix);
+            String latestPath = latestCheckpointPath(tableSpace);
+            for (String file : files) {
+                // never delete the latest pointer
+                if (file.equals(latestPath)) {
+                    continue;
+                }
+                LogSequenceNumber fileLsn = parseLsnFromMetadataPath(file);
+                if (fileLsn != null && retainLsn.after(fileLsn)) {
+                    LOGGER.log(Level.FINE, "Cleaning up old metadata file: {0}", file);
+                    client.deleteFile(file);
+                }
+            }
+        } catch (Exception err) {
+            LOGGER.log(Level.WARNING, "Failed to cleanup old metadata for " + tableSpace, err);
+        }
+    }
+
+    /**
+     * Attempts to parse the LSN ({ledgerId}.{offset}) from a metadata file path.
+     * Returns null if the path doesn't match the expected pattern.
+     */
+    static LogSequenceNumber parseLsnFromMetadataPath(String path) {
+        // Expected patterns:
+        //   .../{name}.{ledgerId}.{offset}.{extension}
+        String fileName = path;
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash >= 0) {
+            fileName = path.substring(lastSlash + 1);
+        }
+        // Remove extension
+        String[] parts = fileName.split("\\.");
+        // We need at least: name, ledgerId, offset, extension = 4 parts
+        if (parts.length < 4) {
+            return null;
+        }
+        try {
+            long ledgerId = Long.parseLong(parts[parts.length - 3]);
+            long offset = Long.parseLong(parts[parts.length - 2]);
+            return new LogSequenceNumber(ledgerId, offset);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerRetentionTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerRetentionTest.java
@@ -22,7 +22,6 @@ package herddb.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.core.PageSet;
 import herddb.core.PostCheckpointAction;
@@ -38,7 +37,6 @@ import herddb.utils.VisibleByteArrayOutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerRetentionTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerRetentionTest.java
@@ -1,0 +1,540 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.PageSet;
+import herddb.core.PostCheckpointAction;
+import herddb.log.LogSequenceNumber;
+import herddb.model.Record;
+import herddb.storage.IndexStatus;
+import herddb.storage.TableStatus;
+import herddb.utils.Bytes;
+import herddb.utils.ExtendedDataInputStream;
+import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.SimpleByteArrayInputStream;
+import herddb.utils.VisibleByteArrayOutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises the deferred page-deletion logic ("replica-aware retention") in
+ * {@link RemoteFileDataStorageManager}.
+ *
+ * <p>The scenarios mirror the correctness requirements for shared-storage read replicas:
+ * a page that became stale at checkpoint LSN {@code C_k} must remain accessible until
+ * every replica has advanced past {@code C_k}, OR until a safety time-cap forces cleanup.
+ */
+public class RemoteFileDataStorageManagerRetentionTest {
+
+    private static final String TS = "ts1";
+    private static final String TABLE_UUID = "tbluuid";
+    private static final String INDEX_UUID = "idxuuid";
+    private static final long MIN_RETENTION_MS = 1000;
+    private static final long MAX_RETENTION_MS = 10_000;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+    private ClockControlledStorage storage;
+
+    /**
+     * Models the min-LSN-across-replicas value that the leader would read from ZK.
+     * Tests mutate it to simulate replica progress, restart, and disappearance.
+     */
+    private final ConcurrentHashMap<String, LogSequenceNumber> replicaLsns = new ConcurrentHashMap<>();
+
+    @Before
+    public void setUp() throws Exception {
+        server = new RemoteFileServer(0, folder.newFolder("remote").toPath());
+        server.start();
+        client = new RemoteFileServiceClient(Arrays.asList("localhost:" + server.getPort()));
+
+        Path metadataDir = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmp").toPath();
+        storage = new ClockControlledStorage(metadataDir, tmpDir, 1000, client);
+        storage.start();
+
+        Function<String, LogSequenceNumber> supplier = replicaLsns::get;
+        storage.setRetentionPolicy(supplier, MIN_RETENTION_MS, MAX_RETENTION_MS);
+
+        storage.initTablespace(TS);
+        storage.initTable(TS, TABLE_UUID);
+        storage.initIndex(TS, INDEX_UUID);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        storage.close();
+        client.close();
+        server.stop();
+    }
+
+    // ------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------
+
+    private static PageSet.DataPageMetaData meta() throws Exception {
+        VisibleByteArrayOutputStream baos = new VisibleByteArrayOutputStream(16);
+        try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(baos)) {
+            out.writeVLong(100);
+            out.writeVLong(50);
+            out.writeVLong(0);
+        }
+        try (ExtendedDataInputStream in = new ExtendedDataInputStream(
+                new SimpleByteArrayInputStream(baos.toByteArray()))) {
+            return PageSet.DataPageMetaData.deserialize(in);
+        }
+    }
+
+    /** Write a page and return its ID. */
+    private void writeDataPage(long pageId) throws Exception {
+        List<Record> page = new ArrayList<>();
+        page.add(new Record(Bytes.from_string("k" + pageId), Bytes.from_string("v" + pageId)));
+        storage.writePage(TS, TABLE_UUID, pageId, page);
+    }
+
+    private void writeIndexPage(long pageId) throws Exception {
+        byte[] data = ("idx" + pageId).getBytes();
+        storage.writeIndexPage(TS, INDEX_UUID, pageId, out -> out.write(data));
+    }
+
+    /** Produce a TableStatus with the given active page IDs and LSN. */
+    private TableStatus tableStatus(LogSequenceNumber lsn, long... activePageIds) throws Exception {
+        Map<Long, PageSet.DataPageMetaData> activePages = new HashMap<>();
+        for (long id : activePageIds) {
+            activePages.put(id, meta());
+        }
+        long next = activePageIds.length == 0 ? 1
+                : Arrays.stream(activePageIds).max().getAsLong() + 1;
+        return new TableStatus(TABLE_UUID, lsn, Bytes.longToByteArray(next), next, activePages);
+    }
+
+    private IndexStatus indexStatus(LogSequenceNumber lsn, long... activePageIds) {
+        Set<Long> active = new HashSet<>();
+        for (long id : activePageIds) {
+            active.add(id);
+        }
+        long next = activePageIds.length == 0 ? 1
+                : Arrays.stream(activePageIds).max().getAsLong() + 1;
+        return new IndexStatus(INDEX_UUID, lsn, next, active, new byte[0]);
+    }
+
+    /** Run all {@link PostCheckpointAction}s — simulates what TableSpaceManager does post-checkpoint. */
+    private void runActions(List<PostCheckpointAction> actions) {
+        for (PostCheckpointAction a : actions) {
+            a.run();
+        }
+    }
+
+    private boolean pageExists(long pageId) {
+        return client.readFile(TS + "/" + TABLE_UUID + "/data/" + pageId + ".page") != null;
+    }
+
+    private boolean indexPageExists(long pageId) {
+        return client.readFile(TS + "/" + INDEX_UUID + "/index/" + pageId + ".page") != null;
+    }
+
+    private LogSequenceNumber lsn(long ledger, long offset) {
+        return new LogSequenceNumber(ledger, offset);
+    }
+
+    // ------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------
+
+    /**
+     * Without retention enabled, pages are deleted immediately (current behaviour,
+     * backward compatibility).
+     */
+    @Test
+    public void noRetention_deletionIsImmediate() throws Exception {
+        // recreate storage WITHOUT retention policy
+        storage.close();
+        storage = new ClockControlledStorage(
+                folder.newFolder("metadata2").toPath(),
+                folder.newFolder("tmp2").toPath(), 1000, client);
+        storage.start();
+        storage.initTablespace(TS);
+        storage.initTable(TS, TABLE_UUID);
+
+        writeDataPage(1);
+        writeDataPage(2);
+
+        // checkpoint C1: both pages active
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+
+        // checkpoint C2: page 1 removed
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+
+        assertFalse("without retention, stale page deleted immediately", pageExists(1));
+        assertTrue(pageExists(2));
+    }
+
+    /**
+     * When no replicas are registered, pages are retained for at least {@code maxRetentionMs}
+     * before being force-deleted.
+     */
+    @Test
+    public void noReplicas_pagesRetainedUntilMaxAge() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        // C1: {1,2} active
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+
+        // C2: page 1 becomes stale at LSN (1,2)
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+
+        assertTrue("page 1 must be retained with retention enabled", pageExists(1));
+        assertEquals(1, storage.pendingDataDeletionCount(TS, TABLE_UUID));
+
+        // advance past min but not max: still pending (no replica ever advances, nothing to release)
+        storage.advanceClockMs(MIN_RETENTION_MS + 100);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("still retained before max age", pageExists(1));
+
+        // advance past max: force-deleted on next checkpoint
+        storage.advanceClockMs(MAX_RETENTION_MS);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("force-deleted past max age", pageExists(1));
+        assertEquals(0, storage.pendingDataDeletionCount(TS, TABLE_UUID));
+    }
+
+    /**
+     * A replica that remains at the old checkpoint blocks deletion even past the
+     * min-retention grace period.
+     */
+    @Test
+    public void replicaBehind_pagesRetained_untilAdvances() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        // C1: {1,2} active. Replica registers at C1.
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        replicaLsns.put(TS, lsn(1, 1));
+
+        // C2: page 1 stale at (1,2). Replica still at (1,1).
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+        assertTrue(pageExists(1));
+
+        // advance well past min retention, replica still behind
+        storage.advanceClockMs(MIN_RETENTION_MS * 5);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("replica still at C1 — page retained", pageExists(1));
+
+        // replica refreshes and catches up to C2
+        replicaLsns.put(TS, lsn(1, 2));
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("replica past stale-LSN — page deleted", pageExists(1));
+    }
+
+    /**
+     * When replica advances past stale-LSN but the min-retention grace period has not
+     * elapsed, deletion still waits.
+     */
+    @Test
+    public void minGracePeriodEnforced_evenWhenReplicaCaughtUp() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        // Replica is already ahead — simulate a fresh replica catching up quickly.
+        replicaLsns.put(TS, lsn(5, 0));
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+
+        // No clock advance at all — min grace has not elapsed.
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("min retention not yet elapsed", pageExists(1));
+        assertEquals(1, storage.pendingDataDeletionCount(TS, TABLE_UUID));
+
+        storage.advanceClockMs(MIN_RETENTION_MS + 1);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("min retention elapsed + replica ahead — deleted", pageExists(1));
+    }
+
+    /**
+     * A stuck replica that never advances is bypassed once max retention is hit.
+     */
+    @Test
+    public void stuckReplica_forceDeleteAfterMaxAge() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        replicaLsns.put(TS, lsn(1, 1));
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+
+        // replica never advances. Page retained at first...
+        storage.advanceClockMs(MIN_RETENTION_MS * 2);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("within max retention window — retained", pageExists(1));
+
+        // ...but max retention fires eventually.
+        storage.advanceClockMs(MAX_RETENTION_MS);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("max retention elapsed — force-deleted", pageExists(1));
+    }
+
+    /**
+     * A replica that was present BEFORE the leader's first stale-making checkpoint
+     * then restarts (briefly absent, then back) is tracked correctly: pages are
+     * retained until the (new) replica advances past the stale-LSN.
+     */
+    @Test
+    public void replicaRestart_beforeLeaderCheckpoint() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        // Replica present and at C1.
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        replicaLsns.put(TS, lsn(1, 1));
+
+        // Replica goes down briefly (ephemeral znode removed -> no entry).
+        replicaLsns.remove(TS);
+
+        // Leader checkpoints C2 while replica is down. Page 1 becomes stale at (1,2).
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+        storage.advanceClockMs(MIN_RETENTION_MS + 100);
+
+        // No replica, no minReplicaLsn: retention falls back to max-age cap.
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("still within max age — page retained even with no replica", pageExists(1));
+
+        // Replica comes back up, starts at the latest checkpoint it can find: C2 (or newer).
+        // Its LSN is >= the stale-LSN of page 1, so next promote drops the pending entry.
+        replicaLsns.put(TS, lsn(1, 2));
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("replica restarted at C2 — page can be deleted", pageExists(1));
+    }
+
+    /**
+     * Replica shuts down AFTER a leader checkpoint queues pending deletions. The
+     * ephemeral znode is removed, so the leader now has no replica to wait for.
+     * The leader should still respect max retention before force-deleting (protecting
+     * against the replica briefly flapping).
+     */
+    @Test
+    public void replicaRestart_afterLeaderCheckpoint() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        replicaLsns.put(TS, lsn(1, 1));
+
+        // Leader checkpoints, page 1 becomes stale at (1,2).
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+        assertTrue(pageExists(1));
+
+        // Replica dies (ephemeral node auto-removed).
+        replicaLsns.remove(TS);
+
+        // Without a replica advancing, we rely on the max-age cap.
+        storage.advanceClockMs(MIN_RETENTION_MS * 2);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("before max age — still retained (protects against replica flap)", pageExists(1));
+
+        storage.advanceClockMs(MAX_RETENTION_MS);
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("max age elapsed with no replica — force-deleted", pageExists(1));
+    }
+
+    /**
+     * Multiple replicas: leader must wait for the SLOWEST (minimum LSN).
+     */
+    @Test
+    public void multipleReplicas_waitsForSlowest() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        // We only publish the MINIMUM LSN across replicas through the supplier,
+        // so the test models "min across replicas" directly.
+        replicaLsns.put(TS, lsn(1, 1)); // slowest replica at C1
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+        storage.advanceClockMs(MIN_RETENTION_MS + 100);
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 2), false));
+        assertTrue("slow replica still at C1", pageExists(1));
+
+        // Slowest replica advances to C2
+        replicaLsns.put(TS, lsn(1, 2));
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 2), false));
+        assertFalse("slowest replica caught up — safe to delete", pageExists(1));
+    }
+
+    /**
+     * Same retention logic applied to secondary-index pages.
+     */
+    @Test
+    public void indexPages_followSameRetentionPolicy() throws Exception {
+        writeIndexPage(1);
+        writeIndexPage(2);
+
+        runActions(storage.indexCheckpoint(TS, INDEX_UUID,
+                indexStatus(lsn(1, 1), 1, 2), false));
+        replicaLsns.put(TS, lsn(1, 1));
+
+        runActions(storage.indexCheckpoint(TS, INDEX_UUID,
+                indexStatus(lsn(1, 2), 2), false));
+        assertTrue("index page 1 retained", indexPageExists(1));
+        assertEquals(1, storage.pendingIndexDeletionCount(TS, INDEX_UUID));
+
+        storage.advanceClockMs(MIN_RETENTION_MS + 100);
+        replicaLsns.put(TS, lsn(1, 2));
+        runActions(storage.indexCheckpoint(TS, INDEX_UUID,
+                indexStatus(lsn(1, 3), 2), false));
+        assertFalse("replica caught up — index page deleted", indexPageExists(1));
+    }
+
+    /**
+     * Dropping the table clears pending deletions (pages are removed via bulk delete).
+     */
+    @Test
+    public void dropTable_clearsPendingDeletions() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2), false));
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2), false));
+        assertEquals(1, storage.pendingDataDeletionCount(TS, TABLE_UUID));
+
+        storage.dropTable(TS, TABLE_UUID);
+        assertEquals("drop clears pending", 0, storage.pendingDataDeletionCount(TS, TABLE_UUID));
+    }
+
+    /**
+     * Pages scheduled for deletion at successive checkpoints are released in order
+     * as the replica LSN advances through each.
+     */
+    @Test
+    public void incrementalReplicaProgress_releasesInOrder() throws Exception {
+        writeDataPage(1);
+        writeDataPage(2);
+        writeDataPage(3);
+
+        // C1: {1,2,3}
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 1), 1, 2, 3), false));
+
+        // C2 at lsn(1,2): page 1 stale
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 2), 2, 3), false));
+        // C3 at lsn(1,3): page 2 stale
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 3), 3), false));
+
+        assertTrue(pageExists(1));
+        assertTrue(pageExists(2));
+        assertEquals(2, storage.pendingDataDeletionCount(TS, TABLE_UUID));
+
+        storage.advanceClockMs(MIN_RETENTION_MS + 100);
+
+        // Replica catches up to C2 only: only page 1 should be freed.
+        replicaLsns.put(TS, lsn(1, 2));
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 4), 3), false));
+        assertFalse("page 1 stale at C2, replica at C2 — safe", pageExists(1));
+        assertTrue("page 2 stale at C3, replica only at C2 — retained", pageExists(2));
+
+        // Replica catches up further
+        replicaLsns.put(TS, lsn(1, 3));
+        runActions(storage.tableCheckpoint(TS, TABLE_UUID,
+                tableStatus(lsn(1, 5), 3), false));
+        assertFalse("page 2 now safe to delete", pageExists(2));
+    }
+
+    // ------------------------------------------------------------
+    // Test subclass with a controllable clock
+    // ------------------------------------------------------------
+
+    private static class ClockControlledStorage extends RemoteFileDataStorageManager {
+        private volatile long clockMs;
+
+        ClockControlledStorage(Path meta, Path tmp, int swap, RemoteFileServiceClient client) {
+            super(meta, tmp, swap, client);
+            this.clockMs = 1_000_000L; // arbitrary start
+        }
+
+        @Override
+        long currentTimeMillis() {
+            return clockMs;
+        }
+
+        void advanceClockMs(long ms) {
+            this.clockMs += ms;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a new `server.mode=shared-storage` where data lives on shared S3 (via the remote file server) and replicas can **serve reads** from a consistent checkpoint snapshot. Unlike `diskless-cluster` (where replicas can't serve reads) or `cluster` (where followers replay WAL and maintain per-node copies), shared-storage replicas consume the leader's checkpointed state directly from S3. They never write to S3 or BookKeeper, and are promotable to leader on failover.

## Architecture

```
Leader (server.mode=cluster, server.storage.mode=remote,
        server.checkpoint.publish.to.remote=true):
  WAL          -> BookKeeper
  Pages        -> S3 (existing)
  Checkpoint   -> S3 metadata (TableStatus, IndexStatus, table/index defs)  [NEW]
  LSN notify   -> ZooKeeper                                                  [NEW]

Replica (server.mode=shared-storage):
  ZK watch     -> detects new checkpoint LSN
  Read meta    -> from S3
  Atomic swap  -> rebuild in-memory state under write lock
  Serve reads  -> S3 pages (with per-server local caching)
  On failover  -> promotable to leader, replays BookKeeper WAL from checkpoint
```

## New classes (herddb-remote-file-service)

- **`SharedCheckpointMetadataManager`** — reads/writes checkpoint metadata on S3 (`TableStatus`, `IndexStatus`, table/index definitions, checkpoint LSN marker)
- **`ReadReplicaDataStorageManager`** — read-only `DataStorageManager`; writes throw `UnsupportedOperationException`
- **`PromotableRemoteFileDataStorageManager`** — starts read-only, promotable to writable `RemoteFileDataStorageManager` on leader election

## Modified (herddb-core + herddb-remote-file-service)

- **`ServerConfiguration`** — `PROPERTY_MODE_SHARED_STORAGE` + replica config (poll interval, switch timeout, publish-to-remote flag)
- **`RemoteFileDataStorageManager`** — optional `SharedCheckpointMetadataManager` that publishes metadata to S3 during checkpoint
- **`MetadataStorageManager`** — adds `publishCheckpointLsn` / `getCheckpointLsn` / `watchCheckpointLsn` API (no-op defaults)
- **`ZookeeperMetadataStorageManager`** — ZK-based checkpoint LSN publish/watch at `{basePath}/checkpoints/{tableSpaceUUID}`
- **`TableSpaceManager`** — `CheckpointFollowerThread` (watches ZK, polls as safety net) + `refreshFromCheckpoint()` (atomic view switch under write lock) + shared-storage branches in `startAsFollower()` / `recover()`
- **`DBManager`** — `readOnlyReplica` flag rejects non-read statements (DDL/DML/transactions) on non-leader shared-storage replicas
- **`Server`** — wires shared-storage mode across metadata / storage / commit-log / node-id managers

## Consistency model

- Replicas serve reads at **checkpoint granularity** (default ~15 min, tunable via `server.checkpoint.period`)
- No dirty reads (checkpoints only include committed state)
- No read-your-writes across leader/replica
- On checkpoint switch: write lock blocks new queries; in-flight reads complete against old state; all cached pages for each table are evicted to pick up changes

## Edge cases handled

- BLink/BRIN index consistency during switch (closed + rebooted from new checkpoint)
- Table create/drop/alter detected via checkpoint metadata diff
- Replica boot before first checkpoint: boots empty, picks up state via ZK watch
- Failover WAL gap: leader doesn't trim ledgers past last checkpoint, new leader replays the gap
- S3 unavailability: cached pages still served, checkpoint refresh retries with backoff

## Configuration

**Leader:**
```properties
server.mode=cluster
server.storage.mode=remote
server.checkpoint.publish.to.remote=true   # NEW
```

**Replica:**
```properties
server.mode=shared-storage                 # NEW mode
remote.file.servers=fileserver1:9846,fileserver2:9846
server.zookeeper.address=zk:2181/herddb
server.base.dir=/var/herddb/data           # needed for failover promotion
```

## Test plan

- [ ] Unit-test `SharedCheckpointMetadataManager` round-trip via mock `RemoteFileServiceClient`
- [ ] Unit-test `ReadReplicaDataStorageManager` (reads delegate, writes throw UOE)
- [ ] Integration test: leader inserts + checkpoints -> replica sees rows after refresh
- [ ] Integration test: DDL propagation across checkpoint boundary
- [ ] Integration test: failover from replica to leader, WAL replay of gap
- [ ] Integration test: concurrent queries during checkpoint switch (no partial views)
- [ ] Integration test: replica boot before first checkpoint
- [ ] Existing `DisklessClusterTest`, `RemoteFileServiceClientTest`, `RemoteFileBrinIndexRecoveryTest` still pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)