### PR TITLE
In-heap block cache for RemoteFileServer (issue #82)

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/remote-file-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/remote-file-service-dashboard.json
@@ -1549,6 +1549,306 @@
           "dashes": false,
           "datasource": "Prometheus",
           "fill": 1,
+          "id": 200,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_block_cache_hits{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hits [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(rfs_block_cache_misses{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "misses [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Block Cache Hits / Misses (1m)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 201,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_block_cache_hits{instance=~\"$instance\"}[1m]) / clamp_min(rate(rfs_block_cache_hits{instance=~\"$instance\"}[1m]) + rate(rfs_block_cache_misses{instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hit ratio [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "title": "Block Cache Hit Ratio (1m)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "logBase": 1,
+              "max": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Block Cache Rates Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 202,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rfs_block_cache_size_bytes{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "used [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_block_cache_max_bytes{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "max [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Block Cache Bytes (used vs max)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 203,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_block_cache_evictions{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "evictions [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_block_cache_entries{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "entries [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Block Cache Evictions (1m) & Entries",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Block Cache Size Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
           "id": 109,
           "legend": {
             "avg": true,

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -25,6 +25,7 @@ import herddb.auth.oidc.OidcTokenValidator;
 import herddb.auth.oidc.grpc.JwtAuthServerInterceptor;
 import herddb.metadata.MetadataStorageManager;
 import herddb.remote.storage.CachingObjectStorage;
+import herddb.remote.storage.InMemoryBlockCacheObjectStorage;
 import herddb.remote.storage.LocalObjectStorage;
 import herddb.remote.storage.ObjectStorage;
 import herddb.remote.storage.S3ObjectStorage;
@@ -45,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider;
 import org.apache.bookkeeper.stats.prometheus.PrometheusServlet;
@@ -75,6 +77,10 @@ public class RemoteFileServer implements AutoCloseable {
     static final int DEFAULT_IO_RATIO = 70;
     /** Default block size for multipart files: 4 MB. */
     public static final int DEFAULT_BLOCK_SIZE = 4 * 1024 * 1024;
+    /** Config key: in-heap block cache byte budget. */
+    public static final String CONFIG_BLOCK_CACHE_MAX_BYTES = "block.cache.max.bytes";
+    /** Config key: enable/disable the in-heap block cache. */
+    public static final String CONFIG_BLOCK_CACHE_ENABLED = "block.cache.enabled";
 
     private final String host;
     private final int port;
@@ -128,12 +134,33 @@ public class RemoteFileServer implements AutoCloseable {
             objectStorage = new LocalObjectStorage(dataDirectory, metadataExecutor);
         }
 
+        // Wrap with in-heap block cache if enabled. Sits in front of the inner storage
+        // (local or S3+disk-cache) so hot graph blocks never re-touch disk/S3.
+        boolean blockCacheEnabled = Boolean.parseBoolean(
+                config.getProperty(CONFIG_BLOCK_CACHE_ENABLED, "true"));
+        InMemoryBlockCacheObjectStorage blockCache = null;
+        if (blockCacheEnabled) {
+            long blockCacheMaxBytes = Long.parseLong(
+                    config.getProperty(CONFIG_BLOCK_CACHE_MAX_BYTES,
+                            String.valueOf(defaultBlockCacheMaxBytes())));
+            blockCache = new InMemoryBlockCacheObjectStorage(objectStorage, blockCacheMaxBytes);
+            objectStorage = blockCache;
+            LOGGER.log(Level.INFO,
+                    "In-heap block cache enabled: maxBytes={0} ({1} MB)",
+                    new Object[]{blockCacheMaxBytes, blockCacheMaxBytes / (1024 * 1024)});
+        } else {
+            LOGGER.log(Level.INFO, "In-heap block cache disabled");
+        }
+
         // Initialize metrics
         statsProvider = new PrometheusMetricsProvider();
         PropertiesConfiguration statsConfig = new PropertiesConfiguration();
         statsConfig.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, false);
         statsProvider.start(statsConfig);
         StatsLogger statsLogger = statsProvider.getStatsLogger("");
+        if (blockCache != null) {
+            registerBlockCacheGauges(statsLogger, blockCache);
+        }
 
         int ioRatio = Integer.getInteger("herddb.fileserver.netty.ioRatio", DEFAULT_IO_RATIO);
         this.blockSize = Integer.parseInt(config.getProperty("block.size",
@@ -251,6 +278,97 @@ public class RemoteFileServer implements AutoCloseable {
             s3Client.close();
             throw e;
         }
+    }
+
+    /** Default in-heap block-cache budget: 1/4 of the JVM max heap. */
+    static long defaultBlockCacheMaxBytes() {
+        long max = Runtime.getRuntime().maxMemory();
+        if (max == Long.MAX_VALUE) {
+            // -Xmx unset: fall back to total memory so we don't allocate everything in sight.
+            max = Runtime.getRuntime().totalMemory();
+        }
+        return Math.max(1, max / 4);
+    }
+
+    private static void registerBlockCacheGauges(StatsLogger root, InMemoryBlockCacheObjectStorage cache) {
+        StatsLogger scope = root.scope("rfs").scope("block_cache");
+        scope.registerGauge("max_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.getMaxBytes();
+            }
+        });
+        scope.registerGauge("size_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.estimatedBytes();
+            }
+        });
+        scope.registerGauge("entries", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.estimatedSize();
+            }
+        });
+        scope.registerGauge("hits", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.stats().hitCount();
+            }
+        });
+        scope.registerGauge("misses", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.stats().missCount();
+            }
+        });
+        scope.registerGauge("evictions", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.stats().evictionCount();
+            }
+        });
+        scope.registerGauge("evicted_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.stats().evictionWeight();
+            }
+        });
     }
 
     public int getPort() {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
@@ -1,0 +1,259 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Decorator that holds a bounded in-heap cache of whole multipart blocks in front of an inner
+ * {@link ObjectStorage}. Aimed at the server-side random-I/O pattern of ANN queries against
+ * FusedPQ vector indexes: the HNSW traversal re-reads the same few graph blocks many times, and
+ * serving those from RAM removes both the disk hop and the S3 hop.
+ * <p>
+ * Keys are {@code (path, blockIndex)}; values are the full block bytes as returned by a
+ * {@code readRange(path, blockStartOffset, blockSize, blockSize)} on the inner storage. Range
+ * requests are always answered by slicing the cached block, so the cache is transparent to
+ * callers: it never changes the bytes observed by a client. Concurrent misses for the same
+ * block are deduplicated through an in-flight future map so only one inner read fires.
+ * <p>
+ * The cache is weight-bounded by bytes. Writes and deletes invalidate every cached block that
+ * could have contained stale data. Caffeine stats are exposed via {@link #stats()} so the
+ * server can wire hit/miss/eviction counters into its metrics registry.
+ *
+ * @author enrico.olivelli
+ */
+public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
+
+    private final ObjectStorage inner;
+    private final Cache<BlockKey, byte[]> cache;
+    private final ConcurrentHashMap<BlockKey, CompletableFuture<ReadResult>> inFlight = new ConcurrentHashMap<>();
+    private final long maxBytes;
+
+    public InMemoryBlockCacheObjectStorage(ObjectStorage inner, long maxBytes) {
+        this.inner = Objects.requireNonNull(inner, "inner");
+        if (maxBytes <= 0) {
+            throw new IllegalArgumentException("maxBytes must be positive, got " + maxBytes);
+        }
+        this.maxBytes = maxBytes;
+        this.cache = Caffeine.newBuilder()
+                .maximumWeight(maxBytes)
+                .weigher((BlockKey k, byte[] v) -> v == null ? 0 : v.length)
+                .recordStats()
+                .build();
+    }
+
+    public long getMaxBytes() {
+        return maxBytes;
+    }
+
+    /** Current Caffeine stats snapshot. Safe to call from gauge samplers. */
+    public CacheStats stats() {
+        return cache.stats();
+    }
+
+    /** Approximate number of cached blocks. */
+    public long estimatedSize() {
+        return cache.estimatedSize();
+    }
+
+    /**
+     * Approximate bytes currently held by the cache. Walks the {@code asMap()} view without
+     * triggering maintenance; intended for gauges, not hot-path use.
+     */
+    public long estimatedBytes() {
+        long total = 0;
+        for (byte[] v : cache.asMap().values()) {
+            if (v != null) {
+                total += v.length;
+            }
+        }
+        return total;
+    }
+
+    @Override
+    public CompletableFuture<Void> write(String path, byte[] content) {
+        invalidateAllBlocksOf(path);
+        return inner.write(path, content);
+    }
+
+    @Override
+    public CompletableFuture<ReadResult> read(String path) {
+        // Full-file reads are not block-addressable, so we just pass through.
+        return inner.read(path);
+    }
+
+    @Override
+    public CompletableFuture<Void> writeBlock(String path, long blockIndex, byte[] content) {
+        cache.invalidate(new BlockKey(path, blockIndex));
+        return inner.writeBlock(path, blockIndex, content);
+    }
+
+    @Override
+    public CompletableFuture<ReadResult> readRange(String path, long offset, int length, int blockSize) {
+        long blockIndex = offset / blockSize;
+        int offsetInBlock = (int) (offset % blockSize);
+        BlockKey key = new BlockKey(path, blockIndex);
+
+        byte[] cached = cache.getIfPresent(key);
+        if (cached != null) {
+            return CompletableFuture.completedFuture(slice(cached, offsetInBlock, length));
+        }
+
+        CompletableFuture<ReadResult> pending = new CompletableFuture<>();
+        CompletableFuture<ReadResult> existing = inFlight.putIfAbsent(key, pending);
+        if (existing != null) {
+            return existing.thenApply(full -> slice(fullBytes(full), offsetInBlock, length));
+        }
+
+        long blockStartOffset = blockIndex * (long) blockSize;
+        inner.readRange(path, blockStartOffset, blockSize, blockSize).whenComplete((result, err) -> {
+            try {
+                if (err != null) {
+                    pending.completeExceptionally(err);
+                    return;
+                }
+                if (result.status() == ReadResult.Status.FOUND && result.content() != null) {
+                    cache.put(key, result.content());
+                }
+                pending.complete(result);
+            } finally {
+                inFlight.remove(key, pending);
+            }
+        });
+
+        return pending.thenApply(full -> slice(fullBytes(full), offsetInBlock, length));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> deleteLogical(String path) {
+        invalidateAllBlocksOf(path);
+        return inner.deleteLogical(path);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> listLogical(String prefix) {
+        return inner.listLogical(prefix);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> delete(String path) {
+        invalidateAllBlocksOf(path);
+        return inner.delete(path);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> list(String prefix) {
+        return inner.list(prefix);
+    }
+
+    @Override
+    public CompletableFuture<Integer> deleteByPrefix(String prefix) {
+        return inner.deleteByPrefix(prefix).thenApply(count -> {
+            List<BlockKey> toDrop = new ArrayList<>();
+            for (BlockKey k : cache.asMap().keySet()) {
+                if (k.path.startsWith(prefix)) {
+                    toDrop.add(k);
+                }
+            }
+            cache.invalidateAll(toDrop);
+            return count;
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        cache.invalidateAll();
+        inner.close();
+    }
+
+    private void invalidateAllBlocksOf(String path) {
+        List<BlockKey> toDrop = new ArrayList<>();
+        for (BlockKey k : cache.asMap().keySet()) {
+            if (k.path.equals(path)) {
+                toDrop.add(k);
+            }
+        }
+        cache.invalidateAll(toDrop);
+    }
+
+    private static byte[] fullBytes(ReadResult full) {
+        if (full == null || full.status() != ReadResult.Status.FOUND) {
+            return null;
+        }
+        return full.content();
+    }
+
+    private static ReadResult slice(byte[] block, int offsetInBlock, int length) {
+        if (block == null) {
+            return ReadResult.notFound();
+        }
+        if (offsetInBlock >= block.length) {
+            return ReadResult.notFound();
+        }
+        int to = Math.min(offsetInBlock + length, block.length);
+        int sliceLen = to - offsetInBlock;
+        byte[] out = new byte[sliceLen];
+        System.arraycopy(block, offsetInBlock, out, 0, sliceLen);
+        return ReadResult.found(out);
+    }
+
+    /** Package-private: force Caffeine maintenance. Used by tests. */
+    void cleanUp() {
+        cache.cleanUp();
+    }
+
+    /** Compound cache key: logical path + block index. */
+    private static final class BlockKey {
+        final String path;
+        final long blockIndex;
+
+        BlockKey(String path, long blockIndex) {
+            this.path = path;
+            this.blockIndex = blockIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BlockKey)) {
+                return false;
+            }
+            BlockKey other = (BlockKey) o;
+            return blockIndex == other.blockIndex && path.equals(other.path);
+        }
+
+        @Override
+        public int hashCode() {
+            int h = path.hashCode();
+            h = 31 * h + Long.hashCode(blockIndex);
+            return h;
+        }
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/InMemoryBlockCacheObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/InMemoryBlockCacheObjectStorageTest.java
@@ -1,0 +1,392 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InMemoryBlockCacheObjectStorageTest {
+
+    private static final int BLOCK_SIZE = 1024;
+
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        executor = Executors.newFixedThreadPool(4);
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdown();
+    }
+
+    private static byte[] makeBlock(int seed, int size) {
+        byte[] b = new byte[size];
+        for (int i = 0; i < size; i++) {
+            b[i] = (byte) (seed + i);
+        }
+        return b;
+    }
+
+    @Test
+    public void readRangeCacheHitOnRepeatedRead() throws Exception {
+        CountingFake inner = new CountingFake();
+        byte[] block0 = makeBlock(1, BLOCK_SIZE);
+        inner.putBlock("path/a", 0, block0);
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+
+            ReadResult r1 = cache.readRange("path/a", 0, 256, BLOCK_SIZE).get();
+            assertEquals(ReadResult.Status.FOUND, r1.status());
+            assertArrayEquals(Arrays.copyOfRange(block0, 0, 256), r1.content());
+
+            ReadResult r2 = cache.readRange("path/a", 256, 256, BLOCK_SIZE).get();
+            assertEquals(ReadResult.Status.FOUND, r2.status());
+            assertArrayEquals(Arrays.copyOfRange(block0, 256, 512), r2.content());
+
+            // Only the first range caused a readRange on inner (to fetch the whole block).
+            assertEquals(1, inner.readRangeCalls.get());
+
+            CacheStats stats = cache.stats();
+            assertEquals(1, stats.hitCount());
+            assertEquals(1, stats.missCount());
+        }
+    }
+
+    @Test
+    public void concurrentMissesAreDeduplicated() throws Exception {
+        CountingFake inner = new CountingFake();
+        byte[] block0 = makeBlock(2, BLOCK_SIZE);
+        inner.putBlock("path/b", 0, block0);
+
+        CountDownLatch releaseInner = new CountDownLatch(1);
+        inner.gate = releaseInner;
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+
+            CompletableFuture<ReadResult> f1 = cache.readRange("path/b", 0, 512, BLOCK_SIZE);
+            CompletableFuture<ReadResult> f2 = cache.readRange("path/b", 0, 512, BLOCK_SIZE);
+
+            // Give the second call a moment to land in the in-flight map.
+            Thread.sleep(50);
+            releaseInner.countDown();
+
+            ReadResult r1 = f1.get(5, TimeUnit.SECONDS);
+            ReadResult r2 = f2.get(5, TimeUnit.SECONDS);
+            assertEquals(ReadResult.Status.FOUND, r1.status());
+            assertEquals(ReadResult.Status.FOUND, r2.status());
+            assertArrayEquals(Arrays.copyOfRange(block0, 0, 512), r1.content());
+            assertArrayEquals(Arrays.copyOfRange(block0, 0, 512), r2.content());
+
+            // Only one inner readRange, thanks to in-flight dedup.
+            assertEquals(1, inner.readRangeCalls.get());
+        }
+    }
+
+    @Test
+    public void writeBlockInvalidatesSingleBlock() throws Exception {
+        CountingFake inner = new CountingFake();
+        byte[] original = makeBlock(3, BLOCK_SIZE);
+        inner.putBlock("path/c", 0, original);
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+            cache.readRange("path/c", 0, 16, BLOCK_SIZE).get();
+            assertEquals(1, inner.readRangeCalls.get());
+
+            byte[] updated = makeBlock(99, BLOCK_SIZE);
+            cache.writeBlock("path/c", 0, updated).get();
+
+            ReadResult r = cache.readRange("path/c", 0, 16, BLOCK_SIZE).get();
+            assertArrayEquals(Arrays.copyOfRange(updated, 0, 16), r.content());
+            assertEquals(2, inner.readRangeCalls.get());
+        }
+    }
+
+    @Test
+    public void writeInvalidatesAllBlocksOfPath() throws Exception {
+        CountingFake inner = new CountingFake();
+        inner.putBlock("path/d", 0, makeBlock(4, BLOCK_SIZE));
+        inner.putBlock("path/d", 1, makeBlock(5, BLOCK_SIZE));
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+            cache.readRange("path/d", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("path/d", BLOCK_SIZE, 16, BLOCK_SIZE).get();
+            assertEquals(2, inner.readRangeCalls.get());
+
+            cache.write("path/d", new byte[]{1, 2, 3}).get();
+
+            cache.readRange("path/d", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("path/d", BLOCK_SIZE, 16, BLOCK_SIZE).get();
+            assertEquals("both blocks must be re-fetched after write", 4, inner.readRangeCalls.get());
+        }
+    }
+
+    @Test
+    public void deleteLogicalInvalidatesAllBlocksOfPath() throws Exception {
+        CountingFake inner = new CountingFake();
+        inner.putBlock("path/e", 0, makeBlock(6, BLOCK_SIZE));
+        inner.putBlock("path/e", 1, makeBlock(7, BLOCK_SIZE));
+        inner.putBlock("path/other", 0, makeBlock(8, BLOCK_SIZE));
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+            cache.readRange("path/e", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("path/e", BLOCK_SIZE, 16, BLOCK_SIZE).get();
+            cache.readRange("path/other", 0, 16, BLOCK_SIZE).get();
+
+            cache.deleteLogical("path/e").get();
+
+            // Unrelated path stays cached.
+            int before = inner.readRangeCalls.get();
+            cache.readRange("path/other", 0, 16, BLOCK_SIZE).get();
+            assertEquals(before, inner.readRangeCalls.get());
+        }
+    }
+
+    @Test
+    public void deleteByPrefixInvalidatesMatchingEntries() throws Exception {
+        CountingFake inner = new CountingFake();
+        inner.putBlock("pfx/a", 0, makeBlock(10, BLOCK_SIZE));
+        inner.putBlock("pfx/b", 0, makeBlock(11, BLOCK_SIZE));
+        inner.putBlock("other/c", 0, makeBlock(12, BLOCK_SIZE));
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+            cache.readRange("pfx/a", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("pfx/b", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("other/c", 0, 16, BLOCK_SIZE).get();
+            int before = inner.readRangeCalls.get();
+
+            int deleted = cache.deleteByPrefix("pfx/").get();
+            assertEquals(2, deleted);
+
+            // Unrelated path served from cache.
+            cache.readRange("other/c", 0, 16, BLOCK_SIZE).get();
+            assertEquals(before, inner.readRangeCalls.get());
+        }
+    }
+
+    @Test
+    public void evictionRespectsWeightBound() throws Exception {
+        CountingFake inner = new CountingFake();
+        // Three 1 KB blocks, cache holds 2 KB → the oldest must be evicted.
+        inner.putBlock("w/a", 0, makeBlock(20, BLOCK_SIZE));
+        inner.putBlock("w/b", 0, makeBlock(21, BLOCK_SIZE));
+        inner.putBlock("w/c", 0, makeBlock(22, BLOCK_SIZE));
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 2 * BLOCK_SIZE)) {
+            cache.readRange("w/a", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("w/b", 0, 16, BLOCK_SIZE).get();
+            cache.readRange("w/c", 0, 16, BLOCK_SIZE).get();
+            cache.cleanUp();
+
+            assertTrue("cache must not exceed its weight bound",
+                    cache.estimatedBytes() <= 2L * BLOCK_SIZE);
+        }
+    }
+
+    @Test
+    public void lastPartialBlockServedCorrectly() throws Exception {
+        CountingFake inner = new CountingFake();
+        // "Last" block is only 300 bytes wide.
+        byte[] partial = makeBlock(30, 300);
+        inner.putBlock("path/last", 0, partial);
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+            // Requesting 256 bytes from offset 40: expect 256 bytes of the partial block.
+            ReadResult r = cache.readRange("path/last", 40, 256, BLOCK_SIZE).get();
+            assertEquals(ReadResult.Status.FOUND, r.status());
+            assertArrayEquals(Arrays.copyOfRange(partial, 40, 40 + 256), r.content());
+
+            // Request past the end of the stored bytes: should return the available tail.
+            ReadResult r2 = cache.readRange("path/last", 200, 256, BLOCK_SIZE).get();
+            assertEquals(ReadResult.Status.FOUND, r2.status());
+            assertArrayEquals(Arrays.copyOfRange(partial, 200, 300), r2.content());
+        }
+    }
+
+    @Test
+    public void notFoundIsPropagated() throws Exception {
+        CountingFake inner = new CountingFake();
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, 4 * 1024 * 1024)) {
+            ReadResult r = cache.readRange("missing", 0, 16, BLOCK_SIZE).get();
+            assertEquals(ReadResult.Status.NOT_FOUND, r.status());
+        }
+    }
+
+    @Test
+    public void maxBytesMustBePositive() {
+        CountingFake inner = new CountingFake();
+        try {
+            new InMemoryBlockCacheObjectStorage(inner, 0);
+            fail("should reject zero");
+        } catch (IllegalArgumentException expected) {
+            assertNotNull(expected.getMessage());
+        }
+    }
+
+    // --- Test double: simple block-addressable storage with counters and optional latching. ---
+    static class CountingFake implements ObjectStorage {
+        final Map<String, byte[]> blocks = new ConcurrentHashMap<>();
+        final AtomicInteger readRangeCalls = new AtomicInteger();
+        /** If non-null, doReadRange blocks on this before responding. */
+        volatile CountDownLatch gate;
+
+        void putBlock(String path, long blockIndex, byte[] bytes) {
+            blocks.put(key(path, blockIndex), bytes);
+        }
+
+        private static String key(String path, long blockIndex) {
+            return path + ObjectStorage.MULTIPART_SUFFIX + "/" + blockIndex;
+        }
+
+        @Override
+        public CompletableFuture<Void> write(String path, byte[] content) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> read(String path) {
+            return CompletableFuture.completedFuture(ReadResult.notFound());
+        }
+
+        @Override
+        public CompletableFuture<Void> writeBlock(String path, long blockIndex, byte[] content) {
+            blocks.put(key(path, blockIndex), content);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> readRange(String path, long offset, int length, int blockSize) {
+            readRangeCalls.incrementAndGet();
+            CountDownLatch g = gate;
+            CompletableFuture<ReadResult> out = new CompletableFuture<>();
+            Runnable task = () -> {
+                long blockIndex = offset / blockSize;
+                int offsetInBlock = (int) (offset % blockSize);
+                byte[] block = blocks.get(key(path, blockIndex));
+                if (block == null) {
+                    out.complete(ReadResult.notFound());
+                    return;
+                }
+                int end = Math.min(offsetInBlock + length, block.length);
+                if (offsetInBlock >= block.length) {
+                    out.complete(ReadResult.notFound());
+                    return;
+                }
+                out.complete(ReadResult.found(Arrays.copyOfRange(block, offsetInBlock, end)));
+            };
+            if (g != null) {
+                new Thread(() -> {
+                    try {
+                        g.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                    task.run();
+                }).start();
+            } else {
+                task.run();
+            }
+            return out;
+        }
+
+        @Override
+        public CompletableFuture<Boolean> deleteLogical(String path) {
+            String prefix = path + ObjectStorage.MULTIPART_SUFFIX + "/";
+            List<String> toDrop = new ArrayList<>();
+            for (String k : blocks.keySet()) {
+                if (k.startsWith(prefix)) {
+                    toDrop.add(k);
+                }
+            }
+            toDrop.forEach(blocks::remove);
+            return CompletableFuture.completedFuture(!toDrop.isEmpty());
+        }
+
+        @Override
+        public CompletableFuture<List<String>> listLogical(String prefix) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+
+        @Override
+        public CompletableFuture<Boolean> delete(String path) {
+            return CompletableFuture.completedFuture(blocks.remove(path) != null);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> list(String prefix) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+
+        @Override
+        public CompletableFuture<Integer> deleteByPrefix(String prefix) {
+            List<String> toDrop = new ArrayList<>();
+            for (String k : blocks.keySet()) {
+                // Keys are stored as "<path>.multipart/<idx>"; match the logical prefix.
+                int mp = k.indexOf(ObjectStorage.MULTIPART_SUFFIX + "/");
+                String logical = mp >= 0 ? k.substring(0, mp) : k;
+                if (logical.startsWith(prefix)) {
+                    toDrop.add(k);
+                }
+            }
+            toDrop.forEach(blocks::remove);
+            // Distinct logical paths removed.
+            int distinct = (int) toDrop.stream()
+                    .map(k -> {
+                        int mp = k.indexOf(ObjectStorage.MULTIPART_SUFFIX + "/");
+                        return mp >= 0 ? k.substring(0, mp) : k;
+                    }).distinct().count();
+            return CompletableFuture.completedFuture(distinct);
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/herddb-services/src/main/resources/conf/fileserver.properties
+++ b/herddb-services/src/main/resources/conf/fileserver.properties
@@ -38,6 +38,13 @@ bind.host=0.0.0.0
 # s3.prefix=
 # cache.max.bytes=1073741824
 
+# In-heap block cache (fronts the object storage for readRange requests).
+# Holds whole multipart blocks in memory so repeated random reads from
+# ANN/HNSW traversal are served without touching disk or S3.
+# block.cache.enabled=true
+# Default: 1/4 of the JVM max heap (-Xmx). Override in bytes.
+# block.cache.max.bytes=
+
 # HTTP server for Prometheus metrics and Web UI
 http.enable=true
 http.port=9847


### PR DESCRIPTION
## Summary

ANN queries against FusedPQ vector indexes are dominated by random \`readRange\` requests into a narrow set of HNSW graph blocks, each of which today re-touches disk (local mode) or S3 (object-store mode). This PR adds an optional **in-heap block cache** on the \`RemoteFileServer\` so repeated reads of the same block are served from RAM.

- \`InMemoryBlockCacheObjectStorage\` is a thin \`ObjectStorage\` decorator. On a miss it fetches the *full* block (not just the requested slice) from the inner storage, caches it, and slices the requested range. Concurrent misses for the same block are deduplicated via an in-flight future map. Writes / deletes / \`deleteByPrefix\` invalidate matching entries so callers never see stale bytes.
- Cache is weight-bounded by bytes, backed by Caffeine with \`recordStats()\`.
- Default size: **\`Runtime.getRuntime().maxMemory() / 4\`**. Overridable via \`block.cache.max.bytes\` (or disabled with \`block.cache.enabled=false\`) in \`fileserver.properties\`.
- Stats exposed as Prometheus gauges under \`rfs_block_cache_*\` (hits, misses, evictions, evicted_bytes, entries, size_bytes, max_bytes).
- Grafana \`remote-file-service-dashboard.json\` grows two new rows: **Block Cache Rates** (hits/misses rate, hit ratio) and **Block Cache Size** (bytes used vs max, evictions/entries).

## Changes

- \`herddb-remote-file-service/.../storage/InMemoryBlockCacheObjectStorage.java\` — new decorator
- \`herddb-remote-file-service/.../RemoteFileServer.java\` — wire the decorator + register gauges
- \`herddb-services/.../fileserver.properties\` — document \`block.cache.*\` keys
- \`herddb-kubernetes/.../remote-file-service-dashboard.json\` — Block Cache rows
- \`herddb-remote-file-service/.../InMemoryBlockCacheObjectStorageTest.java\` — 10 unit tests

## Test plan

- [x] \`mvn -pl herddb-remote-file-service -Dtest=InMemoryBlockCacheObjectStorageTest test\` — 10/10 green
- [x] \`mvn -pl herddb-remote-file-service -Dtest=CachingObjectStorageTest,LocalObjectStorageTest,RemoteFileServiceTest,RemoteRandomAccessReaderTest test\` — 36/36 green (confirms the decorator is transparent end-to-end)
- [x] \`mvn -pl herddb-indexing-service -Dtest=PersistentVectorStoreMultipartRecoveryTest test\` — 5/5 green
- [x] \`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins -pl herddb-remote-file-service -am\` — green (SpotBugs: 0 bugs)
- [ ] End-to-end ANN latency comparison via the k3s local vector bench (issue #82 follow-up) — measure p99 readRange latency and Grafana hit ratio under the HNSW traversal workload.

## Notes

- The cache sits **in front of** any existing \`CachingObjectStorage\` (the S3 on-disk cache), so S3 mode gets two tiers: in-heap block cache → on-disk file cache → S3. Local mode skips the disk cache and goes straight to local FS on miss.
- This PR only addresses the **server-side** half of the random-I/O bottleneck from issue #82: it removes repeat disk/S3 reads but each client \`readFileRange\` RPC still pays one network round-trip. A complementary client-side shared-block cache can be added as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)