### PR TITLE
Vector search: parallel fan-out with fail-fast (issue #93)

### DIFF
--- a/VECTOR.md
+++ b/VECTOR.md
@@ -755,16 +755,44 @@ Client INSERT → HerdDB Server → CommitLog (.txlog)
 
 ```
 Client SELECT ... ORDER BY ann_of(vec, ?) DESC LIMIT k
-  → CalcitePlanner intercepts ORDER BY ann_of()
+  → CalcitePlanner intercepts ORDER BY ann_of()  (LIMIT is mandatory; rejected otherwise)
   → VectorANNScanOp.execute()
   → VectorIndexManager.search(queryVector, topK)
-  → gRPC call to IndexingService
-  → IndexingServiceEngine.search()
-  → PersistentVectorStore.search(queryVector, topK)
-  → hybrid search: on-disk segments + live shards + frozen shards
-  → results returned via gRPC to VectorANNScanOp
+  → IndexingServiceClient.search() — parallel fan-out to ALL IS instances
+      ├── gRPC call to IS instance 1 ─┐
+      ├── gRPC call to IS instance 2 ─┤ (dispatched concurrently,
+      └── gRPC call to IS instance N ─┘  each with its own deadline)
+  → each IS: IndexingServiceEngine.search()
+           → PersistentVectorStore.search(queryVector, topK)
+           → hybrid search: on-disk segments + live shards + frozen shards
+  → client waits for ALL futures, merges into a bounded top-K min-heap
+      (fails fast and cancels in-flight RPCs if any instance errors)
+  → results returned to VectorANNScanOp
   → PK fetch + WHERE filter + projection
 ```
+
+**LIMIT is required** for `ORDER BY ann_of(...)` queries. The JSQL
+planner rejects unbounded `ORDER BY ann_of(...)` with
+`StatementExecutionException` so the cluster never fans out an
+unbounded search. With the Calcite planner the LIMIT is pushed into
+`VectorANNScanOp` whenever possible (no `WHERE` predicate); when a
+predicate forces the outer `LimitOp` to stay around, the scan op
+still requests the full result set from the index and the outer
+`LimitOp` truncates the post-predicate output.
+
+**Parallel fan-out.** Each indexing-service instance holds a subset of
+the graph shards (see `IndexingServiceEngine`:
+`shardId % numInstances == instanceId`). Partial results would be
+incorrect, so the client queries **every** configured instance for
+every search, in parallel. If any RPC fails or exceeds its deadline,
+the whole query fails fast and the remaining in-flight RPCs are
+cancelled. Results from the successful instances are merged into a
+top-K min-heap ordered by score ascending: the heap evicts its
+weakest entry whenever a better candidate arrives, so it keeps only
+the globally highest-scoring `topK` PKs across all instances. After
+all futures complete, the heap is drained and sorted descending for
+the final response. A single-instance deployment takes a blocking
+fast-path that skips the future machinery.
 
 ### Checkpoint path
 

--- a/herddb-core/src/main/java/herddb/model/planner/VectorANNScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/VectorANNScanOp.java
@@ -185,6 +185,11 @@ public class VectorANNScanOp implements PlannerOp {
                 topK = Integer.MAX_VALUE;
             }
         } else {
+            // LimitOp stayed external (e.g. because a WHERE predicate prevents
+            // absorbing the limit into this op). The outer LimitOp still applies
+            // the final row cap; fetch as much as the index has so the outer
+            // limit sees enough post-predicate rows. IndexingServiceClient caps
+            // the PriorityQueue initial capacity so this is safe.
             topK = Integer.MAX_VALUE;
         }
 

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -1287,6 +1287,9 @@ public class CalcitePlanner extends AbstractSQLPlanner {
         // and optimize immediately so that the limit is pushed into
         // VectorANNScanOp (LimitOp.optimize() won't be called later
         // because ProjectOp.optimize() does not recurse into children).
+        // When LIMIT is on a separate EnumerableLimit node above the Sort,
+        // planLimit() wraps the result in a LimitOp and optimizes it so the
+        // limit is pushed into VectorANNScanOp whenever possible.
         if (op.fetch != null) {
             CompiledSQLExpression maxRows = SQLExpressionCompiler.compileExpression(op.fetch);
             CompiledSQLExpression offset = op.offset != null
@@ -1305,8 +1308,12 @@ public class CalcitePlanner extends AbstractSQLPlanner {
         PlannerOp input = convertRelNode(op.getInput(), rowType, false, false);
         CompiledSQLExpression maxRows = SQLExpressionCompiler.compileExpression(op.fetch);
         CompiledSQLExpression offset = SQLExpressionCompiler.compileExpression(op.offset);
-        return new LimitOp(input, maxRows, offset);
-
+        // Optimize immediately so the limit is pushed into any underlying
+        // VectorANNScanOp (LimitOp.optimize() won't be called later because
+        // ProjectOp.optimize() does not recurse into children). This matters
+        // for plans shaped like Project(Limit(Sort(ann_of))) where Calcite
+        // did not fuse the LIMIT into the Sort node.
+        return new LimitOp(input, maxRows, offset).optimize();
     }
 
     private PlannerOp planFilter(EnumerableFilter op, RelDataType rowType, boolean returnValues) {

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -2131,6 +2131,12 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         CompiledSQLExpression queryVecExpr =
                 SQLParserExpressionCompiler.compileExpression(secondArg, schema);
 
+        if (plainSelect.getLimit() == null && plainSelect.getTop() == null) {
+            throw new StatementExecutionException(
+                    "ORDER BY ann_of(column, ?) requires a LIMIT clause — "
+                            + "unbounded vector-search queries are not supported");
+        }
+
         return new VectorANNScanOp(
                 primaryTableSchema.tableSpace, tableImpl, columnName,
                 queryVecExpr,

--- a/herddb-core/src/test/java/herddb/core/indexes/VectorIndexJSQLParserPlannerTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/VectorIndexJSQLParserPlannerTest.java
@@ -225,6 +225,62 @@ public class VectorIndexJSQLParserPlannerTest {
         }
     }
 
+    /**
+     * ORDER BY ann_of(...) without a LIMIT clause must be rejected by the planner.
+     * The bounded top-K merge in IndexingServiceClient relies on a finite limit.
+     */
+    @Test
+    public void testAnnOfWithoutLimitIsRejectedJSQLParser() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        final String nodeId = "localhost";
+
+        final float[] vecX = {1.0f, 0.0f, 0.0f};
+        final float[] query = {0.05f, 0.99f, 0.0f};
+        normalize(query);
+
+        MockRemoteVectorIndexService mockService = new MockRemoteVectorIndexService();
+        mockService.addVector("t1", "vidx", Bytes.from_int(1), vecX);
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir, nodeId, mockService)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement(
+                    "tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (id int primary key, vec floata not null)",
+                    Collections.emptyList());
+            execute(manager, "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)",
+                    Collections.emptyList());
+            executeUpdate(manager, "INSERT INTO tblspace1.t1(id, vec) VALUES(?, ?)",
+                    Arrays.asList(1, vecX));
+
+            // No LIMIT → planner must reject.
+            try (DataScanner scan = scan(manager,
+                    "SELECT id FROM tblspace1.t1 ORDER BY ann_of(vec, ?) DESC",
+                    Arrays.asList((Object) query))) {
+                scan.consume();
+                fail("Expected StatementExecutionException for unbounded ORDER BY ann_of(...)");
+            } catch (StatementExecutionException e) {
+                assertTrue("Exception must mention LIMIT requirement: " + e.getMessage(),
+                        e.getMessage().contains("LIMIT"));
+            }
+
+            // Same query *with* LIMIT must still plan and execute fine.
+            try (DataScanner scan = scan(manager,
+                    "SELECT id FROM tblspace1.t1 ORDER BY ann_of(vec, ?) DESC LIMIT 10",
+                    Arrays.asList((Object) query))) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals("bounded query must succeed", 1, results.size());
+            }
+        }
+    }
+
     private static void normalize(float[] v) {
         float norm = 0;
         for (float f : v) {

--- a/herddb-core/src/test/java/herddb/core/indexes/VectorIndexTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/VectorIndexTest.java
@@ -302,7 +302,7 @@ public class VectorIndexTest {
                     Arrays.asList(3, vecZ));
 
             try (DataScanner scan = scan(manager,
-                    "SELECT id FROM tblspace1.t1 ORDER BY ann_of(vec, cast(? as FLOAT ARRAY)) DESC",
+                    "SELECT id FROM tblspace1.t1 ORDER BY ann_of(vec, cast(? as FLOAT ARRAY)) DESC LIMIT 10",
                     Arrays.asList((Object) query))) {
                 List<DataAccessor> results = scan.consume();
                 assertEquals(3, results.size());

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -20,6 +20,7 @@
 
 package herddb.indexing;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import herddb.index.vector.RemoteVectorIndexService;
 import herddb.indexing.proto.GetIndexStatusRequest;
 import herddb.indexing.proto.GetIndexStatusResponse;
@@ -42,9 +43,12 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -182,8 +186,18 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
     }
 
     /**
-     * Searches all IndexingService instances and merges results by score.
-     * If only one instance exists and returnScore is false, results are passed through.
+     * Searches the IndexingService cluster and returns the top-{@code limit}
+     * entries by score.
+     *
+     * <p>With multiple instances, the search RPC is fanned out to <b>every</b>
+     * configured instance in parallel (each instance owns a subset of the
+     * graph shards, so partial results would be incorrect). Results are
+     * merged into a bounded min-heap of size {@code limit} as each future
+     * completes. If any RPC fails, the remaining in-flight RPCs are
+     * cancelled and the whole call fails fast.
+     *
+     * <p>With a single instance, a blocking fast-path skips the future
+     * machinery.
      */
     public List<Map.Entry<Bytes, Float>> search(String tablespace, String table, String index,
                                                   float[] vector, int limit) {
@@ -191,6 +205,9 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
 
         if (s.servers.isEmpty()) {
             throw new RuntimeException("No indexing service instances available");
+        }
+        if (limit <= 0) {
+            throw new IllegalArgumentException("search limit must be positive, got " + limit);
         }
 
         boolean multiInstance = s.servers.size() > 1;
@@ -212,7 +229,7 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
         SearchRequest request = requestBuilder.build();
 
         if (!multiInstance) {
-            // Single instance: pass through
+            // Single instance: blocking fast-path
             ManagedChannel channel = s.channels.values().iterator().next();
             IndexingServiceGrpc.IndexingServiceBlockingStub stub =
                     IndexingServiceGrpc.newBlockingStub(channel)
@@ -225,29 +242,88 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
             return results;
         }
 
-        // Multiple instances: fan out, merge by score
-        List<Map.Entry<Bytes, Float>> merged = new ArrayList<>();
+        // Multiple instances: parallel fan-out with fail-fast and bounded top-K merge.
+        // Dispatch ALL RPCs up front so per-call gRPC deadlines run concurrently.
+        List<Map.Entry<String, ListenableFuture<SearchResponse>>> inflight =
+                new ArrayList<>(s.channels.size());
         for (Map.Entry<String, ManagedChannel> entry : s.channels.entrySet()) {
-            try {
-                IndexingServiceGrpc.IndexingServiceBlockingStub stub =
-                        IndexingServiceGrpc.newBlockingStub(entry.getValue())
-                                .withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
-                SearchResponse response = stub.search(request);
-                merged.addAll(toEntryList(response));
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Search failed on instance " + entry.getKey(), e);
-            }
+            IndexingServiceGrpc.IndexingServiceFutureStub stub =
+                    IndexingServiceGrpc.newFutureStub(entry.getValue())
+                            .withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
+            inflight.add(new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), stub.search(request)));
         }
 
-        // Re-rank by score descending and limit
-        merged.sort(Comparator.<Map.Entry<Bytes, Float>, Float>comparing(Map.Entry::getValue).reversed());
-        if (merged.size() > limit) {
-            merged = merged.subList(0, limit);
+        // Bounded min-heap: peek() returns the weakest (smallest-score) entry currently
+        // held, so it is the one to evict when a better candidate arrives. After the
+        // loop we drain and sort descending for the final response.
+        //
+        // The heap grows dynamically, so initial capacity is just an optimization.
+        // Cap it to avoid an Integer.MAX_VALUE allocation when callers (e.g. a
+        // VectorANNScanOp with a WHERE predicate wrapped in an external LimitOp)
+        // pass an unbounded limit — the eviction loop below still respects `limit`.
+        int initialCapacity = Math.max(1, Math.min(limit, 1024));
+        PriorityQueue<Map.Entry<Bytes, Float>> topK =
+                new PriorityQueue<>(initialCapacity, Comparator.comparing(Map.Entry::getValue));
+
+        try {
+            for (Map.Entry<String, ListenableFuture<SearchResponse>> f : inflight) {
+                SearchResponse response = f.getValue().get(timeoutSeconds, TimeUnit.SECONDS);
+                for (Map.Entry<Bytes, Float> e : toEntryList(response)) {
+                    if (topK.size() < limit) {
+                        topK.offer(e);
+                    } else if (e.getValue() > topK.peek().getValue()) {
+                        topK.poll();
+                        topK.offer(e);
+                    }
+                }
+            }
+        } catch (ExecutionException e) {
+            cancelAll(inflight);
+            throw new RuntimeException("Search failed on indexing-service instance: "
+                    + failingAddress(inflight) + " — " + e.getCause(), e.getCause());
+        } catch (TimeoutException e) {
+            cancelAll(inflight);
+            throw new RuntimeException("Search timed out waiting for indexing-service instances after "
+                    + timeoutSeconds + "s", e);
+        } catch (InterruptedException e) {
+            cancelAll(inflight);
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Search interrupted while waiting for indexing-service instances", e);
         }
+
+        List<Map.Entry<Bytes, Float>> out = new ArrayList<>(topK);
+        out.sort(Comparator.<Map.Entry<Bytes, Float>, Float>comparing(Map.Entry::getValue).reversed());
         long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
         LOGGER.log(Level.FINE, "client search completed (multi-instance fan-out): index={0}, {1} results in {2} ms",
-                new Object[]{index, merged.size(), elapsedMs});
-        return merged;
+                new Object[]{index, out.size(), elapsedMs});
+        return out;
+    }
+
+    private static void cancelAll(List<Map.Entry<String, ListenableFuture<SearchResponse>>> futures) {
+        for (Map.Entry<String, ListenableFuture<SearchResponse>> f : futures) {
+            if (!f.getValue().isDone()) {
+                f.getValue().cancel(true);
+            }
+        }
+    }
+
+    private static String failingAddress(List<Map.Entry<String, ListenableFuture<SearchResponse>>> futures) {
+        for (Map.Entry<String, ListenableFuture<SearchResponse>> f : futures) {
+            ListenableFuture<SearchResponse> lf = f.getValue();
+            if (lf.isDone() && !lf.isCancelled()) {
+                try {
+                    lf.get(0, TimeUnit.MILLISECONDS);
+                } catch (ExecutionException ex) {
+                    return f.getKey();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    return f.getKey();
+                } catch (TimeoutException ex) {
+                    // still running — not the culprit
+                }
+            }
+        }
+        return "<unknown>";
     }
 
     @Override

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceClientFanOutTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceClientFanOutTest.java
@@ -1,0 +1,272 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import com.google.protobuf.ByteString;
+import herddb.indexing.proto.IndexingServiceGrpc;
+import herddb.indexing.proto.SearchRequest;
+import herddb.indexing.proto.SearchResponse;
+import herddb.indexing.proto.SearchResult;
+import herddb.utils.Bytes;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Exercises the parallel fan-out / fail-fast / bounded top-K merge behaviour
+ * of {@link IndexingServiceClient#search}. Uses lightweight fake gRPC servers
+ * with controllable responses (normal, error, slow) instead of a real
+ * IndexingService instance.
+ */
+public class IndexingServiceClientFanOutTest {
+
+    private final List<FakeIndexingServer> servers = new ArrayList<>();
+    private IndexingServiceClient client;
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        for (FakeIndexingServer s : servers) {
+            s.close();
+        }
+        servers.clear();
+    }
+
+    private FakeIndexingServer start(IndexingServiceGrpc.IndexingServiceImplBase impl) throws IOException {
+        FakeIndexingServer s = new FakeIndexingServer(impl);
+        s.start();
+        servers.add(s);
+        return s;
+    }
+
+    /**
+     * Two instances: one returns a normal response, the other throws UNAVAILABLE.
+     * The client must fail fast, not silently return partial results.
+     */
+    @Test
+    public void searchFailsFastWhenOneInstanceThrows() throws Exception {
+        FakeIndexingServer ok = start(new StaticResponseImpl(Arrays.asList(
+                entry(new byte[]{1}, 0.9f),
+                entry(new byte[]{2}, 0.8f))));
+        FakeIndexingServer broken = start(new ThrowingImpl(Status.UNAVAILABLE.withDescription("boom")));
+
+        client = new IndexingServiceClient(Arrays.asList(ok.address(), broken.address()), 10);
+
+        try {
+            client.search("herd", "t1", "vidx", new float[]{1, 0, 0}, 5);
+            fail("Expected the search to fail fast when an instance errors");
+        } catch (RuntimeException e) {
+            // Root cause must be a gRPC status exception carrying UNAVAILABLE.
+            Throwable root = e;
+            while (root.getCause() != null) {
+                root = root.getCause();
+            }
+            assertTrue("root cause mentions UNAVAILABLE or boom: " + root,
+                    root.getMessage() != null
+                            && (root.getMessage().contains("UNAVAILABLE") || root.getMessage().contains("boom")));
+        }
+    }
+
+    /**
+     * Two instances, each returning 4 entries with overlapping score ranges.
+     * The merged top-3 must pick the globally highest scores across both
+     * instances, sorted descending, and must not include lower-score entries
+     * that a plain sort-and-truncate would still hold in memory.
+     */
+    @Test
+    public void searchMergesTopKFromAllInstances() throws Exception {
+        // Instance A scores: 0.9, 0.7, 0.5, 0.3
+        FakeIndexingServer serverA = start(new StaticResponseImpl(Arrays.asList(
+                entry(new byte[]{'a', 1}, 0.9f),
+                entry(new byte[]{'a', 2}, 0.7f),
+                entry(new byte[]{'a', 3}, 0.5f),
+                entry(new byte[]{'a', 4}, 0.3f))));
+        // Instance B scores: 0.85, 0.6, 0.4, 0.2
+        FakeIndexingServer serverB = start(new StaticResponseImpl(Arrays.asList(
+                entry(new byte[]{'b', 1}, 0.85f),
+                entry(new byte[]{'b', 2}, 0.6f),
+                entry(new byte[]{'b', 3}, 0.4f),
+                entry(new byte[]{'b', 4}, 0.2f))));
+
+        client = new IndexingServiceClient(Arrays.asList(serverA.address(), serverB.address()), 10);
+
+        List<Map.Entry<Bytes, Float>> results =
+                client.search("herd", "t1", "vidx", new float[]{1, 0, 0}, 3);
+
+        assertEquals(3, results.size());
+        // Expected top-3: a1 (0.9), b1 (0.85), a2 (0.7) — descending by score.
+        assertEquals(Float.valueOf(0.9f), results.get(0).getValue());
+        assertEquals(Float.valueOf(0.85f), results.get(1).getValue());
+        assertEquals(Float.valueOf(0.7f), results.get(2).getValue());
+
+        assertEquals(Bytes.from_array(new byte[]{'a', 1}), results.get(0).getKey());
+        assertEquals(Bytes.from_array(new byte[]{'b', 1}), results.get(1).getKey());
+        assertEquals(Bytes.from_array(new byte[]{'a', 2}), results.get(2).getKey());
+    }
+
+    /**
+     * Two slow instances (~700 ms each). With a sequential loop this would
+     * take ~1.4 s; with parallel dispatch it must finish in well under 1 s.
+     * Asserts both correctness and that the fan-out actually runs in parallel.
+     */
+    @Test
+    public void searchParallelDispatchRunsWithinSingleDeadline() throws Exception {
+        long delayMs = 700;
+        FakeIndexingServer slowA = start(new DelayedResponseImpl(Collections.singletonList(
+                entry(new byte[]{'a'}, 0.9f)), delayMs));
+        FakeIndexingServer slowB = start(new DelayedResponseImpl(Collections.singletonList(
+                entry(new byte[]{'b'}, 0.8f)), delayMs));
+
+        client = new IndexingServiceClient(Arrays.asList(slowA.address(), slowB.address()), 10);
+
+        long start = System.nanoTime();
+        List<Map.Entry<Bytes, Float>> results =
+                client.search("herd", "t1", "vidx", new float[]{1, 0, 0}, 5);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        assertEquals(2, results.size());
+        assertTrue("parallel fan-out should finish well under 2 * delayMs, elapsed=" + elapsedMs + "ms",
+                elapsedMs < (2L * delayMs) - 100);
+    }
+
+    /**
+     * A single-instance deployment must take the blocking fast-path and still
+     * return the expected results unchanged.
+     */
+    @Test
+    public void searchSingleInstanceUsesBlockingFastPath() throws Exception {
+        FakeIndexingServer only = start(new StaticResponseImpl(Arrays.asList(
+                entry(new byte[]{1}, 0.9f),
+                entry(new byte[]{2}, 0.5f))));
+
+        client = new IndexingServiceClient(Collections.singletonList(only.address()), 10);
+
+        List<Map.Entry<Bytes, Float>> results =
+                client.search("herd", "t1", "vidx", new float[]{1, 0, 0}, 5);
+
+        assertEquals(2, results.size());
+        assertEquals(Float.valueOf(0.9f), results.get(0).getValue());
+        assertEquals(Float.valueOf(0.5f), results.get(1).getValue());
+    }
+
+    // ----------------- helpers -----------------
+
+    private static SearchResult entry(byte[] pk, float score) {
+        return SearchResult.newBuilder()
+                .setPrimaryKey(ByteString.copyFrom(pk))
+                .setScore(score)
+                .build();
+    }
+
+    /** Thin wrapper that binds a BindableService on a random TCP port. */
+    private static final class FakeIndexingServer implements AutoCloseable {
+        private final io.grpc.BindableService impl;
+        private Server server;
+
+        FakeIndexingServer(io.grpc.BindableService impl) {
+            this.impl = impl;
+        }
+
+        void start() throws IOException {
+            server = ServerBuilder.forPort(0).addService(impl).build().start();
+            assertNotNull(server);
+        }
+
+        String address() {
+            return "localhost:" + server.getPort();
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            if (server != null) {
+                server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /** Returns a fixed list of entries on every search. */
+    private static final class StaticResponseImpl extends IndexingServiceGrpc.IndexingServiceImplBase {
+        private final List<SearchResult> entries;
+
+        StaticResponseImpl(List<SearchResult> entries) {
+            this.entries = entries;
+        }
+
+        @Override
+        public void search(SearchRequest request, StreamObserver<SearchResponse> responseObserver) {
+            responseObserver.onNext(SearchResponse.newBuilder().addAllResults(entries).build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    /** Throws the given gRPC status on every search. */
+    private static final class ThrowingImpl extends IndexingServiceGrpc.IndexingServiceImplBase {
+        private final Status status;
+
+        ThrowingImpl(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public void search(SearchRequest request, StreamObserver<SearchResponse> responseObserver) {
+            responseObserver.onError(status.asRuntimeException());
+        }
+    }
+
+    /** Sleeps for {@code delayMs} before returning a fixed list of entries. */
+    private static final class DelayedResponseImpl extends IndexingServiceGrpc.IndexingServiceImplBase {
+        private final List<SearchResult> entries;
+        private final long delayMs;
+
+        DelayedResponseImpl(List<SearchResult> entries, long delayMs) {
+            this.entries = entries;
+            this.delayMs = delayMs;
+        }
+
+        @Override
+        public void search(SearchRequest request, StreamObserver<SearchResponse> responseObserver) {
+            try {
+                Thread.sleep(delayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                responseObserver.onError(Status.ABORTED.withCause(e).asRuntimeException());
+                return;
+            }
+            responseObserver.onNext(SearchResponse.newBuilder().addAllResults(entries).build());
+            responseObserver.onCompleted();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Rewrites `IndexingServiceClient.search` so the multi-instance branch dispatches the search RPC to **every** configured indexing-service instance **in parallel** via `ListenableFuture` stubs, then merges into a bounded top-K min-heap.
- **Fails fast**: on any `ExecutionException`, deadline or interrupt the still-in-flight RPCs are cancelled and a `RuntimeException` carrying the failing instance address is thrown — no more silent partial results when one shard is unreachable.
- Each indexing-service instance owns a subset of the graph shards (`shardId % numInstances == instanceId`), so partial results were always wrong; the previous loop just hid the symptom.
- The JSQL planner rejects unbounded `ORDER BY ann_of(...)` (no `LIMIT`) at plan time, matching the contract that vector-search needs a finite top-K.

This addresses the vector-query slice of #93. The other points of #93 are out of scope here.

## Context

Today, with N instances:
- `for (instance : channels) { try { stub.search(...); } catch (Exception e) { LOGGER.warning(...); } }` — sequential, swallows errors. Tail latency stacks N × deadline; one dead pod silently truncates results.

After:
- All RPCs dispatched up front → wall-clock bounded by the slowest instance, not by the sum.
- Bounded min-heap keeps only the K best PKs across all instances; heap initial capacity is capped so the predicate-with-external-LimitOp case (`topK = Integer.MAX_VALUE`) does not pre-allocate a giant array.
- Single-instance deployments take the existing blocking fast-path.

## Test plan

- [x] `mvn -pl herddb-indexing-service -Dtest='IndexingServiceClient*Test' test` — 9 pass (5 existing + 4 new fan-out tests).
- [x] `mvn -pl herddb-core -Dtest='VectorIndex*Test' test` — 13 pass.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins -pl herddb-core,herddb-indexing-service -am` — green.
- [ ] CI cluster + core workflows on the PR.

### New tests (`IndexingServiceClientFanOutTest`)

- `searchFailsFastWhenOneInstanceThrows` — two in-process gRPC servers, one returns a normal response, the other throws `Status.UNAVAILABLE`. Asserts the client raises (no silent truncation).
- `searchMergesTopKFromAllInstances` — two instances with overlapping score ranges; asserts the merged top-3 picks the globally highest scores in descending order.
- `searchParallelDispatchRunsWithinSingleDeadline` — two instances each sleeping 700 ms; asserts the call finishes well under `2 × 700 ms`, proving the fan-out is actually parallel.
- `searchSingleInstanceUsesBlockingFastPath` — one instance; asserts the fast-path still works.

### Planner test (`VectorIndexJSQLParserPlannerTest`)

- `testAnnOfWithoutLimitIsRejectedJSQLParser` — `SELECT ... ORDER BY ann_of(vec, ?) DESC` (no `LIMIT`) is rejected; the same query with `LIMIT 10` still plans and executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)