### PR TITLE
indexing-admin: compaction progress, upload progress, JVM heap (#80)

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -335,6 +335,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** Metric: total checkpoint failures over the lifetime of the store. */
     private final AtomicLong totalCheckpointFailures = new AtomicLong(0);
 
+    // Compaction progress counters (issue #80).
+    //
+    // The supervisor loop (indexing-admin + Grafana) needs to see Phase-B
+    // progress without grepping logs. Counters are reset at the start of
+    // each Phase B and left populated after it finishes so a post-hoc
+    // describe-index still shows the final totals of the last compaction.
+    private final AtomicInteger writingGraphActive = new AtomicInteger();
+    private final AtomicInteger uploadingActive = new AtomicInteger();
+    private final AtomicLong compactionNodesDone = new AtomicLong();
+    private final AtomicLong compactionNodesTotal = new AtomicLong();
+    private final AtomicLong uploadBytesDone = new AtomicLong();
+    private final AtomicLong uploadBytesTotal = new AtomicLong();
+
     public long getTotalRolledBackPages() {
         return totalRolledBackPages.get();
     }
@@ -345,6 +358,66 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public long getTotalCheckpointFailures() {
         return totalCheckpointFailures.get();
+    }
+
+    /**
+     * Returns the current compaction phase: {@code "idle"},
+     * {@code "writing-graph"}, or {@code "uploading-segment"}. Priority is
+     * upload &gt; graph-write, so when segment writes overlap (Phase B
+     * parallelism) the most advanced phase wins.
+     */
+    public String getCompactionPhase() {
+        if (uploadingActive.get() > 0) {
+            return "uploading-segment";
+        }
+        if (writingGraphActive.get() > 0) {
+            return "writing-graph";
+        }
+        return "idle";
+    }
+
+    public int getWritingGraphActiveCount() {
+        return writingGraphActive.get();
+    }
+
+    public int getUploadingActiveCount() {
+        return uploadingActive.get();
+    }
+
+    public long getCompactionNodesDone() {
+        return compactionNodesDone.get();
+    }
+
+    public long getCompactionNodesTotal() {
+        return compactionNodesTotal.get();
+    }
+
+    public long getUploadBytesDone() {
+        return uploadBytesDone.get();
+    }
+
+    public long getUploadBytesTotal() {
+        return uploadBytesTotal.get();
+    }
+
+    /**
+     * Returns the progress percentage of whichever phase is currently
+     * active, or {@code -1} when idle. During {@code uploading-segment} it
+     * reflects bytes-based progress; during {@code writing-graph} it
+     * reflects node-count progress.
+     */
+    public int getCompactionProgressPercent() {
+        if (uploadingActive.get() > 0) {
+            long total = uploadBytesTotal.get();
+            long done = uploadBytesDone.get();
+            return total > 0 ? (int) Math.min(100L, (100L * done) / total) : 0;
+        }
+        if (writingGraphActive.get() > 0) {
+            long total = compactionNodesTotal.get();
+            long done = compactionNodesDone.get();
+            return total > 0 ? (int) Math.min(100L, (100L * done) / total) : 0;
+        }
+        return -1;
     }
 
     // -------------------------------------------------------------------------
@@ -1374,6 +1447,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // can reclaim partially-written pages instead of leaking them until the
         // next (possibly never-arriving) successful checkpoint.
         this.provisionalPageIds = Collections.synchronizedList(new ArrayList<>());
+        // Reset compaction progress counters so a describe-index sampled
+        // mid-Phase-B reflects this checkpoint's totals, not the previous one.
+        compactionNodesDone.set(0);
+        compactionNodesTotal.set(0);
+        uploadBytesDone.set(0);
+        uploadBytesTotal.set(0);
         List<SegmentWriteResult> newSegmentResults;
         try {
             Runnable hook = checkpointPhaseBHook;
@@ -2265,24 +2344,42 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // Try multipart write via storage manager
         Path graphTempFile = writeFusedPQGraphToTempFile(partVectors, partNodeToPk, snapshotDimension);
         try {
-            String graphFilePath = dataStorageManager.writeMultipartIndexFile(
-                    tableSpaceUUID,
-                    indexUUID + "_seg" + s.segmentId,
-                    "graph",
-                    graphTempFile);
+            long graphTempSize = Files.size(graphTempFile);
+            uploadBytesTotal.addAndGet(graphTempSize);
+            String graphFilePath;
+            uploadingActive.incrementAndGet();
+            try {
+                graphFilePath = dataStorageManager.writeMultipartIndexFile(
+                        tableSpaceUUID,
+                        indexUUID + "_seg" + s.segmentId,
+                        "graph",
+                        graphTempFile,
+                        uploadBytesDone::addAndGet);
+            } finally {
+                uploadingActive.decrementAndGet();
+            }
             if (graphFilePath != null) {
-                long graphFileSize = Files.size(graphTempFile);
+                long graphFileSize = graphTempSize;
                 // Map data
                 Path mapTempFile = writeFusedPQMapDataToTempFile(
                         new VectorStorageRandomAccessVectorValues(partStorage, snapshotDimension),
                         partNodeToPk);
                 try {
-                    String mapFilePath = dataStorageManager.writeMultipartIndexFile(
-                            tableSpaceUUID,
-                            indexUUID + "_seg" + s.segmentId,
-                            "map",
-                            mapTempFile);
-                    long mapFileSize = Files.size(mapTempFile);
+                    long mapTempSize = Files.size(mapTempFile);
+                    uploadBytesTotal.addAndGet(mapTempSize);
+                    String mapFilePath;
+                    uploadingActive.incrementAndGet();
+                    try {
+                        mapFilePath = dataStorageManager.writeMultipartIndexFile(
+                                tableSpaceUUID,
+                                indexUUID + "_seg" + s.segmentId,
+                                "map",
+                                mapTempFile,
+                                uploadBytesDone::addAndGet);
+                    } finally {
+                        uploadingActive.decrementAndGet();
+                    }
+                    long mapFileSize = mapTempSize;
                     long estimatedSize = graphFileSize + mapFileSize;
                     return new SegmentWriteResult(s.segmentId,
                             graphFilePath, graphFileSize,
@@ -2467,77 +2564,82 @@ public class PersistentVectorStore extends AbstractVectorStore {
             Path empty = Files.createTempFile(tmpDirectory, "herddb-vector-empty-", ".idx");
             return empty;
         }
-        int totalVectors = allNodeToPk.size();
-        VectorStorage allStorage = new VectorStorage(allVectors.size());
-        allVectors.forEach(allStorage::set);
-        VectorStorageRandomAccessVectorValues allMravv =
-                new VectorStorageRandomAccessVectorValues(allStorage, dim, allVectors.size());
-        BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(allMravv, similarityFunction);
-        GraphIndexBuilder mergedBuilder = new GraphIndexBuilder(
-                bsp, dim, m, beamWidth, neighborOverflow, alpha, ADD_HIERARCHY, REFINE_FINAL_GRAPH,
-                PhysicalCoreExecutor.pool(), CHECKPOINT_POOL);
-
-        int progressInterval = Math.max(1000, totalVectors / 10);
-        AtomicInteger nodesAdded = new AtomicInteger(0);
-        java.util.concurrent.ForkJoinTask<?> graphTask = CHECKPOINT_POOL.submit(() ->
-                allVectors.entrySet().parallelStream()
-                    .filter(e -> allNodeToPk.containsKey(e.getKey()))
-                    .forEach(e -> {
-                        mergedBuilder.addGraphNode(e.getKey(), e.getValue());
-                        int count = nodesAdded.incrementAndGet();
-                        if (count % progressInterval == 0) {
-                            LOGGER.log(Level.INFO,
-                                    "writeFusedPQGraphToTempFile {0}: added {1}/{2} nodes ({3}%)",
-                                    new Object[]{indexName, count, totalVectors,
-                                            (int) (100.0 * count / totalVectors)});
-                        }
-                    })
-        );
+        writingGraphActive.incrementAndGet();
         try {
-            graphTask.get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("writeFusedPQGraphToTempFile interrupted", e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof IOException) {
-                throw (IOException) cause;
-            }
-            throw new IOException("writeFusedPQGraphToTempFile failed", cause);
-        }
-        mergedBuilder.cleanup();
-        OnHeapGraphIndex mergedGraph = (OnHeapGraphIndex) mergedBuilder.getGraph();
+            int totalVectors = allNodeToPk.size();
+            compactionNodesTotal.addAndGet(totalVectors);
+            VectorStorage allStorage = new VectorStorage(allVectors.size());
+            allVectors.forEach(allStorage::set);
+            VectorStorageRandomAccessVectorValues allMravv =
+                    new VectorStorageRandomAccessVectorValues(allStorage, dim, allVectors.size());
+            BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(allMravv, similarityFunction);
+            GraphIndexBuilder mergedBuilder = new GraphIndexBuilder(
+                    bsp, dim, m, beamWidth, neighborOverflow, alpha, ADD_HIERARCHY, REFINE_FINAL_GRAPH,
+                    PhysicalCoreExecutor.pool(), CHECKPOINT_POOL);
 
-        int pqSubspaces = Math.max(1, dim / 4);
-        ProductQuantization pq = ProductQuantization.compute(allMravv, pqSubspaces, 256, true);
-        PQVectors pqv = pq.encodeAll(allMravv, PhysicalCoreExecutor.pool());
-
-        Path tempFile = Files.createTempFile(tmpDirectory, "herddb-vector-", ".idx");
-        boolean success = false;
-        try {
-            try (OnDiskGraphIndexWriter writer = new OnDiskGraphIndexWriter.Builder(mergedGraph, tempFile)
-                    .with(new FusedPQ(mergedGraph.maxDegree(), pq))
-                    .with(new InlineVectors(dim))
-                    .build()) {
-                ImmutableGraphIndex.View view = mergedGraph.getView();
-                EnumMap<FeatureId, IntFunction<io.github.jbellis.jvector.graph.disk.feature.Feature.State>> suppliers =
-                        new EnumMap<>(FeatureId.class);
-                suppliers.put(FeatureId.FUSED_PQ, ordinal -> new FusedPQ.State(view, pqv, ordinal));
-                suppliers.put(FeatureId.INLINE_VECTORS,
-                        ordinal -> new InlineVectors.State(allMravv.getVector(ordinal)));
-                writer.write(suppliers);
-            }
-            success = true;
-            return tempFile;
-        } finally {
-            if (!success) {
-                Files.deleteIfExists(tempFile);
-            }
+            int progressInterval = Math.max(1000, totalVectors / 10);
+            java.util.concurrent.ForkJoinTask<?> graphTask = CHECKPOINT_POOL.submit(() ->
+                    allVectors.entrySet().parallelStream()
+                        .filter(e -> allNodeToPk.containsKey(e.getKey()))
+                        .forEach(e -> {
+                            mergedBuilder.addGraphNode(e.getKey(), e.getValue());
+                            long count = compactionNodesDone.incrementAndGet();
+                            if (count % progressInterval == 0) {
+                                LOGGER.log(Level.INFO,
+                                        "writeFusedPQGraphToTempFile {0}: added {1}/{2} nodes ({3}%)",
+                                        new Object[]{indexName, count, totalVectors,
+                                                (int) (100.0 * count / totalVectors)});
+                            }
+                        })
+            );
             try {
-                mergedBuilder.close();
-            } catch (IOException e) {
-                // ignore
+                graphTask.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("writeFusedPQGraphToTempFile interrupted", e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IOException) {
+                    throw (IOException) cause;
+                }
+                throw new IOException("writeFusedPQGraphToTempFile failed", cause);
             }
+            mergedBuilder.cleanup();
+            OnHeapGraphIndex mergedGraph = (OnHeapGraphIndex) mergedBuilder.getGraph();
+
+            int pqSubspaces = Math.max(1, dim / 4);
+            ProductQuantization pq = ProductQuantization.compute(allMravv, pqSubspaces, 256, true);
+            PQVectors pqv = pq.encodeAll(allMravv, PhysicalCoreExecutor.pool());
+
+            Path tempFile = Files.createTempFile(tmpDirectory, "herddb-vector-", ".idx");
+            boolean success = false;
+            try {
+                try (OnDiskGraphIndexWriter writer = new OnDiskGraphIndexWriter.Builder(mergedGraph, tempFile)
+                        .with(new FusedPQ(mergedGraph.maxDegree(), pq))
+                        .with(new InlineVectors(dim))
+                        .build()) {
+                    ImmutableGraphIndex.View view = mergedGraph.getView();
+                    EnumMap<FeatureId, IntFunction<io.github.jbellis.jvector.graph.disk.feature.Feature.State>> suppliers =
+                            new EnumMap<>(FeatureId.class);
+                    suppliers.put(FeatureId.FUSED_PQ, ordinal -> new FusedPQ.State(view, pqv, ordinal));
+                    suppliers.put(FeatureId.INLINE_VECTORS,
+                            ordinal -> new InlineVectors.State(allMravv.getVector(ordinal)));
+                    writer.write(suppliers);
+                }
+                success = true;
+                return tempFile;
+            } finally {
+                if (!success) {
+                    Files.deleteIfExists(tempFile);
+                }
+                try {
+                    mergedBuilder.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+        } finally {
+            writingGraphActive.decrementAndGet();
         }
     }
 

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -158,6 +159,18 @@ public abstract class DataStorageManager implements AutoCloseable {
                                           Path tempFile)
             throws IOException, DataStorageManagerException {
         return null; // default: not supported; caller falls back to page-based writes
+    }
+
+    /**
+     * Overload that reports upload progress to the caller via {@code progress}.
+     * The callback is invoked with the number of bytes written since the last
+     * invocation (a delta, not a running total). Default implementation ignores
+     * {@code progress} and delegates to the non-progress overload.
+     */
+    public String writeMultipartIndexFile(String tableSpace, String uuid, String fileType,
+                                          Path tempFile, LongConsumer progress)
+            throws IOException, DataStorageManagerException {
+        return writeMultipartIndexFile(tableSpace, uuid, fileType, tempFile);
     }
 
     /**

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1024,6 +1024,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.fusedPQEnabled = pvs.isFusedPQEnabled();
             d.m = pvs.getM();
             d.beamWidth = pvs.getBeamWidth();
+            d.compactionPhase = pvs.getCompactionPhase();
+            d.compactionProgress = pvs.getCompactionProgressPercent();
+            d.compactionNodesDone = pvs.getCompactionNodesDone();
+            d.compactionNodesTotal = pvs.getCompactionNodesTotal();
+            d.uploadBytesDone = pvs.getUploadBytesDone();
+            d.uploadBytesTotal = pvs.getUploadBytesTotal();
+            if (!"idle".equals(d.compactionPhase)) {
+                d.status = d.compactionPhase;
+            }
         } else if (store instanceof InMemoryVectorStore) {
             d.similarity = ((InMemoryVectorStore) store).getSimilarityType().name();
             d.segmentCount = 1;
@@ -1430,6 +1439,80 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     return pvs.getLastPhaseBBytesWritten();
                 }
             });
+            // Compaction progress gauges (issue #80). compaction_phase is not
+            // a scalar, so we expose two 0/1 "active" gauges and let clients
+            // derive the phase from whichever is non-zero.
+            indexStats.registerGauge("compaction_nodes_done", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getCompactionNodesDone();
+                }
+            });
+            indexStats.registerGauge("compaction_nodes_total", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getCompactionNodesTotal();
+                }
+            });
+            indexStats.registerGauge("compaction_progress_pct", new Gauge<Integer>() {
+                @Override
+                public Integer getDefaultValue() {
+                    return 0;
+                }
+                @Override
+                public Integer getSample() {
+                    int v = pvs.getCompactionProgressPercent();
+                    return v < 0 ? 0 : v;
+                }
+            });
+            indexStats.registerGauge("upload_bytes_done", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getUploadBytesDone();
+                }
+            });
+            indexStats.registerGauge("upload_bytes_total", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getUploadBytesTotal();
+                }
+            });
+            indexStats.registerGauge("writing_graph_active", new Gauge<Integer>() {
+                @Override
+                public Integer getDefaultValue() {
+                    return 0;
+                }
+                @Override
+                public Integer getSample() {
+                    return pvs.getWritingGraphActiveCount() > 0 ? 1 : 0;
+                }
+            });
+            indexStats.registerGauge("uploading_segment_active", new Gauge<Integer>() {
+                @Override
+                public Integer getDefaultValue() {
+                    return 0;
+                }
+                @Override
+                public Integer getSample() {
+                    return pvs.getUploadingActiveCount() > 0 ? 1 : 0;
+                }
+            });
             indexStats.registerGauge("phase_b_vectors_per_second", new Gauge<Long>() {
                 @Override
                 public Long getDefaultValue() {
@@ -1704,5 +1787,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         public int beamWidth;
         public boolean persistent;
         public String storeClass;
+        // Compaction progress (issue #80). compactionPhase is "idle" when
+        // no Phase-B activity is in flight; progress is -1 when idle.
+        public String compactionPhase = "idle";
+        public int compactionProgress = -1;
+        public long compactionNodesDone;
+        public long compactionNodesTotal;
+        public long uploadBytesDone;
+        public long uploadBytesTotal;
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -218,7 +218,13 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setM(details.m)
                     .setBeamWidth(details.beamWidth)
                     .setPersistent(details.persistent)
-                    .setStoreClass(nullToEmpty(details.storeClass));
+                    .setStoreClass(nullToEmpty(details.storeClass))
+                    .setCompactionPhase(nullToEmpty(details.compactionPhase))
+                    .setCompactionProgress(details.compactionProgress)
+                    .setCompactionNodesDone(details.compactionNodesDone)
+                    .setCompactionNodesTotal(details.compactionNodesTotal)
+                    .setUploadBytesDone(details.uploadBytesDone)
+                    .setUploadBytesTotal(details.uploadBytesTotal);
             responseObserver.onNext(builder.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
@@ -280,6 +286,11 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             long start = engine.getStartTimeMillis();
             long uptime = start > 0 ? System.currentTimeMillis() - start : 0L;
             LogSequenceNumber lsn = engine.getLastProcessedLsn();
+            java.lang.management.MemoryUsage heap =
+                    java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+            long heapUsed = heap.getUsed();
+            long heapMax = heap.getMax();
+            int heapPct = heapMax > 0 ? (int) Math.min(100L, (100L * heapUsed) / heapMax) : -1;
             GetEngineStatsResponse response = GetEngineStatsResponse.newBuilder()
                     .setUptimeMillis(uptime)
                     .setTailerWatermarkLedger(lsn != null ? lsn.ledgerId : -1L)
@@ -291,6 +302,9 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setTotalEstimatedMemoryBytes(engine.getTotalEstimatedMemoryBytes())
                     .setLoadedIndexCount(engine.getLoadedIndexCount())
                     .setApplyParallelism(engine.getApplyParallelism())
+                    .setJvmHeapUsedBytes(heapUsed)
+                    .setJvmHeapMaxBytes(heapMax)
+                    .setJvmHeapUsedPct(heapPct)
                     .build();
             responseObserver.onNext(response);
             responseObserver.onCompleted();

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -365,6 +365,9 @@ public final class IndexingAdminCli {
                 out.printf(Locale.ROOT, "  apply_parallelism           = %d%n", response.getApplyParallelism());
                 out.printf(Locale.ROOT, "  loaded_index_count          = %d%n", response.getLoadedIndexCount());
                 out.printf(Locale.ROOT, "  total_estimated_memory_bytes= %d%n", response.getTotalEstimatedMemoryBytes());
+                out.printf(Locale.ROOT, "  jvm_heap                    = %d / %d bytes (%d%%)%n",
+                        response.getJvmHeapUsedBytes(), response.getJvmHeapMaxBytes(),
+                        response.getJvmHeapUsedPct());
             }
         }
         return 0;
@@ -474,6 +477,12 @@ public final class IndexingAdminCli {
         m.put("beam_width", r.getBeamWidth());
         m.put("persistent", r.getPersistent());
         m.put("store_class", r.getStoreClass());
+        m.put("compaction_phase", r.getCompactionPhase());
+        m.put("compaction_progress", r.getCompactionProgress());
+        m.put("compaction_nodes_done", r.getCompactionNodesDone());
+        m.put("compaction_nodes_total", r.getCompactionNodesTotal());
+        m.put("upload_bytes_done", r.getUploadBytesDone());
+        m.put("upload_bytes_total", r.getUploadBytesTotal());
         return m;
     }
 
@@ -489,6 +498,9 @@ public final class IndexingAdminCli {
         m.put("apply_parallelism", r.getApplyParallelism());
         m.put("loaded_index_count", r.getLoadedIndexCount());
         m.put("total_estimated_memory_bytes", r.getTotalEstimatedMemoryBytes());
+        m.put("jvm_heap_used_bytes", r.getJvmHeapUsedBytes());
+        m.put("jvm_heap_max_bytes", r.getJvmHeapMaxBytes());
+        m.put("jvm_heap_used_pct", r.getJvmHeapUsedPct());
         return m;
     }
 
@@ -528,6 +540,20 @@ public final class IndexingAdminCli {
         out.printf(Locale.ROOT, "  m / beam_width        = %d / %d%n", r.getM(), r.getBeamWidth());
         out.printf(Locale.ROOT, "  last_lsn              = %d/%d%n",
                 r.getLastLsnLedger(), r.getLastLsnOffset());
+        String phase = r.getCompactionPhase();
+        if (phase != null && !phase.isEmpty() && !"idle".equals(phase)) {
+            if ("uploading-segment".equals(phase)) {
+                out.printf(Locale.ROOT, "  compaction            = %s %d%% (%d/%d bytes)%n",
+                        phase, r.getCompactionProgress(),
+                        r.getUploadBytesDone(), r.getUploadBytesTotal());
+            } else {
+                out.printf(Locale.ROOT, "  compaction            = %s %d%% (%d/%d nodes)%n",
+                        phase, r.getCompactionProgress(),
+                        r.getCompactionNodesDone(), r.getCompactionNodesTotal());
+            }
+        } else {
+            out.printf(Locale.ROOT, "  compaction            = idle%n");
+        }
     }
 
     static String toHex(byte[] arr) {

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -109,6 +109,15 @@ message DescribeIndexResponse {
     int32 beam_width = 16;
     bool persistent = 17;
     string store_class = 18;
+    // Compaction progress (issue #80). compaction_phase is one of
+    // "idle", "writing-graph", "uploading-segment". compaction_progress
+    // is an integer 0..100, or -1 when idle.
+    string compaction_phase = 19;
+    int32 compaction_progress = 20;
+    int64 compaction_nodes_done = 21;
+    int64 compaction_nodes_total = 22;
+    int64 upload_bytes_done = 23;
+    int64 upload_bytes_total = 24;
 }
 
 message ListPrimaryKeysRequest {
@@ -139,6 +148,10 @@ message GetEngineStatsResponse {
     int64 total_estimated_memory_bytes = 8;
     int32 loaded_index_count = 9;
     int32 apply_parallelism = 10;
+    // JVM heap (issue #80): read from ManagementFactory.getMemoryMXBean()
+    int64 jvm_heap_used_bytes = 11;
+    int64 jvm_heap_max_bytes = 12;
+    int32 jvm_heap_used_pct = 13;
 }
 
 message GetInstanceInfoRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
@@ -134,6 +134,15 @@ public class IndexingServiceDiagnosticsGrpcTest {
         assertEquals(1, response.getSegmentCount());
         assertTrue(response.getEstimatedMemoryBytes() > 0);
         assertTrue(!response.getPersistent());
+        // Compaction progress defaults (issue #80): idle, zero counters.
+        // InMemoryVectorStore never enters Phase B, so the values should
+        // stay at their zero/idle defaults regardless of what was seeded.
+        assertEquals("idle", response.getCompactionPhase());
+        assertEquals(-1, response.getCompactionProgress());
+        assertEquals(0L, response.getCompactionNodesDone());
+        assertEquals(0L, response.getCompactionNodesTotal());
+        assertEquals(0L, response.getUploadBytesDone());
+        assertEquals(0L, response.getUploadBytesTotal());
     }
 
     @Test
@@ -213,6 +222,11 @@ public class IndexingServiceDiagnosticsGrpcTest {
         assertTrue(response.getApplyParallelism() >= 1);
         assertTrue(response.getApplyQueueCapacity() > 0);
         assertTrue(response.getTotalEstimatedMemoryBytes() > 0);
+        // JVM heap fields (issue #80).
+        assertTrue("jvm_heap_used_bytes should be > 0", response.getJvmHeapUsedBytes() > 0);
+        assertTrue("jvm_heap_max_bytes should be > 0", response.getJvmHeapMaxBytes() > 0);
+        assertTrue("jvm_heap_used_pct should be in [0,100]",
+                response.getJvmHeapUsedPct() >= 0 && response.getJvmHeapUsedPct() <= 100);
     }
 
     @Test

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionProgressTest.java
@@ -1,0 +1,157 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises the compaction progress instrumentation added for issue #80:
+ * the {@link PersistentVectorStore} tracks how many nodes have been added
+ * to the FusedPQ graph during Phase B and exposes the counters via
+ * {@link PersistentVectorStore#getCompactionNodesDone()} /
+ * {@link PersistentVectorStore#getCompactionNodesTotal()} /
+ * {@link PersistentVectorStore#getCompactionPhase()}.
+ *
+ * <p>This test uses {@link MemoryDataStorageManager}, which does not
+ * support multipart writes, so the upload counters stay at zero here;
+ * the node counters are the signal we verify.
+ */
+public class PersistentVectorStoreCompactionProgressTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void testIdleDefaults() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("idle").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            assertEquals("idle", store.getCompactionPhase());
+            assertEquals(-1, store.getCompactionProgressPercent());
+            assertEquals(0L, store.getCompactionNodesDone());
+            assertEquals(0L, store.getCompactionNodesTotal());
+            assertEquals(0L, store.getUploadBytesDone());
+            assertEquals(0L, store.getUploadBytesTotal());
+            assertEquals(0, store.getWritingGraphActiveCount());
+            assertEquals(0, store.getUploadingActiveCount());
+        }
+    }
+
+    @Test
+    public void testCountersTrackPhaseBWork() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("phase-b").toPath();
+        int numVectors = 5_000;
+        int dim = 64;
+        Random rng = new Random(42);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            for (int i = 0; i < numVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertEquals(numVectors, store.size());
+
+            // Background watcher samples compaction counters while Phase B
+            // is running. Phase B on MemoryDataStorageManager is fast but
+            // the watcher has a good chance to see a non-zero snapshot at
+            // some point; more importantly, we assert that the final
+            // post-checkpoint counters reflect all the work that happened.
+            AtomicLong maxNodesDone = new AtomicLong();
+            AtomicLong maxNodesTotal = new AtomicLong();
+            AtomicBoolean watcherStop = new AtomicBoolean();
+            Thread watcher = new Thread(() -> {
+                while (!watcherStop.get()) {
+                    long done = store.getCompactionNodesDone();
+                    long total = store.getCompactionNodesTotal();
+                    if (done > maxNodesDone.get()) {
+                        maxNodesDone.set(done);
+                    }
+                    if (total > maxNodesTotal.get()) {
+                        maxNodesTotal.set(total);
+                    }
+                }
+            }, "cp-watcher");
+            watcher.setDaemon(true);
+            watcher.start();
+
+            store.checkpoint();
+
+            watcherStop.set(true);
+            watcher.join(5000);
+
+            // After a clean checkpoint the phase should settle back to idle
+            // and the active-phase counters drain to zero.
+            assertEquals("idle", store.getCompactionPhase());
+            assertEquals(-1, store.getCompactionProgressPercent());
+            assertEquals(0, store.getWritingGraphActiveCount());
+            assertEquals(0, store.getUploadingActiveCount());
+
+            // The final counters are left populated (not reset on exit) so a
+            // post-hoc describe-index call shows the totals of the last
+            // compaction. We expect all `numVectors` to have flowed through
+            // the instrumented graph-write path.
+            assertEquals("compactionNodesTotal should equal vectors processed",
+                    (long) numVectors, store.getCompactionNodesTotal());
+            assertEquals("compactionNodesDone should equal vectors processed",
+                    (long) numVectors, store.getCompactionNodesDone());
+
+            // The watcher should have seen the intermediate totals too
+            // (same final value is fine — we only require the instance
+            // counters got above zero while Phase B was active).
+            assertTrue("watcher should have observed non-zero nodesTotal mid-checkpoint",
+                    maxNodesTotal.get() > 0);
+            assertTrue("watcher should have observed non-zero nodesDone mid-checkpoint",
+                    maxNodesDone.get() > 0);
+        }
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -2192,6 +2192,126 @@
           "dashes": false,
           "datasource": "Prometheus",
           "fill": 1,
+          "id": 211,
+          "legend": {"avg": false, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 4,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_compaction_nodes_done\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "nodes done",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_compaction_nodes_total\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "nodes total",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Compaction — Graph Node Progress",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "decimals": 0, "show": true},
+            {"format": "short", "show": true}
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 212,
+          "legend": {"avg": false, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 4,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_upload_bytes_done\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "bytes done",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_upload_bytes_total\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "bytes total",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Compaction — Upload Bytes Progress",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "bytes", "show": true},
+            {"format": "short", "show": true}
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 213,
+          "legend": {"avg": false, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 4,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_writing_graph_active\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "writing-graph",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_uploading_segment_active\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "uploading-segment",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Compaction — Active Phase",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "decimals": 0, "min": 0, "max": 1, "show": true},
+            {"format": "short", "show": true}
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
           "id": 202,
           "legend": {"avg": false, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
           "lines": true,

--- a/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
@@ -283,6 +283,14 @@ public class PromotableRemoteFileDataStorageManager extends DataStorageManager {
     }
 
     @Override
+    public String writeMultipartIndexFile(String tableSpace, String uuid, String fileType,
+                                          java.nio.file.Path tempFile,
+                                          java.util.function.LongConsumer progress)
+            throws java.io.IOException, DataStorageManagerException {
+        return activeDelegate.writeMultipartIndexFile(tableSpace, uuid, fileType, tempFile, progress);
+    }
+
+    @Override
     public io.github.jbellis.jvector.disk.ReaderSupplier multipartIndexReaderSupplier(
             String tableSpace, String uuid, String fileType, long fileSize)
             throws DataStorageManagerException {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -57,6 +57,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -461,16 +462,58 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     public String writeMultipartIndexFile(String tableSpace, String uuid, String fileType,
                                           Path tempFile)
             throws IOException, DataStorageManagerException {
+        return writeMultipartIndexFile(tableSpace, uuid, fileType, tempFile, null);
+    }
+
+    @Override
+    public String writeMultipartIndexFile(String tableSpace, String uuid, String fileType,
+                                          Path tempFile, LongConsumer progress)
+            throws IOException, DataStorageManagerException {
         String logicalPath = remoteMultipartPath(tableSpace, uuid, fileType);
         int blockSize = Math.max(client.getBlockSize(), MULTIPART_BLOCK_SIZE);
         long totalBytes;
-        try (java.io.InputStream in = java.nio.file.Files.newInputStream(tempFile)) {
+        try (java.io.InputStream raw = java.nio.file.Files.newInputStream(tempFile);
+             java.io.InputStream in = progress != null
+                     ? new CountingInputStream(raw, progress)
+                     : raw) {
             totalBytes = client.writeMultipartFile(logicalPath, in, blockSize);
         }
         LOGGER.log(Level.INFO,
                 "writeMultipartIndexFile: {0} written {1} bytes in blocks of {2}",
                 new Object[]{logicalPath, totalBytes, blockSize});
         return logicalPath;
+    }
+
+    /**
+     * Wraps an InputStream and reports the number of bytes read since the last
+     * report via a {@link LongConsumer}. Used by Phase-B multipart uploads so
+     * that the PersistentVectorStore can expose mid-flight upload progress.
+     */
+    private static final class CountingInputStream extends java.io.FilterInputStream {
+        private final LongConsumer progress;
+
+        CountingInputStream(java.io.InputStream in, LongConsumer progress) {
+            super(in);
+            this.progress = progress;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int r = super.read();
+            if (r >= 0) {
+                progress.accept(1L);
+            }
+            return r;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int r = super.read(b, off, len);
+            if (r > 0) {
+                progress.accept(r);
+            }
+            return r;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Closes #80. Surfaces four pieces of information the k3s-local bench supervisor
currently has to scrape from raw pod logs: FusedPQ graph-write progress, Phase-B
multipart upload progress, a richer \`status\` value that distinguishes idle
tailing from active compaction, and JVM heap usage.

- \`DescribeIndexResponse\` gains \`compaction_phase\` (\`idle\` / \`writing-graph\` /
  \`uploading-segment\`), \`compaction_progress\` (0..100, −1 idle), and four
  done/total counters for nodes and upload bytes. The \`status\` field on
  \`IndexDescriptor.basic\` now carries the phase name when non-idle.
- \`GetEngineStatsResponse\` gains \`jvm_heap_used_bytes\`, \`jvm_heap_max_bytes\`, and
  \`jvm_heap_used_pct\`, read from \`ManagementFactory.getMemoryMXBean()\`.
- \`PersistentVectorStore\` tracks the counters as instance state, reset at the
  start of each Phase B and populated by \`writeFusedPQGraphToTempFile\` and the
  two \`writeMultipartIndexFile\` call sites. A new \`LongConsumer\` overload on
  \`DataStorageManager.writeMultipartIndexFile\` plumbs mid-flight byte progress
  through a \`CountingInputStream\` wrapper in \`RemoteFileDataStorageManager\`.
- \`IndexingServiceEngine\` registers seven new per-index Prometheus gauges next
  to \`phase_b_bytes_written\`: \`compaction_nodes_done/_total\`,
  \`compaction_progress_pct\`, \`upload_bytes_done/_total\`, \`writing_graph_active\`,
  \`uploading_segment_active\`.
- The Grafana indexing-service dashboard gets three new panels (ids 211/212/213)
  — *Graph Node Progress*, *Upload Bytes Progress*, *Active Phase*.
- \`indexing-admin describe-index\` prints a \`compaction = <phase> <pct>% (...)\`
  line in text mode and adds the new keys in \`--json\` output;
  \`engine-stats\` prints \`jvm_heap\`.

All existing wire fields keep their numbers; the new proto fields are additive.

## Test plan

- [x] \`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins\` — green.
- [x] \`mvn -pl herddb-indexing-service -Dtest=IndexingServiceDiagnosticsGrpcTest test\` — 9/9 (extended to assert idle defaults for compaction fields and non-zero JVM heap).
- [x] \`mvn -pl herddb-indexing-service -Dtest=PersistentVectorStoreCompactionProgressTest test\` — 2/2 (new test: idle defaults and end-state counters after Phase B, with a watcher thread observing mid-flight advancement).
- [x] \`mvn -pl herddb-indexing-service -Dtest='PersistentVectorStoreConcurrentCheckpointTest,PersistentVectorStoreMultipartRecoveryTest,PersistentVectorStoreParallelPhaseBTest' test\` — 12/12 (adjacent Phase-B regression check).
- [ ] Manual sanity check on the k3s-local vector bench: run \`indexing-admin describe-index --json\` during a checkpoint and confirm \`compaction_phase\` flips between \`writing-graph\` and \`uploading-segment\`; scrape \`/metrics\` and confirm the new per-index metrics appear; open the Grafana dashboard and check the three new panels render live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)