### PR TITLE
Add Kubernetes example deployments and GCS credentials support

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/README.md
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/README.md
@@ -1,0 +1,232 @@
+# HerdDB on GKE with Google Cloud Storage
+
+Deploy HerdDB on Google Kubernetes Engine using Google Cloud Storage (GCS) as
+the object store via its S3-compatible endpoint.
+
+## Architecture
+
+| Component        | Replicas | Purpose                                          |
+|------------------|----------|--------------------------------------------------|
+| HerdDB server    | 1        | JDBC endpoint, metadata (ZooKeeper), commit log (BookKeeper) |
+| File server      | 1        | gRPC page storage, backed by GCS (S3 endpoint)   |
+| ZooKeeper        | 1        | Cluster coordination and metadata storage         |
+| BookKeeper       | 1        | Distributed commit log                            |
+| Indexing service | 1        | Vector indexing service                           |
+| Tools pod        | 1        | Pre-configured CLI for interactive queries        |
+
+MinIO is **not** deployed; the file server connects directly to GCS.
+
+## Prerequisites
+
+- A running GKE cluster with `kubectl` configured
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- `gcloud` CLI authenticated
+- The HerdDB Docker image pushed to a registry accessible from GKE
+  (e.g. Artifact Registry)
+
+## Setup
+
+### 1. Create a GCS bucket
+
+```bash
+gcloud storage buckets create gs://my-herddb-pages --location=us-central1
+```
+
+### 2. Create HMAC keys
+
+GCS exposes an S3-compatible API that uses HMAC credentials for
+authentication. Create a pair for a service account that has
+`roles/storage.objectAdmin` on the bucket:
+
+```bash
+gcloud storage hmac create SERVICE_ACCOUNT_EMAIL
+```
+
+Save the **Access ID** and **Secret** from the output.
+
+### 3. Create a Kubernetes Secret
+
+```bash
+kubectl create secret generic herddb-gcs-credentials \
+  --from-literal=S3_ACCESS_KEY=<access-id> \
+  --from-literal=S3_SECRET_KEY=<secret>
+```
+
+The Helm chart references this Secret by name
+(`fileServer.s3.credentialsSecret`) and injects the values at pod startup.
+Credentials never appear in ConfigMaps or Helm values stored in the cluster.
+
+### 4. Install the Helm chart
+
+From the `herddb-kubernetes/src/main/helm/herddb/` directory:
+
+```bash
+helm install herddb . -f examples/gke/values.yaml \
+  --set fileServer.s3.bucket=my-herddb-pages
+```
+
+If the Docker image is in a private registry, also set:
+
+```bash
+--set image.repository=us-docker.pkg.dev/MY_PROJECT/herddb/herddb-server
+```
+
+### 5. Wait for pods
+
+```bash
+kubectl get pods -w
+```
+
+All pods (server, file-server, zookeeper, bookkeeper, indexing-service, tools)
+should reach `Running` / `Ready`.
+
+### 6. Verify
+
+```bash
+kubectl exec -it deploy/herddb-tools -- herddb-cli
+```
+
+```sql
+SELECT * FROM SYSTABLES;
+```
+
+Check the file server logs to confirm a successful connection to GCS:
+
+```bash
+kubectl logs statefulset/herddb-file-server
+```
+
+## Vector search example
+
+HerdDB supports vector search with approximate nearest neighbor (ANN) indexes.
+Here is a quick walkthrough using the CLI's Groovy scripting support.
+
+### Create a table with a vector column and an index
+
+```bash
+kubectl exec deploy/herddb-tools -- herddb-cli \
+  -q "CREATE TABLE documents (id int primary key, content string, embedding floata not null)"
+
+kubectl exec deploy/herddb-tools -- herddb-cli \
+  -q "CREATE VECTOR INDEX vidx ON documents(embedding)"
+```
+
+### Insert and search via a Groovy script
+
+Vector data must be inserted through JDBC prepared statements. The CLI's
+`-g` flag runs a Groovy script with a pre-configured `connection` object.
+
+Create a file called `vector_demo.groovy` on the tools pod:
+
+```bash
+kubectl exec deploy/herddb-tools -- bash -c 'cat > /tmp/vector_demo.groovy << '\''SCRIPT'\''
+import java.sql.*
+
+// Insert sample documents with 3-dimensional embeddings
+def insertSql = "INSERT INTO documents(id, content, embedding) VALUES(?, ?, CAST(? AS FLOAT ARRAY))"
+def ps = connection.prepareStatement(insertSql)
+
+def data = [
+  [1, "The cat sat on the mat",       [0.1f, 0.9f, 0.0f] as float[]],
+  [2, "The dog chased the ball",      [0.8f, 0.1f, 0.0f] as float[]],
+  [3, "A kitten played with yarn",    [0.2f, 0.8f, 0.1f] as float[]],
+  [4, "The puppy ran in the park",    [0.7f, 0.2f, 0.1f] as float[]],
+  [5, "Birds were singing at dawn",   [0.0f, 0.1f, 0.9f] as float[]],
+]
+
+data.each { row ->
+  ps.setInt(1, row[0])
+  ps.setString(2, row[1])
+  ps.setObject(3, row[2])
+  ps.executeUpdate()
+}
+ps.close()
+println "Inserted ${data.size()} documents"
+
+// Cosine similarity search
+def searchVec = [0.15f, 0.85f, 0.05f] as float[]
+def searchSql = """SELECT id, content,
+  cosine_similarity(embedding, CAST(? AS FLOAT ARRAY)) AS score
+  FROM documents
+  ORDER BY cosine_similarity(embedding, CAST(? AS FLOAT ARRAY)) DESC
+  LIMIT 3"""
+def query = connection.prepareStatement(searchSql)
+query.setObject(1, searchVec)
+query.setObject(2, searchVec)
+def rs = query.executeQuery()
+
+println ""
+println "Top 3 documents by cosine similarity to [0.15, 0.85, 0.05]:"
+println "-------------------------------------------------------------"
+while (rs.next()) {
+  printf "  id=%d  score=%.4f  \"%s\"%n", rs.getInt("id"), rs.getFloat("score"), rs.getString("content")
+}
+rs.close()
+query.close()
+
+// ANN search (uses the vector index)
+println ""
+def annSql = "SELECT id, content FROM documents ORDER BY ann_of(embedding, CAST(? AS FLOAT ARRAY)) DESC LIMIT 3"
+def annQuery = connection.prepareStatement(annSql)
+annQuery.setObject(1, searchVec)
+def annRs = annQuery.executeQuery()
+println "ANN search results (uses vector index):"
+println "-----------------------------------------"
+while (annRs.next()) {
+  printf "  id=%d  \"%s\"%n", annRs.getInt("id"), annRs.getString("content")
+}
+annRs.close()
+annQuery.close()
+SCRIPT
+'
+```
+
+Run the script:
+
+```bash
+kubectl exec deploy/herddb-tools -- herddb-cli -g /tmp/vector_demo.groovy
+```
+
+Expected output:
+
+```
+Inserted 5 documents
+
+Top 3 documents by cosine similarity to [0.15, 0.85, 0.05]:
+-------------------------------------------------------------
+  id=1  score=0.9963  "The cat sat on the mat"
+  id=3  score=0.9956  "A kitten played with yarn"
+  id=4  score=0.4407  "The puppy ran in the park"
+
+ANN search results (uses vector index):
+-----------------------------------------
+  id=1  "The cat sat on the mat"
+  id=3  "A kitten played with yarn"
+  id=4  "The puppy ran in the park"
+```
+
+### Vector search SQL reference
+
+| Function | Description |
+|----------|-------------|
+| `cosine_similarity(col, vec)` | Cosine similarity (brute-force, higher = more similar) |
+| `ann_of(col, vec)` | Approximate nearest neighbor (uses vector index if available) |
+| `dot_product(col, vec)` | Dot product distance |
+| `euclidean_distance(col, vec)` | Euclidean distance (lower = more similar) |
+
+Vectors are passed as JDBC parameters with `CAST(? AS FLOAT ARRAY)`.
+The column type for vector data is `floata` (float array).
+
+## Teardown
+
+```bash
+helm uninstall herddb
+```
+
+To also remove persistent volumes:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=herddb
+```
+
+The GCS bucket and its contents are **not** deleted by Helm.

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -1,0 +1,70 @@
+# HerdDB on GKE with Google Cloud Storage (S3-compatible endpoint).
+#
+# Prerequisites:
+#   1. A GKE cluster
+#   2. A GCS bucket
+#   3. HMAC keys for a service account with access to the bucket
+#   4. A Kubernetes Secret with the HMAC credentials:
+#
+#      kubectl create secret generic herddb-gcs-credentials \
+#        --from-literal=S3_ACCESS_KEY=<HMAC-access-key-id> \
+#        --from-literal=S3_SECRET_KEY=<HMAC-secret-access-key>
+#
+# Install:
+#   helm install herddb . -f examples/gke/values.yaml \
+#     --set fileServer.s3.bucket=<your-bucket-name>
+
+server:
+  mode: cluster
+  storageMode: remote
+  replicaCount: 1
+  storage:
+    data:
+      size: 10Gi
+    commitlog:
+      size: 5Gi
+
+fileServer:
+  replicaCount: 1
+  storageMode: s3
+  s3:
+    endpoint: "https://storage.googleapis.com"
+    region: "auto"
+    # Bucket name — must be provided at install time via --set
+    bucket: ""
+    # Credentials are read from this Kubernetes Secret instead of
+    # being embedded in the ConfigMap.
+    credentialsSecret: "herddb-gcs-credentials"
+  storage:
+    size: 10Gi
+
+minio:
+  enabled: false
+
+zookeeper:
+  enabled: true
+  storage:
+    size: 5Gi
+
+bookkeeper:
+  enabled: true
+  storage:
+    journal:
+      size: 5Gi
+    ledger:
+      size: 10Gi
+
+indexingService:
+  enabled: true
+  replicaCount: 1
+  storage:
+    data:
+      size: 10Gi
+    log:
+      size: 5Gi
+
+tools:
+  enabled: true
+
+vectorBench:
+  enabled: false

--- a/herddb-kubernetes/src/main/helm/herddb/examples/kind-local/README.md
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/kind-local/README.md
@@ -1,0 +1,199 @@
+# HerdDB on Kind (local development)
+
+Deploy HerdDB with the full distributed stack on a local
+[Kind](https://kind.sigs.k8s.io/) cluster.
+
+## Architecture
+
+| Component        | Replicas | Purpose                                         |
+|------------------|----------|-------------------------------------------------|
+| HerdDB server    | 1        | JDBC endpoint, metadata (ZooKeeper), commit log (BookKeeper) |
+| File server      | 1        | gRPC page storage, backed by MinIO (S3)         |
+| MinIO            | 1        | S3-compatible object store for data and indexes  |
+| ZooKeeper        | 1        | Cluster coordination and metadata storage        |
+| BookKeeper       | 1        | Distributed commit log                           |
+| Indexing service | 1        | Vector indexing service                          |
+| Tools pod        | 1        | Pre-configured CLI for interactive queries       |
+
+## Prerequisites
+
+- [Kind](https://kind.sigs.k8s.io/) installed
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) configured
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- Docker image available in the cluster (see below)
+
+## Quick start
+
+### 1. Create a Kind cluster
+
+```bash
+kind create cluster --name herddb
+```
+
+### 2. Load the HerdDB Docker image
+
+If you built the image locally:
+
+```bash
+kind load docker-image herddb/herddb-server:0.30.0-SNAPSHOT --name herddb
+```
+
+### 3. Install the Helm chart
+
+From the `herddb-kubernetes/src/main/helm/herddb/` directory:
+
+```bash
+helm install herddb . -f examples/kind-local/values.yaml
+```
+
+### 4. Wait for all pods to become ready
+
+```bash
+kubectl get pods -w
+```
+
+You should see 7 pods (server, file-server, minio, zookeeper, bookkeeper,
+indexing-service, and tools) all reach `Running` / `Ready` status.
+
+### 5. Connect with the CLI
+
+```bash
+kubectl exec -it deploy/herddb-tools -- herddb-cli
+```
+
+Run a test query:
+
+```sql
+SELECT * FROM SYSTABLES;
+```
+
+## Vector search example
+
+HerdDB supports vector search with approximate nearest neighbor (ANN) indexes.
+Here is a quick walkthrough using the CLI's Groovy scripting support.
+
+### Create a table with a vector column and an index
+
+```bash
+kubectl exec deploy/herddb-tools -- herddb-cli \
+  -q "CREATE TABLE documents (id int primary key, content string, embedding floata not null)"
+
+kubectl exec deploy/herddb-tools -- herddb-cli \
+  -q "CREATE VECTOR INDEX vidx ON documents(embedding)"
+```
+
+### Insert and search via a Groovy script
+
+Vector data must be inserted through JDBC prepared statements. The CLI's
+`-g` flag runs a Groovy script with a pre-configured `connection` object.
+
+Create a file called `vector_demo.groovy` on the tools pod:
+
+```bash
+kubectl exec deploy/herddb-tools -- bash -c 'cat > /tmp/vector_demo.groovy << '\''SCRIPT'\''
+import java.sql.*
+
+// Insert sample documents with 3-dimensional embeddings
+def insertSql = "INSERT INTO documents(id, content, embedding) VALUES(?, ?, CAST(? AS FLOAT ARRAY))"
+def ps = connection.prepareStatement(insertSql)
+
+def data = [
+  [1, "The cat sat on the mat",       [0.1f, 0.9f, 0.0f] as float[]],
+  [2, "The dog chased the ball",      [0.8f, 0.1f, 0.0f] as float[]],
+  [3, "A kitten played with yarn",    [0.2f, 0.8f, 0.1f] as float[]],
+  [4, "The puppy ran in the park",    [0.7f, 0.2f, 0.1f] as float[]],
+  [5, "Birds were singing at dawn",   [0.0f, 0.1f, 0.9f] as float[]],
+]
+
+data.each { row ->
+  ps.setInt(1, row[0])
+  ps.setString(2, row[1])
+  ps.setObject(3, row[2])
+  ps.executeUpdate()
+}
+ps.close()
+println "Inserted ${data.size()} documents"
+
+// Cosine similarity search
+def searchVec = [0.15f, 0.85f, 0.05f] as float[]
+def searchSql = """SELECT id, content,
+  cosine_similarity(embedding, CAST(? AS FLOAT ARRAY)) AS score
+  FROM documents
+  ORDER BY cosine_similarity(embedding, CAST(? AS FLOAT ARRAY)) DESC
+  LIMIT 3"""
+def query = connection.prepareStatement(searchSql)
+query.setObject(1, searchVec)
+query.setObject(2, searchVec)
+def rs = query.executeQuery()
+
+println ""
+println "Top 3 documents by cosine similarity to [0.15, 0.85, 0.05]:"
+println "-------------------------------------------------------------"
+while (rs.next()) {
+  printf "  id=%d  score=%.4f  \"%s\"%n", rs.getInt("id"), rs.getFloat("score"), rs.getString("content")
+}
+rs.close()
+query.close()
+
+// ANN search (uses the vector index)
+println ""
+def annSql = "SELECT id, content FROM documents ORDER BY ann_of(embedding, CAST(? AS FLOAT ARRAY)) DESC LIMIT 3"
+def annQuery = connection.prepareStatement(annSql)
+annQuery.setObject(1, searchVec)
+def annRs = annQuery.executeQuery()
+println "ANN search results (uses vector index):"
+println "-----------------------------------------"
+while (annRs.next()) {
+  printf "  id=%d  \"%s\"%n", annRs.getInt("id"), annRs.getString("content")
+}
+annRs.close()
+annQuery.close()
+SCRIPT
+'
+```
+
+Run the script:
+
+```bash
+kubectl exec deploy/herddb-tools -- herddb-cli -g /tmp/vector_demo.groovy
+```
+
+Expected output:
+
+```
+Inserted 5 documents
+
+Top 3 documents by cosine similarity to [0.15, 0.85, 0.05]:
+-------------------------------------------------------------
+  id=1  score=0.9963  "The cat sat on the mat"
+  id=3  score=0.9956  "A kitten played with yarn"
+  id=4  score=0.4407  "The puppy ran in the park"
+
+ANN search results (uses vector index):
+-----------------------------------------
+  id=1  "The cat sat on the mat"
+  id=3  "A kitten played with yarn"
+  id=4  "The puppy ran in the park"
+```
+
+### Vector search SQL reference
+
+| Function | Description |
+|----------|-------------|
+| `cosine_similarity(col, vec)` | Cosine similarity (brute-force, higher = more similar) |
+| `ann_of(col, vec)` | Approximate nearest neighbor (uses vector index if available) |
+| `dot_product(col, vec)` | Dot product distance |
+| `euclidean_distance(col, vec)` | Euclidean distance (lower = more similar) |
+
+Vectors are passed as JDBC parameters with `CAST(? AS FLOAT ARRAY)`.
+The column type for vector data is `floata` (float array).
+
+## Teardown
+
+```bash
+helm uninstall herddb
+kind delete cluster --name herddb
+```
+
+> **Note:** PersistentVolumeClaims are not deleted by `helm uninstall`.
+> Deleting the Kind cluster removes everything.

--- a/herddb-kubernetes/src/main/helm/herddb/examples/kind-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/kind-local/values.yaml
@@ -1,0 +1,112 @@
+# Full-stack HerdDB on a local Kind cluster.
+#
+# Deploys: HerdDB server (cluster mode) + file server (S3 on MinIO) +
+#           indexing service + ZooKeeper + BookKeeper + MinIO + tools pod.
+#
+# Install:
+#   helm install herddb . -f examples/kind-local/values.yaml
+
+server:
+  mode: cluster
+  storageMode: remote
+  replicaCount: 1
+  javaOpts: "-Xms512m -Xmx512m"
+  storage:
+    data:
+      size: 2Gi
+    commitlog:
+      size: 1Gi
+  resources:
+    requests:
+      memory: "768Mi"
+      cpu: "0.5"
+    limits:
+      memory: "768Mi"
+      cpu: "1"
+
+fileServer:
+  replicaCount: 1
+  storageMode: s3
+  javaOpts: "-Xms256m -Xmx384m -Djava.net.preferIPv4Stack=true"
+  # S3 endpoint, bucket, and credentials are auto-configured from the
+  # minio section below — no need to set them explicitly.
+  storage:
+    size: 2Gi
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "0.5"
+    limits:
+      memory: "512Mi"
+      cpu: "1"
+
+minio:
+  enabled: true
+  storage:
+    size: 5Gi
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "0.25"
+    limits:
+      memory: "256Mi"
+      cpu: "0.5"
+
+zookeeper:
+  enabled: true
+  javaOpts: "-Xms128m -Xmx256m"
+  storage:
+    size: 1Gi
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "0.25"
+    limits:
+      memory: "512Mi"
+      cpu: "0.5"
+
+bookkeeper:
+  enabled: true
+  javaOpts: "-Xms256m -Xmx384m"
+  storage:
+    journal:
+      size: 1Gi
+    ledger:
+      size: 2Gi
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "0.25"
+    limits:
+      memory: "512Mi"
+      cpu: "0.5"
+
+indexingService:
+  enabled: true
+  replicaCount: 1
+  javaOpts: "-Xms384m -Xmx512m -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector"
+  storage:
+    data:
+      size: 2Gi
+    log:
+      size: 1Gi
+  resources:
+    requests:
+      memory: "768Mi"
+      cpu: "0.5"
+    limits:
+      memory: "768Mi"
+      cpu: "1"
+
+tools:
+  enabled: true
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "0.25"
+    limits:
+      memory: "512Mi"
+      cpu: "0.5"
+
+vectorBench:
+  enabled: false

--- a/herddb-kubernetes/src/main/helm/herddb/templates/_helpers.tpl
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/_helpers.tpl
@@ -89,10 +89,11 @@ ZooKeeper connection address (first ZK pod via headless service).
 {{- end }}
 
 {{/*
-JDBC URL for the first server pod (used by the tools pod).
+JDBC URL for the tools pod.
+Uses a direct server connection to the first server pod (FQDN).
 */}}
 {{- define "herddb.jdbcUrl" -}}
-{{- printf "jdbc:herddb:server://%s-server-0.%s-server.%s.svc.cluster.local:%d/herd"
+{{- printf "jdbc:herddb:server:%s-server-0.%s-server.%s.svc.cluster.local:%d"
     (include "herddb.fullname" .)
     (include "herddb.fullname" .)
     .Release.Namespace

--- a/herddb-kubernetes/src/main/helm/herddb/templates/file-server-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/file-server-configmap.yaml
@@ -23,6 +23,7 @@ data:
     s3.bucket={{ .Values.minio.bucket }}
     {{- end }}
     s3.region={{ .Values.fileServer.s3.region }}
+    {{- if not .Values.fileServer.s3.credentialsSecret }}
     {{- if .Values.fileServer.s3.accessKey }}
     s3.access.key={{ .Values.fileServer.s3.accessKey }}
     {{- else if .Values.minio.enabled }}
@@ -32,6 +33,7 @@ data:
     s3.secret.key={{ .Values.fileServer.s3.secretKey }}
     {{- else if .Values.minio.enabled }}
     s3.secret.key={{ .Values.minio.adminPassword }}
+    {{- end }}
     {{- end }}
     {{- if .Values.fileServer.s3.prefix }}
     s3.prefix={{ .Values.fileServer.s3.prefix }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/file-server-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/file-server-statefulset.yaml
@@ -29,11 +29,27 @@ spec:
           args:
             - |
               POD_FQDN="${HOSTNAME}.{{ include "herddb.fullname" . }}-file-server.{{ .Release.Namespace }}.svc.cluster.local"
+              {{- if .Values.fileServer.s3.credentialsSecret }}
+              cp /opt/herddb/conf-ro/fileserver.properties /opt/herddb/conf/fileserver.properties
+              echo "s3.access.key=${S3_ACCESS_KEY}" >> /opt/herddb/conf/fileserver.properties
+              echo "s3.secret.key=${S3_SECRET_KEY}" >> /opt/herddb/conf/fileserver.properties
+              {{- end }}
               exec /opt/herddb/bin/service file-server console \
                 /opt/herddb/conf/fileserver.properties \
                 --port={{ .Values.fileServer.port }} \
                 --data-dir=/opt/herddb/filedata \
                 --bind-host=${POD_FQDN}
+          {{- else if .Values.fileServer.s3.credentialsSecret }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              cp /opt/herddb/conf-ro/fileserver.properties /opt/herddb/conf/fileserver.properties
+              echo "s3.access.key=${S3_ACCESS_KEY}" >> /opt/herddb/conf/fileserver.properties
+              echo "s3.secret.key=${S3_SECRET_KEY}" >> /opt/herddb/conf/fileserver.properties
+              exec /opt/herddb/bin/service file-server console \
+                /opt/herddb/conf/fileserver.properties \
+                --port={{ .Values.fileServer.port }} \
+                --data-dir=/opt/herddb/filedata
           {{- else }}
           command: ["/opt/herddb/bin/service"]
           args:
@@ -43,10 +59,24 @@ spec:
             - "--port={{ .Values.fileServer.port }}"
             - "--data-dir=/opt/herddb/filedata"
           {{- end }}
-          {{- if .Values.fileServer.javaOpts }}
+          {{- if or .Values.fileServer.javaOpts .Values.fileServer.s3.credentialsSecret }}
           env:
+            {{- if .Values.fileServer.javaOpts }}
             - name: JAVA_OPTS
               value: {{ .Values.fileServer.javaOpts | quote }}
+            {{- end }}
+            {{- if .Values.fileServer.s3.credentialsSecret }}
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fileServer.s3.credentialsSecret }}
+                  key: S3_ACCESS_KEY
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fileServer.s3.credentialsSecret }}
+                  key: S3_SECRET_KEY
+            {{- end }}
           {{- end }}
           ports:
             - name: grpc
@@ -65,12 +95,24 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /opt/herddb/filedata
+            {{- if .Values.fileServer.s3.credentialsSecret }}
+            - name: config
+              mountPath: /opt/herddb/conf-ro
+              readOnly: true
+            - name: config-writable
+              mountPath: /opt/herddb/conf
+            {{- else }}
             - name: config
               mountPath: /opt/herddb/conf
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "herddb.fullname" . }}-file-server-config
+        {{- if .Values.fileServer.s3.credentialsSecret }}
+        - name: config-writable
+          emptyDir: {}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-configmap.yaml
@@ -9,5 +9,5 @@ metadata:
 data:
   herddb-cli: |
     #!/bin/bash
-    exec /opt/herddb/bin/herddb-cli.sh -u "${HERDDB_JDBC_URL}" "$@"
+    exec /opt/herddb/bin/herddb-cli.sh -x "${HERDDB_JDBC_URL}" "$@"
 {{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-deployment.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-deployment.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: HERDDB_JDBC_URL
               value: {{ include "herddb.jdbcUrl" . | quote }}
+            - name: JAVA_OPTS
+              value: {{ .Values.tools.javaOpts | default "-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true" | quote }}
           resources:
             {{- toYaml .Values.tools.resources | nindent 12 }}
           volumeMounts:

--- a/herddb-kubernetes/src/main/helm/herddb/tests/file-server-configmap_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/file-server-configmap_test.yaml
@@ -174,6 +174,39 @@ tests:
           path: data["fileserver.properties"]
           pattern: "s3\\.endpoint=http://RELEASE-NAME-herddb-minio:9000"
 
+  - it: should omit credentials when credentialsSecret is set
+    set:
+      fileServer.storageMode: s3
+      fileServer.s3.bucket: my-bucket
+      fileServer.s3.endpoint: "https://storage.googleapis.com"
+      fileServer.s3.credentialsSecret: "my-gcs-secret"
+    asserts:
+      - matchRegex:
+          path: data["fileserver.properties"]
+          pattern: "storage\\.mode=s3"
+      - matchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.bucket=my-bucket"
+      - notMatchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.access\\.key"
+      - notMatchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.secret\\.key"
+
+  - it: should omit credentials from minio when credentialsSecret is set
+    set:
+      fileServer.storageMode: s3
+      fileServer.s3.credentialsSecret: "my-secret"
+      minio.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.access\\.key"
+      - notMatchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.secret\\.key"
+
   - it: should prefer explicit s3 credentials over minio auto-config
     set:
       fileServer.storageMode: s3

--- a/herddb-kubernetes/src/main/helm/herddb/tests/file-server-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/file-server-statefulset_test.yaml
@@ -115,6 +115,56 @@ tests:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: "4"
 
+  - it: should mount configmap to conf-ro and emptyDir to conf when credentialsSecret is set
+    set:
+      fileServer.s3.credentialsSecret: "my-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /opt/herddb/conf-ro
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config-writable
+            mountPath: /opt/herddb/conf
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config-writable
+            emptyDir: {}
+
+  - it: should have S3 env vars from secret when credentialsSecret is set
+    set:
+      fileServer.s3.credentialsSecret: "my-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: S3_ACCESS_KEY
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: S3_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: S3_SECRET_KEY
+
+  - it: should use bash command when credentialsSecret is set without zookeeper
+    set:
+      fileServer.s3.credentialsSecret: "my-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["/bin/bash", "-c"]
+
   - it: should use the configured service account
     asserts:
       - equal:

--- a/herddb-kubernetes/src/main/helm/herddb/tests/tools-deployment_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/tools-deployment_test.yaml
@@ -40,7 +40,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: HERDDB_JDBC_URL
-            value: "jdbc:herddb:server://RELEASE-NAME-herddb-server-0.RELEASE-NAME-herddb-server.NAMESPACE.svc.cluster.local:7000/herd"
+            value: "jdbc:herddb:server:RELEASE-NAME-herddb-server-0.RELEASE-NAME-herddb-server.NAMESPACE.svc.cluster.local:7000"
 
   - it: should mount the tools scripts configmap
     template: templates/tools-deployment.yaml

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -59,6 +59,10 @@ fileServer:
     # Credentials. When minio.enabled=true defaults to minio.adminUser/adminPassword.
     accessKey: ""
     secretKey: ""
+    # Name of an existing Kubernetes Secret containing S3_ACCESS_KEY and
+    # S3_SECRET_KEY entries. When set, credentials are read from the Secret
+    # instead of from accessKey/secretKey above.
+    credentialsSecret: ""
     # Optional key prefix within the bucket
     prefix: ""
     # Local disk cache size in bytes (default 1 GB). The PVC is always used as cache dir.
@@ -159,6 +163,8 @@ indexingService:
 # Tools pod — sleep + pre-configured CLI for kubectl exec
 tools:
   enabled: true
+  # JVM options for the CLI (defaults to lightweight settings)
+  javaOpts: ""
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
## Summary

- Add `examples/kind-local/` — full-stack HerdDB deployment on Kind (server, file server, MinIO, ZooKeeper, BookKeeper, indexing service) with reduced resource requests suitable for local development
- Add `examples/gke/` — HerdDB on GKE with Google Cloud Storage via S3-compatible endpoint, credentials stored in a Kubernetes Secret
- Add `fileServer.s3.credentialsSecret` Helm value to read S3 credentials from a Kubernetes Secret instead of embedding them in ConfigMaps
- Fix tools pod CLI wrapper (`-x` URL flag instead of `-u` username flag)
- Fix JDBC URL format (`jdbc:herddb:server:host:port` — no `//`, no `/herd`)
- Add lightweight `JAVA_OPTS` to the tools pod to avoid inheriting the server's 4GB heap default
- Both READMEs include a complete vector search walkthrough (table creation, vector index, insert+search via Groovy script, ANN search, SQL reference)

## Test plan

- [x] `helm lint` passes for both example values files
- [x] `helm template` renders correctly (kind-local has MinIO credentials in ConfigMap, GKE omits credentials)
- [x] All 107 helm-unittest tests pass (including 5 new tests for credentialsSecret)
- [x] Deployed on Kind cluster — all 7 pods running
- [x] CLI connects and basic queries work
- [x] Vector search scenario verified end-to-end: CREATE TABLE with `floata`, CREATE VECTOR INDEX, insert 5 documents, cosine_similarity search returns correct ranked results, ANN search via vector index works

🤖 Generated with [Claude Code](https://claude.com/claude-code)