### PR TITLE
Fix retryAsync to handle synchronous exceptions from empty hash ring

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -110,6 +110,11 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
 
     @Override
     public synchronized void updateServers(List<String> newServers) {
+        if (newServers.isEmpty()) {
+            LOGGER.log(Level.WARNING, "updateServers called with empty list, keeping current servers");
+            return;
+        }
+
         ServerSnapshot current = this.snapshot;
 
         // Compute diff
@@ -273,6 +278,10 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
     @Override
     public boolean waitForCatchUp(String tablespace, LogSequenceNumber sequenceNumber, long timeoutMs) throws InterruptedException {
         ServerSnapshot s = this.snapshot;
+        if (s.servers.isEmpty()) {
+            LOGGER.log(Level.WARNING, "waitForCatchUp: no indexing service instances available");
+            return false;
+        }
         for (Map.Entry<String, ManagedChannel> serverEntry : s.channels.entrySet()) {
             String server = serverEntry.getKey();
             ManagedChannel channel = serverEntry.getValue();

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceClientDynamicTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceClientDynamicTest.java
@@ -21,6 +21,9 @@
 package herddb.indexing;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import herddb.log.LogSequenceNumber;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -86,5 +89,55 @@ public class IndexingServiceClientDynamicTest {
 
         // Verify search still works after update (empty index returns empty results)
         client.search("herd", "testtable", "testindex", new float[]{1.0f, 2.0f, 3.0f}, 10);
+    }
+
+    @Test
+    public void testUpdateServersEmptyListKeepsCurrent() throws Exception {
+        String addr1 = service1.getAddress();
+
+        client = new IndexingServiceClient(Collections.singletonList(addr1));
+        assertEquals(1, client.getServers().size());
+
+        // Empty list should be ignored
+        client.updateServers(Collections.emptyList());
+
+        // Server list should be unchanged
+        assertEquals(1, client.getServers().size());
+        assertEquals(addr1, client.getServers().get(0));
+
+        // Search should still work
+        client.search("herd", "testtable", "testindex", new float[]{1.0f, 2.0f, 3.0f}, 10);
+    }
+
+    @Test
+    public void testSearchThrowsWithEmptyServerList() {
+        client = new IndexingServiceClient(Collections.emptyList());
+
+        try {
+            client.search("herd", "testtable", "testindex", new float[]{1.0f, 2.0f, 3.0f}, 10);
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            assertEquals("No indexing service instances available", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetIndexStatusThrowsWithEmptyServerList() {
+        client = new IndexingServiceClient(Collections.emptyList());
+
+        try {
+            client.getIndexStatus("herd", "testtable", "testindex");
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            assertEquals("No indexing service instances available", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWaitForCatchUpReturnsFalseWithEmptyServerList() throws Exception {
+        client = new IndexingServiceClient(Collections.emptyList());
+
+        boolean result = client.waitForCatchUp("herd", new LogSequenceNumber(1, 0), 5000);
+        assertFalse("waitForCatchUp should return false when no servers are available", result);
     }
 }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -629,7 +629,17 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
 
     private <T> CompletableFuture<T> retryAsync(AsyncAction<T> action, String opName, String path, int attempt) {
         CompletableFuture<T> result = new CompletableFuture<>();
-        action.execute().whenComplete((value, error) -> {
+        CompletableFuture<T> actionResult;
+        try {
+            actionResult = action.execute();
+        } catch (Exception e) {
+            // Handle synchronous failures (e.g. "Hash ring is empty" when no
+            // servers have been discovered yet) the same as async failures so
+            // that the retry logic below can kick in.
+            actionResult = new CompletableFuture<>();
+            actionResult.completeExceptionally(e);
+        }
+        actionResult.whenComplete((value, error) -> {
             if (error == null) {
                 result.complete(value);
                 return;

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -256,7 +256,14 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
     private CompletableFuture<Long> writeFileAsync(String path, ByteString content) {
         // Writes are not idempotent — no retry
         CompletableFuture<Long> future = new CompletableFuture<>();
-        asyncStubForPath(path).writeFile(
+        RemoteFileServiceGrpc.RemoteFileServiceStub stub;
+        try {
+            stub = asyncStubForPath(path);
+        } catch (Exception e) {
+            future.completeExceptionally(e);
+            return future;
+        }
+        stub.writeFile(
                 WriteFileRequest.newBuilder()
                         .setPath(path)
                         .setContent(content)

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
@@ -23,6 +23,8 @@ package herddb.remote;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -173,6 +175,33 @@ public class RemoteFileServiceClientDynamicTest {
 
             // The list should eventually succeed
             listFuture.get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Verify that writeFileAsync returns a failed CompletableFuture (rather
+     * than throwing synchronously) when the hash ring is empty.  Writes are
+     * not retried, so the future should complete exceptionally.
+     */
+    @Test
+    public void testWriteAsyncFailsGracefullyWithEmptyHashRing() throws Exception {
+        try (RemoteFileServiceClient client = new RemoteFileServiceClient(
+                Collections.emptyList())) {
+
+            CompletableFuture<Long> writeFuture = client.writeFileAsync(
+                    "test/file.dat", "hello".getBytes());
+
+            // The future must be returned (no synchronous throw) and must
+            // complete exceptionally because there are no servers.
+            try {
+                writeFuture.get(5, TimeUnit.SECONDS);
+                fail("Expected an exception from writeFileAsync with empty hash ring");
+            } catch (java.util.concurrent.ExecutionException e) {
+                // Verify the root cause is the empty hash ring
+                assertTrue("Expected IllegalStateException, got: " + e.getCause(),
+                        e.getCause() instanceof IllegalStateException);
+                assertTrue(e.getCause().getMessage().contains("Hash ring is empty"));
+            }
         }
     }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
@@ -22,11 +22,14 @@ package herddb.remote;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -121,6 +124,55 @@ public class RemoteFileServiceClientDynamicTest {
             // Should still work
             client.writeFile("test/file.dat", "hello".getBytes());
             assertNotNull(client.readFile("test/file.dat"));
+        }
+    }
+
+    /**
+     * Reproducer for the indexing service startup crash: when the client starts
+     * with an empty server list (ZK discovery pending), readFileAsync() must
+     * retry with backoff until servers appear, not crash immediately with
+     * "Hash ring is empty".
+     */
+    @Test
+    public void testReadRetriesUntilServerAppears() throws Exception {
+        String addr1 = "localhost:" + server1.getPort();
+
+        try (RemoteFileServiceClient client = new RemoteFileServiceClient(
+                Collections.emptyList())) {
+
+            // Start an async read — hash ring is empty, so this must retry
+            CompletableFuture<byte[]> readFuture = client.readFileAsync("test/nonexistent.dat");
+
+            // Simulate ZK discovery arriving after a short delay
+            Thread.sleep(1500);
+            client.updateServers(Collections.singletonList(addr1));
+
+            // The read should eventually succeed (file doesn't exist → null)
+            byte[] result = readFuture.get(30, TimeUnit.SECONDS);
+            assertNull("Non-existent file should return null", result);
+        }
+    }
+
+    /**
+     * Verify that listFilesAsync also retries on synchronous failures from
+     * an initially empty hash ring.
+     */
+    @Test
+    public void testListRetriesUntilServerAppears() throws Exception {
+        String addr1 = "localhost:" + server1.getPort();
+
+        try (RemoteFileServiceClient client = new RemoteFileServiceClient(
+                Collections.emptyList())) {
+
+            // Start an async list — hash ring is empty, so this must retry
+            CompletableFuture<?> listFuture = client.listFilesAsync("test/");
+
+            // Simulate ZK discovery arriving after a short delay
+            Thread.sleep(1500);
+            client.updateServers(Collections.singletonList(addr1));
+
+            // The list should eventually succeed
+            listFuture.get(30, TimeUnit.SECONDS);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix empty server list handling in both gRPC clients (`RemoteFileServiceClient` and `IndexingServiceClient`) that caused the indexing service to crash on startup before ZK discovery could populate the server lists.

### RemoteFileServiceClient

- `retryAsync()` calls `action.execute().whenComplete(...)`. When `action.execute()` throws synchronously (e.g. `IllegalStateException("Hash ring is empty")` before returning a `CompletableFuture`), the exception bypasses `.whenComplete()` entirely — no retries happen and the service crashes.
- **Fix:** Wrap `action.execute()` in a try-catch so synchronous exceptions are converted to failed `CompletableFuture`s and processed by the existing exponential backoff retry logic.
- **Fix:** `writeFileAsync()` now catches synchronous exceptions from `asyncStubForPath()` and returns a failed `CompletableFuture` instead of throwing, for consistent async API semantics.

### IndexingServiceClient

- `updateServers()` accepted empty lists, clearing all known servers when ZK temporarily reports zero instances.
- `waitForCatchUp()` silently returned `true` with no servers (empty for-loop falls through), which could cause commit log files to be deleted before any indexing instance has consumed them.
- **Fix:** `updateServers()` rejects empty lists (keeps current servers), matching `RemoteFileServiceClient`'s existing guard.
- **Fix:** `waitForCatchUp()` returns `false` when no servers are available.

## Test plan

- [x] `RemoteFileServiceClientDynamicTest#testReadRetriesUntilServerAppears` — read with empty hash ring retries until server appears
- [x] `RemoteFileServiceClientDynamicTest#testListRetriesUntilServerAppears` — list with empty hash ring retries until server appears
- [x] `RemoteFileServiceClientDynamicTest#testWriteAsyncFailsGracefullyWithEmptyHashRing` — writeFileAsync returns failed future (not synchronous throw)
- [x] `IndexingServiceClientDynamicTest#testUpdateServersEmptyListKeepsCurrent` — empty list keeps current servers
- [x] `IndexingServiceClientDynamicTest#testSearchThrowsWithEmptyServerList` — search throws with no servers
- [x] `IndexingServiceClientDynamicTest#testGetIndexStatusThrowsWithEmptyServerList` — getIndexStatus throws with no servers
- [x] `IndexingServiceClientDynamicTest#testWaitForCatchUpReturnsFalseWithEmptyServerList` — waitForCatchUp returns false with no servers
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)