### PR TITLE
CI: upload surefire reports on failure and bump fork timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,16 @@ jobs:
           path: ~/.m2/repository
       - name: 'Test herddb-core (non-cluster)'
         run: mvn -B verify -DforkCount=2 -Dtest.excludedGroups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pjenkins
+      - name: 'Upload surefire reports'
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-core
+          path: |
+            **/target/surefire-reports/**
+            **/hs_err_pid*.log
+          retention-days: 7
+          if-no-files-found: ignore
 
   test-cluster:
     name: HerdDB Core Cluster tests
@@ -110,6 +120,16 @@ jobs:
           path: ~/.m2/repository
       - name: 'Test herddb-core (cluster)'
         run: mvn -B verify -DforkCount=2 -Dtest.groups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pjenkins
+      - name: 'Upload surefire reports'
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-cluster
+          path: |
+            **/target/surefire-reports/**
+            **/hs_err_pid*.log
+          retention-days: 7
+          if-no-files-found: ignore
 
   test-other:
     name: Other modules tests
@@ -135,6 +155,16 @@ jobs:
           path: ~/.m2/repository
       - name: 'Test other modules'
         run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins -pl !herddb-core,!herddb-remote-file-service,!herddb-indexing-service
+      - name: 'Upload surefire reports'
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-other
+          path: |
+            **/target/surefire-reports/**
+            **/hs_err_pid*.log
+          retention-days: 7
+          if-no-files-found: ignore
 
   test-remote-file-service:
     name: Remote File Service tests
@@ -160,6 +190,16 @@ jobs:
           path: ~/.m2/repository
       - name: 'Test herddb-remote-file-service'
         run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins -pl herddb-remote-file-service
+      - name: 'Upload surefire reports'
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-remote-file-service
+          path: |
+            **/target/surefire-reports/**
+            **/hs_err_pid*.log
+          retention-days: 7
+          if-no-files-found: ignore
 
   test-indexing-service:
     name: Indexing Service tests
@@ -185,3 +225,13 @@ jobs:
           path: ~/.m2/repository
       - name: 'Test herddb-indexing-service'
         run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins -pl herddb-indexing-service
+      - name: 'Upload surefire reports'
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-indexing-service
+          path: |
+            **/target/surefire-reports/**
+            **/hs_err_pid*.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/pom.xml
+++ b/pom.xml
@@ -972,7 +972,8 @@
                             <reuseForks>false</reuseForks>
                             <argLine> --add-opens=java.base/java.nio=ALL-UNNAMED  --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Xmx2G -XX:+UseG1GC  @{argLine}</argLine>
                             <trimStackTrace>false</trimStackTrace>
-                            <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
+                            <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+                            <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Summary

Investigating the flaky cluster-tests CI failure on https://github.com/eolivelli/herddb/actions/runs/24327916883/job/71027507179?pr=78 — all 109 tests passed, then a surefire fork stalled for ~79 seconds during shutdown and the build died with:

```
[INFO] Tests run: 109, Failures: 0, Errors: 0, Skipped: 0
[ERROR] Failed to execute goal ... maven-surefire-plugin:3.0.0-M5:test ... There was a timeout in the fork
```

Root cause of the *lack of diagnostics*: the workflow runs with `-Dmaven.test.redirectTestOutputToFile=true`, so all test stdout/stderr (and any surefire-generated thread dumps on timeout) go to `target/surefire-reports/*-output.txt` / `*.dumpstream`, which are never uploaded as artifacts. When a fork hangs we're left with zero context.

## Changes

- **`pom.xml` jenkins profile**: bump `forkedProcessTimeoutInSeconds` from 900s to 1800s, and set `forkedProcessExitTimeoutInSeconds` to 120s (default 30s) so slow non-daemon threads at JVM shutdown have a chance to finish cleanly before surefire kills the fork.
- **`.github/workflows/ci.yml`**: add an `if: failure()` step to every Java test job (`test-core`, `test-cluster`, `test-other`, `test-remote-file-service`, `test-indexing-service`) that uploads `**/target/surefire-reports/**` and any `hs_err_pid*.log` as an artifact, with 7-day retention. Next time a fork hangs we'll actually be able to see which test class left threads behind.

## Test plan

- [ ] PR CI runs green on a healthy build
- [ ] Next time a test job fails, confirm the `surefire-reports-*` artifact is attached to the run and contains the per-class `*-output.txt` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)