### PR TITLE
Fix FusedPQ checkpoint cycle starving the BK tailer (issue #90)

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -152,19 +152,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * checkpoints bypass the gate; the very first checkpoint on an empty
      * index also bypasses it so the index never sits entirely in memory.
      *
-     * <p><b>Opt-in.</b> Defaults to 0 (gate disabled) to preserve legacy
-     * checkpoint cadence in tests and small workloads. Production indexing
-     * services running catch-up-heavy workloads (e.g. the k3s-bench 1M-vector
-     * gist1m ingest in issue #90) set this to 50 000 or higher via system
-     * property {@code herddb.vectorindex.minLiveVectorsForCheckpoint} to
-     * amortize Phase B across larger batches.
+     * <p><b>Default 50 000.</b> Tuned for the 1M-vector gist1m catch-up
+     * workload in issue #90: during catch-up the tailer drains past 50 000
+     * vectors within seconds, so the gate adds zero latency on the hot
+     * path. Small-workload unit tests that rely on multiple back-to-back
+     * checkpoints override this to 0 in {@code @Before}. Set to 0 globally
+     * to restore pre-fix behaviour.
      *
-     * <p>Non-final to let unit tests override after class load; production
-     * code should only read, never write.
+     * <p>Initialized from system property
+     * {@code herddb.vectorindex.minLiveVectorsForCheckpoint}. Non-final to
+     * let unit tests override after class load; production code should only
+     * read, never write.
      */
     public static volatile int minLiveVectorsForCheckpoint =
             Math.max(0, Integer.getInteger(
-                    "herddb.vectorindex.minLiveVectorsForCheckpoint", 0));
+                    "herddb.vectorindex.minLiveVectorsForCheckpoint", 50_000));
 
     /**
      * Maximum time the {@link #minLiveVectorsForCheckpoint} gate may defer

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -1565,13 +1565,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
         uploadBytesTotal.set(0);
         List<SegmentWriteResult> newSegmentResults;
         try {
+            newSegmentResults = doCheckpointFusedPQPhaseB(
+                    snapshotShards, snapshotDimension, sealedSegments, mergeableSegments, sequenceNumber);
+
+            // Hook fires AFTER the heavy Phase B work but still while holding
+            // the checkpoint lock, so the concurrent-tryLock-skip test can
+            // park here without having to race slow PQ training on the
+            // release path.
             Runnable hook = checkpointPhaseBHook;
             if (hook != null) {
                 hook.run();
             }
-
-            newSegmentResults = doCheckpointFusedPQPhaseB(
-                    snapshotShards, snapshotDimension, sealedSegments, mergeableSegments, sequenceNumber);
         } catch (IOException | RuntimeException e) {
             LOGGER.log(Level.SEVERE, "checkpoint " + indexName + ": Phase B exception", e);
             rollbackProvisionalPages();

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -144,6 +144,45 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     "herddb.vectorindex.maxLiveVectorsPerCheckpoint", 0));
 
     /**
+     * Minimum number of live vectors that must have accumulated in the live
+     * shard before a non-bootstrap Phase A is allowed to run. Below this
+     * threshold, {@code doCheckpointUnderLock} defers the cycle (subject to
+     * {@link #maxCheckpointDeferralMs}) so the tailer has time to drain a
+     * larger batch of entries. Memory-pressure checkpoints and segment-merge
+     * checkpoints bypass the gate; the very first checkpoint on an empty
+     * index also bypasses it so the index never sits entirely in memory.
+     *
+     * <p><b>Opt-in.</b> Defaults to 0 (gate disabled) to preserve legacy
+     * checkpoint cadence in tests and small workloads. Production indexing
+     * services running catch-up-heavy workloads (e.g. the k3s-bench 1M-vector
+     * gist1m ingest in issue #90) set this to 50 000 or higher via system
+     * property {@code herddb.vectorindex.minLiveVectorsForCheckpoint} to
+     * amortize Phase B across larger batches.
+     *
+     * <p>Non-final to let unit tests override after class load; production
+     * code should only read, never write.
+     */
+    public static volatile int minLiveVectorsForCheckpoint =
+            Math.max(0, Integer.getInteger(
+                    "herddb.vectorindex.minLiveVectorsForCheckpoint", 0));
+
+    /**
+     * Maximum time the {@link #minLiveVectorsForCheckpoint} gate may defer
+     * a pending checkpoint. Once {@code now - lastSuccessfulCheckpointMs}
+     * exceeds this bound, the gate unconditionally releases and Phase A runs
+     * even with a partial live shard. Guarantees bounded flush latency when
+     * ingest has stopped mid-shard (issue #90).
+     *
+     * <p>Initialized from system property
+     * {@code herddb.vectorindex.maxCheckpointDeferralMs}. Default: 60 s.
+     * Non-final to let unit tests override after class load; production
+     * code should only read, never write.
+     */
+    public static volatile long maxCheckpointDeferralMs =
+            Math.max(0L, Long.getLong(
+                    "herddb.vectorindex.maxCheckpointDeferralMs", 60_000L));
+
+    /**
      * How many Phase B segment builds may run concurrently. Each parallel
      * segment build allocates ~{@code segSize × dim × 4} bytes for the live
      * vector copy plus PQ codebooks, so the default is deliberately low;
@@ -294,11 +333,25 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private final AtomicLong totalCheckpointCount = new AtomicLong(0);
     private final AtomicLong totalFusedPQCheckpointCount = new AtomicLong(0);
     private final AtomicLong totalSimpleCheckpointCount = new AtomicLong(0);
+    /**
+     * Number of times {@link #doCheckpointUnderLock} skipped a cycle because
+     * the min-live-vectors gate tripped and the max-deferral bound had not
+     * yet elapsed. Incremented only on the deferral path — not on the
+     * "nothing dirty" early return, which represents a durable state.
+     */
+    private final AtomicLong totalCheckpointsDeferred = new AtomicLong(0);
     private final AtomicLong lastCheckpointVectorsProcessed = new AtomicLong(0);
     /** Approximate bytes written by the last completed Phase B. */
     private final AtomicLong lastPhaseBBytesWritten = new AtomicLong(0);
     /** Pages reclaimed by the most recent failure recovery. */
     private final AtomicLong lastRolledBackPages = new AtomicLong(0);
