### PR TITLE
Fix building-page race in applyUpdate/applyDelete (indexes==null)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -2299,12 +2299,24 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             if (page != null) {
                 pageReplacementPolicy.pageHit(page);
-                previous = page.get(key);
-
-                if (previous == null) {
+                Record found = page.get(key);
+                if (found == null && !page.immutable) {
+                    /* Same building-page race as in applyUpdate: keyToPage can be updated
+                     * before the record is published into the building page. Retry under
+                     * the page read lock to wait for Phase B compaction to finish the put. */
+                    final Lock lock = page.pageLock.readLock();
+                    lock.lock();
+                    try {
+                        found = page.get(key);
+                    } finally {
+                        lock.unlock();
+                    }
+                }
+                if (found == null) {
                     throw new PageNotFoundException("corrupted PK: old page " + pageId + " for deleted record at " + key
                             + " was not found in table " + table.tablespace + "." + table.name);
                 }
+                previous = found;
             } else {
                 previous = null;
             }
@@ -2405,12 +2417,26 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             if (prevPage != null) {
                 pageReplacementPolicy.pageHit(prevPage);
-                previous = prevPage.get(key);
-
-                if (previous == null) {
+                Record found = prevPage.get(key);
+                if (found == null && !prevPage.immutable) {
+                    /* During checkpoint Phase B, cleanAndCompactPages updates keyToPage
+                     * (pointing to the building page) before adding the record to that page.
+                     * The building page's write lock is held during this window, so acquiring
+                     * the read lock here will block until the record has been fully added.
+                     * This mirrors the retry logic in fetchRecord(). */
+                    final Lock lock = prevPage.pageLock.readLock();
+                    lock.lock();
+                    try {
+                        found = prevPage.get(key);
+                    } finally {
+                        lock.unlock();
+                    }
+                }
+                if (found == null) {
                     throw new IllegalStateException("corrupted PK: old page " + prevPageId + " for updated record at "
                             + key + " was not found in table " + table.tablespace + "." + table.name);
                 }
+                previous = found;
             } else {
                 previous = null;
             }


### PR DESCRIPTION
## Summary
- Fixes flaky `MultipleConcurrentUpdatesTest.testWithTransactionsWithCheckpoints` which intermittently failed on CI with `IllegalStateException: corrupted PK: old page N for updated record at K was not found in table herd.mytable`.
- Root cause is a race with non-blocking checkpoint Phase B (`cleanAndCompactPages`): for dirty pages it updates `keyToPage` to point at the building page **before** inserting the record into that page, relying on the building page's write lock to make the gap invisible to concurrent readers.
- `fetchRecord()` and the `indexes != null` branches of `applyUpdate`/`applyDelete` already close this gap by retrying under the building page's `pageLock.readLock()`. The `indexes == null` fast paths did not — they fetched the record once, saw `null`, and threw. This PR mirrors the same retry pattern on those paths.

## Test plan
- [x] `mvn -pl herddb-core test -Dtest=MultipleConcurrentUpdatesTest` — all 8 tests pass locally (including `testWithTransactionsWithCheckpoints` across multiple repeated runs).
- [x] Compiles cleanly; checkstyle passes.
- [ ] CI: full PR validation workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)