### PR TITLE
Add vector-bench runner pod to Helm chart + package VectorBench in services zip

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/templates/vector-bench-headless-svc.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/vector-bench-headless-svc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.vectorBench.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "herddb.fullname" . }}-vector-bench
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vector-bench
+spec:
+  clusterIP: None
+  # No ports — this headless service exists solely to provide stable DNS for the
+  # vector-bench StatefulSet pod (required by the StatefulSet serviceName field).
+  selector:
+    {{- include "herddb.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: vector-bench
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/vector-bench-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/vector-bench-statefulset.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.vectorBench.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "herddb.fullname" . }}-vector-bench
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vector-bench
+spec:
+  serviceName: {{ include "herddb.fullname" . }}-vector-bench
+  replicas: 1
+  # Retain the datasets PVC across StatefulSet deletion / scale-down so
+  # downloaded datasets survive helm uninstall + reinstall cycles.
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: vector-bench
+  template:
+    metadata:
+      labels:
+        {{- include "herddb.labels" . | nindent 8 }}
+        app.kubernetes.io/component: vector-bench
+    spec:
+      serviceAccountName: {{ include "herddb.serviceAccountName" . }}
+      containers:
+        - name: vector-bench
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sleep"]
+          args: ["infinity"]
+          env:
+            - name: HERDDB_JDBC_URL
+              value: {{ include "herddb.jdbcUrl" . | quote }}
+            - name: VECTORBENCH_HEAP
+              value: {{ .Values.vectorBench.javaOpts | quote }}
+            - name: VECTORBENCH_DATASET_DIR
+              value: /opt/herddb/vector-datasets
+          resources:
+            {{- toYaml .Values.vectorBench.resources | nindent 12 }}
+          volumeMounts:
+            - name: datasets
+              mountPath: /opt/herddb/vector-datasets
+  volumeClaimTemplates:
+    - metadata:
+        name: datasets
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.vectorBench.storage.datasets.storageClass }}
+        storageClassName: {{ .Values.vectorBench.storage.datasets.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.vectorBench.storage.datasets.size }}
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -166,3 +166,24 @@ tools:
     limits:
       memory: "256Mi"
       cpu: "0.5"
+
+# Vector benchmark runner — sleep pod with VectorBench installed and a persistent
+# PVC for downloaded datasets (sift1m, gist1m, deep-image-96, ...). Exec into it:
+#   kubectl exec -it <release>-vector-bench-0 -- /opt/herddb/bin/vector-bench.sh --dataset sift1m
+vectorBench:
+  enabled: false
+  # JVM heap options, exported as VECTORBENCH_HEAP and read by vector-bench.sh
+  javaOpts: "-Xms2g -Xmx8g"
+  # Persistent storage for downloaded datasets. PVC is retained across helm
+  # upgrades and StatefulSet deletions (whenDeleted/whenScaled: Retain).
+  storage:
+    datasets:
+      size: 100Gi
+      storageClass: ""
+  resources:
+    requests:
+      memory: "8Gi"
+      cpu: "2"
+    limits:
+      memory: "12Gi"
+      cpu: "4"

--- a/herddb-services/pom.xml
+++ b/herddb-services/pom.xml
@@ -58,6 +58,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>vector-testings</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
             <version>${libs.javaxactivation.api}</version>

--- a/herddb-services/src/main/assemble/zip-assembly.xml
+++ b/herddb-services/src/main/assemble/zip-assembly.xml
@@ -65,19 +65,30 @@
             <useStrictFiltering>true</useStrictFiltering>
             <unpack>false</unpack>                       
             <excludes>
-                <exclude>org.herddb:herddb-jdbc:jar:uber</exclude>                                
+                <exclude>org.herddb:herddb-jdbc:jar:uber</exclude>
+                <exclude>org.herddb:vector-testings:*</exclude>
             </excludes>
             <outputDirectory>lib</outputDirectory>
-        </dependencySet>         
+        </dependencySet>
         <dependencySet>
             <useProjectArtifact>true</useProjectArtifact>
             <useStrictFiltering>true</useStrictFiltering>
-            <unpack>false</unpack>           
-            <includes>                
+            <unpack>false</unpack>
+            <includes>
                 <include>org.herddb:herddb-jdbc:*</include>
-            </includes>            
+            </includes>
             <outputDirectory>.</outputDirectory>
             <outputFileNameMapping>herddb-jdbc-${project.version}.jar</outputFileNameMapping>
+        </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useStrictFiltering>true</useStrictFiltering>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.herddb:vector-testings:*</include>
+            </includes>
+            <outputDirectory>vector-testings</outputDirectory>
+            <outputFileNameMapping>vector-testings-${project.version}.jar</outputFileNameMapping>
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>true</useProjectArtifact>

