### PR TITLE
indexing-admin: diagnostic CLI + 5 new gRPC RPCs for indexing service

### DIFF
--- a/VECTOR.md
+++ b/VECTOR.md
@@ -894,3 +894,93 @@ mvn -f vector-testings/pom.xml package -DskipTests
 | `sift1m` | 1M | 128 | ~170 MB |
 | `sift10m` | 10M | 128 | ~98 GB |
 | `bigann` | 1B | 128 | ~98 GB |
+
+---
+
+## indexing-admin — diagnostic CLI
+
+`indexing-admin` is a lightweight gRPC CLI for inspecting the internal state
+of a **single** indexing service instance. It's bundled with `herddb-services`
+at `bin/indexing-admin.sh` and pre-wired into the k3s tools pod as
+`/usr/local/bin/indexing-admin`. Use it when you need to understand what an
+indexing replica is actually holding — loaded indexes, live/on-disk node
+counts, tailer lag, apply-queue backpressure, or the set of primary keys
+backing an index — without scraping Prometheus or reading `sysindexstatus`
+from the main HerdDB server.
+
+All commands talk to **one** instance at a time. `list-instances` is the only
+command that reads ZooKeeper; every other sub-command takes `--server host:port`
+pointing at the specific replica you want to inspect.
+
+### Sub-commands
+
+| Command | Purpose |
+|---|---|
+| `list-instances` | Read ZooKeeper and print every registered indexing service address |
+| `list-indexes` | Enumerate the indexes loaded by one instance (tablespace, table, index, vector count, status) |
+| `describe-index` | Full per-index detail: dimension, similarity, live vs on-disk node counts, segments, shards, memory, LSN, FusedPQ/M/beam-width, dirty flag |
+| `status` | One-line wrapper over the legacy `GetIndexStatus` RPC |
+| `list-pks` | Stream the list of primary keys backing an index (hex or base64 output, optional `--include-ondisk`, `--limit`) |
+| `engine-stats` | Tailer watermark, entries processed, apply queue size/capacity/parallelism, loaded index count, total estimated memory, uptime |
+| `instance-info` | Instance id, gRPC host:port, storage type, data dir, tablespace name + UUID, ordinal/numInstances, JVM max heap |
+
+### gRPC methods exposed by the indexing service
+
+Five new RPCs were added to `indexing_service.proto` to back the CLI
+(`ListIndexes`, `DescribeIndex`, `ListPrimaryKeys` — server-streamed —
+`GetEngineStats`, `GetInstanceInfo`). They are strictly additive; the existing
+`Search` and `GetIndexStatus` wire format is unchanged.
+
+### Examples
+
+```bash
+# Build and run locally against a released zip
+mvn -pl herddb-indexing-service,herddb-services -am package -DskipTests
+./target/herddb-services-*/bin/indexing-admin.sh list-indexes \
+    --server localhost:9850
+
+# Extended view of a single index
+./target/herddb-services-*/bin/indexing-admin.sh describe-index \
+    --server localhost:9850 \
+    --tablespace herd --table docs --index emb_hnsw
+
+# Dump up to 1000 PKs as hex (live graph only)
+./target/herddb-services-*/bin/indexing-admin.sh list-pks \
+    --server localhost:9850 \
+    --table docs --index emb_hnsw --limit 1000
+
+# Engine snapshot in JSON
+./target/herddb-services-*/bin/indexing-admin.sh engine-stats \
+    --server localhost:9850 --json
+```
+
+### In the k3s tools pod
+
+The helm chart mounts the CLI as `indexing-admin` in `$PATH` and injects
+`HERDDB_INDEXING_ZK` into the tools container. `list-instances` picks up the
+ZK connect string automatically; every other command still requires an
+explicit `--server` so the operator is aware which replica they are talking
+to.
+
+```bash
+kubectl exec -it herddb-tools-0 -- indexing-admin list-instances
+kubectl exec -it herddb-tools-0 -- indexing-admin list-indexes \
+    --server herddb-indexing-service-0.herddb-indexing-service:9850
+kubectl exec -it herddb-tools-0 -- indexing-admin engine-stats \
+    --server herddb-indexing-service-0.herddb-indexing-service:9850 --json
+```
+
+Setting `HERDDB_INDEXING_SERVER=host:port` in the environment lets the wrapper
+auto-fill `--server` for commands that need it — useful for scripted health
+checks that target one replica at a time.
+
+### Out of scope (v1)
+
+- Live TUI / dashboards. `watch -n2 indexing-admin engine-stats` covers the
+  live case with stdlib tools.
+- Write operations (force-checkpoint, drop-segment, etc.). This tool is
+  diagnostic; destructive verbs belong to a separate change.
+- Automated tuning suggestions. The raw numbers are exposed today; a future
+  `indexing-admin advise` sub-command can layer rules on top of
+  `describe-index` + `engine-stats`.
+

--- a/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
@@ -23,6 +23,7 @@ package herddb.index.vector;
 import herddb.utils.Bytes;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Abstract base class for vector stores.
@@ -53,6 +54,20 @@ public abstract class AbstractVectorStore implements AutoCloseable {
     public abstract long estimatedMemoryUsageBytes();
 
     public abstract void start() throws Exception;
+
+    /**
+     * Visits every primary key currently stored in the vector store. Used by
+     * the indexing-admin diagnostic CLI. The visitor returns {@code false} to
+     * stop the traversal early.
+     *
+     * @param includeOnDisk if true, also visit primary keys that live only in
+     *                      on-disk segments (ignored by in-memory stores)
+     * @param visitor callback invoked for each PK; return false to stop
+     */
+    public void forEachPrimaryKey(boolean includeOnDisk, Predicate<Bytes> visitor) {
+        throw new UnsupportedOperationException(
+                "forEachPrimaryKey not implemented by " + getClass().getName());
+    }
 
     @Override
     public void close() throws Exception {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -80,6 +80,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -3318,6 +3319,54 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public int getOnDiskNodeCount() {
         return (int) onDiskNodeToPkSize();
+    }
+
+    /**
+     * Visits every primary key currently stored in this vector store.
+     * Walks live shards (and frozen shards, if a checkpoint is running)
+     * first, then, if {@code includeOnDisk} is true, walks on-disk segments
+     * via {@link VectorSegment#scanNodeToPk()}.
+     *
+     * <p>The visitor returns {@code false} to stop the traversal early.
+     *
+     * <p>PKs that only exist in sealed on-disk segments may collide with
+     * live PKs when the live graph still holds a newer copy of the same
+     * record; callers that need deduplication must track seen PKs
+     * themselves.
+     */
+    @Override
+    public void forEachPrimaryKey(boolean includeOnDisk, Predicate<Bytes> visitor) {
+        for (LiveGraphShard shard : liveShards) {
+            for (Bytes pk : shard.nodeToPk.values()) {
+                if (!visitor.test(pk)) {
+                    return;
+                }
+            }
+        }
+        List<LiveGraphShard> frozen = this.frozenShards;
+        if (frozen != null) {
+            for (LiveGraphShard shard : frozen) {
+                for (Bytes pk : shard.nodeToPk.values()) {
+                    if (!visitor.test(pk)) {
+                        return;
+                    }
+                }
+            }
+        }
+        if (!includeOnDisk) {
+            return;
+        }
+        for (VectorSegment seg : segments) {
+            try (Stream<Map.Entry<Bytes, Bytes>> stream = seg.scanNodeToPk()) {
+                java.util.Iterator<Map.Entry<Bytes, Bytes>> it = stream.iterator();
+                while (it.hasNext()) {
+                    Bytes pk = it.next().getValue();
+                    if (!visitor.test(pk)) {
+                        return;
+                    }
+                }
+            }
+        }
     }
 
     public int getSegmentCount() {

--- a/herddb-indexing-service/pom.xml
+++ b/herddb-indexing-service/pom.xml
@@ -123,10 +123,10 @@
             <artifactId>commons-logging</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Used by the indexing-admin CLI (herddb.indexing.admin package). -->
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -184,6 +184,51 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
+            </plugin>
+            <!--
+              Secondary shade execution that produces
+              herddb-indexing-service-<version>-admin-cli.jar, an uber-jar
+              bundling the main indexing service classes plus commons-cli,
+              with herddb.indexing.admin.IndexingAdminCli as Main-Class.
+
+              Used by the indexing-admin launcher script shipped in
+              herddb-services; the regular (unshaded) jar produced by
+              maven-jar-plugin is unaffected and is the artifact published
+              for downstream modules.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>indexing-admin-cli</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>admin-cli</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>herddb.indexing.admin.IndexingAdminCli</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/herddb-indexing-service/src/main/java/herddb/indexing/InMemoryVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/InMemoryVectorStore.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * In-memory brute-force vector store used by the IndexingServiceEngine.
@@ -104,6 +105,19 @@ class InMemoryVectorStore extends AbstractVectorStore {
             results.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
         }
         return results.size() <= topK ? results : results.subList(0, topK);
+    }
+
+    @Override
+    public void forEachPrimaryKey(boolean includeOnDisk, Predicate<Bytes> visitor) {
+        List<VectorEntry> snapshot;
+        synchronized (entries) {
+            snapshot = new ArrayList<>(entries);
+        }
+        for (VectorEntry entry : snapshot) {
+            if (!visitor.test(entry.pk)) {
+                return;
+            }
+        }
     }
 
     @Override

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -323,7 +323,10 @@ public class IndexingServer implements AutoCloseable {
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "Failed to register indexing service", e);
             }
+        } else {
+            registeredServiceId = host + ":" + server.getPort();
         }
+        engine.setInstanceIdLabel(registeredServiceId);
 
         LOGGER.log(Level.INFO, "IndexingServer started on port {0}", getPort());
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -44,6 +44,7 @@ import herddb.utils.Bytes;
 import herddb.utils.XXHash64Utils;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -55,6 +56,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.Gauge;
@@ -111,6 +113,18 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     private ExecutorService[] applyWorkers;
     private int applyParallelism;
     private volatile Throwable asyncError;
