### PR TITLE
Fix CachingObjectStorage: retain disk files as L2 cache on heap eviction (#53)

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -5,7 +5,7 @@
 # tools pod.
 #
 # Mirrors the structure of examples/gke/values.yaml but with resources
-# and PVCs sized for a developer laptop / workstation. No PVC exceeds 10 GiB.
+# and PVCs sized for a developer laptop / workstation.
 #
 # Prometheus and Grafana are disabled by default to save RAM; enable them
 # ad-hoc with --set prometheus.enabled=true --set grafana.enabled=true.
@@ -23,6 +23,21 @@
 # Tools heap raised to 2 g: loading the sift1m base set (1M × 128 × 4 B
 # = 512 MB) into the vector-bench JVM plus JVM overhead exceeds 512 Mi;
 # the old 512 Mi container limit caused OOMKill during ingest.
+#
+# File-server two-tier cache (L1 heap + L2 disk):
+#   CachingObjectStorage keeps hot blocks in JVM heap (L1, bounded by
+#   s3.cacheMaxBytes) and retains disk copies when items are evicted from heap
+#   (L2).  On a Caffeine miss the loader reads from disk first (~GB/s) and
+#   only falls back to MinIO (~4 MB/s in Docker) when the disk file is absent.
+#   s3.cacheMaxBytes controls the L1 heap allocation; the PVC holds the L2
+#   disk files (retained across evictions, cleared only on pod restart).
+#
+#   Sizing for sift1m M=8 through gist1m M=32:
+#   - sift1m M=8  graph : ~280 MB across ~7 segments
+#   - gist1m M=32 graph : ~4.8 GB across ~7 segments
+#   - gist1m data pages : ~3.7 GB
+#   Peak L1 demand      : ~5 GB → 6 GiB L1 gives ~1.2× headroom
+#   Peak L2 disk demand : ~8.5 GB → 50 GiB PVC gives ~6× headroom
 #
 # Install via ./install.sh (which runs k3s inside a Docker container
 # and imports the HerdDB image into containerd so imagePullPolicy=Never
@@ -59,29 +74,39 @@ server:
 fileServer:
   replicaCount: 1
   storageMode: s3
-  # Heap raised to 4 g: gist1m segments (310k+ vectors × 960 dim × 4 B) can
-  # exceed 1 GB; the previous 1 g heap caused OOM in CachingObjectStorage
-  # during compaction. Allow -Xms2g so the JVM starts with headroom and
-  # can grow to 4 g on demand.
-  javaOpts: "-Xms2g -Xmx4g -Djava.net.preferIPv4Stack=true"
+  # Heap raised to 8 g: CachingObjectStorage L1 heap cache (6 GiB) plus JVM
+  # overhead requires ~8 GB.  The previous 4 g heap caused OOM when multiple
+  # concurrent queries each held a 200+ MB graph block in the Caffeine cache
+  # and cacheMaxBytes was set larger than the available heap.
+  javaOpts: "-Xms2g -Xmx8g -Djava.net.preferIPv4Stack=true"
   # S3 endpoint, bucket, and credentials are auto-wired from the
   # minio section below.
+  s3:
+    # L1 heap cache: 6 GiB — Caffeine evicts entries from heap once total
+    # weight exceeds this value.  Evicted entries are retained on disk (L2)
+    # so subsequent reads hit local disk instead of MinIO.
+    # NOTE: this key must be under fileServer.s3 — the Helm template reads
+    # .Values.fileServer.s3.cacheMaxBytes (not .Values.fileServer.cacheMaxBytes).
+    cacheMaxBytes: 6442450944
   storage:
-    size: 10Gi
-  # Local disk cache sized to match the PVC (10 GiB = 10737418240 bytes).
-  cacheMaxBytes: 10737418240
+    # 50 GiB L2 disk cache: holds the complete gist1m index (~4.8 GB) plus
+    # data pages (~3.7 GB) with ~5× headroom.  Entries survive heap eviction
+    # and are only cleared on pod restart.
+    size: 50Gi
   resources:
     requests:
-      memory: "5Gi"
+      memory: "9Gi"
       cpu: "0.5"
     limits:
-      memory: "5Gi"
+      memory: "10Gi"
       cpu: "1"
 
 minio:
   enabled: true
   storage:
-    size: 10Gi
+    # 20 GiB: holds gist1m data (~8.5 GB) plus multiple benchmark runs
+    # without running out of object-storage space.
+    size: 20Gi
   resources:
     requests:
       memory: "256Mi"

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
@@ -22,7 +22,6 @@ package herddb.remote.storage;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalListener;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,11 +35,43 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 /**
- * Decorator that wraps an inner {@link ObjectStorage} (e.g. S3) with a local disk cache
- * backed by a Caffeine {@link AsyncLoadingCache}.
- * <p>
- * The cache directory is cleared on construction. Cache files are stored flat in
- * {@code cacheDir} with {@code /} replaced by {@code _} in filenames.
+ * Two-tier cache decorator for {@link ObjectStorage} (e.g. S3 / MinIO).
+ *
+ * <h3>Caching tiers</h3>
+ * <ol>
+ *   <li><b>L1 – JVM heap</b>: a Caffeine {@link AsyncLoadingCache} limited to
+ *       {@code maxCacheBytes} of raw byte array weight.  Items are kept in heap
+ *       for the fastest possible access; they are evicted when the total weight
+ *       exceeds the limit.</li>
+ *   <li><b>L2 – local disk</b>: when a block is first fetched from object storage
+ *       it is written to a flat file under {@code cacheDir}.  The disk file is
+ *       <em>not</em> deleted when the item is evicted from the heap cache — it is
+ *       retained as a disk-backed fallback.  On a subsequent Caffeine miss the
+ *       loader reads the disk file first (local I/O, typically ≥ 100 MB/s) instead
+ *       of re-fetching from MinIO (~4 MB/s in a local Docker cluster).</li>
+ *   <li><b>L3 – object storage (MinIO)</b>: fallback when neither heap nor disk
+ *       has the item.</li>
+ * </ol>
+ *
+ * <h3>Why disk files are retained on heap eviction</h3>
+ * The previous implementation deleted disk files in the Caffeine eviction listener.
+ * This made the "disk cache" a pure mirror of the heap cache rather than an
+ * independent tier: once an item was evicted from heap (and its disk file removed),
+ * the next access had to re-fetch from MinIO, causing repeated multi-second stalls
+ * for large FusedPQ graph blocks during vector-search benchmarks.
+ *
+ * <h3>Disk cache lifecycle</h3>
+ * <ul>
+ *   <li>Created/updated: whenever a block is written ({@link #writeBlock}) or a
+ *       small object is written ({@link #write}), and whenever the L3 loader fetches
+ *       from MinIO ({@link #loadFromObjectStorage}).</li>
+ *   <li>Deleted: only via an explicit {@link #deleteLogical}, {@link #delete}, or
+ *       {@link #deleteByPrefix} call, or when the cache directory is cleared on
+ *       construction ({@link #clearCacheDir}).</li>
+ * </ul>
+ *
+ * Cache files are stored flat in {@code cacheDir} with {@code /} replaced by
+ * {@code _} in filenames.
  *
  * @author enrico.olivelli
  */
@@ -62,21 +93,49 @@ public class CachingObjectStorage implements ObjectStorage {
         this.cache = Caffeine.newBuilder()
                 .maximumWeight(maxCacheBytes)
                 .weigher((String key, byte[] value) -> value.length)
-                .evictionListener((RemovalListener<String, byte[]>) (key, value, cause) -> {
-                    // Synchronous: called on the maintenance thread before removal completes.
-                    if (key != null) {
-                        deleteCacheFile(key);
-                    }
-                })
-                .buildAsync((path, exec) ->
-                        inner.read(path).thenApply(result -> {
-                            if (result.status() == ReadResult.Status.NOT_FOUND) {
-                                return null;
-                            }
-                            byte[] bytes = result.content();
-                            writeCacheFile(path, bytes);
-                            return bytes;
-                        }));
+                // Do NOT delete disk files on heap eviction: the disk file continues
+                // to serve as an L2 cache, sparing a MinIO round-trip on the next access.
+                .buildAsync((path, exec) -> loadFromDiskOrObjectStorage(path, executor));
+    }
+
+    /**
+     * L2/L3 loader: try the local disk cache first; fall back to object storage if
+     * the disk file does not exist or cannot be read.
+     */
+    private CompletableFuture<byte[]> loadFromDiskOrObjectStorage(String path, ExecutorService executor) {
+        Path diskFile = cacheFilePath(path);
+        if (Files.exists(diskFile)) {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    byte[] bytes = Files.readAllBytes(diskFile);
+                    LOGGER.fine(() -> "cache L2 hit (disk): " + path + " (" + bytes.length + " bytes)");
+                    return bytes;
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to read disk cache file, falling back to object storage: " + path, e);
+                    return null;
+                }
+            }, executor).thenCompose(bytes -> {
+                if (bytes != null) {
+                    return CompletableFuture.completedFuture(bytes);
+                }
+                return loadFromObjectStorage(path);
+            });
+        }
+        return loadFromObjectStorage(path);
+    }
+
+    /**
+     * L3 loader: fetch from object storage (MinIO) and persist to disk for future L2 hits.
+     */
+    private CompletableFuture<byte[]> loadFromObjectStorage(String path) {
+        return inner.read(path).thenApply(result -> {
+            if (result.status() == ReadResult.Status.NOT_FOUND) {
+                return null;
+            }
+            byte[] bytes = result.content();
+            writeCacheFile(path, bytes);
+            return bytes;
+        });
     }
 
     private void clearCacheDir() throws IOException {
@@ -151,7 +210,7 @@ public class CachingObjectStorage implements ObjectStorage {
         long blockIndex = offset / blockSize;
         int offsetInBlock = (int) (offset % blockSize);
         String blockPath = path + ObjectStorage.MULTIPART_SUFFIX + "/" + blockIndex;
-        // Load the whole block from cache (or from inner storage), then slice
+        // Load the whole block from L1 heap (or L2 disk, or L3 MinIO), then slice
         return cache.get(blockPath).thenApply(blockBytes -> {
             if (blockBytes == null) {
                 return ReadResult.notFound();
@@ -169,7 +228,7 @@ public class CachingObjectStorage implements ObjectStorage {
 
     @Override
     public CompletableFuture<Boolean> deleteLogical(String path) {
-        // Invalidate all cached entries for this logical file
+        // Invalidate all cached entries for this logical file and delete disk files
         String multipartPrefix = path + ObjectStorage.MULTIPART_SUFFIX + "/";
         List<String> toInvalidate = new ArrayList<>(cache.synchronous().asMap().keySet());
         toInvalidate.stream()

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
@@ -259,11 +259,15 @@ public class CachingObjectStorageTest {
         assertFalse(Files.exists(caching.cacheFilePath("pfx/b.page")));
     }
 
+    /**
+     * Disk files must survive heap eviction so they can serve as an L2 cache,
+     * avoiding a MinIO round-trip when the heap entry is re-accessed after eviction.
+     */
     @Test
-    public void testEvictionDeletesLocalFile() throws Exception {
+    public void testEvictionRetainsDiskFile() throws Exception {
         FakeObjectStorage inner = new FakeObjectStorage();
         Path cacheDir = folder.newFolder("cache3").toPath();
-        // 1 byte max cache — any write will be evicted
+        // 1 byte max heap cache — any write will be evicted from L1
         CachingObjectStorage caching = new CachingObjectStorage(inner, cacheDir, executor, 1);
 
         byte[] data = new byte[100];
@@ -272,7 +276,32 @@ public class CachingObjectStorageTest {
         // Force Caffeine to process pending evictions
         caching.cleanUp();
 
+        // The disk file must NOT be deleted — it is the L2 cache
         Path cacheFile = caching.cacheFilePath("evict/big.page");
-        assertFalse("evicted entry's local file should be deleted", Files.exists(cacheFile));
+        assertTrue("evicted entry's local file must be retained as L2 cache", Files.exists(cacheFile));
+    }
+
+    /**
+     * After a heap eviction, the next read must be served from the disk L2 cache,
+     * not from object storage.
+     */
+    @Test
+    public void testEvictedEntryServedFromDisk() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        Path cacheDir = folder.newFolder("cache4").toPath();
+        // 1 byte max heap cache — forces immediate eviction
+        CachingObjectStorage caching = new CachingObjectStorage(inner, cacheDir, executor, 1);
+
+        byte[] data = "disk-cached payload".getBytes();
+        caching.write("l2/test.page", data).get();
+        caching.cleanUp(); // evict from heap
+
+        // Read should hit disk L2, not object storage
+        int readsBefore = inner.readCalls.get();
+        ReadResult result = caching.read("l2/test.page").get();
+        assertEquals(ReadResult.Status.FOUND, result.status());
+        assertArrayEquals(data, result.content());
+        assertEquals("read should be served from disk L2 cache, not object storage",
+                readsBefore, inner.readCalls.get());
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: `CachingObjectStorage` deleted disk cache files in the Caffeine eviction listener, making the disk files a mirror of the heap cache rather than an independent tier. On every heap eviction the disk file was deleted, so the next `readFileRange` re-fetched from MinIO (~4 MB/s in Docker) instead of local disk.
- **Fix**: remove `deleteCacheFile()` from the eviction listener. The Caffeine loader now checks local disk first before falling back to object storage, giving a proper two-tier cache (L1 heap → L2 disk → L3 MinIO).
- **k3s-local values.yaml**: fix `cacheMaxBytes` YAML path (`fileServer.cacheMaxBytes` → `fileServer.s3.cacheMaxBytes`, which is what the Helm template actually reads), raise heap to `-Xmx8g`, set L1 to 6 GiB, grow PVC to 50 GiB for L2 disk tier.

## Root cause details

The original loader always called `inner.read(path)` (MinIO) on every Caffeine miss. On eviction, the disk file was deleted, so _every_ miss after the first was a MinIO round-trip even if the data had been on disk seconds earlier.

In a local k3s-in-Docker cluster with MinIO throughput of ~4 MB/s, loading a 208 MB FusedPQ graph block took ~52 s. With 4 concurrent query threads each loading a block, the 300 s gRPC deadline was hit on almost every query — causing `DEADLINE_EXCEEDED` and recall@100 ≈ 0.

## Cache tier table (after fix)

| Tier | Storage | Typical speed | Bounded by |
|---|---|---|---|
| L1 | JVM heap (Caffeine) | ~GB/s | `s3.cacheMaxBytes` |
| L2 | Local disk | ~100–500 MB/s | PVC size |
| L3 | MinIO / S3 | ~4 MB/s (Docker) | — |

Disk files are still explicitly removed by `deleteLogical`, `delete`, `deleteByPrefix`, and `clearCacheDir` (on pod restart).

## Test plan

- [x] `testEvictionRetainsDiskFile`: verifies disk file survives heap eviction
- [x] `testEvictedEntryServedFromDisk`: verifies re-read after eviction hits disk (zero `inner.readCalls` increment), not MinIO
- [x] All 8 existing `CachingObjectStorageTest` tests pass
- [ ] Run sift1m M=8 benchmark on k3s-local cluster; verify `rfs_readrange_bytes` stops growing after first checkpoint (blocks served from disk cache)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)