### PR TITLE
Fix SLF4J and native-access warnings in indexing-admin (#85)

### DIFF
--- a/herddb-indexing-service/pom.xml
+++ b/herddb-indexing-service/pom.xml
@@ -95,10 +95,16 @@
             <artifactId>jetty-servlet</artifactId>
             <version>9.4.51.v20230217</version>
         </dependency>
+        <!--
+          slf4j-jdk14 is bundled at runtime so the shaded admin-cli uber jar
+          always has an slf4j provider that routes to JUL (the logging
+          framework actually used by HerdDB). Without it slf4j-api 2.x would
+          fall through to the NOP logger and print a "No SLF4J providers
+          were found" warning (issue #85).
+        -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <scope>test</scope>
         </dependency>
         <!-- BookKeeper test dependencies for BK commit log tailing tests -->
         <dependency>
@@ -223,6 +229,23 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <!--
+                                  log4j-slf4j-impl is pulled in transitively
+                                  via bookkeeper-server. It targets the
+                                  slf4j 1.7 API and does not register as a
+                                  ServiceLoader provider for slf4j 2.x, so
+                                  leaving it in the uber jar produces a
+                                  spurious "No SLF4J providers were found"
+                                  warning and a log4j getCallerClass warning
+                                  on modern JDKs. slf4j-jdk14 (above) is the
+                                  actual provider we want to use.
+                                -->
+                                <filter>
+                                    <artifact>org.apache.logging.log4j:log4j-slf4j-impl</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/herddb-services/src/main/resources/bin/setenv.sh
+++ b/herddb-services/src/main/resources/bin/setenv.sh
@@ -19,6 +19,10 @@
 #JAVA_HOME=
 JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS:---add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --enable-native-access=ALL-UNNAMED}"
 JAVA_OPTS="${JAVA_OPTS:--XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=1g -XX:+DisableExplicitGC -Djava.awt.headless=true -Djava.util.logging.config.file=conf/logging.properties --add-modules jdk.incubator.vector}"
+# Export so the settings reach child java processes started by launcher
+# scripts that rely on the JDK picking JDK_JAVA_OPTIONS up automatically
+# (e.g. indexing-admin.sh, herddb-cli.sh, vector-bench.sh, bookkeeper).
+export JDK_JAVA_OPTIONS JAVA_OPTS
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA_PATH=`which java 2>/dev/null`


### PR DESCRIPTION
## Summary

Fixes #85.

The `indexing-admin` CLI printed several warnings on modern JDKs:

```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation.
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
WARNING: sun.reflect.Reflection.getCallerClass is not supported ...
WARNING: java.lang.System::loadLibrary has been called by
         io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryUtil ...
```

### Root causes & fixes

1. **SLF4J + log4j warnings** — `herddb-indexing-service` declared `slf4j-jdk14` only at **test scope**, so the `admin-cli` uber jar bundled `slf4j-api` without a runtime provider. `log4j-slf4j-impl:2.18.0` was pulled in transitively from `bookkeeper-server` but targets slf4j 1.7 (no ServiceLoader entry for slf4j 2.x), so slf4j-api fell through to the NOP logger and `log4j-api` emitted its own `getCallerClass` warning on startup.

   Fix in `herddb-indexing-service/pom.xml`:
   - Move `slf4j-jdk14` to compile scope so it is bundled in the uber jar.
   - Add a shade filter that drops `log4j-slf4j-impl` from the uber jar.

   Resulting jar has a single provider (`slf4j-jdk14`), so all slf4j output now routes through `java.util.logging` (the framework HerdDB already uses).

2. **`loadLibrary` / native-access warning** — `bin/setenv.sh` already defined `JDK_JAVA_OPTIONS` with `--enable-native-access=ALL-UNNAMED` plus the existing `--add-opens` flags, but it never **exported** the variable. Every launcher that `. setenv.sh` (`indexing-admin.sh`, `herddb-cli.sh`, `vector-bench.sh`, `bookkeeper`) silently dropped those options.

   Fix in `herddb-services/src/main/resources/bin/setenv.sh`: `export JDK_JAVA_OPTIONS JAVA_OPTS` so the JDK picks them up automatically in every such launcher.

### Out of scope

The `sun.misc.Unsafe::objectFieldOffset` warning from `grpc-netty-shaded:1.68.2` originates inside netty's own internals and can't be silenced with launcher flags; it will disappear when gRPC/Netty are updated.

## Test plan

- [x] `mvn -B -pl herddb-indexing-service,herddb-services -am -DskipTests -Pjenkins checkstyle:check apache-rat:check spotbugs:check install` — clean.
- [x] `mvn -pl herddb-indexing-service -Dtest=IndexingAdminCliTest test` — 13/13 green.
- [x] Unpacked the resulting services zip and ran `./bin/indexing-admin.sh` plus `./bin/indexing-admin.sh list-instances --zookeeper 127.0.0.1:2181` on JDK 25 — no `SLF4J:` warnings, no `getCallerClass` warning, no `loadLibrary` warning; ZooKeeper client output now flows through JUL via `slf4j-jdk14`.
- [x] Inspected `META-INF/services/org.slf4j.spi.SLF4JServiceProvider` inside the shaded jar: single entry `org.slf4j.jul.JULServiceProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)