+
+    /**
+     * Wall-clock time at which {@link #start()} finished, used by the
+     * admin CLI to compute engine uptime.
+     */
+    private volatile long startTimeMillis;
+
+    /**
+     * Human-readable identifier for this engine instance, populated by
+     * {@link IndexingServer} once the gRPC endpoint is bound. Nullable.
+     */
+    private volatile String instanceIdLabel;
 
     /**
      * Hook invoked after the tablespace UUID has been resolved but before the
@@ -174,6 +188,10 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
 
     public Path getDataDirectory() {
         return dataDirectory;
+    }
+
+    public IndexingServerConfiguration getConfig() {
+        return config;
     }
 
     /**
@@ -457,9 +475,77 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         tailerThread.setDaemon(true);
         tailerThread.start();
 
+        this.startTimeMillis = System.currentTimeMillis();
+
         LOGGER.log(Level.INFO,
                 "IndexingServiceEngine started, watermark={0}, tailerStart={1}",
                 new Object[]{watermark, tailerStart});
+    }
+
+    /**
+     * Injects the human-readable identifier for this engine instance (usually
+     * {@code host:port} once gRPC has bound to a port). Used by the admin CLI.
+     */
+    public void setInstanceIdLabel(String instanceIdLabel) {
+        this.instanceIdLabel = instanceIdLabel;
+    }
+
+    public String getInstanceIdLabel() {
+        return instanceIdLabel;
+    }
+
+    public String getTableSpaceUUID() {
+        return tableSpaceUUID;
+    }
+
+    public long getStartTimeMillis() {
+        return startTimeMillis;
+    }
+
+    public int getApplyParallelism() {
+        return applyParallelism;
+    }
+
+    public int getLoadedIndexCount() {
+        return vectorStores.size();
+    }
+
+    public int getApplyQueueSize() {
+        ExecutorService[] workers = this.applyWorkers;
+        if (workers == null) {
+            return 0;
+        }
+        int total = 0;
+        for (ExecutorService w : workers) {
+            if (w instanceof ThreadPoolExecutor) {
+                total += ((ThreadPoolExecutor) w).getQueue().size();
+            }
+        }
+        return total;
+    }
+
+    public int getApplyQueueCapacity() {
+        ExecutorService[] workers = this.applyWorkers;
+        if (workers == null || workers.length == 0 || !(workers[0] instanceof ThreadPoolExecutor)) {
+            return 0;
+        }
+        BlockingQueue<?> q = ((ThreadPoolExecutor) workers[0]).getQueue();
+        int perStripeCapacity = q.size() + q.remainingCapacity();
+        return perStripeCapacity * workers.length;
+    }
+
+    public long getTailerEntriesProcessed() {
+        CommitLogTailing t = tailer;
+        return t != null ? t.getEntriesProcessed() : 0L;
+    }
+
+    public boolean isTailerRunning() {
+        CommitLogTailing t = tailer;
+        return t != null && t.isRunning();
+    }
+
+    public LogSequenceNumber getLastProcessedLsn() {
+        return lastProcessedLsn;
     }
 
     /**
@@ -847,6 +933,152 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 lastProcessedLsn != null ? lastProcessedLsn.ledgerId : -1,
                 lastProcessedLsn != null ? lastProcessedLsn.offset : -1,
                 "tailing");
+    }
+
+    /**
+     * Test-only helper: registers a pre-built vector store under the given
+     * index, so diagnostic RPCs can be exercised without replaying a commit
+     * log. Visible for tests within the same package.
+     */
+    // package-private for testing
+    void registerIndexForTest(Index index, AbstractVectorStore store) {
+        if (schemaTracker == null) {
+            schemaTracker = new SchemaTracker();
+        }
+        // Simulate what applyEntry would do for a CREATE_INDEX record.
+        java.util.Map<String, Index> tracked =
+                getSchemaTrackerIndexes();
+        tracked.put(index.name, index);
+        vectorStores.put(storeKey(index.table, index.name), store);
+    }
+
+    /**
+     * Reflection-free accessor used only by
+     * {@link #registerIndexForTest(Index, AbstractVectorStore)}. Exposes the
+     * private {@code indexes} map on {@link SchemaTracker} so tests can seed
+     * it. We avoid a public setter on {@code SchemaTracker} because the
+     * production code only mutates it via log entries.
+     */
+    @SuppressWarnings("unchecked")
+    private java.util.Map<String, Index> getSchemaTrackerIndexes() {
+        try {
+            java.lang.reflect.Field f = SchemaTracker.class.getDeclaredField("indexes");
+            f.setAccessible(true);
+            return (java.util.Map<String, Index>) f.get(schemaTracker);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("failed to access SchemaTracker.indexes", e);
+        }
+    }
+
+    /**
+     * Enumerates every vector index loaded by this engine instance. Used by
+     * the indexing-admin CLI.
+     */
+    public List<IndexDescriptor> listIndexes() {
+        List<IndexDescriptor> out = new ArrayList<>(vectorStores.size());
+        if (schemaTracker == null) {
+            return out;
+        }
+        for (Index idx : schemaTracker.getAllIndexes()) {
+            if (!Index.TYPE_VECTOR.equals(idx.type)) {
+                continue;
+            }
+            AbstractVectorStore store = vectorStores.get(storeKey(idx.table, idx.name));
+            long vectorCount = store != null ? store.size() : 0;
+            String status = store != null ? "tailing" : "missing";
+            out.add(new IndexDescriptor(idx.tablespace, idx.table, idx.name, vectorCount, status));
+        }
+        return out;
+    }
+
+    /**
+     * Returns extended diagnostic information for a single vector index.
+     * Returns {@code null} if the index is not loaded on this instance.
+     */
+    public IndexDetails describeIndex(String tablespace, String table, String index) {
+        AbstractVectorStore store = vectorStores.get(storeKey(table, index));
+        if (store == null) {
+            return null;
+        }
+        IndexDetails d = new IndexDetails();
+        d.tablespace = tablespace;
+        d.table = table;
+        d.index = index;
+        d.vectorCount = store.size();
+        d.status = "tailing";
+        d.estimatedMemoryBytes = store.estimatedMemoryUsageBytes();
+        d.liveVectorsMemoryBytes = store.estimatedMemoryUsageBytes();
+        d.storeClass = store.getClass().getSimpleName();
+        d.persistent = store instanceof PersistentVectorStore;
+        if (store instanceof PersistentVectorStore) {
+            PersistentVectorStore pvs = (PersistentVectorStore) store;
+            d.dimension = pvs.getDimension();
+            d.similarity = pvs.getSimilarityFunction();
+            d.liveNodeCount = pvs.getLiveNodeCount();
+            d.onDiskNodeCount = pvs.getOnDiskNodeCount();
+            d.segmentCount = pvs.getSegmentCount();
+            d.liveShardCount = pvs.getLiveShardCount();
+            d.liveVectorsMemoryBytes = pvs.getLiveVectorsMemoryBytes();
+            d.onDiskSizeBytes = pvs.getEstimatedSizeBytes();
+            d.dirty = pvs.isDirty();
+            d.fusedPQEnabled = pvs.isFusedPQEnabled();
+            d.m = pvs.getM();
+            d.beamWidth = pvs.getBeamWidth();
+        } else if (store instanceof InMemoryVectorStore) {
+            d.similarity = ((InMemoryVectorStore) store).getSimilarityType().name();
+            d.segmentCount = 1;
+            d.liveNodeCount = store.size();
+            d.liveShardCount = 1;
+        }
+        LogSequenceNumber lsn = lastProcessedLsn;
+        if (lsn != null) {
+            d.lastLsnLedger = lsn.ledgerId;
+            d.lastLsnOffset = lsn.offset;
+        } else {
+            d.lastLsnLedger = -1L;
+            d.lastLsnOffset = -1L;
+        }
+        return d;
+    }
+
+    /**
+     * Streams every primary key held by the given vector index through the
+     * supplied visitor. Returns the total number of PKs visited. The visitor
+     * may return {@code false} to stop the walk early (e.g. the server handler
+     * uses this to implement a chunked-response limit).
+     *
+     * @param limit maximum number of PKs to visit, or {@code <= 0} for no cap
+     */
+    public long streamPrimaryKeys(String tablespace, String table, String index,
+                                   boolean includeOnDisk, long limit,
+                                   Predicate<Bytes> visitor) {
+        AbstractVectorStore store = vectorStores.get(storeKey(table, index));
+        if (store == null) {
+            return 0;
+        }
+        long[] count = new long[]{0L};
+        store.forEachPrimaryKey(includeOnDisk, pk -> {
+            count[0]++;
+            if (limit > 0 && count[0] > limit) {
+                return false;
+            }
+            return visitor.test(pk);
+        });
+        if (limit > 0 && count[0] > limit) {
+            count[0] = limit;
+        }
+        return count[0];
+    }
+
+    /**
+     * Sum of estimated memory used by every loaded vector store.
+     */
+    public long getTotalEstimatedMemoryBytes() {
+        long total = 0;
+        for (AbstractVectorStore store : vectorStores.values()) {
+            total += store.estimatedMemoryUsageBytes();
+        }
+        return total;
     }
 
     public void setStatsLogger(StatsLogger statsLogger) {
@@ -1403,5 +1635,74 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         public String getStatus() {
             return status;
         }
+    }
+
+    /**
+     * Lightweight per-index row for {@link #listIndexes()}.
+     */
+    public static final class IndexDescriptor {
+        private final String tablespace;
+        private final String table;
+        private final String index;
+        private final long vectorCount;
+        private final String status;
+
+        public IndexDescriptor(String tablespace, String table, String index, long vectorCount, String status) {
+            this.tablespace = tablespace;
+            this.table = table;
+            this.index = index;
+            this.vectorCount = vectorCount;
+            this.status = status;
+        }
+
+        public String getTablespace() {
+            return tablespace;
+        }
+
+        public String getTable() {
+            return table;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+
+        public long getVectorCount() {
+            return vectorCount;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+    }
+
+    /**
+     * Extended per-index diagnostic record returned by
+     * {@link #describeIndex(String, String, String)}. Fields are mutable so
+     * {@code describeIndex} can assemble the record lazily.
+     */
+    public static final class IndexDetails {
+        public String tablespace;
+        public String table;
+        public String index;
+        public long vectorCount;
+        public String status;
+        public int dimension;
+        public String similarity;
+        public long liveNodeCount;
+        public long onDiskNodeCount;
+        public int segmentCount;
+        public int liveShardCount;
+        public long estimatedMemoryBytes;
+        public long liveVectorsMemoryBytes;
+        public long onDiskSizeBytes;
+        public boolean dirty;
+        public long lastLsnLedger;
+        public long lastLsnOffset;
+        public boolean fusedPQEnabled;
+        public int m;
+        public int beamWidth;
+        public boolean persistent;
+        public String storeClass;
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -21,15 +21,28 @@
 package herddb.indexing;
 
 import com.google.protobuf.ByteString;
+import herddb.indexing.proto.DescribeIndexRequest;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.indexing.proto.GetEngineStatsRequest;
+import herddb.indexing.proto.GetEngineStatsResponse;
 import herddb.indexing.proto.GetIndexStatusRequest;
 import herddb.indexing.proto.GetIndexStatusResponse;
+import herddb.indexing.proto.GetInstanceInfoRequest;
+import herddb.indexing.proto.GetInstanceInfoResponse;
+import herddb.indexing.proto.IndexDescriptor;
 import herddb.indexing.proto.IndexingServiceGrpc;
+import herddb.indexing.proto.ListIndexesRequest;
+import herddb.indexing.proto.ListIndexesResponse;
+import herddb.indexing.proto.ListPrimaryKeysRequest;
+import herddb.indexing.proto.PrimaryKeysChunk;
 import herddb.indexing.proto.SearchRequest;
 import herddb.indexing.proto.SearchResponse;
 import herddb.indexing.proto.SearchResult;
+import herddb.log.LogSequenceNumber;
 import herddb.utils.Bytes;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +60,9 @@ import org.apache.bookkeeper.stats.StatsLogger;
 public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImplBase {
 
     private static final Logger LOGGER = Logger.getLogger(IndexingServiceImpl.class.getName());
+
+    private static final int DEFAULT_PK_CHUNK_SIZE = 1000;
+    private static final int MAX_PK_CHUNK_SIZE = 10000;
 
     private final IndexingServiceEngine engine;
 
@@ -98,7 +114,7 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             searchLatency.registerSuccessfulEvent(elapsedMicros, TimeUnit.MICROSECONDS);
             responseObserver.onNext(responseBuilder.build());
             responseObserver.onCompleted();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             searchErrors.inc();
             long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
             searchLatency.registerFailedEvent(elapsedMicros, TimeUnit.MICROSECONDS);
@@ -129,7 +145,7 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
 
             responseObserver.onNext(response);
             responseObserver.onCompleted();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             statusErrors.inc();
             LOGGER.log(Level.SEVERE, "GetIndexStatus failed for index " + request.getIndex(), e);
             responseObserver.onError(Status.INTERNAL
@@ -137,5 +153,212 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .withCause(e)
                     .asRuntimeException());
         }
+    }
+
+    @Override
+    public void listIndexes(ListIndexesRequest request, StreamObserver<ListIndexesResponse> responseObserver) {
+        try {
+            List<IndexingServiceEngine.IndexDescriptor> indexes = engine.listIndexes();
+            ListIndexesResponse.Builder builder = ListIndexesResponse.newBuilder();
+            for (IndexingServiceEngine.IndexDescriptor d : indexes) {
+                builder.addIndexes(IndexDescriptor.newBuilder()
+                        .setTablespace(nullToEmpty(d.getTablespace()))
+                        .setTable(nullToEmpty(d.getTable()))
+                        .setIndex(nullToEmpty(d.getIndex()))
+                        .setVectorCount(d.getVectorCount())
+                        .setStatus(nullToEmpty(d.getStatus()))
+                        .build());
+            }
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "ListIndexes failed", e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void describeIndex(DescribeIndexRequest request, StreamObserver<DescribeIndexResponse> responseObserver) {
+        try {
+            IndexingServiceEngine.IndexDetails details = engine.describeIndex(
+                    request.getTablespace(),
+                    request.getTable(),
+                    request.getIndex());
+            if (details == null) {
+                responseObserver.onError(Status.NOT_FOUND
+                        .withDescription("index not loaded on this instance: "
+                                + request.getTable() + "." + request.getIndex())
+                        .asRuntimeException());
+                return;
+            }
+            DescribeIndexResponse.Builder builder = DescribeIndexResponse.newBuilder()
+                    .setBasic(IndexDescriptor.newBuilder()
+                            .setTablespace(nullToEmpty(details.tablespace))
+                            .setTable(nullToEmpty(details.table))
+                            .setIndex(nullToEmpty(details.index))
+                            .setVectorCount(details.vectorCount)
+                            .setStatus(nullToEmpty(details.status))
+                            .build())
+                    .setDimension(details.dimension)
+                    .setSimilarity(nullToEmpty(details.similarity))
+                    .setLiveNodeCount(details.liveNodeCount)
+                    .setOndiskNodeCount(details.onDiskNodeCount)
+                    .setSegmentCount(details.segmentCount)
+                    .setLiveShardCount(details.liveShardCount)
+                    .setEstimatedMemoryBytes(details.estimatedMemoryBytes)
+                    .setLiveVectorsMemoryBytes(details.liveVectorsMemoryBytes)
+                    .setOndiskSizeBytes(details.onDiskSizeBytes)
+                    .setDirty(details.dirty)
+                    .setLastLsnLedger(details.lastLsnLedger)
+                    .setLastLsnOffset(details.lastLsnOffset)
+                    .setFusedPqEnabled(details.fusedPQEnabled)
+                    .setM(details.m)
+                    .setBeamWidth(details.beamWidth)
+                    .setPersistent(details.persistent)
+                    .setStoreClass(nullToEmpty(details.storeClass));
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "DescribeIndex failed for index " + request.getIndex(), e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void listPrimaryKeys(ListPrimaryKeysRequest request,
+                                 StreamObserver<PrimaryKeysChunk> responseObserver) {
+        try {
+            int chunkSize = request.getChunkSize() > 0 ? request.getChunkSize() : DEFAULT_PK_CHUNK_SIZE;
+            if (chunkSize > MAX_PK_CHUNK_SIZE) {
+                chunkSize = MAX_PK_CHUNK_SIZE;
+            }
+            final int effectiveChunkSize = chunkSize;
+            final List<ByteString>[] buffer = new List[]{new ArrayList<>(effectiveChunkSize)};
+            engine.streamPrimaryKeys(
+                    request.getTablespace(),
+                    request.getTable(),
+                    request.getIndex(),
+                    request.getIncludeOndisk(),
+                    request.getLimit(),
+                    pk -> {
+                        buffer[0].add(ByteString.copyFrom(pk.getBuffer(), pk.getOffset(), pk.getLength()));
+                        if (buffer[0].size() >= effectiveChunkSize) {
+                            responseObserver.onNext(PrimaryKeysChunk.newBuilder()
+                                    .addAllPrimaryKeys(buffer[0])
+                                    .setLast(false)
+                                    .build());
+                            buffer[0] = new ArrayList<>(effectiveChunkSize);
+                        }
+                        return true;
+                    });
+            // Always send a terminal chunk so clients can detect end-of-stream
+            // even when the total count is an exact multiple of chunkSize.
+            responseObserver.onNext(PrimaryKeysChunk.newBuilder()
+                    .addAllPrimaryKeys(buffer[0])
+                    .setLast(true)
+                    .build());
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "ListPrimaryKeys failed for index " + request.getIndex(), e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void getEngineStats(GetEngineStatsRequest request,
+                                StreamObserver<GetEngineStatsResponse> responseObserver) {
+        try {
+            long start = engine.getStartTimeMillis();
+            long uptime = start > 0 ? System.currentTimeMillis() - start : 0L;
+            LogSequenceNumber lsn = engine.getLastProcessedLsn();
+            GetEngineStatsResponse response = GetEngineStatsResponse.newBuilder()
+                    .setUptimeMillis(uptime)
+                    .setTailerWatermarkLedger(lsn != null ? lsn.ledgerId : -1L)
+                    .setTailerWatermarkOffset(lsn != null ? lsn.offset : -1L)
+                    .setTailerEntriesProcessed(engine.getTailerEntriesProcessed())
+                    .setTailerRunning(engine.isTailerRunning())
+                    .setApplyQueueSize(engine.getApplyQueueSize())
+                    .setApplyQueueCapacity(engine.getApplyQueueCapacity())
+                    .setTotalEstimatedMemoryBytes(engine.getTotalEstimatedMemoryBytes())
+                    .setLoadedIndexCount(engine.getLoadedIndexCount())
+                    .setApplyParallelism(engine.getApplyParallelism())
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "GetEngineStats failed", e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void getInstanceInfo(GetInstanceInfoRequest request,
+                                 StreamObserver<GetInstanceInfoResponse> responseObserver) {
+        try {
+            IndexingServerConfiguration cfg = engine.getConfig();
+            String storageType = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE,
+                            IndexingServerConfiguration.PROPERTY_STORAGE_TYPE_DEFAULT)
+                    : "";
+            String dataDir = engine.getDataDirectory() != null
+                    ? engine.getDataDirectory().toAbsolutePath().toString()
+                    : "";
+            String tablespaceName = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_TABLESPACE_NAME,
+                            IndexingServerConfiguration.PROPERTY_TABLESPACE_NAME_DEFAULT)
+                    : "";
+            int grpcPort = cfg != null
+                    ? cfg.getInt(IndexingServerConfiguration.PROPERTY_GRPC_PORT,
+                            IndexingServerConfiguration.PROPERTY_GRPC_PORT_DEFAULT)
+                    : 0;
+            String grpcHost = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_GRPC_HOST,
+                            IndexingServerConfiguration.PROPERTY_GRPC_HOST_DEFAULT)
+                    : "";
+            int instanceOrdinal = cfg != null
+                    ? cfg.getInt(IndexingServerConfiguration.PROPERTY_INSTANCE_ID,
+                            IndexingServerConfiguration.PROPERTY_INSTANCE_ID_DEFAULT)
+                    : 0;
+            int numInstances = cfg != null
+                    ? cfg.getInt(IndexingServerConfiguration.PROPERTY_NUM_INSTANCES,
+                            IndexingServerConfiguration.PROPERTY_NUM_INSTANCES_DEFAULT)
+                    : 1;
+            GetInstanceInfoResponse response = GetInstanceInfoResponse.newBuilder()
+                    .setInstanceId(nullToEmpty(engine.getInstanceIdLabel()))
+                    .setGrpcHost(nullToEmpty(grpcHost))
+                    .setGrpcPort(grpcPort)
+                    .setStorageType(nullToEmpty(storageType))
+                    .setDataDir(nullToEmpty(dataDir))
+                    .setJvmMaxHeapBytes(Runtime.getRuntime().maxMemory())
+                    .setTablespaceName(nullToEmpty(tablespaceName))
+                    .setTablespaceUuid(nullToEmpty(engine.getTableSpaceUUID()))
+                    .setInstanceOrdinal(instanceOrdinal)
+                    .setNumInstances(numInstances)
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "GetInstanceInfo failed", e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/SchemaTracker.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/SchemaTracker.java
@@ -107,4 +107,12 @@ public class SchemaTracker {
                 .filter(idx -> Index.TYPE_VECTOR.equals(idx.type) && tableName.equals(idx.table))
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Returns a snapshot of every tracked index. Used by the indexing-admin
+     * diagnostic CLI to enumerate indexes without knowing the table name.
+     */
+    public Collection<Index> getAllIndexes() {
+        return new java.util.ArrayList<>(indexes.values());
+    }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -1,0 +1,543 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import com.google.protobuf.ByteString;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.indexing.proto.GetEngineStatsResponse;
+import herddb.indexing.proto.GetIndexStatusResponse;
+import herddb.indexing.proto.GetInstanceInfoResponse;
+import herddb.indexing.proto.IndexDescriptor;
+import herddb.indexing.proto.ListIndexesResponse;
+import herddb.indexing.proto.PrimaryKeysChunk;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Diagnostic CLI for a HerdDB indexing service instance.
+ *
+ * <p>Usage:
+ * <pre>
+ *   indexing-admin &lt;command&gt; [options]
+ *
+ *   Commands:
+ *     list-instances   Read ZooKeeper and print registered indexing services
+ *     list-indexes     Enumerate indexes loaded by one instance
+ *     describe-index   Print detailed state of a single index
+ *     status           Short single-line GetIndexStatus wrapper
+ *     list-pks         Stream the list of primary keys for an index
+ *     engine-stats     Tailer / apply / memory stats of one instance
+ *     instance-info    Config/identity/heap snapshot of one instance
+ * </pre>
+ *
+ * <p>All RPCs (except {@code list-instances}) target exactly one indexing
+ * service instance selected via {@code --server host:port}. The
+ * {@code list-instances} command reads ZooKeeper directly via
+ * {@link ZkInstanceDiscovery}.
+ */
+public final class IndexingAdminCli {
+
+    static final String COMMAND_LIST_INSTANCES = "list-instances";
+    static final String COMMAND_LIST_INDEXES = "list-indexes";
+    static final String COMMAND_DESCRIBE_INDEX = "describe-index";
+    static final String COMMAND_STATUS = "status";
+    static final String COMMAND_LIST_PKS = "list-pks";
+    static final String COMMAND_ENGINE_STATS = "engine-stats";
+    static final String COMMAND_INSTANCE_INFO = "instance-info";
+
+    private final PrintStream out;
+    private final PrintStream err;
+
+    public IndexingAdminCli(PrintStream out, PrintStream err) {
+        this.out = out;
+        this.err = err;
+    }
+
+    public static void main(String[] args) {
+        int rc = new IndexingAdminCli(System.out, System.err).run(args);
+        System.exit(rc);
+    }
+
+    /**
+     * Entry point used by {@link #main(String[])} and by tests. Returns a
+     * process exit code: 0 = success, 1 = command failed, 2 = bad usage.
+     */
+    public int run(String[] args) {
+        if (args.length == 0 || "-h".equals(args[0]) || "--help".equals(args[0])) {
+            printUsage();
+            return args.length == 0 ? 2 : 0;
+        }
+        String command = args[0];
+        String[] rest = Arrays.copyOfRange(args, 1, args.length);
+        try {
+            switch (command) {
+                case COMMAND_LIST_INSTANCES:
+                    return runListInstances(rest);
+                case COMMAND_LIST_INDEXES:
+                    return runListIndexes(rest);
+                case COMMAND_DESCRIBE_INDEX:
+                    return runDescribeIndex(rest);
+                case COMMAND_STATUS:
+                    return runStatus(rest);
+                case COMMAND_LIST_PKS:
+                    return runListPks(rest);
+                case COMMAND_ENGINE_STATS:
+                    return runEngineStats(rest);
+                case COMMAND_INSTANCE_INFO:
+                    return runInstanceInfo(rest);
+                default:
+                    err.println("Unknown command: " + command);
+                    printUsage();
+                    return 2;
+            }
+        } catch (ParseException e) {
+            err.println("Invalid arguments: " + e.getMessage());
+            return 2;
+        } catch (RuntimeException e) {
+            err.println("ERROR: " + e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            err.println("ERROR: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    private void printUsage() {
+        out.println("Usage: indexing-admin <command> [options]");
+        out.println();
+        out.println("Commands:");
+        out.println("  list-instances   Read ZooKeeper and print registered indexing services");
+        out.println("  list-indexes     Enumerate indexes loaded by one instance");
+        out.println("  describe-index   Print detailed state of a single index");
+        out.println("  status           Short one-line GetIndexStatus wrapper");
+        out.println("  list-pks         Stream the list of primary keys for an index");
+        out.println("  engine-stats     Tailer / apply / memory stats of one instance");
+        out.println("  instance-info    Config / identity / heap snapshot of one instance");
+        out.println();
+        out.println("Run 'indexing-admin <command> --help' for command-specific flags.");
+    }
+
+    // ---------------------------------------------------------------
+    // Command implementations
+    // ---------------------------------------------------------------
+
+    private int runListInstances(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        opts.addOption(Option.builder().longOpt("zookeeper").hasArg().argName("HOST:PORT")
+                .desc("ZooKeeper connect string (required)").required().build());
+        opts.addOption(Option.builder().longOpt("zk-path").hasArg().argName("PATH")
+                .desc("ZooKeeper base path (default /herddb)").build());
+        opts.addOption(Option.builder().longOpt("zk-session-timeout-ms").hasArg().argName("MS")
+                .desc("ZooKeeper session timeout (default 10000)").build());
+
+        CommandLine cli = parse(opts, args, COMMAND_LIST_INSTANCES);
+        if (cli == null) {
+            return 0;
+        }
+        String zk = cli.getOptionValue("zookeeper");
+        String zkPath = cli.getOptionValue("zk-path", "/herddb");
+        int sessionTimeout = Integer.parseInt(cli.getOptionValue("zk-session-timeout-ms", "10000"));
+
+        List<String> instances = ZkInstanceDiscovery.listInstances(zk, zkPath, sessionTimeout);
+
+        if (cli.hasOption("json")) {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("zookeeper", zk);
+            payload.put("zk_path", zkPath);
+            payload.put("instances", instances);
+            out.println(JsonWriter.toJson(payload));
+        } else {
+            if (instances.isEmpty()) {
+                out.println("(no indexing service instances registered at " + zkPath + ")");
+            } else {
+                out.println("Registered indexing services (" + instances.size() + "):");
+                for (String inst : instances) {
+                    out.println("  " + inst);
+                }
+            }
+        }
+        return 0;
+    }
+
+    private int runListIndexes(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+
+        CommandLine cli = parse(opts, args, COMMAND_LIST_INDEXES);
+        if (cli == null) {
+            return 0;
+        }
+        try (IndexingAdminClient client = buildClient(cli)) {
+            ListIndexesResponse response = client.listIndexes();
+            if (cli.hasOption("json")) {
+                List<Map<String, Object>> rows = new ArrayList<>();
+                for (IndexDescriptor d : response.getIndexesList()) {
+                    rows.add(indexDescriptorToMap(d));
+                }
+                out.println(JsonWriter.toJson(rows));
+            } else {
+                if (response.getIndexesCount() == 0) {
+                    out.println("(no indexes loaded on this instance)");
+                } else {
+                    out.printf(Locale.ROOT, "%-20s %-20s %-20s %12s %-10s%n",
+                            "TABLESPACE", "TABLE", "INDEX", "VECTORS", "STATUS");
+                    for (IndexDescriptor d : response.getIndexesList()) {
+                        out.printf(Locale.ROOT, "%-20s %-20s %-20s %12d %-10s%n",
+                                d.getTablespace(), d.getTable(), d.getIndex(),
+                                d.getVectorCount(), d.getStatus());
+                    }
+                }
+            }
+        }
+        return 0;
+    }
+
+    private int runDescribeIndex(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+        addIndexOptions(opts);
+
+        CommandLine cli = parse(opts, args, COMMAND_DESCRIBE_INDEX);
+        if (cli == null) {
+            return 0;
+        }
+        try (IndexingAdminClient client = buildClient(cli)) {
+            DescribeIndexResponse response = client.describeIndex(
+                    cli.getOptionValue("tablespace"),
+                    cli.getOptionValue("table"),
+                    cli.getOptionValue("index"));
+            if (cli.hasOption("json")) {
+                out.println(JsonWriter.toJson(describeIndexToMap(response)));
+            } else {
+                printDescribeIndexText(response);
+            }
+        }
+        return 0;
+    }
+
+    private int runStatus(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+        addIndexOptions(opts);
+
+        CommandLine cli = parse(opts, args, COMMAND_STATUS);
+        if (cli == null) {
+            return 0;
+        }
+        try (IndexingAdminClient client = buildClient(cli)) {
+            GetIndexStatusResponse response = client.getIndexStatus(
+                    cli.getOptionValue("tablespace"),
+                    cli.getOptionValue("table"),
+                    cli.getOptionValue("index"));
+            if (cli.hasOption("json")) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("vector_count", response.getVectorCount());
+                m.put("segment_count", response.getSegmentCount());
+                m.put("last_lsn_ledger", response.getLastLsnLedger());
+                m.put("last_lsn_offset", response.getLastLsnOffset());
+                m.put("status", response.getStatus());
+                out.println(JsonWriter.toJson(m));
+            } else {
+                out.printf(Locale.ROOT,
+                        "vectors=%d segments=%d lsn=%d/%d status=%s%n",
+                        response.getVectorCount(),
+                        response.getSegmentCount(),
+                        response.getLastLsnLedger(),
+                        response.getLastLsnOffset(),
+                        response.getStatus());
+            }
+        }
+        return 0;
+    }
+
+    private int runListPks(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+        addIndexOptions(opts);
+        opts.addOption(Option.builder().longOpt("limit").hasArg().argName("N")
+                .desc("maximum number of PKs to return (default 0 = unlimited)").build());
+        opts.addOption(Option.builder().longOpt("chunk-size").hasArg().argName("N")
+                .desc("PKs per gRPC chunk (default 1000)").build());
+        opts.addOption(Option.builder().longOpt("include-ondisk")
+                .desc("also include PKs that live only in on-disk segments").build());
+        opts.addOption(Option.builder().longOpt("format").hasArg().argName("FMT")
+                .desc("output format: hex | base64 (default hex)").build());
+
+        CommandLine cli = parse(opts, args, COMMAND_LIST_PKS);
+        if (cli == null) {
+            return 0;
+        }
+        long limit = Long.parseLong(cli.getOptionValue("limit", "0"));
+        int chunkSize = Integer.parseInt(cli.getOptionValue("chunk-size", "1000"));
+        boolean includeOnDisk = cli.hasOption("include-ondisk");
+        String format = cli.getOptionValue("format", "hex").toLowerCase(Locale.ROOT);
+        if (!"hex".equals(format) && !"base64".equals(format)) {
+            err.println("--format must be hex or base64");
+            return 2;
+        }
+
+        try (IndexingAdminClient client = buildClient(cli)) {
+            Iterator<PrimaryKeysChunk> stream = client.listPrimaryKeys(
+                    cli.getOptionValue("tablespace"),
+                    cli.getOptionValue("table"),
+                    cli.getOptionValue("index"),
+                    chunkSize, includeOnDisk, limit);
+            long total = 0;
+            while (stream.hasNext()) {
+                PrimaryKeysChunk chunk = stream.next();
+                for (ByteString pk : chunk.getPrimaryKeysList()) {
+                    total++;
+                    byte[] arr = pk.toByteArray();
+                    if ("base64".equals(format)) {
+                        out.println(Base64.getEncoder().encodeToString(arr));
+                    } else {
+                        out.println(toHex(arr));
+                    }
+                }
+                if (chunk.getLast()) {
+                    break;
+                }
+            }
+            err.println("# total: " + total);
+        }
+        return 0;
+    }
+
+    private int runEngineStats(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+
+        CommandLine cli = parse(opts, args, COMMAND_ENGINE_STATS);
+        if (cli == null) {
+            return 0;
+        }
+        try (IndexingAdminClient client = buildClient(cli)) {
+            GetEngineStatsResponse response = client.getEngineStats();
+            if (cli.hasOption("json")) {
+                out.println(JsonWriter.toJson(engineStatsToMap(response)));
+            } else {
+                out.println("Engine stats:");
+                out.printf(Locale.ROOT, "  uptime_ms                   = %d%n", response.getUptimeMillis());
+                out.printf(Locale.ROOT, "  tailer_running              = %s%n", response.getTailerRunning());
+                out.printf(Locale.ROOT, "  tailer_watermark            = %d/%d%n",
+                        response.getTailerWatermarkLedger(), response.getTailerWatermarkOffset());
+                out.printf(Locale.ROOT, "  tailer_entries_processed    = %d%n", response.getTailerEntriesProcessed());
+                out.printf(Locale.ROOT, "  apply_queue_size/capacity   = %d / %d%n",
+                        response.getApplyQueueSize(), response.getApplyQueueCapacity());
+                out.printf(Locale.ROOT, "  apply_parallelism           = %d%n", response.getApplyParallelism());
+                out.printf(Locale.ROOT, "  loaded_index_count          = %d%n", response.getLoadedIndexCount());
+                out.printf(Locale.ROOT, "  total_estimated_memory_bytes= %d%n", response.getTotalEstimatedMemoryBytes());
+            }
+        }
+        return 0;
+    }
+
+    private int runInstanceInfo(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+
+        CommandLine cli = parse(opts, args, COMMAND_INSTANCE_INFO);
+        if (cli == null) {
+            return 0;
+        }
+        try (IndexingAdminClient client = buildClient(cli)) {
+            GetInstanceInfoResponse response = client.getInstanceInfo();
+            if (cli.hasOption("json")) {
+                out.println(JsonWriter.toJson(instanceInfoToMap(response)));
+            } else {
+                out.println("Instance info:");
+                out.printf(Locale.ROOT, "  instance_id      = %s%n", response.getInstanceId());
+                out.printf(Locale.ROOT, "  grpc_host:port   = %s:%d%n", response.getGrpcHost(), response.getGrpcPort());
+                out.printf(Locale.ROOT, "  storage_type     = %s%n", response.getStorageType());
+                out.printf(Locale.ROOT, "  data_dir         = %s%n", response.getDataDir());
+                out.printf(Locale.ROOT, "  tablespace       = %s (uuid=%s)%n",
+                        response.getTablespaceName(), response.getTablespaceUuid());
+                out.printf(Locale.ROOT, "  ordinal          = %d / %d%n",
+                        response.getInstanceOrdinal(), response.getNumInstances());
+                out.printf(Locale.ROOT, "  jvm_max_heap     = %d bytes (%d MB)%n",
+                        response.getJvmMaxHeapBytes(), response.getJvmMaxHeapBytes() / (1024 * 1024));
+            }
+        }
+        return 0;
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static void addCommonOptions(Options opts) {
+        opts.addOption(Option.builder("h").longOpt("help").desc("show help for this command").build());
+        opts.addOption(Option.builder().longOpt("json").desc("emit JSON instead of plain text").build());
+        opts.addOption(Option.builder().longOpt("timeout-seconds").hasArg().argName("SECS")
+                .desc("gRPC call deadline in seconds (default 30)").build());
+    }
+
+    private static void addServerOption(Options opts) {
+        opts.addOption(Option.builder().longOpt("server").hasArg().argName("HOST:PORT")
+                .desc("indexing service gRPC endpoint (required)").required().build());
+    }
+
+    private static void addIndexOptions(Options opts) {
+        opts.addOption(Option.builder().longOpt("tablespace").hasArg().argName("NAME")
+                .desc("tablespace name (optional; sent through to server)").build());
+        opts.addOption(Option.builder().longOpt("table").hasArg().argName("NAME")
+                .desc("table name (required)").required().build());
+        opts.addOption(Option.builder().longOpt("index").hasArg().argName("NAME")
+                .desc("index name (required)").required().build());
+    }
+
+    private CommandLine parse(Options opts, String[] args, String commandName) throws ParseException {
+        if (args.length == 1 && ("-h".equals(args[0]) || "--help".equals(args[0]))) {
+            java.io.PrintWriter pw = new java.io.PrintWriter(
+                    new java.io.OutputStreamWriter(out, java.nio.charset.StandardCharsets.UTF_8), true);
+            HelpFormatter hf = new HelpFormatter();
+            hf.printHelp(pw, 100, "indexing-admin " + commandName + " [options]",
+                    "", opts, 2, 4, "", true);
+            pw.flush();
+            return null;
+        }
+        CommandLineParser parser = new DefaultParser();
+        return parser.parse(opts, args);
+    }
+
+    private IndexingAdminClient buildClient(CommandLine cli) {
+        long timeout = Long.parseLong(cli.getOptionValue("timeout-seconds", "30"));
+        return new IndexingAdminClient(cli.getOptionValue("server"), timeout);
+    }
+
+    private static Map<String, Object> indexDescriptorToMap(IndexDescriptor d) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("tablespace", d.getTablespace());
+        m.put("table", d.getTable());
+        m.put("index", d.getIndex());
+        m.put("vector_count", d.getVectorCount());
+        m.put("status", d.getStatus());
+        return m;
+    }
+
+    private static Map<String, Object> describeIndexToMap(DescribeIndexResponse r) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("basic", indexDescriptorToMap(r.getBasic()));
+        m.put("dimension", r.getDimension());
+        m.put("similarity", r.getSimilarity());
+        m.put("live_node_count", r.getLiveNodeCount());
+        m.put("ondisk_node_count", r.getOndiskNodeCount());
+        m.put("segment_count", r.getSegmentCount());
+        m.put("live_shard_count", r.getLiveShardCount());
+        m.put("estimated_memory_bytes", r.getEstimatedMemoryBytes());
+        m.put("live_vectors_memory_bytes", r.getLiveVectorsMemoryBytes());
+        m.put("ondisk_size_bytes", r.getOndiskSizeBytes());
+        m.put("dirty", r.getDirty());
+        m.put("last_lsn_ledger", r.getLastLsnLedger());
+        m.put("last_lsn_offset", r.getLastLsnOffset());
+        m.put("fused_pq_enabled", r.getFusedPqEnabled());
+        m.put("m", r.getM());
+        m.put("beam_width", r.getBeamWidth());
+        m.put("persistent", r.getPersistent());
+        m.put("store_class", r.getStoreClass());
+        return m;
+    }
+
+    private static Map<String, Object> engineStatsToMap(GetEngineStatsResponse r) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("uptime_millis", r.getUptimeMillis());
+        m.put("tailer_running", r.getTailerRunning());
+        m.put("tailer_watermark_ledger", r.getTailerWatermarkLedger());
+        m.put("tailer_watermark_offset", r.getTailerWatermarkOffset());
+        m.put("tailer_entries_processed", r.getTailerEntriesProcessed());
+        m.put("apply_queue_size", r.getApplyQueueSize());
+        m.put("apply_queue_capacity", r.getApplyQueueCapacity());
+        m.put("apply_parallelism", r.getApplyParallelism());
+        m.put("loaded_index_count", r.getLoadedIndexCount());
+        m.put("total_estimated_memory_bytes", r.getTotalEstimatedMemoryBytes());
+        return m;
+    }
+
+    private static Map<String, Object> instanceInfoToMap(GetInstanceInfoResponse r) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("instance_id", r.getInstanceId());
+        m.put("grpc_host", r.getGrpcHost());
+        m.put("grpc_port", r.getGrpcPort());
+        m.put("storage_type", r.getStorageType());
+        m.put("data_dir", r.getDataDir());
+        m.put("tablespace_name", r.getTablespaceName());
+        m.put("tablespace_uuid", r.getTablespaceUuid());
+        m.put("instance_ordinal", r.getInstanceOrdinal());
+        m.put("num_instances", r.getNumInstances());
+        m.put("jvm_max_heap_bytes", r.getJvmMaxHeapBytes());
+        return m;
+    }
+
+    private void printDescribeIndexText(DescribeIndexResponse r) {
+        IndexDescriptor basic = r.getBasic();
+        out.printf(Locale.ROOT, "Index %s.%s (tablespace=%s)%n",
+                basic.getTable(), basic.getIndex(), basic.getTablespace());
+        out.printf(Locale.ROOT, "  status                = %s%n", basic.getStatus());
+        out.printf(Locale.ROOT, "  store_class           = %s (persistent=%s)%n",
+                r.getStoreClass(), r.getPersistent());
+        out.printf(Locale.ROOT, "  dimension             = %d%n", r.getDimension());
+        out.printf(Locale.ROOT, "  similarity            = %s%n", r.getSimilarity());
+        out.printf(Locale.ROOT, "  vector_count          = %d%n", basic.getVectorCount());
+        out.printf(Locale.ROOT, "  live_node_count       = %d%n", r.getLiveNodeCount());
+        out.printf(Locale.ROOT, "  ondisk_node_count     = %d%n", r.getOndiskNodeCount());
+        out.printf(Locale.ROOT, "  segment_count         = %d%n", r.getSegmentCount());
+        out.printf(Locale.ROOT, "  live_shard_count      = %d%n", r.getLiveShardCount());
+        out.printf(Locale.ROOT, "  estimated_memory_bytes= %d%n", r.getEstimatedMemoryBytes());
+        out.printf(Locale.ROOT, "  ondisk_size_bytes     = %d%n", r.getOndiskSizeBytes());
+        out.printf(Locale.ROOT, "  dirty                 = %s%n", r.getDirty());
+        out.printf(Locale.ROOT, "  fused_pq_enabled      = %s%n", r.getFusedPqEnabled());
+        out.printf(Locale.ROOT, "  m / beam_width        = %d / %d%n", r.getM(), r.getBeamWidth());
+        out.printf(Locale.ROOT, "  last_lsn              = %d/%d%n",
+                r.getLastLsnLedger(), r.getLastLsnOffset());
+    }
+
+    static String toHex(byte[] arr) {
+        char[] hex = "0123456789abcdef".toCharArray();
+        char[] out = new char[arr.length * 2];
+        for (int i = 0; i < arr.length; i++) {
+            int b = arr[i] & 0xff;
+            out[i * 2] = hex[b >>> 4];
+            out[i * 2 + 1] = hex[b & 0x0f];
+        }
+        return new String(out);
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminClient.java
@@ -1,0 +1,122 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import herddb.indexing.proto.DescribeIndexRequest;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.indexing.proto.GetEngineStatsRequest;
+import herddb.indexing.proto.GetEngineStatsResponse;
+import herddb.indexing.proto.GetIndexStatusRequest;
+import herddb.indexing.proto.GetIndexStatusResponse;
+import herddb.indexing.proto.GetInstanceInfoRequest;
+import herddb.indexing.proto.GetInstanceInfoResponse;
+import herddb.indexing.proto.IndexingServiceGrpc;
+import herddb.indexing.proto.ListIndexesRequest;
+import herddb.indexing.proto.ListIndexesResponse;
+import herddb.indexing.proto.ListPrimaryKeysRequest;
+import herddb.indexing.proto.PrimaryKeysChunk;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thin gRPC client used by the {@link IndexingAdminCli} to talk to a single
+ * indexing service instance. Unlike
+ * {@link herddb.indexing.IndexingServiceClient}, this class does not fan out
+ * or participate in ZooKeeper discovery — it targets exactly one
+ * {@code host:port} selected by the CLI user.
+ */
+public final class IndexingAdminClient implements Closeable {
+
+    private final ManagedChannel channel;
+    private final IndexingServiceGrpc.IndexingServiceBlockingStub stub;
+    private final long timeoutSeconds;
+
+    public IndexingAdminClient(String target, long timeoutSeconds) {
+        this.channel = ManagedChannelBuilder.forTarget(target)
+                .usePlaintext()
+                .keepAliveTime(60, TimeUnit.SECONDS)
+                .keepAliveTimeout(20, TimeUnit.SECONDS)
+                .build();
+        this.stub = IndexingServiceGrpc.newBlockingStub(channel);
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    private IndexingServiceGrpc.IndexingServiceBlockingStub stub() {
+        return stub.withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
+    }
+
+    public ListIndexesResponse listIndexes() {
+        return stub().listIndexes(ListIndexesRequest.newBuilder().build());
+    }
+
+    public DescribeIndexResponse describeIndex(String tablespace, String table, String index) {
+        return stub().describeIndex(DescribeIndexRequest.newBuilder()
+                .setTablespace(tablespace == null ? "" : tablespace)
+                .setTable(table)
+                .setIndex(index)
+                .build());
+    }
+
+    public GetIndexStatusResponse getIndexStatus(String tablespace, String table, String index) {
+        return stub().getIndexStatus(GetIndexStatusRequest.newBuilder()
+                .setTablespace(tablespace == null ? "" : tablespace)
+                .setTable(table)
+                .setIndex(index)
+                .build());
+    }
+
+    public Iterator<PrimaryKeysChunk> listPrimaryKeys(String tablespace, String table, String index,
+                                                      int chunkSize, boolean includeOnDisk, long limit) {
+        ListPrimaryKeysRequest req = ListPrimaryKeysRequest.newBuilder()
+                .setTablespace(tablespace == null ? "" : tablespace)
+                .setTable(table)
+                .setIndex(index)
+                .setChunkSize(chunkSize)
+                .setIncludeOndisk(includeOnDisk)
+                .setLimit(limit)
+                .build();
+        return stub().listPrimaryKeys(req);
+    }
+
+    public GetEngineStatsResponse getEngineStats() {
+        return stub().getEngineStats(GetEngineStatsRequest.newBuilder().build());
+    }
+
+    public GetInstanceInfoResponse getInstanceInfo() {
+        return stub().getInstanceInfo(GetInstanceInfoRequest.newBuilder().build());
+    }
+
+    @Override
+    public void close() {
+        channel.shutdown();
+        try {
+            if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                channel.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            channel.shutdownNow();
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/JsonWriter.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/JsonWriter.java
@@ -1,0 +1,141 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Minimal JSON writer used by {@link IndexingAdminCli} to emit {@code --json}
+ * output. Kept intentionally dependency-free — adding Jackson to the indexing
+ * service's runtime classpath just for a diagnostic CLI would be overkill.
+ *
+ * <p>Supported value types: {@code null}, {@code String}, {@code Number},
+ * {@code Boolean}, {@code Map&lt;String,Object&gt;}, {@code Collection},
+ * and Java arrays. Any other type is serialized via {@link Object#toString()}.
+ */
+final class JsonWriter {
+
+    private JsonWriter() {
+    }
+
+    static String toJson(Object value) {
+        StringBuilder sb = new StringBuilder();
+        write(sb, value);
+        return sb.toString();
+    }
+
+    private static void write(StringBuilder sb, Object value) {
+        if (value == null) {
+            sb.append("null");
+        } else if (value instanceof String) {
+            writeString(sb, (String) value);
+        } else if (value instanceof Number || value instanceof Boolean) {
+            sb.append(value);
+        } else if (value instanceof Map) {
+            writeMap(sb, (Map<?, ?>) value);
+        } else if (value instanceof Collection) {
+            writeCollection(sb, (Collection<?>) value);
+        } else if (value.getClass().isArray()) {
+            writeArray(sb, value);
+        } else {
+            writeString(sb, value.toString());
+        }
+    }
+
+    private static void writeMap(StringBuilder sb, Map<?, ?> map) {
+        sb.append('{');
+        boolean first = true;
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            writeString(sb, String.valueOf(e.getKey()));
+            sb.append(':');
+            write(sb, e.getValue());
+        }
+        sb.append('}');
+    }
+
+    private static void writeCollection(StringBuilder sb, Collection<?> c) {
+        sb.append('[');
+        boolean first = true;
+        for (Object item : c) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            write(sb, item);
+        }
+        sb.append(']');
+    }
+
+    private static void writeArray(StringBuilder sb, Object array) {
+        sb.append('[');
+        int len = java.lang.reflect.Array.getLength(array);
+        for (int i = 0; i < len; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            write(sb, java.lang.reflect.Array.get(array, i));
+        }
+        sb.append(']');
+    }
+
+    private static void writeString(StringBuilder sb, String s) {
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            switch (ch) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (ch < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        sb.append(ch);
+                    }
+                    break;
+            }
+        }
+        sb.append('"');
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/ZkInstanceDiscovery.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/ZkInstanceDiscovery.java
@@ -1,0 +1,57 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.metadata.MetadataStorageManagerException;
+import java.util.List;
+
+/**
+ * One-shot helper that connects to ZooKeeper, reads the list of registered
+ * indexing service instances, and disconnects. Used by the
+ * {@code indexing-admin list-instances} CLI command.
+ */
+public final class ZkInstanceDiscovery {
+
+    private static final int DEFAULT_SESSION_TIMEOUT_MS = 10_000;
+
+    private ZkInstanceDiscovery() {
+    }
+
+    public static List<String> listInstances(String zkAddress, String basePath) throws MetadataStorageManagerException {
+        return listInstances(zkAddress, basePath, DEFAULT_SESSION_TIMEOUT_MS);
+    }
+
+    public static List<String> listInstances(String zkAddress, String basePath,
+                                               int sessionTimeoutMs) throws MetadataStorageManagerException {
+        ZookeeperMetadataStorageManager mgr = new ZookeeperMetadataStorageManager(zkAddress, sessionTimeoutMs, basePath);
+        try {
+            mgr.start();
+            return mgr.listIndexingServices();
+        } finally {
+            try {
+                mgr.close();
+            } catch (MetadataStorageManagerException ignore) {
+                // best effort
+            }
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -26,6 +26,13 @@ package indexing;
 service IndexingService {
     rpc Search (SearchRequest) returns (SearchResponse);
     rpc GetIndexStatus (GetIndexStatusRequest) returns (GetIndexStatusResponse);
+
+    // Diagnostic RPCs used by the indexing-admin CLI.
+    rpc ListIndexes (ListIndexesRequest) returns (ListIndexesResponse);
+    rpc DescribeIndex (DescribeIndexRequest) returns (DescribeIndexResponse);
+    rpc ListPrimaryKeys (ListPrimaryKeysRequest) returns (stream PrimaryKeysChunk);
+    rpc GetEngineStats (GetEngineStatsRequest) returns (GetEngineStatsResponse);
+    rpc GetInstanceInfo (GetInstanceInfoRequest) returns (GetInstanceInfoResponse);
 }
 
 message SearchRequest {
@@ -58,4 +65,94 @@ message GetIndexStatusResponse {
     int64 last_lsn_ledger = 3;
     int64 last_lsn_offset = 4;
     string status = 5;
+}
+
+// ---- Diagnostic RPCs ----
+
+message IndexDescriptor {
+    string tablespace = 1;
+    string table = 2;
+    string index = 3;
+    int64 vector_count = 4;
+    string status = 5;
+}
+
+message ListIndexesRequest {
+}
+
+message ListIndexesResponse {
+    repeated IndexDescriptor indexes = 1;
+}
+
+message DescribeIndexRequest {
+    string tablespace = 1;
+    string table = 2;
+    string index = 3;
+}
+
+message DescribeIndexResponse {
+    IndexDescriptor basic = 1;
+    int32 dimension = 2;
+    string similarity = 3;
+    int64 live_node_count = 4;
+    int64 ondisk_node_count = 5;
+    int32 segment_count = 6;
+    int32 live_shard_count = 7;
+    int64 estimated_memory_bytes = 8;
+    int64 live_vectors_memory_bytes = 9;
+    int64 ondisk_size_bytes = 10;
+    bool dirty = 11;
+    int64 last_lsn_ledger = 12;
+    int64 last_lsn_offset = 13;
+    bool fused_pq_enabled = 14;
+    int32 m = 15;
+    int32 beam_width = 16;
+    bool persistent = 17;
+    string store_class = 18;
+}
+
+message ListPrimaryKeysRequest {
+    string tablespace = 1;
+    string table = 2;
+    string index = 3;
+    int32 chunk_size = 4;
+    bool include_ondisk = 5;
+    int64 limit = 6;
+}
+
+message PrimaryKeysChunk {
+    repeated bytes primary_keys = 1;
+    bool last = 2;
+}
+
+message GetEngineStatsRequest {
+}
+
+message GetEngineStatsResponse {
+    int64 uptime_millis = 1;
+    int64 tailer_watermark_ledger = 2;
+    int64 tailer_watermark_offset = 3;
+    int64 tailer_entries_processed = 4;
+    bool tailer_running = 5;
+    int32 apply_queue_size = 6;
+    int32 apply_queue_capacity = 7;
+    int64 total_estimated_memory_bytes = 8;
+    int32 loaded_index_count = 9;
+    int32 apply_parallelism = 10;
+}
+
+message GetInstanceInfoRequest {
+}
+
+message GetInstanceInfoResponse {
+    string instance_id = 1;
+    string grpc_host = 2;
+    int32 grpc_port = 3;
+    string storage_type = 4;
+    string data_dir = 5;
+    int64 jvm_max_heap_bytes = 6;
+    string tablespace_name = 7;
+    string tablespace_uuid = 8;
+    int32 instance_ordinal = 9;
+    int32 num_instances = 10;
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingAdminCliTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingAdminCliTest.java
@@ -1,0 +1,265 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.indexing.admin.IndexingAdminCli;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end smoke tests for {@link IndexingAdminCli}: spin up an embedded
+ * indexing service, run each sub-command via the CLI's {@code run()} entry
+ * point, and assert the output on stdout/stderr.
+ */
+public class IndexingAdminCliTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+    private ByteArrayOutputStream stdoutBytes;
+    private ByteArrayOutputStream stderrBytes;
+    private IndexingAdminCli cli;
+
+    @Before
+    public void setUp() throws Exception {
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        for (int i = 0; i < 6; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i, -i, i * 0.25f});
+        }
+        service.getEngine().registerIndexForTest(
+                Index.builder()
+                        .name("idx_docs")
+                        .table("docs")
+                        .tablespace("default")
+                        .type(Index.TYPE_VECTOR)
+                        .column("embedding", ColumnTypes.FLOATARRAY)
+                        .build(),
+                store);
+
+        stdoutBytes = new ByteArrayOutputStream();
+        stderrBytes = new ByteArrayOutputStream();
+        cli = new IndexingAdminCli(new PrintStream(stdoutBytes, true, StandardCharsets.UTF_8),
+                new PrintStream(stderrBytes, true, StandardCharsets.UTF_8));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private String stdout() {
+        return new String(stdoutBytes.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private String stderr() {
+        return new String(stderrBytes.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testListIndexesText() {
+        int rc = cli.run(new String[]{
+            "list-indexes",
+            "--server", service.getAddress()
+        });
+        assertEquals("CLI should succeed; stderr=\n" + stderr(), 0, rc);
+        String out = stdout();
+        assertTrue("expected table header, got:\n" + out, out.contains("TABLESPACE"));
+        assertTrue(out.contains("idx_docs"));
+        assertTrue(out.contains("docs"));
+    }
+
+    @Test
+    public void testListIndexesJson() {
+        int rc = cli.run(new String[]{
+            "list-indexes",
+            "--server", service.getAddress(),
+            "--json"
+        });
+        assertEquals(0, rc);
+        String out = stdout().trim();
+        assertTrue("expected JSON array, got: " + out, out.startsWith("["));
+        assertTrue(out.contains("\"idx_docs\""));
+        assertTrue(out.contains("\"vector_count\":6"));
+    }
+
+    @Test
+    public void testDescribeIndexText() {
+        int rc = cli.run(new String[]{
+            "describe-index",
+            "--server", service.getAddress(),
+            "--tablespace", "default",
+            "--table", "docs",
+            "--index", "idx_docs"
+        });
+        assertEquals(0, rc);
+        String out = stdout();
+        assertTrue(out.contains("Index docs.idx_docs"));
+        assertTrue(out.contains("vector_count          = 6"));
+        assertTrue(out.contains("store_class           = InMemoryVectorStore"));
+    }
+
+    @Test
+    public void testDescribeIndexJson() {
+        int rc = cli.run(new String[]{
+            "describe-index",
+            "--server", service.getAddress(),
+            "--table", "docs",
+            "--index", "idx_docs",
+            "--json"
+        });
+        assertEquals(0, rc);
+        String out = stdout().trim();
+        assertTrue(out.startsWith("{"));
+        assertTrue(out.contains("\"store_class\":\"InMemoryVectorStore\""));
+        assertTrue(out.contains("\"similarity\":\"COSINE\""));
+    }
+
+    @Test
+    public void testDescribeIndexMissing() {
+        int rc = cli.run(new String[]{
+            "describe-index",
+            "--server", service.getAddress(),
+            "--table", "ghost",
+            "--index", "missing"
+        });
+        assertNotEquals("CLI should exit non-zero for missing index", 0, rc);
+        assertTrue("stderr should mention the failure: " + stderr(),
+                stderr().toLowerCase().contains("not loaded")
+                        || stderr().toLowerCase().contains("error"));
+    }
+
+    @Test
+    public void testStatusCommand() {
+        int rc = cli.run(new String[]{
+            "status",
+            "--server", service.getAddress(),
+            "--table", "docs",
+            "--index", "idx_docs"
+        });
+        assertEquals(0, rc);
+        String out = stdout();
+        assertTrue(out.contains("vectors=6"));
+        assertTrue(out.contains("status=tailing"));
+    }
+
+    @Test
+    public void testListPksHexFormat() {
+        int rc = cli.run(new String[]{
+            "list-pks",
+            "--server", service.getAddress(),
+            "--table", "docs",
+            "--index", "idx_docs"
+        });
+        assertEquals(0, rc);
+        String out = stdout();
+        // Expect 6 lines, each a hex-encoded 4-byte PK
+        String[] lines = out.split("\n");
+        assertEquals(6, lines.length);
+        for (String line : lines) {
+            assertTrue("Expected hex PK, got: " + line, line.matches("[0-9a-f]+"));
+            assertEquals("Bytes.from_int produces 4 bytes", 8, line.length());
+        }
+        assertTrue(stderr().contains("# total: 6"));
+    }
+
+    @Test
+    public void testListPksLimit() {
+        int rc = cli.run(new String[]{
+            "list-pks",
+            "--server", service.getAddress(),
+            "--table", "docs",
+            "--index", "idx_docs",
+            "--limit", "2"
+        });
+        assertEquals(0, rc);
+        assertEquals(2, stdout().split("\n").length);
+        assertTrue(stderr().contains("# total: 2"));
+    }
+
+    @Test
+    public void testEngineStatsText() {
+        int rc = cli.run(new String[]{
+            "engine-stats",
+            "--server", service.getAddress()
+        });
+        assertEquals(0, rc);
+        String out = stdout();
+        assertTrue(out.contains("Engine stats:"));
+        assertTrue(out.contains("loaded_index_count          = 1"));
+        assertTrue(out.contains("tailer_running              = true"));
+    }
+
+    @Test
+    public void testInstanceInfoJson() {
+        int rc = cli.run(new String[]{
+            "instance-info",
+            "--server", service.getAddress(),
+            "--json"
+        });
+        assertEquals(0, rc);
+        String out = stdout().trim();
+        assertTrue(out.startsWith("{"));
+        assertTrue(out.contains("\"storage_type\":\"memory\""));
+        assertTrue(out.contains("\"num_instances\":1"));
+    }
+
+    @Test
+    public void testNoArgsPrintsUsageAndExits2() {
+        int rc = cli.run(new String[]{});
+        assertEquals(2, rc);
+        assertTrue(stdout().contains("Usage: indexing-admin"));
+    }
+
+    @Test
+    public void testUnknownCommandExits2() {
+        int rc = cli.run(new String[]{"gronk"});
+        assertEquals(2, rc);
+        assertTrue(stderr().contains("Unknown command"));
+    }
+
+    @Test
+    public void testMissingServerFlagExits2() {
+        int rc = cli.run(new String[]{"list-indexes"});
+        assertEquals(2, rc);
+        assertTrue(stderr().contains("server"));
+    }
+
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
@@ -1,0 +1,229 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import com.google.protobuf.ByteString;
+import herddb.indexing.admin.IndexingAdminClient;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.indexing.proto.GetEngineStatsResponse;
+import herddb.indexing.proto.GetInstanceInfoResponse;
+import herddb.indexing.proto.ListIndexesResponse;
+import herddb.indexing.proto.PrimaryKeysChunk;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import io.grpc.StatusRuntimeException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Integration tests for the new diagnostic RPCs
+ * ({@code ListIndexes}, {@code DescribeIndex}, {@code ListPrimaryKeys},
+ * {@code GetEngineStats}, {@code GetInstanceInfo}) exercised end-to-end
+ * through an in-process {@link EmbeddedIndexingService} and the thin
+ * {@link IndexingAdminClient} used by the CLI.
+ */
+public class IndexingServiceDiagnosticsGrpcTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+    private IndexingAdminClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+        client = new IndexingAdminClient(service.getAddress(), 10);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private Index vectorIndex(String indexName, String table, String tablespace) {
+        return Index.builder()
+                .name(indexName)
+                .table(table)
+                .tablespace(tablespace)
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    private void seedIndex(String table, String indexName, int vectors) {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        for (int i = 0; i < vectors; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i, -i, i * 0.5f});
+        }
+        service.getEngine().registerIndexForTest(
+                vectorIndex(indexName, table, "default"), store);
+    }
+
+    @Test
+    public void testListIndexesEmpty() {
+        ListIndexesResponse response = client.listIndexes();
+        assertEquals(0, response.getIndexesCount());
+    }
+
+    @Test
+    public void testListIndexesWithSeededData() {
+        seedIndex("docs", "idx_docs", 5);
+        seedIndex("users", "idx_users", 3);
+
+        ListIndexesResponse response = client.listIndexes();
+        assertEquals(2, response.getIndexesCount());
+
+        Set<String> qualifiedNames = new HashSet<>();
+        for (herddb.indexing.proto.IndexDescriptor d : response.getIndexesList()) {
+            qualifiedNames.add(d.getTable() + "." + d.getIndex() + "=" + d.getVectorCount());
+            assertEquals("default", d.getTablespace());
+            assertEquals("tailing", d.getStatus());
+        }
+        assertTrue(qualifiedNames.contains("docs.idx_docs=5"));
+        assertTrue(qualifiedNames.contains("users.idx_users=3"));
+    }
+
+    @Test
+    public void testDescribeIndex() {
+        seedIndex("docs", "idx_docs", 4);
+
+        DescribeIndexResponse response = client.describeIndex("default", "docs", "idx_docs");
+        assertEquals("docs", response.getBasic().getTable());
+        assertEquals("idx_docs", response.getBasic().getIndex());
+        assertEquals(4L, response.getBasic().getVectorCount());
+        assertEquals("InMemoryVectorStore", response.getStoreClass());
+        assertEquals("COSINE", response.getSimilarity());
+        assertEquals(1, response.getSegmentCount());
+        assertTrue(response.getEstimatedMemoryBytes() > 0);
+        assertTrue(!response.getPersistent());
+    }
+
+    @Test
+    public void testDescribeIndexUnknownReturnsNotFound() {
+        try {
+            client.describeIndex("default", "ghost", "missing");
+            fail("Expected NOT_FOUND");
+        } catch (StatusRuntimeException e) {
+            assertEquals(io.grpc.Status.Code.NOT_FOUND, e.getStatus().getCode());
+        }
+    }
+
+    @Test
+    public void testListPrimaryKeysStreamsAllPks() {
+        int total = 25;
+        seedIndex("docs", "idx_docs", total);
+
+        Iterator<PrimaryKeysChunk> stream = client.listPrimaryKeys(
+                "default", "docs", "idx_docs", 10, false, 0);
+
+        Set<Bytes> collected = new HashSet<>();
+        boolean sawLast = false;
+        while (stream.hasNext()) {
+            PrimaryKeysChunk chunk = stream.next();
+            for (ByteString pk : chunk.getPrimaryKeysList()) {
+                collected.add(Bytes.from_array(pk.toByteArray()));
+            }
+            if (chunk.getLast()) {
+                sawLast = true;
+                break;
+            }
+        }
+        assertTrue("Server must emit a terminal chunk", sawLast);
+        assertEquals(total, collected.size());
+        for (int i = 0; i < total; i++) {
+            assertTrue(collected.contains(Bytes.from_int(i)));
+        }
+    }
+
+    @Test
+    public void testListPrimaryKeysRespectsLimit() {
+        seedIndex("docs", "idx_docs", 50);
+
+        Iterator<PrimaryKeysChunk> stream = client.listPrimaryKeys(
+                "default", "docs", "idx_docs", 10, false, 12);
+
+        int total = 0;
+        while (stream.hasNext()) {
+            PrimaryKeysChunk chunk = stream.next();
+            total += chunk.getPrimaryKeysCount();
+            if (chunk.getLast()) {
+                break;
+            }
+        }
+        assertEquals(12, total);
+    }
+
+    @Test
+    public void testListPrimaryKeysEmptyIndex() {
+        Iterator<PrimaryKeysChunk> stream = client.listPrimaryKeys(
+                "default", "missing", "missing", 10, false, 0);
+        // Unknown index yields an immediate terminal (empty) chunk.
+        assertTrue(stream.hasNext());
+        PrimaryKeysChunk chunk = stream.next();
+        assertTrue(chunk.getLast());
+        assertEquals(0, chunk.getPrimaryKeysCount());
+    }
+
+    @Test
+    public void testGetEngineStats() {
+        seedIndex("docs", "idx_docs", 4);
+
+        GetEngineStatsResponse response = client.getEngineStats();
+        assertTrue(response.getUptimeMillis() >= 0);
+        assertTrue(response.getTailerRunning());
+        assertEquals(1, response.getLoadedIndexCount());
+        assertTrue(response.getApplyParallelism() >= 1);
+        assertTrue(response.getApplyQueueCapacity() > 0);
+        assertTrue(response.getTotalEstimatedMemoryBytes() > 0);
+    }
+
+    @Test
+    public void testGetInstanceInfo() {
+        GetInstanceInfoResponse response = client.getInstanceInfo();
+        assertNotNull(response.getInstanceId());
+        assertTrue("Instance id should include the bound port",
+                response.getInstanceId().contains(":"));
+        assertTrue(response.getJvmMaxHeapBytes() > 0);
+        assertEquals(1, response.getNumInstances());
+        assertEquals(0, response.getInstanceOrdinal());
+        assertEquals("memory", response.getStorageType());
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDiagnosticsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDiagnosticsTest.java
@@ -1,0 +1,208 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests the diagnostic helpers added to {@link IndexingServiceEngine}
+ * ({@code listIndexes}, {@code describeIndex}, {@code streamPrimaryKeys},
+ * {@code getTotalEstimatedMemoryBytes}) against a seeded in-memory store.
+ */
+public class IndexingServiceEngineDiagnosticsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+
+    @Before
+    public void setUp() throws Exception {
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private Index vectorIndex(String indexName, String table, String tablespace) {
+        return Index.builder()
+                .name(indexName)
+                .table(table)
+                .tablespace(tablespace)
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    @Test
+    public void testListIndexesEmptyInstance() {
+        List<IndexingServiceEngine.IndexDescriptor> indexes = service.getEngine().listIndexes();
+        assertNotNull(indexes);
+        assertTrue("A fresh instance has no loaded indexes", indexes.isEmpty());
+    }
+
+    @Test
+    public void testListIndexesReturnsSeededEntries() {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        store.addVector(Bytes.from_int(1), new float[]{1f, 0f, 0f});
+        store.addVector(Bytes.from_int(2), new float[]{0f, 1f, 0f});
+        service.getEngine().registerIndexForTest(
+                vectorIndex("idx_docs", "docs", "default"), store);
+
+        List<IndexingServiceEngine.IndexDescriptor> indexes = service.getEngine().listIndexes();
+        assertEquals(1, indexes.size());
+        IndexingServiceEngine.IndexDescriptor d = indexes.get(0);
+        assertEquals("default", d.getTablespace());
+        assertEquals("docs", d.getTable());
+        assertEquals("idx_docs", d.getIndex());
+        assertEquals(2L, d.getVectorCount());
+        assertEquals("tailing", d.getStatus());
+    }
+
+    @Test
+    public void testDescribeIndexInMemoryStore() {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        store.addVector(Bytes.from_int(1), new float[]{1f, 0f, 0f});
+        store.addVector(Bytes.from_int(2), new float[]{0f, 1f, 0f});
+        store.addVector(Bytes.from_int(3), new float[]{0f, 0f, 1f});
+        service.getEngine().registerIndexForTest(
+                vectorIndex("idx_docs", "docs", "default"), store);
+
+        IndexingServiceEngine.IndexDetails details =
+                service.getEngine().describeIndex("default", "docs", "idx_docs");
+        assertNotNull(details);
+        assertEquals("docs", details.table);
+        assertEquals("idx_docs", details.index);
+        assertEquals(3L, details.vectorCount);
+        assertEquals("tailing", details.status);
+        assertEquals("InMemoryVectorStore", details.storeClass);
+        assertFalse("In-memory stores are not persistent", details.persistent);
+        assertEquals("COSINE", details.similarity);
+        assertEquals(1, details.segmentCount);
+        assertEquals(1, details.liveShardCount);
+        assertTrue("Estimated memory should be positive", details.estimatedMemoryBytes > 0);
+    }
+
+    @Test
+    public void testDescribeIndexUnknownReturnsNull() {
+        IndexingServiceEngine.IndexDetails details =
+                service.getEngine().describeIndex("default", "does-not-exist", "missing");
+        assertNull(details);
+    }
+
+    @Test
+    public void testStreamPrimaryKeysReturnsAllPks() {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        Set<Bytes> expected = new HashSet<>();
+        for (int i = 0; i < 25; i++) {
+            Bytes pk = Bytes.from_int(i);
+            expected.add(pk);
+            store.addVector(pk, new float[]{i, -i, i * 0.5f});
+        }
+        service.getEngine().registerIndexForTest(
+                vectorIndex("idx_docs", "docs", "default"), store);
+
+        Set<Bytes> seen = new HashSet<>();
+        long visited = service.getEngine().streamPrimaryKeys(
+                "default", "docs", "idx_docs", false, 0,
+                pk -> {
+                    seen.add(pk);
+                    return true;
+                });
+        assertEquals(25L, visited);
+        assertEquals(expected, seen);
+    }
+
+    @Test
+    public void testStreamPrimaryKeysHonoursLimit() {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        for (int i = 0; i < 100; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i, 0f, 0f});
+        }
+        service.getEngine().registerIndexForTest(
+                vectorIndex("idx_docs", "docs", "default"), store);
+
+        long visited = service.getEngine().streamPrimaryKeys(
+                "default", "docs", "idx_docs", false, 7,
+                pk -> true);
+        assertEquals(7L, visited);
+    }
+
+    @Test
+    public void testStreamPrimaryKeysUnknownIndex() {
+        long visited = service.getEngine().streamPrimaryKeys(
+                "default", "missing", "missing", false, 0, pk -> true);
+        assertEquals(0L, visited);
+    }
+
+    @Test
+    public void testGetTotalEstimatedMemoryBytesSumsLoadedStores() {
+        InMemoryVectorStore s1 = new InMemoryVectorStore("embedding");
+        InMemoryVectorStore s2 = new InMemoryVectorStore("embedding");
+        s1.addVector(Bytes.from_int(1), new float[]{1f, 2f, 3f});
+        s2.addVector(Bytes.from_int(1), new float[]{4f, 5f, 6f});
+        s2.addVector(Bytes.from_int(2), new float[]{7f, 8f, 9f});
+        service.getEngine().registerIndexForTest(
+                vectorIndex("idx_a", "ta", "default"), s1);
+        service.getEngine().registerIndexForTest(
+                vectorIndex("idx_b", "tb", "default"), s2);
+
+        assertEquals(2, service.getEngine().getLoadedIndexCount());
+        long total = service.getEngine().getTotalEstimatedMemoryBytes();
+        assertEquals(s1.estimatedMemoryUsageBytes() + s2.estimatedMemoryUsageBytes(), total);
+    }
+
+    @Test
+    public void testEnginePlumbsTailerAndApplyStats() {
+        // The tailer is running in a fresh instance with no entries processed.
+        assertTrue(service.getEngine().isTailerRunning());
+        assertEquals(0L, service.getEngine().getTailerEntriesProcessed());
+
+        // The apply queue is configured with the default parallelism and a
+        // positive capacity; exact numbers depend on the host CPU count.
+        assertTrue(service.getEngine().getApplyParallelism() >= 1);
+        assertTrue(service.getEngine().getApplyQueueCapacity() > 0);
+        assertEquals(0, service.getEngine().getApplyQueueSize());
+        assertTrue(service.getEngine().getStartTimeMillis() > 0);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/admin/JsonWriterTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/admin/JsonWriterTest.java
@@ -1,0 +1,92 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class JsonWriterTest {
+
+    @Test
+    public void testNull() {
+        assertEquals("null", JsonWriter.toJson(null));
+    }
+
+    @Test
+    public void testPrimitives() {
+        assertEquals("42", JsonWriter.toJson(42));
+        assertEquals("3.14", JsonWriter.toJson(3.14));
+        assertEquals("true", JsonWriter.toJson(Boolean.TRUE));
+        assertEquals("\"hello\"", JsonWriter.toJson("hello"));
+    }
+
+    @Test
+    public void testStringEscaping() {
+        assertEquals("\"line1\\nline2\"", JsonWriter.toJson("line1\nline2"));
+        assertEquals("\"quote\\\"here\"", JsonWriter.toJson("quote\"here"));
+        assertEquals("\"back\\\\slash\"", JsonWriter.toJson("back\\slash"));
+        assertEquals("\"tab\\there\"", JsonWriter.toJson("tab\there"));
+    }
+
+    @Test
+    public void testControlCharactersAreEscaped() {
+        String s = JsonWriter.toJson("\u0001");
+        assertEquals("\"\\u0001\"", s);
+    }
+
+    @Test
+    public void testMapPreservesInsertionOrder() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("a", 1);
+        m.put("b", "two");
+        m.put("c", true);
+        assertEquals("{\"a\":1,\"b\":\"two\",\"c\":true}", JsonWriter.toJson(m));
+    }
+
+    @Test
+    public void testNestedStructures() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("items", Arrays.asList(1, 2, 3));
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("name", "docs");
+        inner.put("count", 10);
+        m.put("nested", inner);
+        assertEquals("{\"items\":[1,2,3],\"nested\":{\"name\":\"docs\",\"count\":10}}",
+                JsonWriter.toJson(m));
+    }
+
+    @Test
+    public void testArray() {
+        String s = JsonWriter.toJson(new int[]{1, 2, 3});
+        assertEquals("[1,2,3]", s);
+    }
+
+    @Test
+    public void testByteArrayIsSerializedAsList() {
+        String s = JsonWriter.toJson(new byte[]{1, 2});
+        assertTrue(s.startsWith("["));
+        assertTrue(s.endsWith("]"));
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-configmap.yaml
@@ -10,4 +10,7 @@ data:
   herddb-cli: |
     #!/bin/bash
     exec /opt/herddb/bin/herddb-cli.sh -x "${HERDDB_JDBC_URL}" "$@"
+  indexing-admin: |
+    #!/bin/bash
+    exec /opt/herddb/bin/indexing-admin.sh "$@"
 {{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
@@ -38,6 +38,8 @@ spec:
           env:
             - name: HERDDB_JDBC_URL
               value: {{ include "herddb.jdbcUrl" . | quote }}
+            - name: HERDDB_INDEXING_ZK
+              value: {{ include "herddb.zkAddress" . | quote }}
             - name: JAVA_OPTS
               value: {{ .Values.tools.javaOpts | default "-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true" | quote }}
             - name: VECTORBENCH_DATASET_DIR
@@ -60,6 +62,9 @@ spec:
             - name: tools-scripts
               mountPath: /usr/local/bin/herddb-cli
               subPath: herddb-cli
+            - name: tools-scripts
+              mountPath: /usr/local/bin/indexing-admin
+              subPath: indexing-admin
             - name: datasets
               mountPath: /opt/herddb/vector-datasets
       volumes:

--- a/herddb-services/pom.xml
+++ b/herddb-services/pom.xml
@@ -184,6 +184,13 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>herddb-indexing-service</artifactId>
             <version>${project.version}</version>
+            <classifier>admin-cli</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>herddb-indexing-service</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/herddb-services/src/main/assemble/zip-assembly.xml
+++ b/herddb-services/src/main/assemble/zip-assembly.xml
@@ -93,6 +93,16 @@
         <dependencySet>
             <useProjectArtifact>true</useProjectArtifact>
             <useStrictFiltering>true</useStrictFiltering>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.herddb:herddb-indexing-service:jar:admin-cli</include>
+            </includes>
+            <outputDirectory>indexing-admin</outputDirectory>
+            <outputFileNameMapping>herddb-indexing-admin-${project.version}.jar</outputFileNameMapping>
+        </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useStrictFiltering>true</useStrictFiltering>
             <unpack>true</unpack>           
             <includes>
                 <include>org.herddb:herddb-ui:war:war-no-libs</include>                                

--- a/herddb-services/src/main/resources/bin/indexing-admin.sh
+++ b/herddb-services/src/main/resources/bin/indexing-admin.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+### BASE_DIR discovery
+if [ -z "$BASE_DIR" ]; then
+  BASE_DIR="`dirname \"$0\"`"
+  BASE_DIR="`( cd \"$BASE_DIR\" && pwd )`"
+fi
+BASE_DIR=$BASE_DIR/..
+BASE_DIR="`( cd \"$BASE_DIR\" && pwd )`"
+
+. $BASE_DIR/bin/setenv.sh
+
+JAVA="$JAVA_HOME/bin/java"
+JAR=$(ls "$BASE_DIR"/indexing-admin/herddb-indexing-admin-*.jar 2>/dev/null | head -1)
+
+if [ -z "$JAR" ]; then
+    echo "ERROR: herddb-indexing-admin jar not found under $BASE_DIR/indexing-admin/" >&2
+    exit 1
+fi
+
+JAVA_HEAP="${INDEXING_ADMIN_HEAP:--Xms64m -Xmx256m}"
+
+# When HERDDB_INDEXING_ZK is set (typically injected by the Helm chart inside
+# the k3s tools pod), auto-wire --zookeeper for sub-commands that accept it
+# unless the user already passed it.
+EXTRA_ARGS=()
+if [ -n "$HERDDB_INDEXING_ZK" ] && [ "$1" = "list-instances" ]; then
+    HAS_ZK=false
+    for arg in "$@"; do
+        if [ "$arg" = "--zookeeper" ]; then
+            HAS_ZK=true
+            break
+        fi
+    done
+    if [ "$HAS_ZK" = false ]; then
+        EXTRA_ARGS+=("--zookeeper" "$HERDDB_INDEXING_ZK")
+    fi
+fi
+
+# HERDDB_INDEXING_SERVER, if set, auto-fills --server for sub-commands that
+# expect a direct gRPC target when the user hasn't passed one themselves.
+if [ -n "$HERDDB_INDEXING_SERVER" ] && [ "$1" != "list-instances" ] && [ -n "$1" ]; then
+    HAS_SERVER=false
+    for arg in "$@"; do
+        if [ "$arg" = "--server" ]; then
+            HAS_SERVER=true
+            break
+        fi
+    done
+    if [ "$HAS_SERVER" = false ]; then
+        EXTRA_ARGS+=("--server" "$HERDDB_INDEXING_SERVER")
+    fi
+fi
+
+exec $JAVA $JAVA_HEAP -jar "$JAR" "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Summary

Adds **`indexing-admin`**, a diagnostic CLI for inspecting a single HerdDB indexing service instance, plus five new additive gRPC methods that back it. The CLI ships in `herddb-services` at `bin/indexing-admin.sh` and is pre-wired into the k3s tools pod as `/usr/local/bin/indexing-admin`.

Goal: make it easy to diagnose what a replica is actually holding — loaded indexes, live vs on-disk node counts, tailer lag, apply-queue backpressure, the set of primary keys behind an index — without scraping Prometheus or reading `sysindexstatus` from the main HerdDB server.

### New gRPC methods (all additive)

| RPC | Purpose |
|---|---|
| `ListIndexes` | Enumerate every vector index loaded by this instance |
| `DescribeIndex` | Dimension, similarity, live/ondisk nodes, segments, shards, memory, LSN, FusedPQ/M/beam-width, dirty flag |
| `ListPrimaryKeys` | Server-streamed PK dump (chunked, optional `--include-ondisk`, `--limit`) |
| `GetEngineStats` | Tailer watermark + entries processed, apply queue size/capacity/parallelism, total memory, uptime |
| `GetInstanceInfo` | Instance id, gRPC host:port, storage type, data dir, tablespace name+UUID, ordinal/numInstances, JVM heap |

Existing `Search` / `GetIndexStatus` wire format is unchanged.

### CLI sub-commands

`list-instances` (reads ZooKeeper only), `list-indexes`, `describe-index`, `status`, `list-pks`, `engine-stats`, `instance-info`. Every non-ZK command requires `--server host:port` — one instance at a time by design. `--json` flag on every command for scriptable output.

### Packaging

- New attached shaded artifact `herddb-indexing-service-<version>-admin-cli.jar` (classifier `admin-cli`) with `herddb.indexing.admin.IndexingAdminCli` as Main-Class. The primary indexing-service jar is unaffected.
- `herddb-services` zip now contains `indexing-admin/herddb-indexing-admin-<version>.jar` + `bin/indexing-admin.sh`.
- Helm tools pod mounts the CLI as `/usr/local/bin/indexing-admin` and injects `HERDDB_INDEXING_ZK` so `list-instances` auto-wires `--zookeeper`. `HERDDB_INDEXING_SERVER` can be exported to auto-fill `--server` for scripted checks.

### Tests

All new tests are in `herddb-indexing-service`:

- `IndexingServiceEngineDiagnosticsTest` (9 tests) — engine-level `listIndexes` / `describeIndex` / `streamPrimaryKeys` / `getTotalEstimatedMemoryBytes` / apply-queue stats.
- `IndexingServiceDiagnosticsGrpcTest` (9 tests) — end-to-end gRPC via the new `IndexingAdminClient` against an `EmbeddedIndexingService`, covers the terminal chunk in `ListPrimaryKeys`, limit semantics, NOT_FOUND for missing indexes.
- `IndexingAdminCliTest` (13 tests) — drives `IndexingAdminCli.run(...)` for every sub-command and asserts text + JSON output on captured stdout/stderr.
- `JsonWriterTest` (8 tests) — the dependency-free JSON writer used by `--json`.

Run with:
```
mvn -pl herddb-indexing-service -Dtest='IndexingServiceEngineDiagnosticsTest,IndexingServiceDiagnosticsGrpcTest,IndexingAdminCliTest,JsonWriterTest' test
```

### Validation

```
mvn -B -pl herddb-indexing-service,herddb-services -am \
    checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins
```
passes locally (checkstyle, RAT, SpotBugs, build).

### Docs

`VECTOR.md` gained an `indexing-admin — diagnostic CLI` section with sub-command table, examples, and k3s usage.

## Test plan

- [x] `mvn -pl herddb-indexing-service -Dtest='IndexingServiceEngineDiagnosticsTest,IndexingServiceDiagnosticsGrpcTest,IndexingAdminCliTest,JsonWriterTest' test`
- [x] `mvn -pl herddb-indexing-service -Dtest='IndexingServiceGrpcTest,SchemaTrackerTest,IndexingServerRegistrationTest,IndexingServiceSimilarityTest,AbstractVectorStoreTest,InMemoryVectorStoreSimilarityTest' test` (regressions)
- [x] `mvn -B -pl herddb-indexing-service,herddb-services -am checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins`
- [x] `helm lint herddb-kubernetes/src/main/helm/herddb`
- [x] Verify the release zip contains `indexing-admin/herddb-indexing-admin-*.jar` + `bin/indexing-admin.sh`
- [ ] Smoke test on k3s-local: `kubectl exec herddb-tools-0 -- indexing-admin list-instances`

🤖 Generated with [Claude Code](https://claude.com/claude-code)