--- a/herddb-services/src/main/resources/bin/vector-bench.sh
+++ b/herddb-services/src/main/resources/bin/vector-bench.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+### BASE_DIR discovery
+if [ -z "$BASE_DIR" ]; then
+  BASE_DIR="`dirname \"$0\"`"
+  BASE_DIR="`( cd \"$BASE_DIR\" && pwd )`"
+fi
+BASE_DIR=$BASE_DIR/..
+BASE_DIR="`( cd \"$BASE_DIR\" && pwd )`"
+
+. $BASE_DIR/bin/setenv.sh
+
+JAVA="$JAVA_HOME/bin/java"
+JAR=$(ls "$BASE_DIR"/vector-testings/vector-testings-*.jar 2>/dev/null | head -1)
+
+if [ -z "$JAR" ]; then
+    echo "ERROR: vector-testings jar not found under $BASE_DIR/vector-testings/" >&2
+    exit 1
+fi
+
+JAVA_HEAP="${VECTORBENCH_HEAP:--Xms1g -Xmx2g}"
+
+exec $JAVA $JAVA_HEAP -jar "$JAR" "$@"

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -62,7 +62,7 @@ public class Config {
         opts.addOption(null, "user", true, "Username (default: sa)");
         opts.addOption(null, "password", true, "Password (default: hdb)");
         opts.addOption(null, "table", true, "Table name (default: vector_bench)");
-        opts.addOption(null, "dataset-dir", true, "Dataset download/cache directory (default: ./datasets)");
+        opts.addOption(null, "dataset-dir", true, "Dataset download/cache directory (default: $VECTORBENCH_DATASET_DIR or ./datasets)");
         opts.addOption(null, "dataset", true, "Dataset preset: sift10k, sift1m, gist1m, sift10m, bigann, glove100, deep-image-96 (default: sift1m)");
         opts.addOption(null, "dataset-url", true, "Override dataset download URL");
         opts.addOption("n", "rows", true, "Number of rows to ingest (default: 100000, cycles dataset if larger)");
@@ -185,6 +185,16 @@ public class Config {
         }
         if (cmd.hasOption("ingest-max-ops")) {
             cfg.ingestMaxOpsPerSecond = Integer.parseInt(cmd.getOptionValue("ingest-max-ops"));
+        }
+
+        // Fall back to VECTORBENCH_DATASET_DIR env var when no explicit CLI/config-file value was given.
+        // This lets the Kubernetes StatefulSet set the dataset path once via env, without every kubectl
+        // exec invocation having to pass --dataset-dir.
+        if (!cmd.hasOption("dataset-dir") && cfg.datasetDir.equals("./datasets")) {
+            String envDir = System.getenv("VECTORBENCH_DATASET_DIR");
+            if (envDir != null && !envDir.isEmpty()) {
+                cfg.datasetDir = envDir;
+            }
         }
 
         return cfg;


### PR DESCRIPTION
## Summary

- Packages the `vector-testings` shaded uber-jar into `herddb-services.zip` (under `vector-testings/`, excluded from `lib/` to avoid ~58MB class duplication), so the Jib-built Docker image ships `VectorBench` at `/opt/herddb/vector-testings/vector-testings-<ver>.jar` plus a new `bin/vector-bench.sh` wrapper.
- Adds an opt-in `vectorBench` Helm section: 1-replica `StatefulSet` (sleeps `infinity` for `kubectl exec`) with a 100Gi `volumeClaimTemplates` PVC mounted at `/opt/herddb/vector-datasets`, and `persistentVolumeClaimRetentionPolicy: {whenDeleted: Retain, whenScaled: Retain}` so downloaded datasets (sift1m, gist1m, deep-image-96, …) survive helm upgrades and uninstall/reinstall cycles.
- `Config.java` `--dataset-dir` now falls back to `$VECTORBENCH_DATASET_DIR` when not passed explicitly, so the StatefulSet sets the path once via env and users don't have to repeat `--dataset-dir` on every `kubectl exec`.

Disabled by default (`vectorBench.enabled: false`).

Usage:
```bash
helm upgrade --set vectorBench.enabled=true ...
kubectl exec -it <release>-vector-bench-0 -- \
    /opt/herddb/bin/vector-bench.sh --url "\$HERDDB_JDBC_URL" --dataset sift1m
```

## Test plan

- [x] ``mvn -pl vector-testings,herddb-services -am package -DskipTests`` — zip contains ``vector-testings/vector-testings-<ver>.jar`` (58MB) + ``bin/vector-bench.sh``, and NO ``lib/vector-testings*.jar``
- [x] ``helm lint --set vectorBench.enabled=true`` — clean
- [x] ``helm template --set vectorBench.enabled=true`` — StatefulSet renders with correct env, PVC and retention policy
- [ ] End-to-end on k3s: install, confirm ``datasets-<release>-vector-bench-0`` PVC is Bound, run ``vector-bench.sh --dataset sift1m`` inside the pod, then ``helm upgrade`` and verify dataset files in ``/opt/herddb/vector-datasets`` persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)