### PR TITLE
Fix helm chart: roll pods on ConfigMap changes (#49)

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/bookkeeper-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.bookkeeper.httpPort }}"
         prometheus.io/path: "/metrics"

--- a/herddb-kubernetes/src/main/helm/herddb/templates/file-server-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/file-server-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/file-server-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.fileServer.httpPort }}"
         prometheus.io/path: "/metrics"

--- a/herddb-kubernetes/src/main/helm/herddb/templates/indexing-service-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/indexing-service-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/indexing-service-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.indexingService.httpPort }}"
         prometheus.io/path: "/metrics"

--- a/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.server.httpPort }}"
         prometheus.io/path: "/metrics"

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/component: tools
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/tools-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "herddb.labels" . | nindent 8 }}
         app.kubernetes.io/component: tools

--- a/herddb-kubernetes/src/main/helm/herddb/templates/zookeeper-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/zookeeper-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.zookeeper.metricsPort }}"
         prometheus.io/path: "/metrics"

--- a/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-statefulset_test.yaml
@@ -1,0 +1,16 @@
+suite: bookkeeper StatefulSet
+templates:
+  - templates/bookkeeper-statefulset.yaml
+  - templates/bookkeeper-configmap.yaml
+tests:
+  - it: should have a checksum/config annotation that rolls pods on ConfigMap changes
+    template: templates/bookkeeper-statefulset.yaml
+    set:
+      server.mode: cluster
+      bookkeeper.enabled: true
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$

--- a/herddb-kubernetes/src/main/helm/herddb/tests/file-server-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/file-server-statefulset_test.yaml
@@ -1,56 +1,66 @@
 suite: file-server StatefulSet
 templates:
   - templates/file-server-statefulset.yaml
+  - templates/file-server-configmap.yaml
 tests:
   - it: should have default replica count of 2
+    template: templates/file-server-statefulset.yaml
     asserts:
       - equal:
           path: spec.replicas
           value: 2
 
   - it: should reference the correct headless service
+    template: templates/file-server-statefulset.yaml
     asserts:
       - equal:
           path: spec.serviceName
           value: RELEASE-NAME-herddb-file-server
 
   - it: should use the configured image
+    template: templates/file-server-statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
           value: "herddb/herddb-server:0.30.0-SNAPSHOT"
 
   - it: should pass file-server role to service launcher
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: file-server
 
   - it: should pass console command to service launcher
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: console
 
   - it: should pass default port as CLI arg
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--port=9846"
 
   - it: should pass data-dir as CLI arg
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--data-dir=/opt/herddb/filedata"
 
   - it: should pass config file path as CLI arg
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "/opt/herddb/conf/fileserver.properties"
 
   - it: should mount config volume at /opt/herddb/conf
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -59,6 +69,7 @@ tests:
             mountPath: /opt/herddb/conf
 
   - it: should include config volume sourced from configmap
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -68,6 +79,7 @@ tests:
               name: RELEASE-NAME-herddb-file-server-config
 
   - it: should expose grpc port 9846
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].ports
@@ -77,12 +89,14 @@ tests:
             protocol: TCP
 
   - it: should have one volumeClaimTemplate
+    template: templates/file-server-statefulset.yaml
     asserts:
       - lengthEqual:
           path: spec.volumeClaimTemplates
           count: 1
 
   - it: should mount data PVC at /opt/herddb/filedata
+    template: templates/file-server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -91,6 +105,7 @@ tests:
             mountPath: /opt/herddb/filedata
 
   - it: should allow overriding replica count
+    template: templates/file-server-statefulset.yaml
     set:
       fileServer.replicaCount: 4
     asserts:
@@ -99,6 +114,7 @@ tests:
           value: 4
 
   - it: should use custom port in args when overridden
+    template: templates/file-server-statefulset.yaml
     set:
       fileServer.port: 9900
     asserts:
@@ -107,6 +123,7 @@ tests:
           content: "--port=9900"
 
   - it: should set default memory and cpu resources
+    template: templates/file-server-statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
@@ -116,6 +133,7 @@ tests:
           value: "4"
 
   - it: should mount configmap to conf-ro and emptyDir to conf when credentialsSecret is set
+    template: templates/file-server-statefulset.yaml
     set:
       fileServer.s3.credentialsSecret: "my-secret"
     asserts:
@@ -137,6 +155,7 @@ tests:
             emptyDir: {}
 
   - it: should have S3 env vars from secret when credentialsSecret is set
+    template: templates/file-server-statefulset.yaml
     set:
       fileServer.s3.credentialsSecret: "my-secret"
     asserts:
@@ -158,6 +177,7 @@ tests:
                 key: S3_SECRET_KEY
 
   - it: should use bash command when credentialsSecret is set without zookeeper
+    template: templates/file-server-statefulset.yaml
     set:
       fileServer.s3.credentialsSecret: "my-secret"
     asserts:
@@ -166,7 +186,17 @@ tests:
           value: ["/bin/bash", "-c"]
 
   - it: should use the configured service account
+    template: templates/file-server-statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: RELEASE-NAME-herddb
+
+  - it: should have a checksum/config annotation that rolls pods on ConfigMap changes
+    template: templates/file-server-statefulset.yaml
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$

