### PR TITLE
Fix indexing-service cold-start race and zombie pod (#42)

### DIFF
--- a/herddb-core/src/main/java/herddb/server/DynamicServiceClient.java
+++ b/herddb-core/src/main/java/herddb/server/DynamicServiceClient.java
@@ -29,4 +29,13 @@ import java.util.List;
  */
 public interface DynamicServiceClient {
     void updateServers(List<String> servers);
+
+    /**
+     * Blocks for up to {@code timeoutMs} milliseconds until the client has at
+     * least one server in its routing table. Returns {@code true} as soon as a
+     * server is visible, {@code false} on timeout. Intended for use at
+     * bootstrap on a cold cluster where service discovery may not yet have
+     * populated the server list by the time the first RPC is issued.
+     */
+    boolean awaitServersReady(long timeoutMs) throws InterruptedException;
 }

--- a/herddb-core/src/main/java/herddb/server/RemoteFileClient.java
+++ b/herddb-core/src/main/java/herddb/server/RemoteFileClient.java
@@ -1,0 +1,41 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+/**
+ * Minimal blocking file-service client contract, lifted into herddb-core so
+ * modules that cannot take a compile-time dependency on
+ * {@code herddb-remote-file-service} (e.g. {@code herddb-indexing-service})
+ * can still invoke the client through an interface instead of reflection.
+ */
+public interface RemoteFileClient extends DynamicServiceClient {
+
+    /**
+     * Writes the given content to {@code path}, creating or overwriting.
+     */
+    void writeFile(String path, byte[] content);
+
+    /**
+     * Reads the bytes at {@code path}, or returns {@code null} if the file
+     * does not exist.
+     */
+    byte[] readFile(String path);
+}

--- a/herddb-core/src/main/java/herddb/server/RemoteFileServiceFactory.java
+++ b/herddb-core/src/main/java/herddb/server/RemoteFileServiceFactory.java
@@ -1,0 +1,79 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import herddb.storage.DataStorageManager;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Factory for constructing {@code herddb-remote-file-service} components
+ * without a compile-time dependency on that module. Loaded reflectively
+ * once at startup via
+ * {@link #load()} and used through typed interfaces afterward.
+ */
+public interface RemoteFileServiceFactory {
+
+    /**
+     * FQN of the implementation shipped in {@code herddb-remote-file-service}.
+     */
+    String IMPL_CLASS_NAME = "herddb.remote.RemoteFileServiceFactoryImpl";
+
+    /**
+     * Loads the implementation reflectively from the current context class
+     * loader. Throws {@link RuntimeException} with a helpful message if the
+     * implementation is not on the classpath.
+     */
+    static RemoteFileServiceFactory load() {
+        try {
+            Class<?> impl = Class.forName(IMPL_CLASS_NAME);
+            return (RemoteFileServiceFactory) impl.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(
+                    "Cannot load " + IMPL_CLASS_NAME
+                            + ". Ensure herddb-remote-file-service is on the classpath.", e);
+        }
+    }
+
+    RemoteFileClient createClient(List<String> servers, Map<String, Object> config);
+
+    SharedCheckpointMetadata createSharedCheckpointMetadata(RemoteFileClient client);
+
+    /**
+     * Creates a writable data storage manager backed by the remote file
+     * service. The returned value is both a {@link DataStorageManager} and a
+     * {@link RemoteFileStorageManager}.
+     */
+    DataStorageManager createDataStorageManager(
+            Path dataDirectory, Path tmpDirectory, int swapThreshold, RemoteFileClient client);
+
+    /**
+     * Creates a promotable (initially read-only) data storage manager for
+     * shared-storage replicas.
+     */
+    DataStorageManager createPromotableDataStorageManager(
+            RemoteFileClient client,
+            SharedCheckpointMetadata metadata,
+            Path dataDirectory,
+            Path tmpDirectory,
+            int swapThreshold);
+}

--- a/herddb-core/src/main/java/herddb/server/RemoteFileStorageManager.java
+++ b/herddb-core/src/main/java/herddb/server/RemoteFileStorageManager.java
@@ -1,0 +1,48 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import herddb.log.LogSequenceNumber;
+import java.util.function.Function;
+
+/**
+ * Subset of {@code RemoteFileDataStorageManager}'s configuration API exposed
+ * to modules that cannot take a compile-time dependency on
+ * {@code herddb-remote-file-service}. Implementations also extend
+ * {@code DataStorageManager}.
+ */
+public interface RemoteFileStorageManager {
+
+    /**
+     * Enables publication of checkpoint metadata to remote storage for
+     * shared-storage read replicas.
+     */
+    void setSharedCheckpointMetadataManager(SharedCheckpointMetadata manager);
+
+    /**
+     * Enables deferred page deletion so read replicas can safely consume
+     * pages from old checkpoints.
+     */
+    void setRetentionPolicy(
+            Function<String, LogSequenceNumber> minReplicaLsnSupplier,
+            long minRetentionMillis,
+            long maxRetentionMillis);
+}

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -55,7 +55,6 @@ import herddb.security.UserManager;
 import herddb.storage.DataStorageManager;
 import herddb.utils.Version;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -451,84 +450,74 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
                         configuration.getInt(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
                                 ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT));
-                try {
-                    Class<?> clientClass = Class.forName("herddb.remote.RemoteFileServiceClient");
-                    Object client = clientClass.getConstructor(List.class, Map.class).newInstance(servers, clientConfig);
-                    // Set up ZK-based discovery listener if applicable
-                    if (useZKDiscovery && client instanceof DynamicServiceClient) {
-                        DynamicServiceClient dynamicClient = (DynamicServiceClient) client;
-                        metadataStorageManager.addServiceDiscoveryListener(
-                                new herddb.metadata.ServiceDiscoveryListener() {
-                                    @Override
-                                    public void onIndexingServicesChanged(List<String> currentAddresses) {
-                                        // handled by ServerMain for IndexingServiceClient
-                                    }
+                RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
+                RemoteFileClient client = factory.createClient(servers, clientConfig);
+                // Set up ZK-based discovery listener if applicable
+                if (useZKDiscovery) {
+                    metadataStorageManager.addServiceDiscoveryListener(
+                            new herddb.metadata.ServiceDiscoveryListener() {
+                                @Override
+                                public void onIndexingServicesChanged(List<String> currentAddresses) {
+                                    // handled by ServerMain for IndexingServiceClient
+                                }
 
-                                    @Override
-                                    public void onFileServersChanged(List<String> currentAddresses) {
-                                        LOGGER.log(Level.INFO, "Remote file servers changed via ZK: {0}",
-                                                currentAddresses);
-                                        dynamicClient.updateServers(currentAddresses);
-                                    }
-                                });
-                        // Re-query after listener registration to close the race window
-                        // between the initial listFileServers() (which sets a one-shot ZK
-                        // watcher) and addServiceDiscoveryListener().  If the file server
-                        // registered in that gap the watcher notification was lost.
-                        try {
-                            List<String> currentServers = metadataStorageManager.listFileServers();
-                            if (!currentServers.isEmpty()) {
-                                dynamicClient.updateServers(currentServers);
-                            }
-                        } catch (Exception e) {
-                            LOGGER.log(Level.WARNING, "Failed to re-query file servers after listener registration", e);
+                                @Override
+                                public void onFileServersChanged(List<String> currentAddresses) {
+                                    LOGGER.log(Level.INFO, "Remote file servers changed via ZK: {0}",
+                                            currentAddresses);
+                                    client.updateServers(currentAddresses);
+                                }
+                            });
+                    // Re-query after listener registration to close the race window
+                    // between the initial listFileServers() (which sets a one-shot ZK
+                    // watcher) and addServiceDiscoveryListener().  If the file server
+                    // registered in that gap the watcher notification was lost.
+                    try {
+                        List<String> currentServers = metadataStorageManager.listFileServers();
+                        if (!currentServers.isEmpty()) {
+                            client.updateServers(currentServers);
                         }
+                    } catch (Exception e) {
+                        LOGGER.log(Level.WARNING, "Failed to re-query file servers after listener registration", e);
                     }
-                    Class<?> storageClass = Class.forName("herddb.remote.RemoteFileDataStorageManager");
-                    Constructor<?> ctor = storageClass.getConstructor(Path.class, Path.class, int.class, clientClass);
-                    Object dsm = ctor.newInstance(dataDirectory, tmpDirectory, diskswapThreshold, client);
-
-                    // Optionally enable checkpoint metadata publication to S3 for read replicas
-                    boolean publishToRemote = configuration.getBoolean(
-                            ServerConfiguration.PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE,
-                            ServerConfiguration.PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE_DEFAULT);
-                    if (publishToRemote) {
-                        LOGGER.log(Level.INFO, "Checkpoint metadata publication to remote storage enabled");
-                        Class<?> metaMgrClass = Class.forName("herddb.remote.SharedCheckpointMetadataManager");
-                        Object metaMgr = metaMgrClass.getConstructor(clientClass).newInstance(client);
-                        storageClass.getMethod("setSharedCheckpointMetadataManager", metaMgrClass)
-                                .invoke(dsm, metaMgr);
-
-                        // Enable deferred page deletion so replicas can safely consume old pages.
-                        long minRetentionMillis = configuration.getLong(
-                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS,
-                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS_DEFAULT);
-                        long maxRetentionMillis = configuration.getLong(
-                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS,
-                                ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS_DEFAULT);
-                        final MetadataStorageManager msm = metadataStorageManager;
-                        java.util.function.Function<String, herddb.log.LogSequenceNumber> supplier = tableSpaceUuid -> {
-                            try {
-                                return msm.getMinReplicaCheckpointLsn(tableSpaceUuid);
-                            } catch (Exception e) {
-                                LOGGER.log(Level.WARNING,
-                                        "Failed to read min replica LSN from metadata for " + tableSpaceUuid, e);
-                                return null;
-                            }
-                        };
-                        storageClass.getMethod("setRetentionPolicy",
-                                java.util.function.Function.class, long.class, long.class)
-                                .invoke(dsm, supplier, minRetentionMillis, maxRetentionMillis);
-                        LOGGER.log(Level.INFO,
-                                "Replica-aware page retention enabled: min={0}ms, max={1}ms",
-                                new Object[]{minRetentionMillis, maxRetentionMillis});
-                    }
-
-                    return (DataStorageManager) dsm;
-                } catch (ReflectiveOperationException e) {
-                    throw new RuntimeException("Cannot create RemoteFileDataStorageManager. "
-                            + "Ensure herddb-remote-file-service is on the classpath.", e);
                 }
+                DataStorageManager dsm = factory.createDataStorageManager(
+                        dataDirectory, tmpDirectory, diskswapThreshold, client);
+
+                // Optionally enable checkpoint metadata publication to S3 for read replicas
+                boolean publishToRemote = configuration.getBoolean(
+                        ServerConfiguration.PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE,
+                        ServerConfiguration.PROPERTY_CHECKPOINT_PUBLISH_TO_REMOTE_DEFAULT);
+                if (publishToRemote) {
+                    LOGGER.log(Level.INFO, "Checkpoint metadata publication to remote storage enabled");
+                    SharedCheckpointMetadata metaMgr = factory.createSharedCheckpointMetadata(client);
+                    RemoteFileStorageManager remoteDsm = (RemoteFileStorageManager) dsm;
+                    remoteDsm.setSharedCheckpointMetadataManager(metaMgr);
+
+                    // Enable deferred page deletion so replicas can safely consume old pages.
+                    long minRetentionMillis = configuration.getLong(
+                            ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS,
+                            ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MIN_MILLIS_DEFAULT);
+                    long maxRetentionMillis = configuration.getLong(
+                            ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS,
+                            ServerConfiguration.PROPERTY_CHECKPOINT_REPLICA_RETENTION_MAX_MILLIS_DEFAULT);
+                    final MetadataStorageManager msm = metadataStorageManager;
+                    java.util.function.Function<String, herddb.log.LogSequenceNumber> supplier = tableSpaceUuid -> {
+                        try {
+                            return msm.getMinReplicaCheckpointLsn(tableSpaceUuid);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.WARNING,
+                                    "Failed to read min replica LSN from metadata for " + tableSpaceUuid, e);
+                            return null;
+                        }
+                    };
+                    remoteDsm.setRetentionPolicy(supplier, minRetentionMillis, maxRetentionMillis);
+                    LOGGER.log(Level.INFO,
+                            "Replica-aware page retention enabled: min={0}ms, max={1}ms",
+                            new Object[]{minRetentionMillis, maxRetentionMillis});
+                }
+
+                return dsm;
             }
             default:
                 throw new RuntimeException("invalid " + ServerConfiguration.PROPERTY_STORAGE_MODE + "=" + storageMode);
@@ -560,53 +549,39 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
                 configuration.getInt(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
                         ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT));
-        try {
-            Class<?> clientClass = Class.forName("herddb.remote.RemoteFileServiceClient");
-            Object client = clientClass.getConstructor(List.class, Map.class).newInstance(servers, clientConfig);
-            // Set up ZK-based discovery listener if applicable
-            if (useZKDiscovery && client instanceof DynamicServiceClient) {
-                DynamicServiceClient dynamicClient = (DynamicServiceClient) client;
-                metadataStorageManager.addServiceDiscoveryListener(
-                        new herddb.metadata.ServiceDiscoveryListener() {
-                            @Override
-                            public void onIndexingServicesChanged(List<String> currentAddresses) {
-                            }
-                            @Override
-                            public void onFileServersChanged(List<String> currentAddresses) {
-                                LOGGER.log(Level.INFO, "Remote file servers changed via ZK (shared-storage): {0}",
-                                        currentAddresses);
-                                dynamicClient.updateServers(currentAddresses);
-                            }
-                        });
-                // Re-query after listener registration to close the race window
-                // between the initial listFileServers() and addServiceDiscoveryListener().
-                try {
-                    List<String> currentServers = metadataStorageManager.listFileServers();
-                    if (!currentServers.isEmpty()) {
-                        dynamicClient.updateServers(currentServers);
-                    }
-                } catch (Exception e) {
-                    LOGGER.log(Level.WARNING,
-                            "Failed to re-query file servers after listener registration (shared-storage)", e);
+        RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
+        RemoteFileClient client = factory.createClient(servers, clientConfig);
+        // Set up ZK-based discovery listener if applicable
+        if (useZKDiscovery) {
+            metadataStorageManager.addServiceDiscoveryListener(
+                    new herddb.metadata.ServiceDiscoveryListener() {
+                        @Override
+                        public void onIndexingServicesChanged(List<String> currentAddresses) {
+                        }
+                        @Override
+                        public void onFileServersChanged(List<String> currentAddresses) {
+                            LOGGER.log(Level.INFO, "Remote file servers changed via ZK (shared-storage): {0}",
+                                    currentAddresses);
+                            client.updateServers(currentAddresses);
+                        }
+                    });
+            // Re-query after listener registration to close the race window
+            // between the initial listFileServers() and addServiceDiscoveryListener().
+            try {
+                List<String> currentServers = metadataStorageManager.listFileServers();
+                if (!currentServers.isEmpty()) {
+                    client.updateServers(currentServers);
                 }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING,
+                        "Failed to re-query file servers after listener registration (shared-storage)", e);
             }
-            // Create SharedCheckpointMetadataManager + ReadReplicaDataStorageManager
-            // wrapped in PromotableRemoteFileDataStorageManager for failover support
-            Class<?> metaMgrClass = Class.forName("herddb.remote.SharedCheckpointMetadataManager");
-            Object metaMgr = metaMgrClass.getConstructor(clientClass).newInstance(client);
-            Class<?> readReplicaClass = Class.forName("herddb.remote.ReadReplicaDataStorageManager");
-            Constructor<?> readReplicaCtor = readReplicaClass.getConstructor(clientClass, metaMgrClass, Path.class, int.class);
-            Object readReplica = readReplicaCtor.newInstance(client, metaMgr, tmpDirectory, diskswapThreshold);
-
-            Class<?> promotableClass = Class.forName("herddb.remote.PromotableRemoteFileDataStorageManager");
-            Constructor<?> promotableCtor = promotableClass.getConstructor(
-                    readReplicaClass, clientClass, metaMgrClass, Path.class, Path.class, int.class);
-            return (DataStorageManager) promotableCtor.newInstance(
-                    readReplica, client, metaMgr, dataDirectory, tmpDirectory, diskswapThreshold);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Cannot create PromotableRemoteFileDataStorageManager. "
-                    + "Ensure herddb-remote-file-service is on the classpath.", e);
         }
+        // Create SharedCheckpointMetadata + PromotableRemoteFileDataStorageManager
+        // (wraps a ReadReplicaDataStorageManager) for failover support.
+        SharedCheckpointMetadata metaMgr = factory.createSharedCheckpointMetadata(client);
+        return factory.createPromotableDataStorageManager(
+                client, metaMgr, dataDirectory, tmpDirectory, diskswapThreshold);
     }
 
     protected CommitLogManager buildCommitLogManager() {

--- a/herddb-core/src/main/java/herddb/server/SharedCheckpointMetadata.java
+++ b/herddb-core/src/main/java/herddb/server/SharedCheckpointMetadata.java
@@ -1,0 +1,42 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Minimal view of the shared checkpoint metadata manager exposed to modules
+ * that cannot take a compile-time dependency on
+ * {@code herddb-remote-file-service}.
+ */
+public interface SharedCheckpointMetadata {
+
+    /**
+     * Downloads the checkpoint metadata files for the given tableSpace from
+     * shared storage into {@code localMetadataDir}, so the local
+     * {@code FileDataStorageManager} can read them as if they had always been
+     * on disk.
+     *
+     * @return number of files hydrated
+     */
+    int hydrateLocalMetadataDir(Path localMetadataDir, String tableSpace) throws IOException;
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -392,6 +392,44 @@ public class IndexingServer implements AutoCloseable {
         int instanceId = config.getInt(IndexingServerConfiguration.PROPERTY_INSTANCE_ID,
                 IndexingServerConfiguration.PROPERTY_INSTANCE_ID_DEFAULT);
         final Object clientRef = remoteFileServiceClient;
+
+        // Before issuing the first readFile for the watermark, block until the
+        // remote file client has at least one server in its consistent-hash
+        // ring. On a cold k3s boot the indexing service can race the
+        // file-server's ZK registration; without this wait the very first
+        // S3WatermarkStore.load() would throw "Hash ring is empty" and leave
+        // the pod in a zombie state. See #42.
+        long bootstrapWaitMs = config.getLong(
+                IndexingServerConfiguration.PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS,
+                IndexingServerConfiguration.PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS_DEFAULT);
+        try {
+            boolean ready = (Boolean) clientRef.getClass()
+                    .getMethod("awaitServersReady", long.class)
+                    .invoke(clientRef, bootstrapWaitMs);
+            if (!ready) {
+                throw new RuntimeException(
+                        "Timed out after " + bootstrapWaitMs + "ms waiting for remote file"
+                                + " servers to be discovered via ZK for tableSpace "
+                                + tableSpaceUUID);
+            }
+        } catch (NoSuchMethodException nsme) {
+            // Older client jar without awaitServersReady: log and continue;
+            // retryAsync in the client should still save us, just noisier.
+            LOGGER.log(Level.WARNING,
+                    "RemoteFileServiceClient has no awaitServersReady(long) method; "
+                            + "skipping bootstrap wait. Upgrade herddb-remote-file-service to fix.");
+        } catch (java.lang.reflect.InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            if (cause instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(
+                        "Interrupted while waiting for remote file servers to be discovered", cause);
+            }
+            throw new RuntimeException(cause);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         S3WatermarkStore.RemoteFileIO io = new S3WatermarkStore.RemoteFileIO() {
             @Override
             public void writeFile(String path, byte[] content) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -28,13 +28,14 @@ import herddb.file.FileDataStorageManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.metadata.MetadataStorageManager;
 import herddb.metadata.ServiceDiscoveryListener;
-import herddb.server.DynamicServiceClient;
 import herddb.server.RemoteFileClient;
+import herddb.server.RemoteFileServiceFactory;
+import herddb.server.RemoteFileStorageManager;
+import herddb.server.SharedCheckpointMetadata;
 import herddb.storage.DataStorageManager;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,8 +77,8 @@ public class IndexingServer implements AutoCloseable {
     // When storage.type=remote, these are set by buildDataStorageManager
     // and consumed by the tablespace-resolved hook.
     private RemoteFileClient remoteFileServiceClient;
-    private Object sharedCheckpointMetadataManager;
-    private Object remoteDataStorageManager;
+    private SharedCheckpointMetadata sharedCheckpointMetadataManager;
+    private RemoteFileStorageManager remoteDataStorageManager;
     private Path remoteMetaDir;
 
     public IndexingServer(String host, int port, IndexingServiceEngine engine, IndexingServerConfiguration config) {
@@ -168,11 +169,9 @@ public class IndexingServer implements AutoCloseable {
                         config.getInt(IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES,
                                 IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT));
                 try {
-                    Class<?> clientClass = Class.forName("herddb.remote.RemoteFileServiceClient");
-                    Object client = clientClass.getConstructor(List.class, Map.class)
-                            .newInstance(servers, clientConfig);
-                    if (useZKDiscovery && client instanceof DynamicServiceClient) {
-                        DynamicServiceClient dynamicClient = (DynamicServiceClient) client;
+                    RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
+                    RemoteFileClient client = factory.createClient(servers, clientConfig);
+                    if (useZKDiscovery) {
                         metadataStorageManager.addServiceDiscoveryListener(
                                 new ServiceDiscoveryListener() {
                                     @Override
@@ -185,7 +184,7 @@ public class IndexingServer implements AutoCloseable {
                                         LOGGER.log(Level.INFO,
                                                 "Remote file servers for indexing changed via ZK: {0}",
                                                 currentAddresses);
-                                        dynamicClient.updateServers(currentAddresses);
+                                        client.updateServers(currentAddresses);
                                     }
                                 });
                         // Re-query after listener registration to close the race window
@@ -193,16 +192,13 @@ public class IndexingServer implements AutoCloseable {
                         try {
                             List<String> currentServers = metadataStorageManager.listFileServers();
                             if (!currentServers.isEmpty()) {
-                                dynamicClient.updateServers(currentServers);
+                                client.updateServers(currentServers);
                             }
                         } catch (Exception re) {
                             LOGGER.log(Level.WARNING,
                                     "Failed to re-query file servers after listener registration (indexing)", re);
                         }
                     }
-                    Class<?> storageClass = Class.forName("herddb.remote.RemoteFileDataStorageManager");
-                    Constructor<?> ctor = storageClass.getConstructor(
-                            Path.class, Path.class, int.class, clientClass);
                     // Give the RemoteFileDataStorageManager its own subdir
                     // under the indexing data dir. The wrapped
                     // FileDataStorageManager wipes its tmp dir on close(),
@@ -219,33 +215,23 @@ public class IndexingServer implements AutoCloseable {
                     Path remoteTmpDir = dataDir.resolve("remote-tmp");
                     java.nio.file.Files.createDirectories(metaDir);
                     java.nio.file.Files.createDirectories(remoteTmpDir);
-                    Object dsm = ctor.newInstance(
+                    DataStorageManager dsm = factory.createDataStorageManager(
                             metaDir, remoteTmpDir, Integer.MAX_VALUE, client);
 
-                    // Create a SharedCheckpointMetadataManager and wire it into
-                    // the RemoteFileDataStorageManager so that every
+                    // Create a SharedCheckpointMetadata manager and wire it into
+                    // the RemoteFileStorageManager so that every
                     // indexCheckpoint publishes its IndexStatus to S3, and a
                     // restart on a wiped disk can hydrate {metaDir} from S3.
-                    Class<?> sharedClass = Class.forName(
-                            "herddb.remote.SharedCheckpointMetadataManager");
-                    Object shared = sharedClass.getConstructor(clientClass)
-                            .newInstance(client);
-                    storageClass.getMethod("setSharedCheckpointMetadataManager", sharedClass)
-                            .invoke(dsm, shared);
+                    SharedCheckpointMetadata shared = factory.createSharedCheckpointMetadata(client);
+                    ((RemoteFileStorageManager) dsm).setSharedCheckpointMetadataManager(shared);
 
                     // Store for later use by the tablespace-resolved hook.
-                    // client was created reflectively but is guaranteed to
-                    // implement RemoteFileClient (the constructor target
-                    // class, RemoteFileServiceClient, declares it).
-                    this.remoteFileServiceClient = (RemoteFileClient) client;
+                    this.remoteFileServiceClient = client;
                     this.sharedCheckpointMetadataManager = shared;
-                    this.remoteDataStorageManager = dsm;
+                    this.remoteDataStorageManager = (RemoteFileStorageManager) dsm;
                     this.remoteMetaDir = metaDir;
 
-                    return (DataStorageManager) dsm;
-                } catch (ReflectiveOperationException e) {
-                    throw new RuntimeException("Cannot create RemoteFileDataStorageManager. "
-                            + "Ensure herddb-remote-file-service is on the classpath.", e);
+                    return dsm;
                 } catch (java.io.IOException e) {
                     throw new RuntimeException(
                             "Cannot create RemoteFileDataStorageManager metadata directory", e);
@@ -376,9 +362,8 @@ public class IndexingServer implements AutoCloseable {
             // Hydrate local metadata dir from S3 if it is empty.
             boolean localEmpty = isMetadataDirEmpty(remoteMetaDir, tableSpaceUUID);
             if (localEmpty) {
-                int count = (Integer) sharedCheckpointMetadataManager.getClass()
-                        .getMethod("hydrateLocalMetadataDir", Path.class, String.class)
-                        .invoke(sharedCheckpointMetadataManager, remoteMetaDir, tableSpaceUUID);
+                int count = sharedCheckpointMetadataManager.hydrateLocalMetadataDir(
+                        remoteMetaDir, tableSpaceUUID);
                 LOGGER.log(Level.INFO,
                         "hydrated {0} checkpoint file(s) for tableSpace {1} from S3",
                         new Object[]{count, tableSpaceUUID});
@@ -387,7 +372,7 @@ public class IndexingServer implements AutoCloseable {
                         "local metadata already present for tableSpace {0}, skipping S3 hydrate",
                         tableSpaceUUID);
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RuntimeException(
                     "Failed to hydrate local metadata from S3 for " + tableSpaceUUID, e);
         }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -29,6 +29,7 @@ import herddb.mem.MemoryDataStorageManager;
 import herddb.metadata.MetadataStorageManager;
 import herddb.metadata.ServiceDiscoveryListener;
 import herddb.server.DynamicServiceClient;
+import herddb.server.RemoteFileClient;
 import herddb.storage.DataStorageManager;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -74,7 +75,7 @@ public class IndexingServer implements AutoCloseable {
 
     // When storage.type=remote, these are set by buildDataStorageManager
     // and consumed by the tablespace-resolved hook.
-    private DynamicServiceClient remoteFileServiceClient;
+    private RemoteFileClient remoteFileServiceClient;
     private Object sharedCheckpointMetadataManager;
     private Object remoteDataStorageManager;
     private Path remoteMetaDir;
@@ -234,9 +235,9 @@ public class IndexingServer implements AutoCloseable {
 
                     // Store for later use by the tablespace-resolved hook.
                     // client was created reflectively but is guaranteed to
-                    // implement DynamicServiceClient (the constructor target
+                    // implement RemoteFileClient (the constructor target
                     // class, RemoteFileServiceClient, declares it).
-                    this.remoteFileServiceClient = (DynamicServiceClient) client;
+                    this.remoteFileServiceClient = (RemoteFileClient) client;
                     this.sharedCheckpointMetadataManager = shared;
                     this.remoteDataStorageManager = dsm;
                     this.remoteMetaDir = metaDir;
@@ -394,7 +395,7 @@ public class IndexingServer implements AutoCloseable {
         // Install S3WatermarkStore for this tablespace UUID + instanceId.
         int instanceId = config.getInt(IndexingServerConfiguration.PROPERTY_INSTANCE_ID,
                 IndexingServerConfiguration.PROPERTY_INSTANCE_ID_DEFAULT);
-        final DynamicServiceClient client = remoteFileServiceClient;
+        final RemoteFileClient client = remoteFileServiceClient;
 
         // Before issuing the first readFile for the watermark, block until the
         // remote file client has at least one server in its consistent-hash
@@ -422,26 +423,12 @@ public class IndexingServer implements AutoCloseable {
         S3WatermarkStore.RemoteFileIO io = new S3WatermarkStore.RemoteFileIO() {
             @Override
             public void writeFile(String path, byte[] content) {
-                try {
-                    client.getClass().getMethod("writeFile", String.class, byte[].class)
-                            .invoke(client, path, content);
-                } catch (java.lang.reflect.InvocationTargetException ite) {
-                    throw new RuntimeException(ite.getCause());
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                client.writeFile(path, content);
             }
 
             @Override
             public byte[] readFile(String path) {
-                try {
-                    return (byte[]) client.getClass().getMethod("readFile", String.class)
-                            .invoke(client, path);
-                } catch (java.lang.reflect.InvocationTargetException ite) {
-                    throw new RuntimeException(ite.getCause());
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                return client.readFile(path);
             }
         };
         S3WatermarkStore s3WatermarkStore = new S3WatermarkStore(io, tableSpaceUUID, instanceId);

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -74,7 +74,7 @@ public class IndexingServer implements AutoCloseable {
 
     // When storage.type=remote, these are set by buildDataStorageManager
     // and consumed by the tablespace-resolved hook.
-    private Object remoteFileServiceClient;
+    private DynamicServiceClient remoteFileServiceClient;
     private Object sharedCheckpointMetadataManager;
     private Object remoteDataStorageManager;
     private Path remoteMetaDir;
@@ -233,7 +233,10 @@ public class IndexingServer implements AutoCloseable {
                             .invoke(dsm, shared);
 
                     // Store for later use by the tablespace-resolved hook.
-                    this.remoteFileServiceClient = client;
+                    // client was created reflectively but is guaranteed to
+                    // implement DynamicServiceClient (the constructor target
+                    // class, RemoteFileServiceClient, declares it).
+                    this.remoteFileServiceClient = (DynamicServiceClient) client;
                     this.sharedCheckpointMetadataManager = shared;
                     this.remoteDataStorageManager = dsm;
                     this.remoteMetaDir = metaDir;
@@ -391,7 +394,7 @@ public class IndexingServer implements AutoCloseable {
         // Install S3WatermarkStore for this tablespace UUID + instanceId.
         int instanceId = config.getInt(IndexingServerConfiguration.PROPERTY_INSTANCE_ID,
                 IndexingServerConfiguration.PROPERTY_INSTANCE_ID_DEFAULT);
-        final Object clientRef = remoteFileServiceClient;
+        final DynamicServiceClient client = remoteFileServiceClient;
 
         // Before issuing the first readFile for the watermark, block until the
         // remote file client has at least one server in its consistent-hash
@@ -403,7 +406,7 @@ public class IndexingServer implements AutoCloseable {
                 IndexingServerConfiguration.PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS,
                 IndexingServerConfiguration.PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS_DEFAULT);
         try {
-            boolean ready = ((DynamicServiceClient) clientRef).awaitServersReady(bootstrapWaitMs);
+            boolean ready = client.awaitServersReady(bootstrapWaitMs);
             if (!ready) {
                 throw new RuntimeException(
                         "Timed out after " + bootstrapWaitMs + "ms waiting for remote file"
@@ -420,8 +423,8 @@ public class IndexingServer implements AutoCloseable {
             @Override
             public void writeFile(String path, byte[] content) {
                 try {
-                    clientRef.getClass().getMethod("writeFile", String.class, byte[].class)
-                            .invoke(clientRef, path, content);
+                    client.getClass().getMethod("writeFile", String.class, byte[].class)
+                            .invoke(client, path, content);
                 } catch (java.lang.reflect.InvocationTargetException ite) {
                     throw new RuntimeException(ite.getCause());
                 } catch (Exception e) {
@@ -432,8 +435,8 @@ public class IndexingServer implements AutoCloseable {
             @Override
             public byte[] readFile(String path) {
                 try {
-                    return (byte[]) clientRef.getClass().getMethod("readFile", String.class)
-                            .invoke(clientRef, path);
+                    return (byte[]) client.getClass().getMethod("readFile", String.class)
+                            .invoke(client, path);
                 } catch (java.lang.reflect.InvocationTargetException ite) {
                     throw new RuntimeException(ite.getCause());
                 } catch (Exception e) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -403,31 +403,17 @@ public class IndexingServer implements AutoCloseable {
                 IndexingServerConfiguration.PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS,
                 IndexingServerConfiguration.PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS_DEFAULT);
         try {
-            boolean ready = (Boolean) clientRef.getClass()
-                    .getMethod("awaitServersReady", long.class)
-                    .invoke(clientRef, bootstrapWaitMs);
+            boolean ready = ((DynamicServiceClient) clientRef).awaitServersReady(bootstrapWaitMs);
             if (!ready) {
                 throw new RuntimeException(
                         "Timed out after " + bootstrapWaitMs + "ms waiting for remote file"
                                 + " servers to be discovered via ZK for tableSpace "
                                 + tableSpaceUUID);
             }
-        } catch (NoSuchMethodException nsme) {
-            // Older client jar without awaitServersReady: log and continue;
-            // retryAsync in the client should still save us, just noisier.
-            LOGGER.log(Level.WARNING,
-                    "RemoteFileServiceClient has no awaitServersReady(long) method; "
-                            + "skipping bootstrap wait. Upgrade herddb-remote-file-service to fix.");
-        } catch (java.lang.reflect.InvocationTargetException ite) {
-            Throwable cause = ite.getCause();
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(
-                        "Interrupted while waiting for remote file servers to be discovered", cause);
-            }
-            throw new RuntimeException(cause);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(
+                    "Interrupted while waiting for remote file servers to be discovered", ie);
         }
 
         S3WatermarkStore.RemoteFileIO io = new S3WatermarkStore.RemoteFileIO() {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -140,6 +140,18 @@ public final class IndexingServerConfiguration {
     public static final String PROPERTY_REMOTE_FILE_CLIENT_RETRIES = "remote.file.client.retries";
     public static final int PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT = 10;
 
+    /**
+     * Maximum time (in milliseconds) to block at bootstrap waiting for at
+     * least one remote file server to be discovered (via ZK) before giving up
+     * and failing startup. Guards against a cold-cluster race where the
+     * indexing service starts before the file-server pod has registered
+     * itself in ZK and the consistent-hash ring is still empty when the first
+     * {@code readFile} for the watermark is issued.
+     */
+    public static final String PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS =
+            "remote.file.bootstrap.wait.ms";
+    public static final long PROPERTY_REMOTE_FILE_BOOTSTRAP_WAIT_MS_DEFAULT = 30_000L;
+
     // Instance identity and clustering
     public static final String PROPERTY_INSTANCE_ID = "indexing.instance.id";
     public static final int PROPERTY_INSTANCE_ID_DEFAULT = 0;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -43,6 +43,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -68,6 +69,13 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
     private volatile ServerSnapshot snapshot;
     private final long timeoutSeconds;
     private final ClientInterceptor clientInterceptor;
+    /**
+     * Released once the client has seen at least one non-empty server list,
+     * either at construction or via {@link #updateServers(List)}. Used by
+     * {@link #awaitServersReady(long)} to let callers block on cold-cluster
+     * ZK discovery before issuing the first RPC.
+     */
+    private final CountDownLatch serversReadyLatch = new CountDownLatch(1);
 
     private static class ServerSnapshot {
         final List<String> servers;
@@ -91,6 +99,9 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
             channels.put(server, buildChannel(server));
         }
         this.snapshot = new ServerSnapshot(servers, channels);
+        if (!servers.isEmpty()) {
+            this.serversReadyLatch.countDown();
+        }
     }
 
     public IndexingServiceClient(List<String> servers) {
@@ -106,6 +117,11 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
             b.intercept(clientInterceptor);
         }
         return b.build();
+    }
+
+    @Override
+    public boolean awaitServersReady(long timeoutMs) throws InterruptedException {
+        return serversReadyLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -136,6 +152,7 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
         }
 
         this.snapshot = new ServerSnapshot(newServers, newChannels);
+        serversReadyLatch.countDown();
 
         LOGGER.log(Level.INFO, "Updated indexing service servers: {0} (added: {1}, removed: {2})",
                 new Object[]{newServers, added, removed});

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh
@@ -61,14 +61,22 @@ elif docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
     docker start "$CONTAINER_NAME" >/dev/null
 else
     echo "==> Starting k3s container '$CONTAINER_NAME' (rancher/k3s:$K3S_VERSION)..."
+    # Provide CoreDNS with a real upstream resolver. On hosts using
+    # systemd-resolved, /etc/resolv.conf points at 127.0.0.53, which is
+    # unreachable from inside the k3s container and leaves CoreDNS
+    # resolving every external name to 127.0.0.1.
+    RESOLV_CONF="$SCRIPT_DIR/.resolv.conf"
+    printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' > "$RESOLV_CONF"
     docker run -d \
         --name "$CONTAINER_NAME" \
         --privileged \
         --tmpfs /run --tmpfs /var/run \
         -p 6443:6443 \
         -e K3S_KUBECONFIG_MODE=666 \
+        -v "$RESOLV_CONF:/etc/k3s-resolv.conf:ro" \
         "rancher/k3s:$K3S_VERSION" \
-        server --disable traefik --disable metrics-server >/dev/null
+        server --disable traefik --disable metrics-server \
+               --resolv-conf /etc/k3s-resolv.conf >/dev/null
 fi
 
 echo "==> Waiting for k3s API to be reachable..."

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -67,7 +67,8 @@ import org.apache.bookkeeper.stats.NullStatsLogger;
  *
  * @author enrico.olivelli
  */
-public class RemoteFileDataStorageManager extends DataStorageManager {
+public class RemoteFileDataStorageManager extends DataStorageManager
+        implements herddb.server.RemoteFileStorageManager {
 
     private static final Logger LOGGER = Logger.getLogger(RemoteFileDataStorageManager.class.getName());
 
@@ -133,8 +134,9 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
     /**
      * Enables publication of checkpoint metadata to remote storage for shared-storage read replicas.
      */
-    public void setSharedCheckpointMetadataManager(SharedCheckpointMetadataManager manager) {
-        this.sharedCheckpointMetadataManager = manager;
+    @Override
+    public void setSharedCheckpointMetadataManager(herddb.server.SharedCheckpointMetadata manager) {
+        this.sharedCheckpointMetadataManager = (SharedCheckpointMetadataManager) manager;
     }
 
     /**
@@ -148,6 +150,7 @@ public class RemoteFileDataStorageManager extends DataStorageManager {
      * @param maxRetentionMillis maximum time a page can be retained; after this, it is force-deleted
      *        even if some replicas are still behind (they will need to re-bootstrap)
      */
+    @Override
     public void setRetentionPolicy(
             Function<String, LogSequenceNumber> minReplicaLsnSupplier,
             long minRetentionMillis,

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -37,7 +37,7 @@ import herddb.remote.proto.WriteFileBlockRequest;
 import herddb.remote.proto.WriteFileBlockResponse;
 import herddb.remote.proto.WriteFileRequest;
 import herddb.remote.proto.WriteFileResponse;
-import herddb.server.DynamicServiceClient;
+import herddb.server.RemoteFileClient;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -70,7 +70,7 @@ import java.util.logging.Logger;
  *
  * @author enrico.olivelli
  */
-public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceClient {
+public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient {
 
     private static final Logger LOGGER = Logger.getLogger(RemoteFileServiceClient.class.getName());
 
@@ -599,6 +599,7 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
 
     // --- Synchronous APIs (wrappers around async) ---
 
+    @Override
     public void writeFile(String path, byte[] content) {
         getUnchecked(writeFileAsync(path, content));
     }
@@ -607,6 +608,7 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
         getUnchecked(writeFileAsync(path, buf, offset, len));
     }
 
+    @Override
     public byte[] readFile(String path) {
         return getUnchecked(readFileAsync(path));
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -96,6 +97,13 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
     }
 
     private volatile ServerSnapshot snapshot;
+    /**
+     * Released once the client has seen at least one non-empty server list,
+     * either at construction or via {@link #updateServers(List)}. Lets
+     * bootstrap callers block on cold-cluster ZK discovery before issuing
+     * the first RPC. See {@link #awaitServersReady(long)}.
+     */
+    private final CountDownLatch serversReadyLatch = new CountDownLatch(1);
     private final int maxRetries;
     private final long clientTimeoutSeconds;
     private final int blockSize;
@@ -127,6 +135,9 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
             channels.put(server, buildChannel(server));
         }
         this.snapshot = new ServerSnapshot(new ConsistentHashRouter(servers), channels);
+        if (!servers.isEmpty()) {
+            this.serversReadyLatch.countDown();
+        }
 
         if (servers.isEmpty()) {
             LOGGER.log(Level.INFO,
@@ -195,6 +206,7 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
         }
 
         this.snapshot = new ServerSnapshot(new ConsistentHashRouter(newServers), newChannels);
+        serversReadyLatch.countDown();
 
         LOGGER.log(Level.INFO, "Updated remote file servers: {0} (added: {1}, removed: {2})",
                 new Object[]{newServers, added, removed});
@@ -221,6 +233,27 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
             shutdownThread.setDaemon(true);
             shutdownThread.start();
         }
+    }
+
+    /**
+     * Returns {@code true} if the client currently has at least one server in
+     * its consistent-hash ring. Used by callers that need to block on cold-boot
+     * ZK discovery before issuing the first RPC.
+     */
+    public boolean hasServers() {
+        ServerSnapshot s = this.snapshot;
+        return !s.channels.isEmpty();
+    }
+
+    /**
+     * Blocks for up to {@code timeoutMs} milliseconds until {@link #hasServers()}
+     * returns {@code true}. Returns {@code true} as soon as a server is visible,
+     * {@code false} on timeout. Intended for use at bootstrap on a cold cluster
+     * where ZK service discovery may not yet have populated the server list by
+     * the time the first RPC is issued.
+     */
+    public boolean awaitServersReady(long timeoutMs) throws InterruptedException {
+        return serversReadyLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
     }
 
     private RemoteFileServiceGrpc.RemoteFileServiceBlockingStub blockingStubForPath(String path) {
@@ -643,6 +676,10 @@ public class RemoteFileServiceClient implements AutoCloseable, DynamicServiceCli
             // Handle synchronous failures (e.g. "Hash ring is empty" when no
             // servers have been discovered yet) the same as async failures so
             // that the retry logic below can kick in.
+            LOGGER.log(Level.INFO,
+                    "remote file {0} synchronous failure for path {1} on attempt {2}, "
+                            + "scheduling retry: {3}",
+                    new Object[]{opName, path, attempt, e.toString()});
             actionResult = new CompletableFuture<>();
             actionResult.completeExceptionally(e);
         }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceFactoryImpl.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceFactoryImpl.java
@@ -1,0 +1,74 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import herddb.server.RemoteFileClient;
+import herddb.server.RemoteFileServiceFactory;
+import herddb.server.SharedCheckpointMetadata;
+import herddb.storage.DataStorageManager;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default {@link RemoteFileServiceFactory} implementation. Lives in
+ * {@code herddb-remote-file-service} so the core modules never take a
+ * compile-time dependency on this artifact; it is loaded reflectively via
+ * {@link RemoteFileServiceFactory#load()}.
+ */
+public class RemoteFileServiceFactoryImpl implements RemoteFileServiceFactory {
+
+    public RemoteFileServiceFactoryImpl() {
+    }
+
+    @Override
+    public RemoteFileClient createClient(List<String> servers, Map<String, Object> config) {
+        return new RemoteFileServiceClient(servers, config);
+    }
+
+    @Override
+    public SharedCheckpointMetadata createSharedCheckpointMetadata(RemoteFileClient client) {
+        return new SharedCheckpointMetadataManager((RemoteFileServiceClient) client);
+    }
+
+    @Override
+    public DataStorageManager createDataStorageManager(
+            Path dataDirectory, Path tmpDirectory, int swapThreshold, RemoteFileClient client) {
+        return new RemoteFileDataStorageManager(
+                dataDirectory, tmpDirectory, swapThreshold, (RemoteFileServiceClient) client);
+    }
+
+    @Override
+    public DataStorageManager createPromotableDataStorageManager(
+            RemoteFileClient client,
+            SharedCheckpointMetadata metadata,
+            Path dataDirectory,
+            Path tmpDirectory,
+            int swapThreshold) {
+        RemoteFileServiceClient concreteClient = (RemoteFileServiceClient) client;
+        SharedCheckpointMetadataManager concreteMetadata = (SharedCheckpointMetadataManager) metadata;
+        ReadReplicaDataStorageManager readReplica = new ReadReplicaDataStorageManager(
+                concreteClient, concreteMetadata, tmpDirectory, swapThreshold);
+        return new PromotableRemoteFileDataStorageManager(
+                readReplica, concreteClient, concreteMetadata,
+                dataDirectory, tmpDirectory, swapThreshold);
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SharedCheckpointMetadataManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SharedCheckpointMetadataManager.java
@@ -65,7 +65,7 @@ import java.util.logging.Logger;
  *
  * @author enrico.olivelli
  */
-public class SharedCheckpointMetadataManager {
+public class SharedCheckpointMetadataManager implements herddb.server.SharedCheckpointMetadata {
 
     private static final Logger LOGGER = Logger.getLogger(SharedCheckpointMetadataManager.class.getName());
 
@@ -480,6 +480,7 @@ public class SharedCheckpointMetadataManager {
      *
      * @return the number of files hydrated (0 if nothing was found on remote)
      */
+    @Override
     public int hydrateLocalMetadataDir(Path localMetadataDir, String tableSpace) throws IOException {
         String prefix = metadataPrefix(tableSpace);
         List<String> remoteFiles;

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
@@ -21,6 +21,7 @@
 package herddb.remote;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -135,6 +136,50 @@ public class RemoteFileServiceClientDynamicTest {
      * retry with backoff until servers appear, not crash immediately with
      * "Hash ring is empty".
      */
+    /**
+     * awaitServersReady returns false on timeout when no servers are ever
+     * discovered, and true as soon as updateServers is called with a
+     * non-empty list from another thread. Guards the #42 cold-boot fix in
+     * IndexingServer.bootstrapRemoteStateForTablespace.
+     */
+    @Test
+    public void testAwaitServersReady() throws Exception {
+        String addr1 = "localhost:" + server1.getPort();
+
+        try (RemoteFileServiceClient client = new RemoteFileServiceClient(
+                Collections.emptyList())) {
+
+            assertFalse("fresh client should have no servers", client.hasServers());
+            long t0 = System.nanoTime();
+            assertFalse("no servers → should time out", client.awaitServersReady(200));
+            long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+            assertTrue("timeout must be honored, got " + elapsedMs + "ms", elapsedMs >= 150);
+
+            // Populate from another thread while the main thread is blocked.
+            Thread populator = new Thread(() -> {
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                client.updateServers(Collections.singletonList(addr1));
+            }, "populator");
+            populator.start();
+            try {
+                long t1 = System.nanoTime();
+                assertTrue("should wake up when servers appear",
+                        client.awaitServersReady(5_000));
+                long waitMs = (System.nanoTime() - t1) / 1_000_000L;
+                assertTrue("should wake up promptly after updateServers, got " + waitMs + "ms",
+                        waitMs < 2_000);
+                assertTrue(client.hasServers());
+            } finally {
+                populator.join(5_000);
+            }
+        }
+    }
+
     @Test
     public void testReadRetriesUntilServerAppears() throws Exception {
         String addr1 = "localhost:" + server1.getPort();

--- a/herddb-services/src/main/java/herddb/server/IndexingServiceMain.java
+++ b/herddb-services/src/main/java/herddb/server/IndexingServiceMain.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -47,6 +48,21 @@ public class IndexingServiceMain {
     private static IndexingServer runningServer;
 
     public static void main(String... args) throws Exception {
+        try {
+            runMain(args);
+        } catch (Throwable t) {
+            // Any failure before shutdownLatch.await() leaves a zombie pod:
+            // the gRPC port is closed by the finally blocks, but non-daemon
+            // ZK/BK/scheduler threads keep the JVM alive, so the readiness
+            // probe fails forever and Kubernetes never restarts the pod.
+            // Exit non-zero so the kubelet sees a crash and replaces us.
+            // See #42.
+            LOG.log(Level.SEVERE, "Indexing service failed to start, exiting", t);
+            System.exit(1);
+        }
+    }
+
+    private static void runMain(String... args) throws Exception {
         Properties configuration = new Properties();
 
         // Pass 1: find and load config file (lowest priority)


### PR DESCRIPTION
## Summary

Fixes #42. On a fresh k3s cluster the indexing service raced the file-server's ZK registration, `IndexingServiceEngine.start()` threw `IllegalStateException: Hash ring is empty` in the very first `S3WatermarkStore.load()`, and the JVM stayed alive as a zombie pod (gRPC port closed by finally blocks, non-daemon threads keeping main alive, readiness probe failing forever).

While investigating, we also cleaned up the long-standing reflective bridge between `herddb-core` / `herddb-indexing-service` and `herddb-remote-file-service`, since the same code paths were where the cold-start race lived.

### Cold-start race fix

- **`RemoteFileServiceClient` gains `hasServers()` / `awaitServersReady(long)`**, backed by a `CountDownLatch` released at construction (if servers are already known) or on the first non-empty `updateServers(...)`.
- **`IndexingServer.bootstrapRemoteStateForTablespace` blocks on `awaitServersReady`** before installing the `S3WatermarkStore`, controlled by a new `remote.file.bootstrap.wait.ms` config (default 30s). On timeout it throws, which now properly crashes the JVM.
- **`IndexingServiceClient`** gets the same `CountDownLatch` pattern (also for symmetry; it implements the same interface).
- **`IndexingServiceMain.main`** now wraps its body in `try { … } catch (Throwable t) { LOG.log(SEVERE, …, t); System.exit(1); }`, so the kubelet restarts the pod instead of leaving it zombied. The ctrl-c shutdown hook and existing finally blocks are preserved.
- **`RemoteFileServiceClient.retryAsync`** gets a diagnostic INFO in the synchronous-failure catch — the existing retries actually work (confirmed by `testReadRetriesUntilServerAppears`), so the explicit bootstrap wait is the primary fix and the log makes future repros self-explanatory.

### Typed interfaces replace the reflective bridge

`herddb-core` and `herddb-indexing-service` cannot take a compile-time dependency on `herddb-remote-file-service` (the dependency runs the other way). Before this PR, both modules reached every remote-file-service class — `RemoteFileServiceClient`, `RemoteFileDataStorageManager`, `SharedCheckpointMetadataManager`, `ReadReplicaDataStorageManager`, `PromotableRemoteFileDataStorageManager` — through `Class.forName` + `getConstructor` + `getMethod` + `invoke`. That's the same code path where the #42 race lived, so it was worth cleaning up now.

New interfaces in `herddb-core`:
- `RemoteFileClient` (extends `DynamicServiceClient`) — `readFile`, `writeFile`, `awaitServersReady`, `updateServers`
- `RemoteFileStorageManager` — `setSharedCheckpointMetadataManager(SharedCheckpointMetadata)`, `setRetentionPolicy(Function, long, long)`
- `SharedCheckpointMetadata` — `hydrateLocalMetadataDir(Path, String)`
- `RemoteFileServiceFactory` — `createClient` / `createSharedCheckpointMetadata` / `createDataStorageManager` / `createPromotableDataStorageManager`, plus a static `load()` helper

Implementations:
- `RemoteFileServiceClient implements RemoteFileClient`
- `RemoteFileDataStorageManager implements RemoteFileStorageManager`
- `SharedCheckpointMetadataManager implements SharedCheckpointMetadata`
- New `RemoteFileServiceFactoryImpl` in `herddb-remote-file-service`

Callers:
- `Server.buildFileDataStorageManager`, `Server.buildSharedStorageDataManager`, `IndexingServer.buildDataStorageManager`, `IndexingServer.bootstrapRemoteStateForTablespace` — all `Class.forName` / `getConstructor` / `getMethod` / `invoke` calls for remote-file-service components are gone. Each call site now does one `RemoteFileServiceFactory.load()` and the rest is typed.
- The entire `ReadReplicaDataStorageManager` + `PromotableRemoteFileDataStorageManager` reflective wiring in `buildSharedStorageDataManager` collapses into a single `factory.createPromotableDataStorageManager(...)` call.

Only reflective boundary left: the single `Class.forName` inside `RemoteFileServiceFactory.load()` itself — everything downstream is interface-typed.

### Unrelated bundled fix

The commit `de6d1ccd` also includes a small fix to `herddb-kubernetes/.../k3s-local/install.sh`: on hosts using `systemd-resolved`, `/etc/resolv.conf` points at 127.0.0.53 which is unreachable from inside the k3s container, so CoreDNS ended up resolving every external name to 127.0.0.1. The script now mounts a `.resolv.conf` with public upstream resolvers and passes `--resolv-conf` to k3s. Kept in this PR at the reporter's request.

## Test plan

- [x] `mvn -pl herddb-remote-file-service -Dtest='RemoteFileServiceClientDynamicTest,RemoteFileServiceClientTest' test` — 15/15 pass (includes the new `testAwaitServersReady` and the existing `testReadRetriesUntilServerAppears` that confirms `retryAsync` does actually fire on synchronous "Hash ring is empty")
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins` — BUILD SUCCESS across all 22 modules
- [ ] End-to-end on a fresh k3s cluster: `herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/install.sh` — `herddb-indexing-service-0` should reach `1/1 Ready` on the first try without a manual `kubectl delete pod`
- [ ] Negative path: deploy with file-server replicas=0 — indexing-service pod should log the "timed out waiting for remote file servers" SEVERE and be restarted by kubelet instead of going zombie

🤖 Generated with [Claude Code](https://claude.com/claude-code)