### PR TITLE
Fix follower ledger switching bug and stabilize SimpleFollowerTest

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -918,7 +918,7 @@ public class BookkeeperCommitLog extends CommitLog {
             long nextLedger = -1;
             for (long lId : actualList) {
                 if (lId > ledgerToTail) {
-                    ledgerToTail = lId;
+                    nextLedger = lId;
                     break;
                 }
             }

--- a/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
@@ -469,10 +469,21 @@ public class SimpleFollowerTest extends MultiServerBase {
                 long tx = executeUpdateRes.transactionId;
                 assertTrue(tx > 0);
 
+                // Force a no-op sync write so that all previous deferred entries
+                // (BEGIN + INSERT) are guaranteed to be visible in BookKeeper
+                // before we start waiting for the follower to see them.
+                server_1.getManager().executeUpdate(
+                        new InsertStatement(TableSpace.DEFAULT, "t1",
+                                RecordSerializer.makeRecord(table, "c", 6)),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        TransactionContext.NO_TRANSACTION);
+
                 // wait for transaction to arrive on server_2
                 TestUtils.waitForCondition(() -> {
-                    return server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransaction(tx) != null;
-                }, TestUtils.NOOP, 100);
+                    TableSpaceManager tsm = server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT);
+                    assertFalse("follower tablespace has failed", tsm.isFailed());
+                    return tsm.getTransaction(tx) != null;
+                }, TestUtils.NOOP, 100, "transaction " + tx + " visible on follower");
 
                 // make the transaction appear "abandoned" to server_2
                 Thread.sleep(1000 + (int) server_2.getManager().getAbandonedTransactionsTimeout());


### PR DESCRIPTION
## Summary
- **BookkeeperCommitLog bug fix**: In `BKFollowerContext.ensureOpenReader()`, the "find next ledger" loop at line 919 was assigning the found ledger ID to `ledgerToTail` instead of `nextLedger`. This meant `nextLedger` always remained `-1`, causing the follower to null out its `currentLedger` and take the "no more ledgers" path every time it needed to switch between closed/fully-read ledgers. This bug could cause the follower to reopen the same ledger repeatedly with incorrect `nextEntryToRead` offsets or fail to advance to new ledgers promptly.
- **SimpleFollowerTest stabilization**: The test's auto-transaction uses `sync=false` (deferred) BK writes, meaning entries may not be visible to the follower immediately. Added a sync write (`NO_TRANSACTION` INSERT) after the transaction to guarantee BK visibility before the wait begins. Also added a fail-fast `isFailed()` check inside the wait condition and a descriptive timeout message for better CI diagnostics.

## Test plan
- [x] `SimpleFollowerTest` — all 5 tests pass
- [x] Verified the ledger switching fix is correct by code review
- [ ] CI should confirm the SimpleFollowerTest no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)