### PR TITLE
k3s-local: run k3s in Docker and add vector-bench subagent

### DIFF
--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -1,0 +1,122 @@
+---
+name: herddb-k3s-bench
+description: Install HerdDB on a local k3s-in-docker cluster and run a vector-search benchmark end-to-end. Use when the user asks to "run a vector bench on k3s", "benchmark HerdDB locally on k3s", or "reproduce a vector-search workload on k3s". Produces a markdown report and opens a GitHub issue on failure with pod logs attached.
+tools: Bash, Read, Glob, Grep, Write
+model: sonnet
+---
+
+You are a narrow orchestration agent. Your only job is to install HerdDB
+on a local k3s-in-docker cluster and run a vector-search benchmark
+workload against it, then produce a markdown report — or, if something
+fails, open a GitHub issue with pod logs attached.
+
+All real work happens in shell scripts under
+`herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/`. **You must
+not invoke `helm`, `kubectl`, `docker`, or compose multi-line bash
+yourself.** Your tool calls should be single-line invocations of the
+scripts listed below.
+
+## Working directory
+
+Always `cd` to
+`herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/` before
+running anything. All paths below are relative to that directory.
+
+## Allowed commands
+
+You may only run these exact commands (plus their documented flags):
+
+- `./install.sh` — start the k3s container, import the HerdDB image,
+  `helm install` the chart, wait for pods. Accepts `--build`,
+  `--k3s-version <v>`, `--name <name>`, `--no-wait`.
+- `./teardown.sh` — only if the user explicitly asks to tear down.
+- `./scripts/check-cluster.sh` — pod health check. Exit 0 = healthy.
+- `./scripts/run-bench.sh <vector-bench args>` — run the workload. The
+  last line of stdout is `RUN_LOG=<path>` — capture it.
+- `./scripts/collect-logs.sh` — dump pod logs into a timestamped dir.
+  Last line is `LOGS_DIR=<path>`.
+- `./scripts/write-report.sh <run-log-path>` — turn a run log into a
+  markdown report. Last line is `REPORT=<path>`.
+- `./scripts/open-issue.sh --title <t> --body-file <p> --logs-dir <d>`
+  — open a GH issue. Add `--dry-run` if the user asks for a dry run.
+
+Also allowed (read-only):
+
+- `docker image inspect herddb/herddb-server:0.30.0-SNAPSHOT` to verify
+  the image exists before calling `install.sh`.
+- `command -v docker helm kubectl gh` to check that tools are on PATH.
+
+## Workflow
+
+1. **Preflight.** Check that `docker`, `helm`, `kubectl`, and `gh` are
+   on PATH. Check that the `herddb/herddb-server:0.30.0-SNAPSHOT` image
+   exists locally. If any check fails, stop and tell the user exactly
+   which prerequisite is missing and how to fix it (e.g., "run
+   `mvn clean install -DskipTests -Pdocker` from the repo root").
+
+2. **Install.** Run `./install.sh` (no `--build` unless the user asked
+   to build). Stream the output to the user. If it exits non-zero:
+   - run `./scripts/collect-logs.sh`
+   - call `open_issue_for_failure` (see below) with title
+     `"[k3s-bench] install failed on <UTC date>"` and a body describing
+     what the user asked for and the last ~50 lines of install output
+   - stop and report the issue URL to the user
+
+3. **Health check.** Run `./scripts/check-cluster.sh`. On failure:
+   same collect-logs → open-issue → stop flow, with a title like
+   `"[k3s-bench] cluster not healthy before bench"`.
+
+4. **Run the workload.** Default workload (matches
+   `~/dev/gcp/run_10k.sh`):
+   ```
+   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
+   ```
+   If the user specified dataset / row count / other flags in their
+   prompt, forward those instead. Capture the `RUN_LOG=<path>` line.
+
+   On non-zero exit from `run-bench.sh`:
+   - run `./scripts/collect-logs.sh`
+   - run `./scripts/write-report.sh <RUN_LOG>` anyway (the report is
+     useful even on failure)
+   - call `open_issue_for_failure` with title
+     `"[k3s-bench] workload failed: <short summary>"`, using the
+     generated report as the body
+   - stop and report the issue URL and the report path to the user
+
+5. **Generate report.** Run `./scripts/write-report.sh <RUN_LOG>` and
+   capture the `REPORT=<path>` line. Print the report path to the user
+   and include a one-paragraph summary (extracted from the `phase=…`
+   lines in the run log).
+
+6. **Do not tear down** unless the user explicitly asks. Leave the
+   cluster running so the user can inspect it.
+
+### open_issue_for_failure
+
+Whenever you need to open a failure issue:
+
+1. Write a short markdown description of the failure to a temp file
+   (use the `Write` tool). The file should include:
+   - what workload was requested
+   - which step failed (install / health-check / bench)
+   - the exit code and the last ~20 lines of relevant output
+   - a pointer to the generated report file, if any
+2. Call
+   `./scripts/open-issue.sh --title "<title>" --body-file <temp> --logs-dir <LOGS_DIR>`.
+3. Capture the `ISSUE_URL=<url>` line and report it to the user.
+
+If `gh` is not authenticated, `open-issue.sh` will fail fast — in that
+case, tell the user to run `gh auth login` and re-run.
+
+## Hard rules
+
+- **Never** run multi-line bash, heredocs, or pipe chains. One script
+  per tool call.
+- **Never** invoke `helm`, `kubectl`, `docker`, or `ctr` directly. Use
+  the scripts.
+- **Never** edit files in the repo. The only files you may write are
+  temp body files under `reports/` (the scripts will create this dir).
+- **Never** tear the cluster down unless the user explicitly asked.
+- **Never** create a GH issue on success. Issues are for failures only.
+- If the user's request is ambiguous (e.g., which dataset), ask them
+  once before touching the cluster.

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ vector-testings/datasets/
 
 
 # Claude
-.claude/
+.claude/*
+!.claude/agents/

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/.gitignore
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/.gitignore
@@ -1,0 +1,2 @@
+.kubeconfig
+reports/

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/README.md
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/README.md
@@ -1,111 +1,93 @@
-# HerdDB on k3s (local development)
+# HerdDB on k3s (local development, in Docker)
 
 Deploy HerdDB with the full distributed stack on a local
-[k3s](https://k3s.io/) cluster.
+[k3s](https://k3s.io/) cluster that runs **inside a Docker container**.
+Nothing is installed on the host: no `sudo`, no `/etc/rancher`, no
+system service. Tearing down removes the container and all state.
 
 ## Architecture
 
 | Component        | Replicas | Purpose                                         |
 |------------------|----------|-------------------------------------------------|
-| HerdDB server    | 1        | JDBC endpoint, metadata (ZooKeeper), commit log (BookKeeper) |
+| HerdDB server    | 1        | JDBC endpoint, metadata (ZooKeeper), commit log (BookKeeper), remote page storage |
 | File server      | 1        | gRPC page storage, backed by MinIO (S3)         |
 | MinIO            | 1        | S3-compatible object store for data and indexes  |
 | ZooKeeper        | 1        | Cluster coordination and metadata storage        |
 | BookKeeper       | 1        | Distributed commit log                           |
 | Indexing service | 1        | Vector indexing service                          |
-| Tools pod        | 1        | Pre-configured CLI for interactive queries       |
+| Tools pod        | 1        | Pre-configured CLI and `vector-bench.sh`         |
+| Prometheus       | 1        | Metrics scraping                                 |
+| Grafana          | 1        | Dashboards                                       |
+
+The values mirror `examples/gke/values.yaml` (cluster mode, remote
+storage, indexing service enabled) but with resources and PVCs sized for
+a laptop — no PVC exceeds 10 GiB.
 
 ## Prerequisites
 
-- [k3s](https://k3s.io/) installed (or use the install script below)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) configured
+- Docker (to run the k3s container and build the HerdDB image)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm 3](https://helm.sh/docs/intro/install/)
-- Docker (for building and saving images)
 
-## Quick start (automated)
+## Quick start
 
 Run the install script from this directory:
 
 ```bash
-./install.sh          # install k3s, import image, install chart
+./install.sh          # start k3s container, import image, install chart
 ./install.sh --build  # also rebuild Docker images with Maven first
 ```
 
-The script installs k3s if needed, imports the Docker image into k3s
-containerd, and installs the Helm chart. Pass `--build` to also rebuild
-the Docker images (`mvn clean install -DskipTests -Pdocker`) before
-importing.
+The script:
 
-## Quick start (manual)
+1. (optional) runs `mvn clean install -DskipTests -Pdocker` at the repo root
+2. starts a privileged `rancher/k3s` container named `herddb-k3s` with
+   port 6443 published on localhost
+3. extracts the kubeconfig to `./.kubeconfig` (gitignored) — the other
+   scripts pick it up automatically
+4. `docker save`s the HerdDB image and imports it into the k3s
+   container's containerd via `ctr images import`
+5. `helm install`s the chart against `values.yaml`
+6. waits for all pods to become Ready
 
-### 1. Install k3s
+All subsequent `kubectl` / `helm` commands in this directory need
+`KUBECONFIG=./.kubeconfig`. The helper scripts under `scripts/` set this
+automatically.
 
-```bash
-curl -sfL https://get.k3s.io | sh -
-```
-
-k3s includes a local-path storage provisioner and Traefik ingress by default.
-
-### 2. Configure kubectl
-
-k3s writes its kubeconfig to `/etc/rancher/k3s/k3s.yaml`:
-
-```bash
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-```
-
-> **Note:** The kubeconfig file is owned by root. Either run commands with
-> `sudo` or copy it to your user:
-> ```bash
-> sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-> sudo chown $(id -u):$(id -g) ~/.kube/config
-> export KUBECONFIG=~/.kube/config
-> ```
-
-### 3. Import the HerdDB Docker image
-
-If you built the image locally with Docker, save and import it into k3s
-containerd:
+Connect with the CLI:
 
 ```bash
-docker save herddb/herddb-server:0.30.0-SNAPSHOT | sudo k3s ctr images import -
-```
-
-> **Tip:** If `k3s ctr` does not work on your version, use the containerd
-> CLI directly:
-> ```bash
-> docker save herddb/herddb-server:0.30.0-SNAPSHOT | \
->   sudo ctr --address /run/k3s/containerd/containerd.sock \
->            --namespace k8s.io images import -
-> ```
-
-### 4. Install the Helm chart
-
-From the `herddb-kubernetes/src/main/helm/herddb/` directory:
-
-```bash
-helm install herddb . -f examples/k3s-local/values.yaml
-```
-
-### 5. Wait for all pods to become ready
-
-```bash
-kubectl get pods -w
-```
-
-You should see 7 pods (server, file-server, minio, zookeeper, bookkeeper,
-indexing-service, and tools) all reach `Running` / `Ready` status.
-
-### 6. Connect with the CLI
-
-```bash
-kubectl exec -it deploy/herddb-tools -- herddb-cli
+export KUBECONFIG=$PWD/.kubeconfig
+kubectl exec -it sts/herddb-tools -- herddb-cli
 ```
 
 Run a test query:
 
 ```sql
 SELECT * FROM SYSTABLES;
+```
+
+## Helper scripts
+
+The `scripts/` directory contains small, independently-callable shell
+scripts intended to be driven either by a human or by the
+`herddb-k3s-bench` Claude subagent:
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/check-cluster.sh` | Print pod status, exit non-zero if any HerdDB pod is not Ready. |
+| `scripts/run-bench.sh <args>` | Forward args to `vector-bench.sh` inside the tools pod, tee output to `reports/run-<ts>.log`. |
+| `scripts/collect-logs.sh` | Dump `kubectl logs` + describe + events into `reports/logs-<ts>/`. |
+| `scripts/write-report.sh <run-log>` | Turn a run log into a markdown report with metrics + cluster state. |
+| `scripts/open-issue.sh --title … --body-file … --logs-dir …` | Open a GH issue with logs attached as collapsible blocks. `--dry-run` skips the API call. |
+
+Example end-to-end benchmark run:
+
+```bash
+./install.sh --build
+./scripts/check-cluster.sh
+./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
+./scripts/write-report.sh reports/run-*.log
 ```
 
 ## Vector search example
@@ -116,10 +98,10 @@ Here is a quick walkthrough using the CLI's Groovy scripting support.
 ### Create a table with a vector column and an index
 
 ```bash
-kubectl exec deploy/herddb-tools -- herddb-cli \
+kubectl exec sts/herddb-tools -- herddb-cli \
   -q "CREATE TABLE documents (id int primary key, content string, embedding floata not null)"
 
-kubectl exec deploy/herddb-tools -- herddb-cli \
+kubectl exec sts/herddb-tools -- herddb-cli \
   -q "CREATE VECTOR INDEX vidx ON documents(embedding)"
 ```
 
@@ -131,7 +113,7 @@ Vector data must be inserted through JDBC prepared statements. The CLI's
 Create a file called `vector_demo.groovy` on the tools pod:
 
 ```bash
-kubectl exec deploy/herddb-tools -- bash -c 'cat > /tmp/vector_demo.groovy << '\''SCRIPT'\''
+kubectl exec sts/herddb-tools -- bash -c 'cat > /tmp/vector_demo.groovy << '\''SCRIPT'\''
 import java.sql.*
 
 // Insert sample documents with 3-dimensional embeddings
@@ -196,7 +178,7 @@ SCRIPT
 Run the script:
 
 ```bash
-kubectl exec deploy/herddb-tools -- herddb-cli -g /tmp/vector_demo.groovy
+kubectl exec sts/herddb-tools -- herddb-cli -g /tmp/vector_demo.groovy
 ```
 
 Expected output:
@@ -231,23 +213,24 @@ The column type for vector data is `floata` (float array).
 
 ## Teardown
 
-Remove the Helm release and PVCs:
+Remove the Helm release, delete PVCs, and destroy the k3s container:
 
 ```bash
 ./teardown.sh
 ```
 
-To also uninstall k3s entirely:
+Keep the k3s container around (e.g., to re-install quickly):
 
 ```bash
-./teardown.sh --remove-k3s
+./teardown.sh --keep-container
 ```
 
-Or manually:
+Manual teardown:
 
 ```bash
+export KUBECONFIG=$PWD/.kubeconfig
 helm uninstall herddb
 kubectl delete pvc -l app.kubernetes.io/instance=herddb
-# Optional: uninstall k3s
-/usr/local/bin/k3s-uninstall.sh
+docker rm -f herddb-k3s
+rm -f .kubeconfig
 ```

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh
@@ -73,7 +73,7 @@ fi
 
 echo "==> Waiting for k3s API to be reachable..."
 for i in {1..60}; do
-    if docker exec "$CONTAINER_NAME" k3s kubectl get --raw=/readyz >/dev/null 2>&1; then
+    if docker exec "$CONTAINER_NAME" kubectl get --raw=/readyz >/dev/null 2>&1; then
         break
     fi
     sleep 2
@@ -91,6 +91,17 @@ docker cp "$CONTAINER_NAME:/etc/rancher/k3s/k3s.yaml" "$KUBECONFIG_FILE" 2>/dev/
 chmod 600 "$KUBECONFIG_FILE"
 echo "==> Wrote kubeconfig to $KUBECONFIG_FILE"
 
+echo "==> Waiting for node to register..."
+for i in {1..60}; do
+    if [[ -n "$(kubectl get nodes -o name 2>/dev/null)" ]]; then
+        break
+    fi
+    sleep 1
+    if [[ $i -eq 60 ]]; then
+        echo "ERROR: no nodes registered within 60s." >&2
+        exit 1
+    fi
+done
 echo "==> Waiting for node to become Ready..."
 kubectl wait --for=condition=ready node --all --timeout=120s >/dev/null
 
@@ -115,13 +126,49 @@ else
 fi
 
 # ── 6. Wait for pods ────────────────────────────────────────────────
+#
+# The indexing service has a cold-start race (see issue #42) where it
+# can lose the ZK file-server discovery window and die with
+# "Hash ring is empty", ending up as a zombie pod (Running but 0/1).
+# As a workaround we retry: after the first wait, any pod still not
+# Ready is deleted and the wait restarts. A clean restart of the
+# indexing service works because ZK has the file-server registered
+# by then.
+wait_pods_ready() {
+    local timeout="$1"
+    kubectl wait --for=condition=ready pod \
+        -l app.kubernetes.io/instance=herddb \
+        --all --timeout="$timeout"
+}
+
+restart_unready_pods() {
+    # Delete any pod owned by the herddb release that is not Ready.
+    # Kubernetes recreates it via the StatefulSet/Deployment owner.
+    local pods
+    pods=$(kubectl get pods -l app.kubernetes.io/instance=herddb \
+        -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==false)]}{.metadata.name}{"\n"}{end}')
+    if [[ -z "$pods" ]]; then
+        return 0
+    fi
+    echo "==> Restarting unready pods: $pods" >&2
+    # shellcheck disable=SC2086
+    kubectl delete pod $pods --wait=false >/dev/null
+}
+
 if $WAIT; then
-    echo "==> Waiting for all pods to become ready (timeout 5m)..."
-    kubectl wait --for=condition=ready pod --all --timeout=300s || {
-        echo "WARNING: not all pods became ready in time." >&2
-        kubectl get pods
-        exit 1
-    }
+    echo "==> Waiting for all HerdDB pods to become ready (timeout 5m)..."
+    if ! wait_pods_ready 300s; then
+        echo "==> Some pods not Ready on first attempt, restarting them..." >&2
+        kubectl get pods >&2
+        restart_unready_pods
+        echo "==> Waiting again (timeout 3m)..."
+        if ! wait_pods_ready 180s; then
+            echo "ERROR: pods still not Ready after restart." >&2
+            kubectl get pods >&2
+            exit 1
+        fi
+    fi
+    kubectl get pods
 fi
 
 cat <<EOF

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh
@@ -1,28 +1,44 @@
 #!/usr/bin/env bash
 #
-# Install HerdDB on a local k3s cluster.
+# Install HerdDB on a local k3s cluster running inside a Docker container.
+#
+# Instead of installing k3s on the host, this script runs the official
+# `rancher/k3s` image in a privileged Docker container, imports the
+# HerdDB image into its containerd, and installs the Helm chart using a
+# kubeconfig pulled out of the container. Nothing is written to the
+# host's /etc/rancher or ~/.kube/config.
 #
 # Usage:
-#   ./install.sh                     # detect k3s, prompt if missing, install chart
-#   ./install.sh --build             # also rebuild Docker images with Maven first
-#   ./install.sh --install-k3s       # install k3s without prompting
+#   ./install.sh                      # start k3s container and install chart
+#   ./install.sh --build              # also rebuild Docker images with Maven first
+#   ./install.sh --k3s-version vX.Y.Z # pin a different rancher/k3s tag
+#   ./install.sh --name mycluster     # use a different container name
+#   ./install.sh --no-wait            # skip waiting for pods to become ready
 #
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 CHART_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-REPO_ROOT="$(cd "$CHART_DIR/../../../.." && pwd)"
+REPO_ROOT="$(cd "$CHART_DIR/../../../../.." && pwd)"
 
 IMAGE="herddb/herddb-server:0.30.0-SNAPSHOT"
-
+K3S_VERSION="v1.31.4-k3s1"
+CONTAINER_NAME="herddb-k3s"
 BUILD=false
-INSTALL_K3S=false
-for arg in "$@"; do
-    case "$arg" in
-        --build)       BUILD=true ;;
-        --install-k3s) INSTALL_K3S=true ;;
+WAIT=true
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build)        BUILD=true; shift ;;
+        --k3s-version)  K3S_VERSION="$2"; shift 2 ;;
+        --name)         CONTAINER_NAME="$2"; shift 2 ;;
+        --no-wait)      WAIT=false; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
     esac
 done
+
+KUBECONFIG_FILE="$SCRIPT_DIR/.kubeconfig"
+export KUBECONFIG="$KUBECONFIG_FILE"
 
 # ── 1. Build Docker images ──────────────────────────────────────────
 if $BUILD; then
@@ -30,37 +46,64 @@ if $BUILD; then
     (cd "$REPO_ROOT" && mvn clean install -DskipTests -Pdocker)
 fi
 
-# ── 2. Ensure k3s is running ────────────────────────────────────────
-if command -v k3s >/dev/null 2>&1 && k3s kubectl get nodes >/dev/null 2>&1; then
-    echo "==> k3s is already running."
-else
-    if ! $INSTALL_K3S; then
-        echo "k3s is not installed or not running."
-        read -rp "Do you want to install k3s now? [y/N] " answer
-        if [[ "$answer" =~ ^[Yy]$ ]]; then
-            INSTALL_K3S=true
-        else
-            echo "Aborting. Install k3s manually or re-run with --install-k3s."
-            exit 1
-        fi
-    fi
-    echo "==> Installing k3s..."
-    curl -sfL https://get.k3s.io | sh -
-    echo "==> Waiting for k3s to be ready..."
-    sleep 5
-    sudo k3s kubectl wait --for=condition=ready node --all --timeout=60s
+# Ensure the image exists locally — it will be side-loaded into k3s.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "ERROR: Docker image $IMAGE not found locally." >&2
+    echo "Build it first with: ./install.sh --build" >&2
+    exit 1
 fi
 
-# ── 3. Configure KUBECONFIG ─────────────────────────────────────────
-# Copy the k3s kubeconfig so that helm/kubectl work without sudo.
-mkdir -p ~/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-sudo chown "$(id -u):$(id -g)" ~/.kube/config
-export KUBECONFIG=~/.kube/config
+# ── 2. Start the k3s container ──────────────────────────────────────
+if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    echo "==> k3s container '$CONTAINER_NAME' is already running."
+elif docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    echo "==> Starting existing k3s container '$CONTAINER_NAME'..."
+    docker start "$CONTAINER_NAME" >/dev/null
+else
+    echo "==> Starting k3s container '$CONTAINER_NAME' (rancher/k3s:$K3S_VERSION)..."
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        --privileged \
+        --tmpfs /run --tmpfs /var/run \
+        -p 6443:6443 \
+        -e K3S_KUBECONFIG_MODE=666 \
+        "rancher/k3s:$K3S_VERSION" \
+        server --disable traefik --disable metrics-server >/dev/null
+fi
 
-# ── 4. Import image into k3s containerd ─────────────────────────────
+echo "==> Waiting for k3s API to be reachable..."
+for i in {1..60}; do
+    if docker exec "$CONTAINER_NAME" k3s kubectl get --raw=/readyz >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+    if [[ $i -eq 60 ]]; then
+        echo "ERROR: k3s API did not become ready within 120s." >&2
+        docker logs --tail=100 "$CONTAINER_NAME" >&2 || true
+        exit 1
+    fi
+done
+
+# ── 3. Extract kubeconfig ───────────────────────────────────────────
+# The kubeconfig inside the container points to https://127.0.0.1:6443,
+# which also works from the host because we published port 6443 above.
+docker cp "$CONTAINER_NAME:/etc/rancher/k3s/k3s.yaml" "$KUBECONFIG_FILE" 2>/dev/null
+chmod 600 "$KUBECONFIG_FILE"
+echo "==> Wrote kubeconfig to $KUBECONFIG_FILE"
+
+echo "==> Waiting for node to become Ready..."
+kubectl wait --for=condition=ready node --all --timeout=120s >/dev/null
+
+# ── 4. Import the HerdDB image into k3s containerd ──────────────────
 echo "==> Importing image $IMAGE into k3s..."
-docker save "$IMAGE" | sudo k3s ctr images import -
+IMAGE_TAR="$(mktemp --suffix=.tar)"
+trap 'rm -f "$IMAGE_TAR"' EXIT
+docker save "$IMAGE" -o "$IMAGE_TAR"
+docker cp "$IMAGE_TAR" "$CONTAINER_NAME:/tmp/herddb.tar"
+docker exec "$CONTAINER_NAME" \
+    ctr --address /run/k3s/containerd/containerd.sock \
+        --namespace k8s.io images import /tmp/herddb.tar >/dev/null
+docker exec "$CONTAINER_NAME" rm -f /tmp/herddb.tar
 
 # ── 5. Install Helm chart ───────────────────────────────────────────
 if helm status herddb >/dev/null 2>&1; then
@@ -72,11 +115,28 @@ else
 fi
 
 # ── 6. Wait for pods ────────────────────────────────────────────────
-echo "==> Waiting for all pods to become ready (timeout 3m)..."
-kubectl wait --for=condition=ready pod --all --timeout=180s
+if $WAIT; then
+    echo "==> Waiting for all pods to become ready (timeout 5m)..."
+    kubectl wait --for=condition=ready pod --all --timeout=300s || {
+        echo "WARNING: not all pods became ready in time." >&2
+        kubectl get pods
+        exit 1
+    }
+fi
 
-echo ""
-echo "==> HerdDB is ready!"
-echo ""
-echo "Connect with the CLI:"
-echo "  kubectl exec -it deploy/herddb-tools -- herddb-cli"
+cat <<EOF
+
+==> HerdDB is ready!
+
+Use this kubeconfig for subsequent commands (scripts already do this):
+  export KUBECONFIG=$KUBECONFIG_FILE
+
+Connect with the CLI:
+  kubectl exec -it sts/herddb-tools -- herddb-cli
+
+Run a vector benchmark:
+  ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
+
+Tear down:
+  ./teardown.sh
+EOF

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/check-cluster.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/check-cluster.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Health check for a HerdDB deployment on the local k3s cluster.
+# Prints pod status and exits non-zero if any HerdDB pod is not Ready.
+#
+# Usage: ./scripts/check-cluster.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+section "HerdDB pods"
+kubectl -n default get pods -l app.kubernetes.io/instance=herddb \
+    -o wide
+
+unhealthy=0
+while read -r pod; do
+    [[ -z "$pod" ]] && continue
+    ready=$(kubectl -n default get pod "$pod" \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+    phase=$(kubectl -n default get pod "$pod" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+    if [[ "$ready" != "True" ]]; then
+        echo "  [NOT READY] $pod (phase=$phase, ready=$ready)" >&2
+        unhealthy=$((unhealthy + 1))
+    fi
+done < <(herddb_pods)
+
+if [[ $unhealthy -gt 0 ]]; then
+    echo ""
+    echo "ERROR: $unhealthy pod(s) not Ready." >&2
+    exit 1
+fi
+
+echo ""
+echo "All HerdDB pods are Ready."

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/collect-logs.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/collect-logs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Dump logs from every HerdDB pod into reports/logs-<timestamp>/.
+# Includes --previous logs if a pod has restarted.
+#
+# Usage: ./scripts/collect-logs.sh [--tail N]
+#
+# On success: prints "LOGS_DIR=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+TAIL=2000
+if [[ "${1:-}" == "--tail" ]]; then
+    TAIL="$2"; shift 2
+fi
+
+TS="$(timestamp)"
+LOGS_DIR="$REPORTS_DIR/logs-$TS"
+mkdir -p "$LOGS_DIR"
+
+section "Collecting logs into $LOGS_DIR"
+
+kubectl -n default get pods -l app.kubernetes.io/instance=herddb \
+    -o wide > "$LOGS_DIR/pods.txt" 2>&1 || true
+kubectl -n default describe pods -l app.kubernetes.io/instance=herddb \
+    > "$LOGS_DIR/describe.txt" 2>&1 || true
+kubectl -n default get events --sort-by=.lastTimestamp \
+    > "$LOGS_DIR/events.txt" 2>&1 || true
+
+while read -r pod; do
+    [[ -z "$pod" ]] && continue
+    echo "  - $pod"
+    kubectl -n default logs "$pod" --all-containers --tail="$TAIL" \
+        > "$LOGS_DIR/$pod.log" 2>&1 || true
+    # Previous logs (only exist if the pod has restarted).
+    kubectl -n default logs "$pod" --all-containers --previous --tail="$TAIL" \
+        > "$LOGS_DIR/$pod.previous.log" 2>/dev/null || \
+        rm -f "$LOGS_DIR/$pod.previous.log"
+done < <(herddb_pods)
+
+echo ""
+echo "LOGS_DIR=$LOGS_DIR"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/common.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/common.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Shared helpers sourced by the other scripts. Not meant to be executed
+# directly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPORTS_DIR="$EXAMPLE_DIR/reports"
+
+KUBECONFIG_FILE="$EXAMPLE_DIR/.kubeconfig"
+if [[ -f "$KUBECONFIG_FILE" ]]; then
+    export KUBECONFIG="$KUBECONFIG_FILE"
+else
+    echo "ERROR: kubeconfig not found at $KUBECONFIG_FILE — run ./install.sh first." >&2
+    exit 1
+fi
+
+mkdir -p "$REPORTS_DIR"
+
+timestamp() { date +%Y%m%d-%H%M%S; }
+
+herddb_pods() {
+    kubectl -n default get pods -l app.kubernetes.io/instance=herddb \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+}
+
+section() { printf '\n==> %s\n' "$1"; }

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/open-issue.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/open-issue.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Open a GitHub issue describing a failed k3s-bench run.
+# Attaches logs from a directory (produced by collect-logs.sh) as
+# collapsible blocks in the issue body. Truncates each log to the last
+# 500 lines so the body stays under GitHub's 65k-character limit.
+#
+# Usage:
+#   ./scripts/open-issue.sh --title "<title>" --body-file <path> --logs-dir <path> [--dry-run]
+#
+# Requires `gh` to be installed and authenticated.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPORTS_DIR="$EXAMPLE_DIR/reports"
+mkdir -p "$REPORTS_DIR"
+
+TITLE=""
+BODY_FILE=""
+LOGS_DIR=""
+DRY_RUN=false
+LABEL="k3s-bench"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)      TITLE="$2"; shift 2 ;;
+        --body-file)  BODY_FILE="$2"; shift 2 ;;
+        --logs-dir)   LOGS_DIR="$2"; shift 2 ;;
+        --label)      LABEL="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$TITLE" || -z "$BODY_FILE" || ! -f "$BODY_FILE" ]]; then
+    echo "Usage: $0 --title <title> --body-file <path> [--logs-dir <path>] [--dry-run]" >&2
+    exit 2
+fi
+
+if ! $DRY_RUN; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "ERROR: 'gh' CLI is not installed." >&2
+        exit 1
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "ERROR: 'gh' is not authenticated. Run 'gh auth login' first." >&2
+        exit 1
+    fi
+fi
+
+TS="$(date +%Y%m%d-%H%M%S)"
+FINAL_BODY="$REPORTS_DIR/issue-body-$TS.md"
+
+{
+    cat "$BODY_FILE"
+    if [[ -n "$LOGS_DIR" && -d "$LOGS_DIR" ]]; then
+        echo ""
+        echo "## Attached pod logs"
+        echo ""
+        echo "_Collected from \`$LOGS_DIR\`. Each log is truncated to the last 500 lines._"
+        echo ""
+        for f in "$LOGS_DIR"/*.txt "$LOGS_DIR"/*.log; do
+            [[ -f "$f" ]] || continue
+            name=$(basename "$f")
+            echo ""
+            echo "<details><summary><code>$name</code></summary>"
+            echo ""
+            echo '```'
+            tail -n 500 "$f"
+            echo '```'
+            echo ""
+            echo '</details>'
+        done
+    fi
+} > "$FINAL_BODY"
+
+echo "==> Issue body written to $FINAL_BODY"
+
+if $DRY_RUN; then
+    echo "==> --dry-run set, not creating GH issue."
+    echo "ISSUE_BODY=$FINAL_BODY"
+    exit 0
+fi
+
+echo "==> Creating GitHub issue..."
+# Ensure the label exists (create if missing). `gh label create` is
+# idempotent with --force.
+gh label create "$LABEL" --description "Automated reports from the k3s vector-bench agent" --force >/dev/null 2>&1 || true
+
+URL=$(gh issue create --title "$TITLE" --body-file "$FINAL_BODY" --label "$LABEL")
+echo "ISSUE_URL=$URL"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/run-bench.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/run-bench.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Run a vector-bench workload against the HerdDB cluster on local k3s.
+# All arguments are forwarded to /opt/herddb/bin/vector-bench.sh inside
+# the tools pod.
+#
+# Usage:
+#   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
+#   ./scripts/run-bench.sh --dataset sift1m -n 100000 --checkpoint
+#
+# On success: writes reports/run-<timestamp>.log and prints its path
+# on the last line (prefixed "RUN_LOG="). Exits non-zero on failure.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <vector-bench args>" >&2
+    echo "Example: $0 --dataset sift10k -n 10000 -k 100 --checkpoint" >&2
+    exit 2
+fi
+
+TS="$(timestamp)"
+RUN_LOG="$REPORTS_DIR/run-$TS.log"
+
+section "Running vector-bench inside sts/herddb-tools"
+echo "  args: $*"
+echo "  log:  $RUN_LOG"
+echo ""
+
+{
+    echo "# vector-bench run $TS"
+    echo "# args: $*"
+    echo "# start: $(date -Iseconds)"
+    echo ""
+} > "$RUN_LOG"
+
+set +e
+kubectl -n default exec sts/herddb-tools -- \
+    /opt/herddb/bin/vector-bench.sh "$@" 2>&1 | tee -a "$RUN_LOG"
+status=${PIPESTATUS[0]}
+set -e
+
+{
+    echo ""
+    echo "# end: $(date -Iseconds)"
+    echo "# exit: $status"
+} >> "$RUN_LOG"
+
+echo ""
+echo "RUN_LOG=$RUN_LOG"
+exit "$status"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/write-report.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/write-report.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Turn a vector-bench run log into a markdown report.
+#
+# Usage: ./scripts/write-report.sh <run-log-path>
+#
+# On success: prints "REPORT=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+RUN_LOG="${1:-}"
+if [[ -z "$RUN_LOG" || ! -f "$RUN_LOG" ]]; then
+    echo "Usage: $0 <run-log-path>" >&2
+    echo "Run log not found: $RUN_LOG" >&2
+    exit 2
+fi
+
+TS="$(timestamp)"
+REPORT="$REPORTS_DIR/report-$TS.md"
+
+# Extract useful bits from the log.
+ARGS_LINE=$(grep -m1 '^# args:' "$RUN_LOG" || echo "# args: (unknown)")
+START_LINE=$(grep -m1 '^# start:' "$RUN_LOG" || echo "# start: (unknown)")
+END_LINE=$(grep -m1 '^# end:' "$RUN_LOG" || echo "# end: (unknown)")
+EXIT_LINE=$(grep -m1 '^# exit:' "$RUN_LOG" || echo "# exit: (unknown)")
+EXIT_CODE=$(echo "$EXIT_LINE" | awk '{print $NF}')
+
+# BENCHMARK SUMMARY block (awk: print from the SUMMARY header until
+# "Benchmark complete" or EOF).
+SUMMARY=$(awk '
+    /^========================================$/ && !seen { seen=1; in_summary=1 }
+    in_summary { print }
+    /^Benchmark complete/ { in_summary=0 }
+' "$RUN_LOG" || true)
+
+# phase=... key=value lines, extracted for a compact table.
+PHASE_LINES=$(grep -E '^phase=' "$RUN_LOG" || true)
+
+# Cluster state.
+CLUSTER_STATE=$("$SCRIPT_DIR/check-cluster.sh" 2>&1 || true)
+
+# Last 200 lines of the run log for an excerpt.
+LOG_TAIL=$(tail -n 200 "$RUN_LOG")
+
+{
+    echo "# HerdDB vector-bench report — $TS"
+    echo ""
+    echo "**Status:** $([[ "$EXIT_CODE" == "0" ]] && echo ":white_check_mark: success" || echo ":x: failed (exit=$EXIT_CODE)")"
+    echo ""
+    echo "## Workload"
+    echo ""
+    echo '```'
+    echo "${ARGS_LINE#\# args: }"
+    echo "${START_LINE#\# }"
+    echo "${END_LINE#\# }"
+    echo "${EXIT_LINE#\# }"
+    echo '```'
+    echo ""
+    echo "## Cluster state"
+    echo ""
+    echo '```'
+    echo "$CLUSTER_STATE"
+    echo '```'
+    echo ""
+    if [[ -n "$PHASE_LINES" ]]; then
+        echo "## Phase metrics"
+        echo ""
+        echo '```'
+        echo "$PHASE_LINES"
+        echo '```'
+        echo ""
+    fi
+    if [[ -n "$SUMMARY" ]]; then
+        echo "## Benchmark summary"
+        echo ""
+        echo '```'
+        echo "$SUMMARY"
+        echo '```'
+        echo ""
+    fi
+    echo "## Run log (last 200 lines)"
+    echo ""
+    echo '<details><summary>expand</summary>'
+    echo ""
+    echo '```'
+    echo "$LOG_TAIL"
+    echo '```'
+    echo ""
+    echo '</details>'
+    echo ""
+    echo "---"
+    echo ""
+    echo "_Full log: \`$RUN_LOG\`_"
+} > "$REPORT"
+
+echo ""
+echo "REPORT=$REPORT"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/teardown.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/teardown.sh
@@ -1,51 +1,51 @@
 #!/usr/bin/env bash
 #
-# Teardown HerdDB from a local k3s cluster.
+# Tear down HerdDB from a local k3s-in-docker cluster.
 #
 # Usage:
-#   ./teardown.sh              # uninstall Helm release and delete PVCs
-#   ./teardown.sh --remove-k3s # also uninstall k3s entirely
+#   ./teardown.sh                   # uninstall chart AND remove k3s container
+#   ./teardown.sh --keep-container  # only uninstall chart, leave k3s running
+#   ./teardown.sh --name mycluster  # use a non-default container name
 #
 set -euo pipefail
 
-KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-export KUBECONFIG
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 
-# Fall back to the k3s default if the user kubeconfig doesn't exist yet.
-if [[ ! -f "$KUBECONFIG" ]] && [[ -f /etc/rancher/k3s/k3s.yaml ]]; then
-    KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    export KUBECONFIG
-fi
+CONTAINER_NAME="herddb-k3s"
+KEEP_CONTAINER=false
 
-REMOVE_K3S=false
-if [[ "${1:-}" == "--remove-k3s" ]]; then
-    REMOVE_K3S=true
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-container) KEEP_CONTAINER=true; shift ;;
+        --name)           CONTAINER_NAME="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+KUBECONFIG_FILE="$SCRIPT_DIR/.kubeconfig"
+if [[ -f "$KUBECONFIG_FILE" ]]; then
+    export KUBECONFIG="$KUBECONFIG_FILE"
 fi
 
 # ── 1. Uninstall Helm release ───────────────────────────────────────
-if helm status herddb >/dev/null 2>&1; then
+if [[ -f "$KUBECONFIG_FILE" ]] && helm status herddb >/dev/null 2>&1; then
     echo "==> Uninstalling Helm release 'herddb'..."
-    helm uninstall herddb
+    helm uninstall herddb || true
+    echo "==> Deleting PersistentVolumeClaims..."
+    kubectl delete pvc -l app.kubernetes.io/instance=herddb --ignore-not-found || true
 else
     echo "==> Helm release 'herddb' not found, skipping."
 fi
 
-# ── 2. Delete PersistentVolumeClaims ────────────────────────────────
-echo "==> Deleting PersistentVolumeClaims..."
-kubectl delete pvc -l app.kubernetes.io/instance=herddb --ignore-not-found
-
-# ── 3. Optionally uninstall k3s ─────────────────────────────────────
-if $REMOVE_K3S; then
-    if [[ -x /usr/local/bin/k3s-uninstall.sh ]]; then
-        echo "==> Uninstalling k3s..."
-        /usr/local/bin/k3s-uninstall.sh
-    else
-        echo "==> k3s uninstall script not found at /usr/local/bin/k3s-uninstall.sh"
-    fi
+# ── 2. Stop and remove k3s container ────────────────────────────────
+if $KEEP_CONTAINER; then
+    echo "==> Leaving k3s container '$CONTAINER_NAME' running (--keep-container)."
+elif docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    echo "==> Removing k3s container '$CONTAINER_NAME'..."
+    docker rm -f "$CONTAINER_NAME" >/dev/null
+    rm -f "$KUBECONFIG_FILE"
 else
-    echo ""
-    echo "k3s is still running. To remove it entirely:"
-    echo "  /usr/local/bin/k3s-uninstall.sh"
+    echo "==> k3s container '$CONTAINER_NAME' not found."
 fi
 
 echo ""

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -1,126 +1,140 @@
-# Full-stack HerdDB on a local k3s cluster.
+# Full-stack HerdDB on a local k3s-in-docker cluster.
 #
-# Deploys: HerdDB server (cluster mode) + file server (S3 on MinIO) +
-#           indexing service + ZooKeeper + BookKeeper + MinIO + tools pod.
+# Deploys: HerdDB server (cluster mode, remote storage) + file server
+# (S3 on MinIO) + indexing service + ZooKeeper + BookKeeper + MinIO +
+# tools pod + Prometheus + Grafana.
 #
-# Install:
-#   helm install herddb . -f examples/k3s-local/values.yaml
+# Mirrors the structure of examples/gke/values.yaml but with resources
+# and PVCs sized for a developer laptop. No PVC exceeds 10 GiB.
+#
+# Install via ./install.sh (which runs k3s inside a Docker container
+# and imports the HerdDB image into containerd so imagePullPolicy=Never
+# works).
+
+image:
+  pullPolicy: Never
 
 server:
   mode: cluster
   storageMode: remote
   replicaCount: 1
-  javaOpts: "-Xms512m -Xmx512m"
+  javaOpts: "-Xms1g -Xmx1g -Djava.net.preferIPv4Stack=true"
   storage:
     data:
-      size: 2Gi
+      size: 5Gi
     commitlog:
-      size: 1Gi
+      size: 2Gi
   resources:
     requests:
-      memory: "768Mi"
+      memory: "2Gi"
       cpu: "0.5"
     limits:
-      memory: "768Mi"
+      memory: "2Gi"
       cpu: "1"
 
 fileServer:
   replicaCount: 1
   storageMode: s3
-  javaOpts: "-Xms256m -Xmx384m -Djava.net.preferIPv4Stack=true"
-  # S3 endpoint, bucket, and credentials are auto-configured from the
-  # minio section below — no need to set them explicitly.
+  javaOpts: "-Xms1g -Xmx1g -Djava.net.preferIPv4Stack=true"
+  # S3 endpoint, bucket, and credentials are auto-wired from the
+  # minio section below.
   storage:
-    size: 2Gi
+    size: 10Gi
+  # Local disk cache sized to match the PVC (10 GiB = 10737418240 bytes).
+  cacheMaxBytes: 10737418240
   resources:
     requests:
-      memory: "512Mi"
+      memory: "1536Mi"
       cpu: "0.5"
     limits:
-      memory: "512Mi"
+      memory: "1536Mi"
       cpu: "1"
 
 minio:
   enabled: true
   storage:
-    size: 5Gi
+    size: 10Gi
   resources:
     requests:
       memory: "256Mi"
       cpu: "0.25"
     limits:
-      memory: "256Mi"
+      memory: "512Mi"
       cpu: "0.5"
 
 zookeeper:
   enabled: true
-  javaOpts: "-Xms128m -Xmx256m"
-  storage:
-    size: 1Gi
-  resources:
-    requests:
-      memory: "512Mi"
-      cpu: "0.25"
-    limits:
-      memory: "512Mi"
-      cpu: "0.5"
-
-bookkeeper:
-  enabled: true
-  javaOpts: "-Xms256m -Xmx384m"
-  storage:
-    journal:
-      size: 1Gi
-    ledger:
-      size: 2Gi
-  resources:
-    requests:
-      memory: "512Mi"
-      cpu: "0.25"
-    limits:
-      memory: "512Mi"
-      cpu: "0.5"
-
-indexingService:
-  enabled: true
-  replicaCount: 1
-  javaOpts: "-Xms384m -Xmx512m -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector"
-  storage:
-    data:
-      size: 2Gi
-    log:
-      size: 1Gi
-  resources:
-    requests:
-      memory: "768Mi"
-      cpu: "0.5"
-    limits:
-      memory: "768Mi"
-      cpu: "1"
-
-tools:
-  enabled: true
-  resources:
-    requests:
-      memory: "512Mi"
-      cpu: "0.25"
-    limits:
-      memory: "512Mi"
-      cpu: "0.5"
-
-vectorBench:
-  enabled: false
-
-prometheus:
-  enabled: true
+  javaOpts: "-Xms512m -Xmx512m -Djava.net.preferIPv4Stack=true"
   storage:
     size: 2Gi
   resources:
     requests:
-      memory: "256Mi"
+      memory: "768Mi"
       cpu: "0.25"
     limits:
+      memory: "768Mi"
+      cpu: "0.5"
+
+bookkeeper:
+  enabled: true
+  replicaCount: 1
+  javaOpts: "-Xms512m -Xmx512m -Djava.net.preferIPv4Stack=true"
+  extraConfig:
+    journalWriteData: "false"
+  storage:
+    journal:
+      size: 1Gi
+    ledger:
+      size: 5Gi
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "0.25"
+    limits:
+      memory: "1Gi"
+      cpu: "0.5"
+
+indexingService:
+  enabled: true
+  storageMode: remote
+  replicaCount: 1
+  javaOpts: "-Xms2g -Xmx2g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector"
+  storage:
+    data:
+      size: 5Gi
+    log:
+      size: 2Gi
+  resources:
+    requests:
+      memory: "3Gi"
+      cpu: "0.5"
+    limits:
+      memory: "3Gi"
+      cpu: "1"
+
+tools:
+  enabled: true
+  storage:
+    datasets:
+      size: 10Gi
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "0.25"
+    limits:
+      memory: "512Mi"
+      cpu: "0.5"
+
+prometheus:
+  enabled: true
+  storage:
+    size: 1Gi
+  resources:
+    requests:
       memory: "256Mi"
+      cpu: "0.1"
+    limits:
+      memory: "512Mi"
       cpu: "0.25"
 
 grafana:
@@ -130,5 +144,5 @@ grafana:
       memory: "128Mi"
       cpu: "0.1"
     limits:
-      memory: "128Mi"
+      memory: "256Mi"
       cpu: "0.25"


### PR DESCRIPTION
## Summary

- Rewrite `examples/k3s-local/` to run `rancher/k3s` inside a privileged Docker container (mirroring the pattern from `HerdDBKubernetesIT`), eliminating host `sudo`/`/etc/rancher` changes. Kubeconfig is extracted to a gitignored `./.kubeconfig`.
- Rewrite `examples/k3s-local/values.yaml` to mirror `examples/gke/values.yaml` (cluster mode, remote storage, indexing service, Prometheus, Grafana) but with laptop-sized resources and every PVC capped at 10 GiB. MinIO stays enabled so the example is self-contained.
- Add helper scripts under `examples/k3s-local/scripts/`: `check-cluster.sh`, `run-bench.sh`, `collect-logs.sh`, `write-report.sh`, `open-issue.sh`. Each is a single-purpose entry point with a line-prefixed capture protocol (`RUN_LOG=…`, `LOGS_DIR=…`, `REPORT=…`, `ISSUE_URL=…`).
- Add `.claude/agents/herddb-k3s-bench.md` — a Claude subagent that orchestrates install → health check → vector-bench workload → markdown report, and on failure collects pod logs and opens a GitHub issue with logs attached as collapsible blocks. Default workload matches `sift10k -n 10000 -k 100 --checkpoint`.
- Unignore `.claude/agents/` in the root `.gitignore` so the subagent ships with the repo.

## Test plan

- [ ] `cd herddb-kubernetes/src/main/helm/herddb/examples/k3s-local && ./install.sh --build` — k3s container comes up, image is imported, all pods reach Ready
- [ ] `./scripts/check-cluster.sh` exits 0
- [ ] `KUBECONFIG=\$PWD/.kubeconfig kubectl exec sts/herddb-tools -- herddb-cli -q "SELECT * FROM SYSTABLES"` returns rows
- [ ] `./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint` completes and produces `reports/run-*.log`
- [ ] `./scripts/write-report.sh reports/run-*.log` produces a markdown report with `phase=…` metrics and a BENCHMARK SUMMARY block
- [ ] `./scripts/collect-logs.sh` dumps per-pod logs into `reports/logs-*`
- [ ] `./scripts/open-issue.sh --title test --body-file reports/report-*.md --logs-dir reports/logs-* --dry-run` builds an issue body without hitting the API
- [ ] `./teardown.sh` removes the helm release and the k3s container

🤖 Generated with [Claude Code](https://claude.com/claude-code)