### PR TITLE
Fix flaky AlterTablespaceSQLTest.escapeTableSpaceName NPE

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -553,6 +553,9 @@ public class CalcitePlanner extends AbstractSQLPlanner {
         _rootSchema.add("ANN_OF", AnnOfFunction.INSTANCE);
         for (String tableSpace : manager.getLocalTableSpaces()) {
             TableSpaceManager tableSpaceManager = manager.getTableSpaceManager(tableSpace);
+            if (tableSpaceManager == null) {
+                continue;
+            }
             SchemaPlus schema = _rootSchema.add(tableSpace, new AbstractSchema());
             List<Table> tables = tableSpaceManager.getAllTablesForPlanner();
             for (Table table : tables) {


### PR DESCRIPTION
## Summary
- Fixes #27
- Adds null check in `CalcitePlanner.getRootSchema()` for `TableSpaceManager` lookup
- Handles TOCTOU race where a tablespace is removed between `getLocalTableSpaces()` snapshot and `getTableSpaceManager()` call

## Root cause
After the Calcite upgrade, `getRootSchema()` iterates local tablespaces to build the schema. A race exists when a tablespace leader changes to another node: the tablespace name appears in `getLocalTableSpaces()` but by the time `getTableSpaceManager()` is called, the manager has been removed, causing a `NullPointerException`.

## Test plan
- [x] `AlterTablespaceSQLTest#escapeTableSpaceName` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)