### PR TITLE
Split herddb-core CI into core and cluster workflows

### DIFF
--- a/.github/workflows/pr-validation-test-cluster.yml
+++ b/.github/workflows/pr-validation-test-cluster.yml
@@ -13,7 +13,7 @@
 # CONDITIONS OF ANY KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations under the License.
 #
-name: Java CI - HerdDB Core
+name: Java CI - HerdDB Core (Cluster)
 on:
   pull_request:
   push:
@@ -50,7 +50,7 @@ jobs:
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector
       - name: 'Build with Maven'
         run: mvn -B install -DskipTests --file pom.xml -Pjenkins
-      - name: 'Test herddb-core (non-cluster)'
-        run: mvn -B verify -DforkCount=2 -Dtest.excludedGroups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pjenkins
+      - name: 'Test herddb-core (cluster)'
+        run: mvn -B verify -DforkCount=2 -Dtest.groups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pjenkins
       - name: 'Remove Snapshots Before Caching'
         run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# HerdDB - Development Guidelines
+
+## Before Sending a PR
+Run the code validation checks locally before opening a pull request:
+```
+mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins
+```
+This matches what `.github/workflows/pr-validation.yml` runs in CI (checkstyle, Apache RAT license headers, SpotBugs).
+
+## Test Categories
+Tests that require ZooKeeper/BookKeeper infrastructure (cluster mode) must be annotated with
+`@Category(ClusterTest.class)` (import `herddb.core.ClusterTest` and `org.junit.experimental.categories.Category`).
+This includes any test that:
+- Uses `ZKTestEnv`
+- Extends `ReplicatedLogtestcase`, `MultiServerBase`, or `BookkeeperFailuresBase`
+- Starts multiple `Server` instances with ZooKeeper coordination
+
+CI runs cluster and core tests in separate workflows. Forgetting the annotation means the test
+will only run in the core workflow and will likely fail there due to missing infrastructure.

--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -31,6 +31,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildNumber>${maven.build.timestamp}</buildNumber>
+        <test.groups/>
+        <test.excludedGroups/>
     </properties>
     <dependencies>
         <dependency>
@@ -245,6 +247,14 @@
                 </executions>
                 <configuration>
                     <shortRevisionLength>11</shortRevisionLength>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <groups>${test.groups}</groups>
+                    <excludedGroups>${test.excludedGroups}</excludedGroups>
                 </configuration>
             </plugin>
         </plugins>

--- a/herddb-core/src/test/java/herddb/cdc/SimpleCDCTest.java
+++ b/herddb-core/src/test/java/herddb/cdc/SimpleCDCTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.client.ClientConfiguration;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.TestUtils;
 import herddb.log.LogSequenceNumber;
 import herddb.model.Column;