--- a/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-statefulset_test.yaml
@@ -1,0 +1,15 @@
+suite: indexing-service StatefulSet
+templates:
+  - templates/indexing-service-statefulset.yaml
+  - templates/indexing-service-configmap.yaml
+tests:
+  - it: should have a checksum/config annotation that rolls pods on ConfigMap changes
+    template: templates/indexing-service-statefulset.yaml
+    set:
+      indexingService.enabled: true
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$

--- a/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
@@ -1,26 +1,31 @@
 suite: server StatefulSet
 templates:
   - templates/server-statefulset.yaml
+  - templates/server-configmap.yaml
 tests:
   - it: should have default replica count of 1
+    template: templates/server-statefulset.yaml
     asserts:
       - equal:
           path: spec.replicas
           value: 1
 
   - it: should reference the correct headless service
+    template: templates/server-statefulset.yaml
     asserts:
       - equal:
           path: spec.serviceName
           value: RELEASE-NAME-herddb-server
 
   - it: should use the configured image
+    template: templates/server-statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
           value: "herddb/herddb-server:0.30.0-SNAPSHOT"
 
   - it: should expose jdbc port 7000
+    template: templates/server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].ports
@@ -30,6 +35,7 @@ tests:
             protocol: TCP
 
   - it: should expose http port 9845
+    template: templates/server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].ports
@@ -39,12 +45,14 @@ tests:
             protocol: TCP
 
   - it: should have two volumeClaimTemplates (data and commitlog)
+    template: templates/server-statefulset.yaml
     asserts:
       - lengthEqual:
           path: spec.volumeClaimTemplates
           count: 2
 
   - it: should mount the server config file
+    template: templates/server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -54,6 +62,7 @@ tests:
             subPath: server.properties
 
   - it: should mount data PVC at /opt/herddb/data
+    template: templates/server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -62,6 +71,7 @@ tests:
             mountPath: /opt/herddb/data
 
   - it: should mount commitlog PVC at /opt/herddb/commitlog
+    template: templates/server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -70,6 +80,7 @@ tests:
             mountPath: /opt/herddb/commitlog
 
   - it: should allow overriding replica count
+    template: templates/server-statefulset.yaml
     set:
       server.replicaCount: 3
     asserts:
@@ -78,6 +89,7 @@ tests:
           value: 3
 
   - it: should set default memory and cpu resources
+    template: templates/server-statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
@@ -87,13 +99,41 @@ tests:
           value: "4"
 
   - it: should use the configured service account
+    template: templates/server-statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: RELEASE-NAME-herddb
 
   - it: should pass config file as argument
+    template: templates/server-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: /opt/herddb/conf/server.properties
+
+  - it: should have a checksum/config annotation that rolls pods on ConfigMap changes
+    template: templates/server-statefulset.yaml
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$
+
+  - it: checksum/config should change when server.extraConfig changes
+    template: templates/server-statefulset.yaml
+    set:
+      server.extraConfig.foo: "bar"
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$
+      # Regression guard for issue #49: the hash below is the default-values
+      # checksum. If this assertion passes, it means the extraConfig change
+      # did NOT propagate — which is exactly the bug we fixed.
+      - notEqual:
+          path: spec.template.metadata.annotations["checksum/config"]
+          value: e03e1ab6bd1f6b88466ef23b2b312809927b3b628dd1ff9f59737e6e3a8cdfd0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/tools-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/tools-statefulset_test.yaml
@@ -137,3 +137,12 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should have a checksum/config annotation that rolls pods on ConfigMap changes
+    template: templates/tools-statefulset.yaml
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$

--- a/herddb-kubernetes/src/main/helm/herddb/tests/zookeeper-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/zookeeper-statefulset_test.yaml
@@ -1,0 +1,16 @@
+suite: zookeeper StatefulSet
+templates:
+  - templates/zookeeper-statefulset.yaml
+  - templates/zookeeper-configmap.yaml
+tests:
+  - it: should have a checksum/config annotation that rolls pods on ConfigMap changes
+    template: templates/zookeeper-statefulset.yaml
+    set:
+      server.mode: cluster
+      zookeeper.enabled: true
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$


### PR DESCRIPTION
## Summary
- Add `checksum/config` annotation to all HerdDB Helm StatefulSet pod templates (server, file-server, indexing-service, zookeeper, bookkeeper, tools) so that `helm upgrade` automatically triggers a rolling restart when the mounted ConfigMap content changes.
- Fixes #49, where `server.extraConfig` (e.g. `indexing.service.timeout=300`) tuned via `helm upgrade` had no effect until pods were manually deleted.
- Uses the standard Helm idiom from https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments.

## Test plan
- [x] `helm lint herddb-kubernetes/src/main/helm/herddb` passes
- [x] `helm template` renders a `checksum/config` on all 6 StatefulSets when every component is enabled
- [x] Changing `server.extraConfig` flips the server-statefulset checksum while leaving unrelated StatefulSets' checksums stable (verified: `e03e1ab6…` → `9f006a10…` for server only)
- [x] `mvn apache-rat:check -pl herddb-kubernetes` passes
- [ ] End-to-end on k3s-local: `helm upgrade` with a changed `server.extraConfig` value rolls `herddb-server-0` automatically and the new property appears in `/opt/herddb/conf/server.properties` without `kubectl delete pod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)