+    /**
+     * Wall-clock time of the most recent checkpoint that left the store in a
+     * fully durable state (successful Phase C, or an early return that
+     * reflects already-durable state). Used by the min-live-vectors gate to
+     * bound how long a partial live shard may be deferred.
+     */
+    private volatile long lastSuccessfulCheckpointMs = System.currentTimeMillis();
 
     // -------------------------------------------------------------------------
     // Memory back-pressure statistics
@@ -1178,28 +1231,39 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /**
      * Performs a checkpoint, persisting live state to disk.
      * Uses three-phase checkpoint for FusedPQ format or simple format for small indexes.
+     *
+     * @return {@code true} if, at return time, the on-disk state fully covers
+     *         every vector this store has observed so far (i.e. the watermark
+     *         may safely advance past any LSN already applied to the live
+     *         shard); {@code false} if the caller did no work AND the live
+     *         shard may contain un-persisted vectors. A {@code false} return
+     *         happens only on the two deferral paths: another checkpoint was
+     *         already in progress (tryLock-skip), or the min-live-vectors
+     *         gate deferred this cycle. In both cases {@code dirty} stays set
+     *         and the caller MUST NOT advance the watermark based on this
+     *         call — retry on the next trigger.
      */
-    public void checkpoint() throws DataStorageManagerException {
+    public boolean checkpoint() throws DataStorageManagerException {
         try {
-            doCheckpoint();
+            return doCheckpoint();
         } catch (IOException e) {
             throw new DataStorageManagerException(e);
         }
     }
 
-    private void doCheckpoint() throws IOException, DataStorageManagerException {
+    private boolean doCheckpoint() throws IOException, DataStorageManagerException {
         if (!checkpointLock.tryLock()) {
             LOGGER.log(Level.INFO, "checkpoint {0}: skipped (another checkpoint in progress)", indexName);
-            return;
+            return false;
         }
         try {
-            doCheckpointUnderLock();
+            return doCheckpointUnderLock();
         } finally {
             checkpointLock.unlock();
         }
     }
 
-    private void doCheckpointUnderLock() throws IOException, DataStorageManagerException {
+    private boolean doCheckpointUnderLock() throws IOException, DataStorageManagerException {
         long checkpointStartMs = System.currentTimeMillis();
         LogSequenceNumber sequenceNumber = LogSequenceNumber.START_OF_TIME;
 
@@ -1208,7 +1272,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
             boolean anySegmentDirty = segments.stream().anyMatch(s -> s.dirty);
             if (!dirty.get() && !anySegmentDirty) {
                 LOGGER.log(Level.FINE, "checkpoint {0}: skipped (no changes)", indexName);
-                return;
+                lastSuccessfulCheckpointMs = System.currentTimeMillis();
+                return true;
             }
 
             int totalLiveVectors = totalLiveSize();
@@ -1221,7 +1286,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 dataStorageManager.indexCheckpoint(tableSpaceUUID, indexUUID, emptyStatus, false);
                 dirty.set(false);
                 LOGGER.log(Level.INFO, "checkpoint {0}: empty", indexName);
-                return;
+                lastSuccessfulCheckpointMs = System.currentTimeMillis();
+                return true;
             }
 
             if (dimension == 0) {
@@ -1230,7 +1296,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 dataStorageManager.indexCheckpoint(tableSpaceUUID, indexUUID, emptyStatus, false);
                 dirty.set(false);
                 LOGGER.log(Level.INFO, "checkpoint {0}: empty dimension", indexName);
-                return;
+                lastSuccessfulCheckpointMs = System.currentTimeMillis();
+                return true;
             }
 
             int totalActiveVectors = (int) onDiskNodeToPkSize() + totalLiveVectors;
@@ -1247,12 +1314,50 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 dataStorageManager.indexCheckpoint(tableSpaceUUID, indexUUID, emptyStatus, false);
                 dirty.set(false);
                 LOGGER.log(Level.INFO, "checkpoint {0}: all vectors deleted, saving empty", indexName);
-                return;
+                lastSuccessfulCheckpointMs = System.currentTimeMillis();
+                return true;
             }
 
             boolean useFusedPQ = fusedPQ
                     && dimension >= MIN_DIM_FOR_FUSED_PQ
                     && totalActiveVectors >= MIN_VECTORS_FOR_FUSED_PQ;
+
+            // Min-live-vectors deferral gate (issue #90).
+            //
+            // During catch-up the live shard blows past the threshold in
+            // seconds and this gate never trips. It only matters when the
+            // compaction loop is about to run a Phase A on a small partial
+            // shard — then we defer the cycle so the tailer can accumulate
+            // more vectors before we pay the Phase B cost. The deferral
+            // is bounded by MAX_CHECKPOINT_DEFERRAL_MS so a partial shard
+            // left behind by stopped ingest is guaranteed to flush.
+            //
+            // Bypasses: bootstrap (segments.isEmpty()), segment-merge
+            // trigger (anySegmentDirty), memory pressure, and the simple
+            // (non-FusedPQ) path for very small indexes.
+            int minLiveGate = minLiveVectorsForCheckpoint;
+            long deferralBoundMs = maxCheckpointDeferralMs;
+            if (useFusedPQ
+                    && minLiveGate > 0
+                    && totalLiveVectors < minLiveGate
+                    && !anySegmentDirty
+                    && !segments.isEmpty()
+                    && !shouldTriggerMemoryPressureCheckpoint()) {
+                long elapsed = System.currentTimeMillis() - lastSuccessfulCheckpointMs;
+                if (elapsed < deferralBoundMs) {
+                    LOGGER.log(Level.FINE,
+                            "checkpoint {0}: deferred ({1} live vectors < {2} threshold, "
+                                    + "{3} ms since last success < {4} ms deferral bound)",
+                            new Object[]{indexName, totalLiveVectors, minLiveGate,
+                                    elapsed, deferralBoundMs});
+                    totalCheckpointsDeferred.incrementAndGet();
+                    return false;
+                }
+                LOGGER.log(Level.INFO,
+                        "checkpoint {0}: deferral bound reached ({1} ms >= {2} ms), "
+                                + "running Phase A with {3} live vectors",
+                        new Object[]{indexName, elapsed, deferralBoundMs, totalLiveVectors});
+            }
 
             if (!useFusedPQ) {
                 doCheckpointSimpleUnderLock(sequenceNumber);
@@ -1260,7 +1365,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 totalCheckpointCount.incrementAndGet();
                 lastCheckpointVectorsProcessed.set(totalActiveVectors);
                 lastCheckpointDurationMs.set(System.currentTimeMillis() - checkpointStartMs);
-                return;
+                lastSuccessfulCheckpointMs = System.currentTimeMillis();
+                return true;
             }
         } finally {
             stateLock.writeLock().unlock();
@@ -1271,6 +1377,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
         totalFusedPQCheckpointCount.incrementAndGet();
         totalCheckpointCount.incrementAndGet();
         lastCheckpointDurationMs.set(System.currentTimeMillis() - checkpointStartMs);
+        lastSuccessfulCheckpointMs = System.currentTimeMillis();
+        return true;
     }
 
     /**
@@ -3559,6 +3667,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public long getTotalSimpleCheckpointCount() {
         return totalSimpleCheckpointCount.get();
+    }
+
+    public long getTotalCheckpointsDeferred() {
+        return totalCheckpointsDeferred.get();
+    }
+
+    public long getLastSuccessfulCheckpointMs() {
+        return lastSuccessfulCheckpointMs;
     }
 
     public long getLastCheckpointVectorsProcessed() {

--- a/herddb-indexing-service/pom.xml
+++ b/herddb-indexing-service/pom.xml
@@ -189,6 +189,24 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
+                    <!--
+                      Disable the PersistentVectorStore min-live-vectors
+                      checkpoint gate for all tests in this module.
+                      Production deployments keep the 50 000 default
+                      (see PersistentVectorStore.minLiveVectorsForCheckpoint),
+                      which is tuned for the 1M-vector gist1m catch-up
+                      workload in issue #90. Unit tests here use small
+                      vector counts (<= a few thousand) and rely on
+                      back-to-back store.checkpoint() calls, so we disable
+                      the gate at the JVM level. Tests that specifically
+                      exercise the gate (PersistentVectorStoreConcurrentCheckpointTest,
+                      CheckpointAndSaveWatermarkTest) override the static
+                      field directly in @Before, so this property does
+                      not affect them.
+                    -->
+                    <systemPropertyVariables>
+                        <herddb.vectorindex.minLiveVectorsForCheckpoint>0</herddb.vectorindex.minLiveVectorsForCheckpoint>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <!--

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -126,6 +126,24 @@ public final class IndexingServerConfiguration {
     public static final String PROPERTY_APPLY_QUEUE_CAPACITY = "indexing.apply.queue.capacity";
     public static final int PROPERTY_APPLY_QUEUE_CAPACITY_DEFAULT = 1000;
 
+    /**
+     * Tailer-driven watermark checkpoint trigger: after this many entries are
+     * processed by the tailer, {@code IndexingServiceEngine} drains pending
+     * DML, forces a checkpoint on every {@code PersistentVectorStore}, and
+     * (if all checkpoints succeed) saves the watermark.
+     *
+     * <p>This is a <em>backstop</em> — the primary checkpoint driver is the
+     * per-store background compaction loop
+     * ({@link #PROPERTY_COMPACTION_INTERVAL}). The tailer trigger exists to
+     * guarantee watermark liveness when the compaction loop is idle. It must
+     * be large enough that it does not coincide with the compaction loop's
+     * cadence during catch-up (see issue #90): a low value causes back-to-back
+     * Phase B/C cycles on the tailer thread, starving BK reads.
+     */
+    public static final String PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES =
+            "indexing.watermark.checkpoint.interval.entries";
+    public static final long PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES_DEFAULT = 100_000L;
+
     // Storage
     public static final String PROPERTY_STORAGE_TYPE = "indexing.storage.type";
     public static final String PROPERTY_STORAGE_TYPE_DEFAULT = "file";

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -75,14 +75,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     private static final Logger LOGGER = Logger.getLogger(IndexingServiceEngine.class.getName());
 
     /**
-     * Minimum number of entries to process between forced checkpoint+watermark
-     * saves. Each trigger calls {@code checkpoint()} on every persistent vector
-     * store and then (on success) writes the watermark. Tuned to keep the cost
-     * of the synchronous S3 write ~ once every few thousand entries (vs every
-     * 1000 previously), since the new policy requires a full checkpoint on
-     * each save.
+     * Minimum number of entries processed between tailer-driven checkpoint
+     * attempts. Each trigger drains pending DML, calls {@code checkpoint()}
+     * on every persistent vector store and — only if all checkpoints complete
+     * successfully — writes the watermark.
+     *
+     * <p>This is a <em>backstop</em>: the primary checkpoint driver is the
+     * per-store background compaction loop
+     * ({@code indexing.compaction.interval}, default 60 s). A low interval
+     * here caused the FusedPQ Phase B on the tailer thread to starve BK
+     * tailing during catch-up (issue #90), so the default is intentionally
+     * large. Configurable via
+     * {@link IndexingServerConfiguration#PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES}.
      */
-    private static final long WATERMARK_CHECKPOINT_INTERVAL_ENTRIES = 5000;
+    private long watermarkCheckpointIntervalEntries;
 
     private final Path logDirectory;
     private final Path dataDirectory;
@@ -344,6 +350,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // tablespace UUID is resolved, because a remote-backed watermark store
         // addresses its S3 object by tablespace UUID).
         entriesSinceLastCheckpoint = 0;
+        watermarkCheckpointIntervalEntries = Math.max(1L, config.getLong(
+                IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES,
+                IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES_DEFAULT));
+        LOGGER.log(Level.INFO, "watermark checkpoint interval: {0} entries",
+                watermarkCheckpointIntervalEntries);
 
         schemaTracker = new SchemaTracker();
         transactionBuffer = new TransactionBuffer();
@@ -590,7 +601,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             // The watermark is saved ONLY after all stores successfully
             // checkpoint — never at any other time. See
             // {@link WatermarkStore} for the save contract.
-            if (entriesSinceLastCheckpoint >= WATERMARK_CHECKPOINT_INTERVAL_ENTRIES) {
+            if (entriesSinceLastCheckpoint >= watermarkCheckpointIntervalEntries) {
                 checkpointAndSaveWatermark();
             }
         } catch (Exception e) {
@@ -685,6 +696,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     // package-private for testing
     void awaitPendingWorkForTest() {
         awaitPendingWork();
+    }
+
+    /**
+     * Sets the "last processed LSN" that
+     * {@link #checkpointAndSaveWatermark()} will capture and persist. Used
+     * by tests that drive the engine via
+     * {@link #applySingleEntryForTest(LogSequenceNumber, herddb.log.LogEntry)}
+     * instead of the real tailer, because that path bypasses
+     * {@code processEntry()} where {@code lastProcessedLsn} would normally
+     * advance.
+     */
+    // package-private for testing
+    void setLastProcessedLsnForTest(LogSequenceNumber lsn) {
+        this.lastProcessedLsn = lsn;
     }
 
     /**
@@ -883,20 +908,39 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             LogSequenceNumber checkpointLsn = lastProcessedLsn;
             entriesSinceLastCheckpoint = 0;
 
-            boolean allCheckpointsSucceeded = true;
-            for (AbstractVectorStore store : vectorStores.values()) {
+            boolean allCheckpointsDurable = true;
+            for (Map.Entry<String, AbstractVectorStore> entry : vectorStores.entrySet()) {
+                AbstractVectorStore store = entry.getValue();
                 if (store instanceof PersistentVectorStore) {
                     try {
-                        ((PersistentVectorStore) store).checkpoint();
+                        boolean durable = ((PersistentVectorStore) store).checkpoint();
+                        if (!durable) {
+                            // Either another checkpoint is in progress
+                            // (tryLock-skip) or the min-live-vectors gate
+                            // deferred this cycle. In both cases the live
+                            // shard may contain vectors not yet on disk, so
+                            // advancing the watermark would violate the
+                            // "watermark <= durable-state LSN" invariant.
+                            // Retry on the next tailer trigger — with the
+                            // raised watermark interval the retry cost is
+                            // negligible.
+                            LOGGER.log(Level.INFO,
+                                    "watermark NOT advanced: checkpoint on store {0} was deferred "
+                                            + "(concurrent cycle or min-live-vectors gate); "
+                                            + "will retry on next trigger",
+                                    entry.getKey());
+                            allCheckpointsDurable = false;
+                            break;
+                        }
                     } catch (Exception e) {
                         LOGGER.log(Level.WARNING,
                                 "checkpoint failed, watermark will NOT be advanced: " + e.getMessage(), e);
-                        allCheckpointsSucceeded = false;
+                        allCheckpointsDurable = false;
                         break;
                     }
                 }
             }
-            if (!allCheckpointsSucceeded) {
+            if (!allCheckpointsDurable) {
                 return;
             }
             // Only now — all stores have durably persisted state covering

--- a/herddb-indexing-service/src/test/java/herddb/indexing/CheckpointAndSaveWatermarkTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/CheckpointAndSaveWatermarkTest.java
@@ -1,0 +1,409 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.codec.RecordSerializer;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end correctness test for
+ * {@link IndexingServiceEngine#forceCheckpointAndSaveWatermark()}:
+ *
+ * <p>Verifies that when a {@link PersistentVectorStore} cannot complete a
+ * checkpoint because another checkpoint is already in progress (the
+ * {@code tryLock} skip path), the engine MUST NOT advance the watermark.
+ * Advancing past LSNs that live only in the new live shard would lose those
+ * entries on restart — this was the latent correctness bug fixed as Part 3
+ * of issue #90.
+ */
+public class CheckpointAndSaveWatermarkTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private int savedMinLive;
+    private long savedDeferral;
+
+    @Before
+    public void saveGateState() {
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        savedDeferral = PersistentVectorStore.maxCheckpointDeferralMs;
+        // Ensure the min-live gate cannot interfere with the watermark
+        // assertions — we want the store to reach Phase B.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreGateState() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+        PersistentVectorStore.maxCheckpointDeferralMs = savedDeferral;
+    }
+
+    /**
+     * In-memory watermark store that records every save() call.
+     */
+    private static final class RecordingWatermarkStore implements WatermarkStore {
+        private final AtomicReference<LogSequenceNumber> saved = new AtomicReference<>();
+        private int saveCount;
+
+        @Override
+        public synchronized LogSequenceNumber load() {
+            LogSequenceNumber v = saved.get();
+            return v != null ? v : LogSequenceNumber.START_OF_TIME;
+        }
+
+        @Override
+        public synchronized void save(LogSequenceNumber lsn) throws IOException {
+            saved.set(lsn);
+            saveCount++;
+        }
+
+        synchronized LogSequenceNumber current() {
+            return saved.get();
+        }
+
+        synchronized int getSaveCount() {
+            return saveCount;
+        }
+    }
+
+    private Table createTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private static MemoryMetadataStorageManager createTestMetadata() throws Exception {
+        MemoryMetadataStorageManager m = new MemoryMetadataStorageManager();
+        m.start();
+        m.ensureDefaultTableSpace("local", "local", 0, 1);
+        return m;
+    }
+
+    @Test
+    public void testWatermarkNotAdvancedWhenCheckpointDeferred() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        // Use the persistent factory path — we need a real PersistentVectorStore.
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, config);
+        engine.setMetadataStorageManager(createTestMetadata());
+
+        RecordingWatermarkStore watermark = new RecordingWatermarkStore();
+        engine.setWatermarkStore(watermark);
+
+        // Install a factory that produces real PersistentVectorStore instances
+        // backed by an in-memory DataStorageManager, exposing the underlying
+        // store so the test can park it in Phase B.
+        AtomicReference<PersistentVectorStore> storeRef = new AtomicReference<>();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(
+                128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName, dataDirectory, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, "tstblspace", vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE,
+                    VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            storeRef.set(pvs);
+            return pvs;
+        });
+
+        try {
+            engine.start();
+
+            Table table = createTable();
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            Index index = Index.builder()
+                    .name("vidx")
+                    .table("vectable")
+                    .type(Index.TYPE_VECTOR)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .build();
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(index, null));
+
+            PersistentVectorStore store = storeRef.get();
+            assertTrue("store should have been created by DDL", store != null);
+
+            // Insert enough vectors to trip the FusedPQ threshold.
+            Random rng = new Random(29);
+            int numVectors = 512;
+            int dim = 32;
+            long baseLsn = 100;
+            LogSequenceNumber lastLsn = null;
+            for (int i = 0; i < numVectors; i++) {
+                Record record = RecordSerializer.makeRecord(table,
+                        "pk", "k" + i,
+                        "vec", randomVector(rng, dim));
+                LogEntry insert = LogEntryFactory.insert(table, record.key, record.value, null);
+                lastLsn = new LogSequenceNumber(1, baseLsn + i);
+                engine.applySingleEntryForTest(lastLsn, insert);
+            }
+            engine.awaitPendingWorkForTest();
+            engine.setLastProcessedLsnForTest(lastLsn);
+
+            // First call: should advance watermark because store.checkpoint()
+            // will run Phase A→B→C cleanly (no concurrent checkpoint).
+            engine.forceCheckpointAndSaveWatermark();
+            assertEquals("first save should advance watermark",
+                    1, watermark.getSaveCount());
+            assertEquals("watermark at LSN of last processed entry",
+                    new LogSequenceNumber(1, baseLsn + numVectors - 1),
+                    watermark.current());
+
+            // Add more vectors so the next checkpoint has real work to do.
+            for (int i = 0; i < 200; i++) {
+                Record record = RecordSerializer.makeRecord(table,
+                        "pk", "k" + (numVectors + i),
+                        "vec", randomVector(rng, dim));
+                LogEntry insert = LogEntryFactory.insert(table, record.key, record.value, null);
+                lastLsn = new LogSequenceNumber(1, baseLsn + numVectors + i);
+                engine.applySingleEntryForTest(lastLsn, insert);
+            }
+            engine.awaitPendingWorkForTest();
+            engine.setLastProcessedLsnForTest(lastLsn);
+
+            // Park a background checkpoint inside Phase B so the next
+            // forceCheckpointAndSaveWatermark() call hits the tryLock-skip.
+            CountDownLatch phaseBEntered = new CountDownLatch(1);
+            CountDownLatch releasePhaseB = new CountDownLatch(1);
+            store.setCheckpointPhaseBHook(() -> {
+                phaseBEntered.countDown();
+                try {
+                    releasePhaseB.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            AtomicBoolean parkedResult = new AtomicBoolean();
+            AtomicReference<Exception> error = new AtomicReference<>();
+            Thread parked = new Thread(() -> {
+                try {
+                    parkedResult.set(store.checkpoint());
+                } catch (Exception e) {
+                    error.compareAndSet(null, e);
+                }
+            }, "parked-cp");
+            parked.start();
+
+            assertTrue("parked checkpoint did not reach Phase B",
+                    phaseBEntered.await(30, TimeUnit.SECONDS));
+
+            LogSequenceNumber watermarkBefore = watermark.current();
+            int saveCountBefore = watermark.getSaveCount();
+
+            // Engine-level attempt: must return without advancing the watermark.
+            engine.forceCheckpointAndSaveWatermark();
+
+            assertEquals("watermark MUST NOT advance on tryLock-skip",
+                    saveCountBefore, watermark.getSaveCount());
+            assertEquals("watermark LSN MUST NOT change on tryLock-skip",
+                    watermarkBefore, watermark.current());
+
+            releasePhaseB.countDown();
+            parked.join(30_000);
+            if (error.get() != null) {
+                throw error.get();
+            }
+            assertTrue("parked checkpoint should have returned true",
+                    parkedResult.get());
+
+            // Clear the hook and retry: now the next call should advance
+            // the watermark to the latest processed LSN.
+            store.setCheckpointPhaseBHook(null);
+            engine.forceCheckpointAndSaveWatermark();
+            assertEquals("second successful save", saveCountBefore + 1,
+                    watermark.getSaveCount());
+            assertEquals("watermark advanced to last processed LSN",
+                    new LogSequenceNumber(1, baseLsn + numVectors + 200 - 1),
+                    watermark.current());
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Sanity check: when {@link PersistentVectorStore.checkpoint()} returns
+     * {@code false} via the min-live-vectors deferral gate, the engine must
+     * also refuse to advance the watermark. This guarantees that the two
+     * deferral paths share the same correctness guarantee.
+     */
+    @Test
+    public void testWatermarkNotAdvancedWhenMinLiveGateDefers() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, config);
+        engine.setMetadataStorageManager(createTestMetadata());
+
+        RecordingWatermarkStore watermark = new RecordingWatermarkStore();
+        engine.setWatermarkStore(watermark);
+
+        AtomicReference<PersistentVectorStore> storeRef = new AtomicReference<>();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(
+                128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName, dataDirectory, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, "tstblspace", vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE,
+                    VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            storeRef.set(pvs);
+            return pvs;
+        });
+
+        try {
+            engine.start();
+
+            Table table = createTable();
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            Index index = Index.builder()
+                    .name("vidx")
+                    .table("vectable")
+                    .type(Index.TYPE_VECTOR)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .build();
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(index, null));
+
+            Random rng = new Random(41);
+            int dim = 32;
+            // Bootstrap with 300 vectors (above FusedPQ threshold of 256).
+            LogSequenceNumber lastLsn = null;
+            for (int i = 0; i < 300; i++) {
+                Record record = RecordSerializer.makeRecord(table,
+                        "pk", "k" + i,
+                        "vec", randomVector(rng, dim));
+                LogEntry insert = LogEntryFactory.insert(table, record.key, record.value, null);
+                lastLsn = new LogSequenceNumber(1, 100 + i);
+                engine.applySingleEntryForTest(lastLsn, insert);
+            }
+            engine.awaitPendingWorkForTest();
+            engine.setLastProcessedLsnForTest(lastLsn);
+
+            // First save: bootstrap — segments.isEmpty(), gate bypassed.
+            engine.forceCheckpointAndSaveWatermark();
+            assertEquals(1, watermark.getSaveCount());
+            LogSequenceNumber firstWatermark = watermark.current();
+            assertEquals(new LogSequenceNumber(1, 100 + 300 - 1), firstWatermark);
+
+            // Arm the gate with a very high threshold and a long deferral,
+            // then add a tiny batch and re-invoke. The store must defer.
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 10_000;
+            PersistentVectorStore.maxCheckpointDeferralMs = 600_000L;
+
+            for (int i = 0; i < 50; i++) {
+                Record record = RecordSerializer.makeRecord(table,
+                        "pk", "k" + (300 + i),
+                        "vec", randomVector(rng, dim));
+                LogEntry insert = LogEntryFactory.insert(table, record.key, record.value, null);
+                lastLsn = new LogSequenceNumber(1, 500 + i);
+                engine.applySingleEntryForTest(lastLsn, insert);
+            }
+            engine.awaitPendingWorkForTest();
+            engine.setLastProcessedLsnForTest(lastLsn);
+
+            engine.forceCheckpointAndSaveWatermark();
+            assertEquals("gate-deferred call MUST NOT advance watermark",
+                    1, watermark.getSaveCount());
+            assertEquals("watermark LSN unchanged",
+                    firstWatermark, watermark.current());
+            assertTrue("store should report a deferred cycle",
+                    storeRef.get().getTotalCheckpointsDeferred() >= 1);
+        } finally {
+            engine.close();
+        }
+    }
+
+    /** Guard against accidental assertNull import removal. */
+    @Test
+    public void testRecordingWatermarkStartsNull() {
+        RecordingWatermarkStore s = new RecordingWatermarkStore();
+        assertNull(s.current());
+        assertEquals(0, s.getSaveCount());
+        assertFalse(s.load() == null);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServerConfigurationTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServerConfigurationTest.java
@@ -91,9 +91,21 @@ public class IndexingServerConfigurationTest {
         assertEquals(2, config.getInt(
                 IndexingServerConfiguration.PROPERTY_COMPACTION_THREADS,
                 IndexingServerConfiguration.PROPERTY_COMPACTION_THREADS_DEFAULT));
+        assertEquals(100_000L, config.getLong(
+                IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES,
+                IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES_DEFAULT));
         assertEquals("file", config.getString(
                 IndexingServerConfiguration.PROPERTY_STORAGE_TYPE,
                 IndexingServerConfiguration.PROPERTY_STORAGE_TYPE_DEFAULT));
+    }
+
+    @Test
+    public void testWatermarkCheckpointIntervalOverride() {
+        IndexingServerConfiguration config = new IndexingServerConfiguration();
+        config.set(IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES, 250_000L);
+        assertEquals(250_000L, config.getLong(
+                IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES,
+                IndexingServerConfiguration.PROPERTY_WATERMARK_CHECKPOINT_INTERVAL_ENTRIES_DEFAULT));
     }
 
     @Test

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreConcurrentCheckpointTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreConcurrentCheckpointTest.java
@@ -23,6 +23,7 @@ package herddb.indexing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import herddb.core.MemoryManager;
 import herddb.index.vector.PersistentVectorStore;
 import herddb.mem.MemoryDataStorageManager;
@@ -163,25 +164,28 @@ public class PersistentVectorStoreConcurrentCheckpointTest {
             store.setCheckpointPhaseBHook(() -> {
                 phaseBEntered.countDown();
                 try {
-                    releasePhaseB.await(30, TimeUnit.SECONDS);
+                    // Long enough to survive slow CI machines; the test
+                    // releases the latch as soon as the second checkpoint
+                    // call returns, so the usual wait is sub-millisecond.
+                    releasePhaseB.await(120, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
             });
 
             AtomicBoolean firstResult = new AtomicBoolean();
-            AtomicReference<Exception> error = new AtomicReference<>();
+            AtomicReference<Throwable> error = new AtomicReference<>();
             Thread parked = new Thread(() -> {
                 try {
                     firstResult.set(store.checkpoint());
-                } catch (Exception e) {
-                    error.compareAndSet(null, e);
+                } catch (Throwable t) {
+                    error.compareAndSet(null, t);
                 }
             }, "cp-parked");
             parked.start();
 
-            assertTrue("first checkpoint did not reach Phase B",
-                    phaseBEntered.await(30, TimeUnit.SECONDS));
+            assertTrue("first checkpoint did not reach Phase B within 60s",
+                    phaseBEntered.await(60, TimeUnit.SECONDS));
 
             // The second caller races the tryLock and must get false back
             // immediately, without blocking on the parked Phase B.
@@ -194,9 +198,19 @@ public class PersistentVectorStoreConcurrentCheckpointTest {
                     elapsed < 5_000);
 
             releasePhaseB.countDown();
-            parked.join(30_000);
+            // Generous timeout: Phase B + Phase C on 512 tiny vectors is
+            // usually sub-second locally but can be much slower on CI
+            // runners under load.
+            parked.join(120_000);
+            if (parked.isAlive()) {
+                StringBuilder dump = new StringBuilder("cp-parked thread did not finish within 120s, stack:\n");
+                for (StackTraceElement f : parked.getStackTrace()) {
+                    dump.append("  at ").append(f).append('\n');
+                }
+                fail(dump.toString());
+            }
             if (error.get() != null) {
-                throw error.get();
+                throw new AssertionError("parked checkpoint threw", error.get());
             }
             assertTrue("first checkpoint should have returned true", firstResult.get());
             assertEquals("vectors lost after parked checkpoint",

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreConcurrentCheckpointTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreConcurrentCheckpointTest.java
@@ -21,6 +21,8 @@
 package herddb.indexing;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import herddb.core.MemoryManager;
 import herddb.index.vector.PersistentVectorStore;
 import herddb.mem.MemoryDataStorageManager;
@@ -28,8 +30,13 @@ import herddb.utils.Bytes;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import java.nio.file.Path;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -41,6 +48,24 @@ public class PersistentVectorStoreConcurrentCheckpointTest {
 
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private int savedMinLive;
+    private long savedMaxDeferral;
+
+    @Before
+    public void saveGateState() {
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        savedMaxDeferral = PersistentVectorStore.maxCheckpointDeferralMs;
+        // Disable the min-live gate by default so the pre-existing test
+        // (which inserts 10k vectors) is not accidentally deferred.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreGateState() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+        PersistentVectorStore.maxCheckpointDeferralMs = savedMaxDeferral;
+    }
 
     private PersistentVectorStore createStore(Path tmpDir) {
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
@@ -111,6 +136,197 @@ public class PersistentVectorStoreConcurrentCheckpointTest {
             // All vectors must still be present
             assertEquals("vectors lost during concurrent checkpoint",
                     numVectors, store.size());
+        }
+    }
+
+    /**
+     * A second checkpoint() call that loses the tryLock race must return
+     * {@code false} so the engine does not advance the watermark past vectors
+     * that live only in the new live shard (issue #90, Part 3).
+     */
+    @Test
+    public void testCheckpointReturnsFalseOnTryLockSkip() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("trylock-skip").toPath();
+        int numVectors = 512; // enough to activate FusedPQ path
+        int dim = 32;
+        Random rng = new Random(7);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            for (int i = 0; i < numVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertEquals(numVectors, store.size());
+
+            CountDownLatch phaseBEntered = new CountDownLatch(1);
+            CountDownLatch releasePhaseB = new CountDownLatch(1);
+            store.setCheckpointPhaseBHook(() -> {
+                phaseBEntered.countDown();
+                try {
+                    releasePhaseB.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            AtomicBoolean firstResult = new AtomicBoolean();
+            AtomicReference<Exception> error = new AtomicReference<>();
+            Thread parked = new Thread(() -> {
+                try {
+                    firstResult.set(store.checkpoint());
+                } catch (Exception e) {
+                    error.compareAndSet(null, e);
+                }
+            }, "cp-parked");
+            parked.start();
+
+            assertTrue("first checkpoint did not reach Phase B",
+                    phaseBEntered.await(30, TimeUnit.SECONDS));
+
+            // The second caller races the tryLock and must get false back
+            // immediately, without blocking on the parked Phase B.
+            long before = System.currentTimeMillis();
+            boolean secondResult = store.checkpoint();
+            long elapsed = System.currentTimeMillis() - before;
+            assertFalse("concurrent checkpoint should return false on tryLock-skip",
+                    secondResult);
+            assertTrue("tryLock-skip should not block on Phase B (elapsed=" + elapsed + "ms)",
+                    elapsed < 5_000);
+
+            releasePhaseB.countDown();
+            parked.join(30_000);
+            if (error.get() != null) {
+                throw error.get();
+            }
+            assertTrue("first checkpoint should have returned true", firstResult.get());
+            assertEquals("vectors lost after parked checkpoint",
+                    numVectors, store.size());
+        }
+    }
+
+    /**
+     * When the min-live-vectors gate is armed and the live shard is below the
+     * threshold, {@code checkpoint()} must return {@code false} and leave
+     * {@code totalFusedPQCheckpointCount} unchanged (issue #90, Part 2). The
+     * bootstrap case (empty segments) and the threshold-crossing case must
+     * still run a real Phase B.
+     */
+    @Test
+    public void testMinLiveVectorsGateDefersTrivialCycles() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("min-live-gate").toPath();
+        int dim = 32;
+        Random rng = new Random(11);
+
+        // 10 min deferral — long enough that the time-based backstop does
+        // not fire during the test.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 1_000;
+        PersistentVectorStore.maxCheckpointDeferralMs = 600_000L;
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Bootstrap: 300 vectors, segments empty → must checkpoint.
+            // Need >= 256 vectors to exercise the FusedPQ path.
+            for (int i = 0; i < 300; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertTrue("bootstrap checkpoint should run", store.checkpoint());
+            long afterBootstrap = store.getTotalFusedPQCheckpointCount();
+            long deferredAfterBootstrap = store.getTotalCheckpointsDeferred();
+            assertTrue("bootstrap should have run FusedPQ Phase B",
+                    afterBootstrap >= 1);
+
+            // Add 500 vectors (below threshold) → gate must defer.
+            for (int i = 300; i < 800; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertFalse("gate should defer when live < threshold",
+                    store.checkpoint());
+            assertEquals("no Phase B should have run during deferral",
+                    afterBootstrap, store.getTotalFusedPQCheckpointCount());
+            assertEquals("deferred counter should advance",
+                    deferredAfterBootstrap + 1, store.getTotalCheckpointsDeferred());
+
+            // Add 600 more vectors (total 1100 live, above threshold) →
+            // gate releases, Phase B runs.
+            for (int i = 800; i < 1400; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertTrue("gate should release above threshold",
+                    store.checkpoint());
+            assertEquals("Phase B should have run after threshold crossed",
+                    afterBootstrap + 1, store.getTotalFusedPQCheckpointCount());
+            assertEquals("total vectors preserved",
+                    1400, store.size());
+        }
+    }
+
+    /**
+     * The min-live-vectors gate must not block the very first checkpoint on
+     * an empty index, otherwise small indexes would sit entirely in memory.
+     */
+    @Test
+    public void testMinLiveVectorsGateDoesNotBlockBootstrap() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("min-live-bootstrap").toPath();
+        int dim = 32;
+        Random rng = new Random(13);
+
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 10_000;
+        PersistentVectorStore.maxCheckpointDeferralMs = 600_000L;
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            // 300 vectors, far below threshold, but segments are empty.
+            for (int i = 0; i < 300; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertTrue("bootstrap must run even with tiny live shard",
+                    store.checkpoint());
+            assertTrue("bootstrap should have produced a Phase B",
+                    store.getTotalFusedPQCheckpointCount() >= 1);
+        }
+    }
+
+    /**
+     * When the deferral bound elapses, the gate must unconditionally release
+     * even if the live shard is still below the min-live threshold. Proves
+     * the idle-flush bound that guarantees bounded latency for the
+     * "ingest stopped mid-shard" scenario (issue #90).
+     */
+    @Test
+    public void testMaxDeferralReleasesPartialShard() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("max-deferral").toPath();
+        int dim = 32;
+        Random rng = new Random(17);
+
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 1_000;
+        PersistentVectorStore.maxCheckpointDeferralMs = 200L;
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Bootstrap with 300 vectors.
+            for (int i = 0; i < 300; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertTrue(store.checkpoint());
+            long afterBootstrap = store.getTotalFusedPQCheckpointCount();
+
+            // 100 more vectors, still below threshold → defer immediately.
+            for (int i = 300; i < 400; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            assertFalse("should defer within the window",
+                    store.checkpoint());
+            assertEquals(afterBootstrap, store.getTotalFusedPQCheckpointCount());
+
+            // Wait past the deferral bound, then call again → must run.
+            Thread.sleep(400);
+            assertTrue("gate should release past deferral bound",
+                    store.checkpoint());
+            assertEquals("a real Phase B should have run after the bound",
+                    afterBootstrap + 1, store.getTotalFusedPQCheckpointCount());
+            assertEquals(400, store.size());
         }
     }
 }


### PR DESCRIPTION
Closes #90.

## Summary

- **Part 1 (main throughput fix):** raise the tailer-driven watermark
  checkpoint interval default from 5000 to 100 000 and make it
  configurable via `indexing.watermark.checkpoint.interval.entries`. At
  the old cadence the tailer thread was synchronously running Phase B
  (~210 s) every 5000 entries, colliding with the 60 s compaction loop
  and starving BK reads; raising the interval 20× lets the compaction
  loop own the cadence and the tailer-driven path becomes a backstop.
- **Part 2 (amortization gate, ON by default):** add a min-live-vectors
  gate in `PersistentVectorStore`
  (`herddb.vectorindex.minLiveVectorsForCheckpoint`, default **50 000**)
  with a max-deferral backstop
  (`herddb.vectorindex.maxCheckpointDeferralMs`, default **60 000 ms**)
  so the compaction loop amortizes Phase B across larger batches during
  catch-up while guaranteeing bounded flush latency when ingest stops
  mid-shard. Bootstrap, memory pressure, and segment-merge triggers all
  bypass the gate. Unit tests in `herddb-indexing-service` insert only a
  few hundred vectors and rely on back-to-back `store.checkpoint()`
  calls, so the surefire plugin for that module disables the gate at
  the JVM level via
  `-Dherddb.vectorindex.minLiveVectorsForCheckpoint=0`.
- **Part 3 (latent correctness bug):** `checkpoint()` now returns a
  boolean. `false` on either deferral path (tryLock-skip OR
  min-live-vectors gate) tells the engine the live shard is not durable,
  so `checkpointAndSaveWatermark()` refuses to advance the watermark.
  Previously the tryLock-skip path was interpreted as success and could
  let the watermark move past LSNs that only lived in the new live
  shard, losing those entries on restart.

Expected impact on the gist1m benchmark in issue #90: catch-up wall time
drops from ~800 min to a few minutes because the tailer thread is no
longer blocked for 240 s at a time, and Phase B is amortized across 50k+
vectors per cycle instead of ~5k.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins` — clean
- [x] `mvn -pl herddb-indexing-service -Dtest='PersistentVectorStore*Test,CheckpointAndSaveWatermarkTest,IndexingServerConfigurationTest' test` → **67/67 passing**
- [x] New unit tests:
  - `PersistentVectorStoreConcurrentCheckpointTest.testCheckpointReturnsFalseOnTryLockSkip`
  - `PersistentVectorStoreConcurrentCheckpointTest.testMinLiveVectorsGateDefersTrivialCycles`
  - `PersistentVectorStoreConcurrentCheckpointTest.testMinLiveVectorsGateDoesNotBlockBootstrap`
  - `PersistentVectorStoreConcurrentCheckpointTest.testMaxDeferralReleasesPartialShard`
  - `CheckpointAndSaveWatermarkTest.testWatermarkNotAdvancedWhenCheckpointDeferred`
  - `CheckpointAndSaveWatermarkTest.testWatermarkNotAdvancedWhenMinLiveGateDefers`
  - `IndexingServerConfigurationTest.testWatermarkCheckpointIntervalOverride` + default assertion
- [ ] k3s-bench gist1m run to verify catch-up drops from hours to minutes
- [ ] CI (PR validation + cluster test matrix)

## New defaults (summary)

| Property | Old | New |
|---|---|---|
| `indexing.watermark.checkpoint.interval.entries` (new) | n/a (hardcoded 5000) | **100 000** |
| `herddb.vectorindex.minLiveVectorsForCheckpoint` (new) | n/a | **50 000** |
| `herddb.vectorindex.maxCheckpointDeferralMs` (new) | n/a | **60 000 ms** |

To restore pre-fix behaviour on a specific deployment, set
`-Dherddb.vectorindex.minLiveVectorsForCheckpoint=0` and
`indexing.watermark.checkpoint.interval.entries=5000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)