@@ -57,6 +58,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 
@@ -65,6 +67,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class SimpleCDCTest {
 
     private static final Logger LOG = Logger.getLogger(SimpleCDCTest.class.getName());

--- a/herddb-core/src/test/java/herddb/client/ZookeeperClientSideMetadataProviderTest.java
+++ b/herddb-core/src/test/java/herddb/client/ZookeeperClientSideMetadataProviderTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.client.impl.UnreachableServerException;
 import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.core.ClusterTest;
 import herddb.model.NodeMetadata;
 import herddb.model.TableSpace;
 import herddb.network.ServerHostData;
@@ -34,8 +35,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+@Category(ClusterTest.class)
 public class ZookeeperClientSideMetadataProviderTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/BackupRestoreTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BackupRestoreTest.java
@@ -28,6 +28,7 @@ import herddb.client.ClientConfiguration;
 import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
 import herddb.model.ColumnTypes;
@@ -56,6 +57,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -63,6 +65,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class BackupRestoreTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/ExpectedReplicaCountTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ExpectedReplicaCountTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import herddb.client.ClientConfiguration;
 import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
+import herddb.core.ClusterTest;
 import herddb.core.TestUtils;
 import herddb.model.TableSpace;
 import herddb.model.TransactionContext;
@@ -44,6 +45,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -51,6 +53,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class ExpectedReplicaCountTest {
 
     private static final Logger LOG = Logger.getLogger(ExpectedReplicaCountTest.class.getName());

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerCreateTableSpaceWaitTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerCreateTableSpaceWaitTest.java
@@ -23,6 +23,7 @@ package herddb.cluster;
 import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
+import herddb.core.ClusterTest;
 import herddb.core.TestUtils;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
@@ -37,6 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -44,6 +46,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class MultiServerCreateTableSpaceWaitTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/PreferLocalBookiePlacementPolicyTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/PreferLocalBookiePlacementPolicyTest.java
@@ -22,6 +22,7 @@ package herddb.cluster;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.core.ClusterTest;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
@@ -30,10 +31,12 @@ import java.util.Set;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author francesco.caliumi
  */
+@Category(ClusterTest.class)
 public class PreferLocalBookiePlacementPolicyTest {
 
     // CHECKSTYLE.OFF: ConstantName

--- a/herddb-core/src/test/java/herddb/cluster/RestartPendingTransactionBookKeeperTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RestartPendingTransactionBookKeeperTest.java
@@ -20,6 +20,7 @@
 package herddb.cluster;
 
 import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
+import herddb.core.ClusterTest;
 import herddb.core.DBManager;
 import herddb.core.RestartPendingTransactionBase;
 import herddb.file.FileDataStorageManager;
@@ -29,7 +30,9 @@ import java.nio.file.Path;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class RestartPendingTransactionBookKeeperTest extends RestartPendingTransactionBase {
 
     private ZKTestEnv testEnv;

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -33,6 +33,7 @@ import herddb.client.HDBConnection;
 import herddb.client.HDBException;
 import herddb.client.ScanResultSet;
 import herddb.core.ActivatorRunRequest;
+import herddb.core.ClusterTest;
 import herddb.core.DBManager;
 import herddb.core.TableSpaceManager;
 import herddb.core.TestUtils;
@@ -61,6 +62,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -68,6 +70,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class RetryOnLeaderChangedTest {
 
     private static final Logger LOG = Logger.getLogger(RetryOnLeaderChangedTest.class.getName());

--- a/herddb-core/src/test/java/herddb/cluster/ServerWithDynamicPortTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ServerWithDynamicPortTest.java
@@ -23,6 +23,7 @@ import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import herddb.client.ClientConfiguration;
 import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
+import herddb.core.ClusterTest;
 import herddb.model.TableSpace;
 import herddb.model.TransactionContext;
 import herddb.server.Server;
@@ -36,6 +37,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -43,6 +45,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class ServerWithDynamicPortTest {
 
     private static final Logger LOG = Logger.getLogger(ServerWithDynamicPortTest.class.getName());

--- a/herddb-core/src/test/java/herddb/cluster/TablespaceReplicasStateTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/TablespaceReplicasStateTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import herddb.core.ClusterTest;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
 import herddb.model.StatementEvaluationContext;
@@ -49,6 +50,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -56,6 +58,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class TablespaceReplicasStateTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
@@ -23,6 +23,7 @@ package herddb.cluster;
 import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
+import herddb.core.ClusterTest;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
 import herddb.model.StatementEvaluationContext;
@@ -41,6 +42,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -48,6 +50,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class WaitForBookiesTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/ZKServiceDiscoveryTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ZKServiceDiscoveryTest.java
@@ -21,6 +21,7 @@ package herddb.cluster;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.core.ClusterTest;
 import herddb.metadata.ServiceDiscoveryListener;
 import herddb.utils.ZKTestEnv;
 import java.util.List;
@@ -31,8 +32,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+@Category(ClusterTest.class)
 public class ZKServiceDiscoveryTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/ZkReplicaCheckpointLsnTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ZkReplicaCheckpointLsnTest.java
@@ -23,18 +23,21 @@ package herddb.cluster;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import herddb.core.ClusterTest;
 import herddb.log.LogSequenceNumber;
 import herddb.utils.ZKTestEnv;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
  * ZooKeeper-backed tests for the replica-checkpoint-LSN tracking API used by the
  * shared-storage retention logic.
  */
+@Category(ClusterTest.class)
 public class ZkReplicaCheckpointLsnTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/ZookeeperMetadataStorageManagerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ZookeeperMetadataStorageManagerTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import herddb.core.ClusterTest;
 import herddb.metadata.MetadataStorageManagerException;
 import herddb.model.TableSpace;
 import herddb.utils.ZKTestEnv;
@@ -39,8 +40,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+@Category(ClusterTest.class)
 public class ZookeeperMetadataStorageManagerTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.BookkeeperCommitLogManager;
 import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.core.ClusterTest;
 import herddb.log.CommitLogResult;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
@@ -52,8 +53,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+@Category(ClusterTest.class)
 public class BookKeeperCommitLogTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperDataStorageManagerRestartTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperDataStorageManagerRestartTest.java
@@ -23,6 +23,7 @@ import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import herddb.cluster.BookKeeperDataStorageManager;
 import herddb.cluster.BookkeeperCommitLogManager;
 import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.core.ClusterTest;
 import herddb.core.DBManager;
 import herddb.core.RestartTestBase;
 import herddb.server.ServerConfiguration;
@@ -31,7 +32,9 @@ import java.nio.file.Path;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class BookKeeperDataStorageManagerRestartTest extends RestartTestBase {
 
     ZKTestEnv testEnv;

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookieNotAvailableTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookieNotAvailableTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.fail;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.codec.RecordSerializer;
 import herddb.core.ActivatorRunRequest;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
@@ -52,7 +53,9 @@ import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.net.BookieId;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class BookieNotAvailableTest extends BookkeeperFailuresBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/FencingTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/FencingTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.fail;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.codec.RecordSerializer;
 import herddb.core.ActivatorRunRequest;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
@@ -48,7 +49,9 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class FencingTest extends BookkeeperFailuresBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/LedgerClosedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/LedgerClosedTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.LedgersInfo;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
@@ -46,7 +47,9 @@ import java.util.HashSet;
 import java.util.List;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class LedgerClosedTest extends BookkeeperFailuresBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/MultiBookieTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/MultiBookieTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.index.SecondaryIndexSeek;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
@@ -48,7 +49,9 @@ import java.util.HashSet;
 import java.util.List;
 import org.apache.bookkeeper.net.BookieId;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class MultiBookieTest extends BookkeeperFailuresBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootAsNewLeaderTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootAsNewLeaderTest.java
@@ -27,6 +27,7 @@ import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.LedgersInfo;
 import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.index.SecondaryIndexSeek;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
@@ -53,11 +54,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class BootAsNewLeaderTest extends MultiServerBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -26,6 +26,7 @@ import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.LedgersInfo;
 import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.index.SecondaryIndexSeek;
 import herddb.log.LogSequenceNumber;
@@ -57,7 +58,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class BootFollowerTest extends MultiServerBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
@@ -23,6 +23,7 @@ import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import static org.junit.Assert.assertEquals;
 import herddb.codec.RecordSerializer;
 import herddb.core.ActivatorRunRequest;
+import herddb.core.ClusterTest;
 import herddb.core.MemoryManager;
 import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
@@ -40,12 +41,14 @@ import herddb.server.ServerConfiguration;
 import java.util.Arrays;
 import java.util.HashSet;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests about changing roles
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class ChangeRoleTest extends MultiServerBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/follower/EdgeCasesFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/EdgeCasesFollowerTest.java
@@ -27,6 +27,7 @@ import herddb.cluster.LedgersInfo;
 import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.codec.RecordSerializer;
 import herddb.core.AbstractTableManager;
+import herddb.core.ClusterTest;
 import herddb.index.SecondaryIndexSeek;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
@@ -55,7 +56,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class EdgeCasesFollowerTest extends MultiServerBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/follower/FollowerReadsTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/FollowerReadsTest.java
@@ -28,6 +28,7 @@ import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
 import herddb.client.ScanResultSet;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.model.ColumnTypes;
 import herddb.model.GetResult;
 import herddb.model.StatementEvaluationContext;
@@ -46,10 +47,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests for reading from follower replicas.
  */
+@Category(ClusterTest.class)
 public class FollowerReadsTest extends MultiServerBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import herddb.codec.RecordSerializer;
 import herddb.core.AbstractTableManager;
 import herddb.core.ActivatorRunRequest;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
@@ -56,7 +57,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(ClusterTest.class)
 public class SimpleFollowerTest extends MultiServerBase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/core/ClusterTest.java
+++ b/herddb-core/src/test/java/herddb/core/ClusterTest.java
@@ -1,0 +1,30 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+/**
+ * JUnit 4 category marker for tests that require ZooKeeper/BookKeeper infrastructure.
+ *
+ * <p>Annotate cluster test classes with {@code @Category(ClusterTest.class)}.
+ * CI uses this to run cluster and core tests in separate workflows.</p>
+ */
+public interface ClusterTest {
+}

--- a/herddb-core/src/test/java/herddb/core/ConcurrentCheckpointBookKeeperTest.java
+++ b/herddb-core/src/test/java/herddb/core/ConcurrentCheckpointBookKeeperTest.java
@@ -32,11 +32,13 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Integration tests for concurrent DML during checkpoint with the BookKeeper
  * commit log backend (ZooKeeper + BookKeeper via ZKTestEnv).
  */
+@Category(ClusterTest.class)
 public class ConcurrentCheckpointBookKeeperTest extends ReplicatedLogtestcase {
 
     /**

--- a/herddb-core/src/test/java/herddb/core/ReplicatedAlterTableTest.java
+++ b/herddb-core/src/test/java/herddb/core/ReplicatedAlterTableTest.java
@@ -32,12 +32,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Basic functionality
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class ReplicatedAlterTableTest extends ReplicatedLogtestcase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/core/SimpleClusterDisklessTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleClusterDisklessTest.java
@@ -48,11 +48,13 @@ import java.util.List;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class SimpleClusterDisklessTest extends BaseTestcase {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/core/SimpleClusterTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleClusterTest.java
@@ -48,11 +48,13 @@ import java.util.List;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class SimpleClusterTest extends BaseTestcase {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/core/SimpleReplicationTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleReplicationTest.java
@@ -34,12 +34,14 @@ import herddb.utils.Bytes;
 import java.util.Arrays;
 import java.util.HashSet;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Basic functionality
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class SimpleReplicationTest extends ReplicatedLogtestcase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/core/UnderreplicationTest.java
+++ b/herddb-core/src/test/java/herddb/core/UnderreplicationTest.java
@@ -27,12 +27,14 @@ import herddb.model.commands.CreateTableSpaceStatement;
 import java.util.Arrays;
 import java.util.HashSet;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Basic functionality
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class UnderreplicationTest extends ReplicatedLogtestcase {
 
     @Test

--- a/herddb-core/src/test/java/herddb/data/consistency/ConsistencyCheckDuringRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/data/consistency/ConsistencyCheckDuringRecoveryTest.java
@@ -22,6 +22,7 @@ package herddb.data.consistency;
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.core.ClusterTest;
 import herddb.core.DBManager;
 import herddb.core.ReplicatedLogtestcase;
 import herddb.model.ColumnTypes;
@@ -38,11 +39,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  *
  * @author hamado
  */
+@Category(ClusterTest.class)
 public class ConsistencyCheckDuringRecoveryTest extends ReplicatedLogtestcase {
 
     final String tableName = "table1";

--- a/herddb-core/src/test/java/herddb/data/consistency/MultiNodeConsistencyCheckTest.java
+++ b/herddb-core/src/test/java/herddb/data/consistency/MultiNodeConsistencyCheckTest.java
@@ -22,6 +22,7 @@ package herddb.data.consistency;
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.core.ClusterTest;
 import herddb.core.DBManager;
 import herddb.core.ReplicatedLogtestcase;
 import herddb.model.ColumnTypes;
@@ -38,12 +39,14 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 
 /**
  *
  * @author hamado
  */
+@Category(ClusterTest.class)
 public class MultiNodeConsistencyCheckTest extends ReplicatedLogtestcase {
 
     final String tableName = "table1";

--- a/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
@@ -32,6 +32,7 @@ import herddb.client.HDBConnection;
 import herddb.client.ScanResultSet;
 import herddb.client.impl.LeaderChangedException;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.GetResult;
@@ -53,6 +54,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -60,6 +62,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class ClientMultiServerTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/DisklessClusterBootReplicatedTest.java
+++ b/herddb-core/src/test/java/herddb/server/DisklessClusterBootReplicatedTest.java
@@ -21,6 +21,7 @@ package herddb.server;
 
 import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import static org.junit.Assert.assertEquals;
+import herddb.core.ClusterTest;
 import herddb.core.TestUtils;
 import herddb.model.TableSpace;
 import herddb.utils.DataAccessor;
@@ -31,8 +32,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+@Category(ClusterTest.class)
 public class DisklessClusterBootReplicatedTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/DisklessClusterTest.java
+++ b/herddb-core/src/test/java/herddb/server/DisklessClusterTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.TestUtils;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
@@ -44,8 +45,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+@Category(ClusterTest.class)
 public class DisklessClusterTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/DownloadTableSpaceTest.java
+++ b/herddb-core/src/test/java/herddb/server/DownloadTableSpaceTest.java
@@ -30,6 +30,7 @@ import herddb.client.HDBConnection;
 import herddb.client.TableSpaceDumpReceiver;
 import herddb.client.ZookeeperClientSideMetadataProvider;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
@@ -51,6 +52,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -58,6 +60,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class DownloadTableSpaceTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/EmbeddedBookieTest.java
+++ b/herddb-core/src/test/java/herddb/server/EmbeddedBookieTest.java
@@ -32,6 +32,7 @@ import herddb.client.HDBConnection;
 import herddb.client.ScanResultSet;
 import herddb.client.impl.LeaderChangedException;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.GetResult;
@@ -52,6 +53,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -59,6 +61,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class EmbeddedBookieTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/LedgerManagementTest.java
+++ b/herddb-core/src/test/java/herddb/server/LedgerManagementTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.LedgersInfo;
+import herddb.core.ClusterTest;
 import herddb.model.ColumnTypes;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.Table;
@@ -39,6 +40,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -46,6 +48,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class LedgerManagementTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/MaxLeaderInactivityTest.java
+++ b/herddb-core/src/test/java/herddb/server/MaxLeaderInactivityTest.java
@@ -25,6 +25,7 @@ import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import herddb.core.ClusterTest;
 import herddb.core.TableSpaceManager;
 import herddb.core.TestUtils;
 import herddb.model.DataScanner;
@@ -36,6 +37,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -43,6 +45,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class MaxLeaderInactivityTest {
 
     @Rule

--- a/herddb-core/src/test/java/herddb/server/UseVirtualTableSpaceIdWithZookKeeperTest.java
+++ b/herddb-core/src/test/java/herddb/server/UseVirtualTableSpaceIdWithZookKeeperTest.java
@@ -29,6 +29,7 @@ import herddb.client.HDBConnection;
 import herddb.client.ScanResultSet;
 import herddb.client.ZookeeperClientSideMetadataProvider;
 import herddb.codec.RecordSerializer;
+import herddb.core.ClusterTest;
 import herddb.model.ColumnTypes;
 import herddb.model.GetResult;
 import herddb.model.StatementEvaluationContext;
@@ -50,6 +51,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -57,6 +59,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
+@Category(ClusterTest.class)
 public class UseVirtualTableSpaceIdWithZookKeeperTest {
 
     @Rule


### PR DESCRIPTION
## Summary
- Add JUnit 4 `@Category(ClusterTest.class)` to 42 test classes requiring ZooKeeper/BookKeeper
- Configure surefire `groups`/`excludedGroups` in herddb-core pom.xml
- Split into two CI workflows: core tests (~623 tests) and cluster tests (~42 classes)
- Add `CLAUDE.md` with dev guidelines (checkstyle/rat/spotbugs before PRs, annotate cluster tests)

## Test plan
- [x] Checkstyle + RAT pass locally
- [x] Core tests pass locally (623 tests, 0 failures)
- [ ] CI: core workflow passes
- [ ] CI: cluster workflow passes
- [ ] Verify total test count matches (core + cluster = all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)