### PR TITLE
GKE vector-bench agent and support scripts

### DIFF
--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -1,0 +1,464 @@
+---
+name: herddb-gke-bench
+description: Install HerdDB on an existing GKE cluster and run a vector-search benchmark end-to-end using Google Cloud Storage. Use when the user asks to "run a vector bench on GKE", "benchmark HerdDB on GKE", or "reproduce a vector-search workload against a GKE cluster". Produces a markdown report and opens a GitHub issue on failure with pod logs attached.
+tools: Bash, Read, Glob, Grep, Write, Edit
+model: sonnet
+---
+
+You are a narrow orchestration agent. Your only job is to install
+HerdDB on an **existing GKE cluster** (selected via the caller's
+ambient `$KUBECONFIG`), run a vector-search benchmark workload against
+it, then produce a markdown report — or, if something fails, open a
+GitHub issue with pod logs attached.
+
+All real work happens in shell scripts under
+`herddb-kubernetes/src/main/helm/herddb/examples/gke/`. You must not
+compose multi-line bash yourself. Your tool calls should be
+single-line invocations of the scripts and the narrowly whitelisted
+read-only commands listed below.
+
+Long runs (minutes → hours) are normal and acceptable. Being slow is
+fine. Being unsupervised is not: while a benchmark is running you
+MUST poll the cluster for errors on a fixed cadence (see
+§Supervision).
+
+You never create, resize, or destroy the GKE cluster itself. You
+never touch `gs://herddb-datasets`. You never run `kubectl delete
+pvc` directly — the only way to delete PVCs is
+`./scripts/reset-cluster.sh`, and only when the user has asked for a
+fresh run.
+
+## Working directory
+
+Always `cd` to `herddb-kubernetes/src/main/helm/herddb/examples/gke/`
+before running anything. All paths below are relative to that
+directory.
+
+## Allowed commands
+
+### Scripts (single-line invocations only)
+
+- `./install.sh --non-interactive [--image-tag <tag>] [--bucket <name>] [--no-wait]`
+  — helm install/upgrade HerdDB on the GKE cluster currently selected
+  by `$KUBECONFIG`. Non-interactive mode never prompts, never builds,
+  never pushes the image. The image must already be pushed to the
+  configured registry (default `ghcr.io/eolivelli/herddb`). The
+  interactive form (no flags) is reserved for humans; the agent must
+  always pass `--non-interactive`.
+- `./teardown.sh` — uninstall the Helm release and delete PVCs. Allowed
+  only when the user explicitly asks to fully remove HerdDB. Does
+  **not** touch GCS buckets.
+- `./scripts/check-cluster.sh` — pod health check. Exit 0 = healthy.
+- `./scripts/run-bench.sh <vector-bench args>` — run the workload
+  inside `sts/herddb-tools`. The last line of stdout is
+  `RUN_LOG=<path>` — capture it. Must be launched with
+  `run_in_background: true` so the supervision loop can run in
+  parallel. The script always prepends `--no-progress` to
+  `vector-bench.sh`, so the captured `RUN_LOG` is `\n`-terminated
+  plain-text output. You can and should `Read` this file during
+  supervision.
+- `./scripts/reset-cluster.sh [--yes]` — wipe all durable HerdDB state
+  between runs: scale StatefulSets to 0, delete their PVCs, empty
+  the file-server pages bucket in GCS, scale back up. The tools pod
+  and its dataset cache PVC are always preserved. Allowed **only**
+  when the user explicitly asks to start from scratch. The script
+  refuses to touch `gs://herddb-datasets`.
+- `./scripts/collect-logs.sh` — dump pod logs into a timestamped dir.
+  Last line is `LOGS_DIR=<path>`.
+- `./scripts/write-report.sh <run-log-path>` — turn a run log into a
+  markdown report. Last line is `REPORT=<path>`.
+- `./scripts/open-issue.sh --title <t> --body-file <p> [--logs-dir <d>]`
+  — open a GH issue. Add `--dry-run` if the user asks for a dry run.
+  Default label is `gke-bench`.
+- `./scripts/diagnostics.sh [--pod <pod>] [--analyze] [--mat-home <path>]`
+  — collect a JVM heap dump from a running pod (default:
+  `herddb-file-server-0`), download it locally, and optionally run
+  Eclipse MAT analysis. Prints `HEAP_DUMP=<path>`; with `--analyze`
+  also prints `MAT_REPORT=<dir>`.
+- `./scripts/diagnostics.sh --pod <pod> --profile [--profile-duration <secs>]`
+  — collect async-profiler flamegraphs (cpu, wall, alloc, lock —
+  30 s each by default). Downloads four HTML files. Prints
+  `PROFILES_DIR=<path>` on the last line. Use this on explicit user
+  request or when a query phase is unexpectedly slow.
+
+### Read-only supervision commands (whitelisted ONLY for the supervision loop)
+
+One invocation per tool call, no pipes:
+
+- `kubectl get pods -o wide`
+- `kubectl get events --sort-by=.lastTimestamp`
+- `kubectl logs --tail=200 <pod>`
+- `kubectl describe pod <pod>`
+- `kubectl get sts -o wide`
+
+### Read-only indexing-admin commands
+
+Run via `kubectl exec` inside the tools pod:
+
+```
+kubectl exec herddb-tools-0 -- \
+    indexing-admin engine-stats \
+        --server herddb-indexing-service-<N>.herddb-indexing-service:9850 --json
+```
+Fields to watch: `tailer_watermark_ledger`, `tailer_watermark_offset`,
+`apply_queue_size`, `total_estimated_memory_bytes`.
+
+```
+kubectl exec herddb-tools-0 -- \
+    indexing-admin describe-index \
+        --server herddb-indexing-service-<N>.herddb-indexing-service:9850 \
+        --tablespace <UUID> --table <table> --index vidx --json
+```
+Fields to watch: `vector_count`, `ondisk_node_count`, `segment_count`,
+`status`, `last_lsn_ledger`, `last_lsn_offset`, `ondisk_size_bytes`.
+
+### File-server metrics
+
+```
+kubectl exec herddb-file-server-0 -- curl -s http://localhost:9847/metrics
+```
+Key metrics: `rfs_readrange_bytes` (total bytes read from cache/GCS),
+`rfs_readrange_requests` (number of `readFileRange` calls),
+`rfs_writeblock_bytes` (bytes written during checkpoint).
+
+If `rfs_readrange_bytes` grows during query phases (not only during
+`--checkpoint`), the disk cache has overflowed and reads are falling
+through to GCS.
+
+### Read-only GCS / gcloud commands
+
+One invocation per tool call:
+
+- `gcloud storage ls gs://herddb-datasets/ | head` — preflight: verify
+  the caller can read the datasets bucket.
+- `gcloud storage ls gs://<pages-bucket>/` — verify the configured
+  file-server bucket exists.
+- `gcloud storage buckets describe gs://<name>` — existence check.
+
+`gcloud storage rm` is **never** allowed from the agent directly; it
+only runs inside `reset-cluster.sh`, which has its own hard guards.
+
+### Other read-only commands
+
+- `command -v docker helm kubectl gh gcloud` — check prerequisites.
+- `kubectl config current-context` — confirm the active cluster.
+- `helm get values herddb -a -o json` — read merged Helm values.
+
+Anything not in the lists above — especially `kubectl delete`,
+`kubectl rollout restart`, `kubectl scale`, direct `helm install/
+upgrade/uninstall`, or direct `gcloud storage rm` — is forbidden.
+`kubectl scale` is specifically forbidden because scale-down state
+must flow through `reset-cluster.sh` to preserve the PVC/bucket
+invariants.
+
+---
+
+## Default workload
+
+```
+./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
+    --ingest-max-ops 1000 --checkpoint
+```
+
+Rules that apply to every workload, including user-specified ones:
+
+- **Ingest is always throttled to `--ingest-max-ops 1000`** unless the
+  user explicitly overrides it. If the user's command omits the flag,
+  add it and tell the user you added it.
+- **Recall / query phases must only run AFTER a successful
+  checkpoint.** If the user's command includes a recall phase but no
+  `--checkpoint`, insert `--checkpoint` before the recall flags and
+  tell the user. If the checkpoint phase fails, do NOT proceed to the
+  recall phase — go to the failure path.
+- **Checkpoint timeout escalation.** Default
+  `--checkpoint-timeout-seconds` is 300. If a checkpoint times out
+  once, use `--checkpoint-timeout-seconds 600` for all subsequent
+  iterations in the same session.
+- **Custom datasets** live in `gs://herddb-datasets`. The tools pod
+  is pre-configured with `VECTORBENCH_DATASETS_BUCKET=gs://herddb-datasets`
+  (via the Helm chart's `tools.gcs.datasetsBucket`). To run a custom
+  dataset, pass
+  `--dataset-url "$VECTORBENCH_DATASETS_BUCKET/<path>"` through
+  `run-bench.sh`. Standard presets (`sift10k`, `sift1m`, `gist1m`,
+  …) resolve via their built-in public URLs as usual.
+
+---
+
+## Workflow
+
+1. **Preflight.** Check that `gcloud`, `helm`, `kubectl`, and `gh`
+   are on PATH. Check that `$KUBECONFIG` is set (or
+   `~/.kube/config` exists) and `kubectl cluster-info` succeeds.
+   Check that `gcloud storage ls gs://herddb-datasets/ | head`
+   returns without error. Check that the configured file-server
+   bucket exists. Check that the `herddb-gcs-credentials` Secret is
+   present (`kubectl get secret herddb-gcs-credentials`). If any
+   check fails, stop and tell the user exactly which prerequisite
+   is missing.
+
+2. **Install.** Run `./install.sh --non-interactive`. Stream output
+   to the user. On non-zero exit go to the failure path with title
+   `"[gke-bench] install failed on <UTC date>"`.
+
+3. **Health check.** Run `./scripts/check-cluster.sh`. On failure go
+   to the failure path.
+
+4. **Run the workload.** Launch `./scripts/run-bench.sh …` with
+   `run_in_background: true`. Capture the background task ID. Enter
+   the supervision loop (§Supervision) until the background task
+   finishes OR the loop detects a fatal signal.
+
+   - If the bench exits 0 and supervision saw no fatal signals →
+     capture `RUN_LOG=<path>` and go to step 5.
+   - Otherwise → go to the failure path.
+
+5. **Generate report.** Run `./scripts/write-report.sh <RUN_LOG>`
+   and capture `REPORT=<path>`. Print the path and include a
+   one-paragraph summary extracted from the run log.
+
+6. **Do not tear down or reset** unless the user explicitly asks.
+
+---
+
+## Supervision
+
+While `run-bench.sh` runs in the background, poll the cluster at
+least every 60 seconds (minimum 30 s, maximum 90 s between polls).
+On each tick, in order:
+
+0. **Tail the run log** — `Read` the `RUN_LOG` path (use `offset` to
+   skip to near the end on large files) to see the current phase and
+   most recent progress sample. Note the current phase on each tick
+   — you'll need it for the failure report. If the log has not
+   produced a new line for more than ~60 s during a phase that should
+   be emitting progress (ingest or recall), treat it as a warning and
+   correlate with cluster state.
+
+1. `./scripts/check-cluster.sh` — any non-zero exit is a fatal
+   signal.
+
+2. `kubectl get pods -o wide` — a pod in `CrashLoopBackOff`, `Error`,
+   `OOMKilled`, `Evicted`, or with an **increasing** `RESTARTS` count
+   is a fatal signal.
+
+3. For each HerdDB component pod (`herddb-server-0`,
+   `herddb-file-server-0`, `herddb-indexing-service-0`,
+   `herddb-indexing-service-1`, plus BK / ZK), run
+   `kubectl logs --tail=200 <pod>` in its own tool call and scan for:
+   - `OutOfMemoryError`
+   - `Exception in thread`
+   - `no space left on device`
+   - `DEADLINE_EXCEEDED` (fatal if it recurs across ticks)
+   - `ReadinessProbe failed` (fatal if it recurs across ticks)
+   - any uncaught `Throwable` / `FATAL` / `SEVERE` log line
+
+4. **indexing-admin status** — for each IS replica, call
+   `indexing-admin engine-stats --json` and
+   `indexing-admin describe-index --json`. Watch for:
+   - `apply_queue_size` consistently > 500 across ticks → warning
+   - `total_estimated_memory_bytes` near the heap limit → warning
+   - `tailer_watermark_*` not advancing across ticks during a
+     checkpoint wait → warning; fatal if stuck > 3 consecutive ticks
+
+5. **File server metrics** — during query phases, poll
+   `curl http://localhost:9847/metrics` every few ticks and check
+   that `rfs_readrange_bytes` growth rate is reasonable (< 10 MB/s
+   average between ticks is normal for cached access; higher
+   suggests cache overflow).
+
+If any fatal signal fires: stop the background `run-bench.sh` task,
+then proceed to §Failure handling. Do NOT attempt to mitigate on
+the running cluster.
+
+---
+
+## Failure handling
+
+You never try to recover a broken cluster. Every failure produces a
+reproducible GitHub issue. On any failure (install, health check,
+bench non-zero exit, or supervision-detected fault):
+
+1. If the bench is still running in the background, stop it.
+
+2. **OOM only — collect profiles and heap dump while the pod is
+   still live.** If the fatal signal was an `OutOfMemoryError` and
+   the affected pod is still `Running`:
+   a. `./scripts/diagnostics.sh --pod <failing-pod> --profile --profile-duration 30`
+      Capture `PROFILES_DIR=<path>`.
+   b. `./scripts/diagnostics.sh --pod <failing-pod> --analyze`
+      Capture `HEAP_DUMP=<path>` and `MAT_REPORT=<dir>`.
+   Include the MAT "Problem Suspect 1" paragraph verbatim in the
+   issue description. If the pod has already restarted, skip these.
+
+3. Run `./scripts/collect-logs.sh` and capture `LOGS_DIR=<dir>`.
+
+4. If a run log exists, run `./scripts/write-report.sh <RUN_LOG>`
+   and capture `REPORT=<path>`.
+
+5. Use `Read` to load the current `values.yaml`.
+
+6. Use `Write` to build an issue body file under `reports/`
+   containing:
+   - the exact workload command (including `--ingest-max-ops` and
+     `--checkpoint` as passed),
+   - which phase failed: `install`, `health-check`, `ingest`,
+     `checkpoint`, `recall`, or `supervision`,
+   - **most relevant stack traces and log lines verbatim** with
+     their source pod — do NOT summarize; paste raw lines.
+   - the exit code of `run-bench.sh`, if applicable,
+   - the **full current `values.yaml`** inlined in a fenced code
+     block,
+   - if profiles/heap dump were taken: the MAT "Problem Suspect 1"
+     description and `PROFILES_DIR` path,
+   - pointers to `REPORT`, `LOGS_DIR`, `HEAP_DUMP` (if taken).
+
+7. **Attach only the log of the failing pod** to the GitHub issue.
+   Create a temporary directory containing only the relevant log
+   file and pass it as `--logs-dir`. Keep the total issue body under
+   GitHub's 65,536-character limit.
+
+8. Run `./scripts/open-issue.sh --title "<title>" --body-file <body>
+   --logs-dir <dir>`, capture `ISSUE_URL=<url>`, and report it to
+   the user.
+
+9. **Stop.** Do not retry. Do not reset. Do not edit any file
+   outside `reports/`. Do not open a PR.
+
+If `gh` is not authenticated, tell the user to run `gh auth login`
+and re-run.
+
+---
+
+## Fresh-start flow (`reset-cluster.sh`)
+
+Run `reset-cluster.sh` only when the user explicitly asks for a
+fresh run ("start from scratch", "reset the cluster", "wipe state").
+Never run it on your own after a failure — the failure handling
+path always ends in "stop".
+
+Ceremony:
+
+1. Make sure any background `run-bench.sh` is already stopped.
+2. `./scripts/reset-cluster.sh --yes` — the script scales down the
+   relevant StatefulSets, deletes their PVCs, empties the file-server
+   pages bucket, then scales back up. The tools pod and its dataset
+   cache PVC are preserved. Capture `RESET_STATE=<path>`.
+3. `./scripts/check-cluster.sh` — must exit 0 before you launch a
+   new benchmark.
+4. Tell the user that all previously ingested data and ledgers were
+   discarded and that the next run starts cold.
+
+If `reset-cluster.sh` fails, follow the normal failure-handling
+path (collect-logs + open-issue). Do not retry the reset.
+
+---
+
+## Diagnostics on demand
+
+When the user explicitly asks for profiling, or when a query phase
+is unexpectedly slow (> 3× the expected latency from prior runs),
+run:
+
+```
+./scripts/diagnostics.sh --pod <pod> --profile --profile-duration 30
+```
+
+Do this for each component of interest sequentially — one call per
+tool invocation. After all sets are downloaded, open a GitHub issue
+(issue, not failure report) describing:
+- What phase the benchmark was in and what each pod was doing
+- The local `PROFILES_DIR` paths for each pod
+- Observations about hot-paths inferred from log patterns
+- Questions for developers about potential optimisations
+
+Use `open-issue.sh` without `--logs-dir`.
+
+---
+
+## Tuning between runs
+
+Between runs, **only when the user explicitly asks for a retry with
+a bigger X**, you may edit `values.yaml` under the GKE example
+directory. Never initiate tuning on your own after a failure.
+
+GKE supports `allowVolumeExpansion` on the standard storage class,
+so PVC resizes do not require the full teardown ceremony — edit the
+relevant `storage.*.size` in `values.yaml` and re-run
+`./install.sh --non-interactive`. If that fails, fall back to a
+full `reset-cluster.sh` only with explicit user consent.
+
+Heap bumps (`-Xms`/`-Xmx`) MUST be paired with matching bumps to
+`resources.requests.memory` and `resources.limits.memory` (heap +
+~1 GiB overhead rule of thumb). Always collect profiles and a heap
+dump first (if the pod is still Running) before editing values.
+
+---
+
+## File modification policy
+
+You may read and write **any** file under:
+
+```
+herddb-kubernetes/src/main/helm/herddb/examples/gke/
+```
+
+including:
+- `values.yaml` — for any tuning the user requests
+- `scripts/*.sh` — create, rename, or update helper scripts as
+  needed
+- `reports/` — temp body files, profile descriptions, issue drafts
+- `README.md` — update the agent-facing walkthrough
+
+**Do NOT touch:**
+- Any HerdDB source code under `herddb-*/`
+- Helm chart templates under
+  `herddb-kubernetes/src/main/helm/herddb/templates/`
+- `pom.xml` files
+- Any file outside the repo (except reading system paths like
+  `~/.kube/config` or `~/mat/`)
+
+When modifying a script, keep the same `set -euo pipefail` style,
+preserve existing `section` / `timestamp` helpers, and add `--help`
+/ usage text to any new flag.
+
+---
+
+## Hard rules
+
+- Never run multi-line bash, heredocs, or pipe chains. One script
+  or one single-line read-only command per tool call.
+- Never invoke `helm`, `docker`, or `gcloud storage rm` directly.
+  `kubectl` is allowed ONLY for the read-only supervision commands,
+  indexing-admin, and file-server metrics listed under "Allowed
+  commands".
+- Never run `kubectl delete`, `kubectl rollout restart`, `kubectl
+  scale`, or `kubectl exec` outside of the provided scripts.
+- **Never touch `gs://herddb-datasets`.** Never pass it as a
+  `--pages-bucket` anywhere, never read-delete from it, never
+  rewrite its contents.
+- **The only way to delete PVCs is `./scripts/reset-cluster.sh`.**
+  Direct `kubectl delete pvc` is forbidden.
+- **Running `reset-cluster.sh` requires an explicit user request.**
+  The agent never resets on its own after a failure.
+- Never create or destroy the GKE cluster itself. The cluster must
+  already exist, and the caller's `$KUBECONFIG` must already point
+  at it.
+- When opening a GitHub issue, **attach only the log(s) of the
+  failing pod** — not all pod logs. Full issue body must stay under
+  GitHub's 65,536-character limit. Include the most relevant stack
+  traces and SEVERE log lines **verbatim**.
+- Never attempt to recover a faulty cluster. Collect, file, stop.
+- Never run recall / query phases before a successful checkpoint.
+- Default ingest is throttled to `--ingest-max-ops 1000` unless the
+  user overrides it.
+- Escalate checkpoint timeout from 300 s to 600 s after any timeout
+  is observed in the session.
+- Long waits (minutes/hours) are acceptable, but supervision MUST
+  tick at least every 60 s while a bench is running.
+- Never create a GH issue on success. Issues are for failures or
+  explicit diagnostics requests (profiling, feature requests). They
+  must be fully reproducible from the embedded `values.yaml` +
+  workload command.
+- Never open a PR and never propose a code patch in an issue body.
+- If the user's request is ambiguous (e.g. which dataset), ask them
+  once before touching the cluster.

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/README.md
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/README.md
@@ -217,6 +217,93 @@ ANN search results (uses vector index):
 Vectors are passed as JDBC parameters with `CAST(? AS FLOAT ARRAY)`.
 The column type for vector data is `floata` (float array).
 
+## Running the vector benchmark
+
+Once HerdDB is up and the `herddb-tools` StatefulSet is Ready, you
+can run the `vector-bench` workload with the helper scripts under
+`scripts/`. They mirror the k3s-local benchmark helpers and are used
+by the `herddb-gke-bench` Claude Code agent (see
+`.claude/agents/herddb-gke-bench.md`).
+
+### Scripted install
+
+For agent-driven workflows, `install.sh` accepts a `--non-interactive`
+flag that consumes flags or environment variables instead of
+prompting:
+
+```bash
+./install.sh --non-interactive \
+    --image-tag 0.30.0-SNAPSHOT \
+    --bucket my-herddb-pages \
+    --location us-central1
+```
+
+All three flags have sensible defaults; the image, HMAC secret, and
+GHCR pull secret must already exist in the cluster (the script
+refuses to create them in non-interactive mode).
+
+### Running a workload
+
+```bash
+./scripts/check-cluster.sh    # health check
+
+./scripts/run-bench.sh \
+    --dataset sift10k -n 10000 -k 100 \
+    --ingest-max-ops 1000 --checkpoint
+```
+
+`run-bench.sh` executes `vector-bench.sh` inside the tools pod and
+tees plain-text output (`--no-progress` is always on) to
+`reports/run-<timestamp>.log`. The last line of stdout is
+`RUN_LOG=<path>`. Turn it into a markdown report with:
+
+```bash
+./scripts/write-report.sh reports/run-20260414-101530.log
+```
+
+### Custom datasets from gs://herddb-datasets
+
+Standard presets (`sift10k`, `sift1m`, `gist1m`, …) are resolved via
+the built-in public URLs in `DatasetLoader`. Custom datasets live in
+the shared bucket `gs://herddb-datasets`. The GKE values set
+`tools.gcs.datasetsBucket=herddb-datasets`, which causes the tools
+StatefulSet to export `VECTORBENCH_DATASETS_BUCKET=gs://herddb-datasets`.
+Pass an explicit `--dataset-url` through `run-bench.sh` to fetch one:
+
+```bash
+./scripts/run-bench.sh \
+    --dataset-url "$VECTORBENCH_DATASETS_BUCKET/my-corpus.fvecs.gz" \
+    -n 100000 --checkpoint
+```
+
+The service account backing `herddb-gcs-credentials` needs
+`roles/storage.objectViewer` on `gs://herddb-datasets` in addition
+to `roles/storage.objectAdmin` on the pages bucket.
+
+### Resetting between runs
+
+`scripts/reset-cluster.sh` scales every HerdDB StatefulSet except
+the tools pod down to zero, deletes their PVCs, empties the
+file-server pages bucket (**never** touching `gs://herddb-datasets`),
+and scales back up. The tools pod and its dataset cache PVC are
+preserved so downloaded datasets don't need to be re-fetched.
+
+```bash
+./scripts/reset-cluster.sh --yes
+```
+
+The script reads the pages bucket name from `helm get values herddb`
+and refuses to run if the resolved name looks like a datasets
+bucket.
+
+### Diagnostics
+
+`scripts/diagnostics.sh` collects either a JVM heap dump (default)
+or async-profiler flamegraphs (`--profile`) from a running pod. See
+the script's `--help` header for details. `scripts/collect-logs.sh`
+dumps per-pod logs into a timestamped directory, and
+`scripts/open-issue.sh` publishes them as a GitHub issue via `gh`.
+
 ## Teardown
 
 ```bash

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/install.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/install.sh
@@ -2,73 +2,139 @@
 #
 # Install HerdDB on a GKE cluster using Google Cloud Storage.
 #
-# Prerequisites:
-#   - KUBECONFIG is set and points to a GKE cluster
-#   - A Kubernetes Secret with GCS HMAC credentials exists:
-#       kubectl create secret generic herddb-gcs-credentials \
-#         --from-literal=S3_ACCESS_KEY=<access-id> \
-#         --from-literal=S3_SECRET_KEY=<secret>
+# Two modes:
 #
-# Usage:
-#   ./install.sh                                           # install chart
-#   ./install.sh --set fileServer.s3.bucket=my-bucket      # pass extra Helm values
+#   ./install.sh                       # interactive — prompts for
+#                                      # image, bucket, credentials,
+#                                      # optionally builds and pushes
+#                                      # the Docker image.
+#
+#   ./install.sh --non-interactive \   # scripted — consumes flags /
+#       --image-tag 0.30.0-SNAPSHOT    # env vars only, never prompts,
+#                                      # never builds or pushes.
+#
+# Non-interactive flags (all optional unless noted):
+#
+#   --image-repo <repo>        default: $IMAGE_REPO or
+#                                       ghcr.io/eolivelli/herddb
+#   --image-tag <tag>          default: $IMAGE_TAG or 0.30.0-SNAPSHOT
+#   --bucket <gcs-bucket>      default: $GCS_BUCKET or herddb-pages
+#   --location <region>        default: $GCS_LOCATION or us-central1
+#   --no-create-bucket         fail instead of creating the file-server bucket
+#   --no-create-secret         fail instead of creating herddb-gcs-credentials
+#   --no-create-pull-secret    fail instead of creating ghcr-credentials
+#   --no-wait                  skip the kubectl wait for pods
+#
+# Prerequisites for non-interactive mode:
+#   - KUBECONFIG is set and points at a reachable GKE cluster
+#   - The image at <image-repo>:<image-tag> is already pushed
+#   - gh, gcloud, helm, kubectl on PATH
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 CHART_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Collect any extra arguments to forward to helm install/upgrade.
-EXTRA_ARGS=("$@")
+# ── Parse flags ──────────────────────────────────────────────────
+NON_INTERACTIVE=false
+IMAGE_REPO="${IMAGE_REPO:-}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+GCS_BUCKET="${GCS_BUCKET:-}"
+GCS_LOCATION="${GCS_LOCATION:-}"
+CREATE_BUCKET=true
+CREATE_SECRET=true
+CREATE_PULL_SECRET=true
+WAIT_FOR_PODS=true
+# Any remaining --set k=v etc. go through to helm.
+HELM_EXTRA_ARGS=()
 
-# ── 0. Ask for Docker image name and version ─────────────────────
-read -rp "Docker image repository [ghcr.io/eolivelli/herddb]: " IMAGE_REPO
-IMAGE_REPO="${IMAGE_REPO:-ghcr.io/eolivelli/herddb}"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --non-interactive)      NON_INTERACTIVE=true; shift ;;
+        --image-repo)           IMAGE_REPO="$2"; shift 2 ;;
+        --image-tag)            IMAGE_TAG="$2"; shift 2 ;;
+        --bucket)               GCS_BUCKET="$2"; shift 2 ;;
+        --location)             GCS_LOCATION="$2"; shift 2 ;;
+        --no-create-bucket)     CREATE_BUCKET=false; shift ;;
+        --no-create-secret)     CREATE_SECRET=false; shift ;;
+        --no-create-pull-secret) CREATE_PULL_SECRET=false; shift ;;
+        --no-wait)              WAIT_FOR_PODS=false; shift ;;
+        --)                     shift; HELM_EXTRA_ARGS+=("$@"); break ;;
+        *)                      HELM_EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
 
-read -rp "Docker image tag [0.30.0-SNAPSHOT]: " IMAGE_TAG
-IMAGE_TAG="${IMAGE_TAG:-0.30.0-SNAPSHOT}"
+fatal() { echo "ERROR: $*" >&2; exit 1; }
 
-EXTRA_ARGS+=(--set "image.repository=$IMAGE_REPO" --set "image.tag=$IMAGE_TAG")
+if $NON_INTERACTIVE; then
+    IMAGE_REPO="${IMAGE_REPO:-ghcr.io/eolivelli/herddb}"
+    IMAGE_TAG="${IMAGE_TAG:-0.30.0-SNAPSHOT}"
+    GCS_BUCKET="${GCS_BUCKET:-herddb-pages}"
+    GCS_LOCATION="${GCS_LOCATION:-us-central1}"
+else
+    # ── 0. Interactive prompts ─────────────────────────────────
+    read -rp "Docker image repository [ghcr.io/eolivelli/herddb]: " in_repo
+    IMAGE_REPO="${in_repo:-${IMAGE_REPO:-ghcr.io/eolivelli/herddb}}"
 
-# ── 0b. Ask for GCS bucket name ──────────────────────────────────
-read -rp "GCS bucket name [herddb-pages]: " GCS_BUCKET
-GCS_BUCKET="${GCS_BUCKET:-herddb-pages}"
+    read -rp "Docker image tag [0.30.0-SNAPSHOT]: " in_tag
+    IMAGE_TAG="${in_tag:-${IMAGE_TAG:-0.30.0-SNAPSHOT}}"
 
-EXTRA_ARGS+=(--set "fileServer.s3.bucket=$GCS_BUCKET")
+    read -rp "GCS bucket name [herddb-pages]: " in_bucket
+    GCS_BUCKET="${in_bucket:-${GCS_BUCKET:-herddb-pages}}"
 
-# ── 0c. Optionally build and push Docker image ─────────────────
-read -rp "Build and push Docker image ${IMAGE_REPO}:${IMAGE_TAG}? [y/N] " build_image
-if [[ "$build_image" =~ ^[Yy]$ ]]; then
-    REPO_ROOT="$(cd "$CHART_DIR/../../../../.." && pwd)"
-    echo "==> Building Docker image (this may take a few minutes)..."
-    (cd "$REPO_ROOT" && mvn clean package -Ddocker -DskipTests)
-    # The Maven build produces herddb/herddb-server:<version>
-    BUILD_VERSION="$(cd "$REPO_ROOT" && mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
-    SOURCE_IMAGE="herddb/herddb-server:${BUILD_VERSION}"
-    if [[ "$SOURCE_IMAGE" != "${IMAGE_REPO}:${IMAGE_TAG}" ]]; then
-        echo "==> Tagging ${SOURCE_IMAGE} as ${IMAGE_REPO}:${IMAGE_TAG}..."
-        docker tag "$SOURCE_IMAGE" "${IMAGE_REPO}:${IMAGE_TAG}"
-    fi
-    echo "==> Pushing ${IMAGE_REPO}:${IMAGE_TAG}..."
-    docker push "${IMAGE_REPO}:${IMAGE_TAG}"
-    echo "Image pushed successfully."
+    read -rp "GCS bucket location [us-central1]: " in_loc
+    GCS_LOCATION="${in_loc:-${GCS_LOCATION:-us-central1}}"
 fi
 
-# ── 0d. Check / create GHCR image-pull secret ────────────────────
+HELM_EXTRA_ARGS+=(--set "image.repository=$IMAGE_REPO" \
+                  --set "image.tag=$IMAGE_TAG" \
+                  --set "fileServer.s3.bucket=$GCS_BUCKET")
+
+echo "==> Image:    ${IMAGE_REPO}:${IMAGE_TAG}"
+echo "==> Bucket:   gs://${GCS_BUCKET} (${GCS_LOCATION})"
+echo "==> Mode:     $( $NON_INTERACTIVE && echo non-interactive || echo interactive )"
+
+# ── 0b. Optional image build & push (interactive only) ──────────
+if ! $NON_INTERACTIVE; then
+    read -rp "Build and push Docker image ${IMAGE_REPO}:${IMAGE_TAG}? [y/N] " build_image
+    if [[ "$build_image" =~ ^[Yy]$ ]]; then
+        REPO_ROOT="$(cd "$CHART_DIR/../../../../.." && pwd)"
+        echo "==> Building Docker image (this may take a few minutes)..."
+        (cd "$REPO_ROOT" && mvn clean package -Ddocker -DskipTests)
+        BUILD_VERSION="$(cd "$REPO_ROOT" && mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+        SOURCE_IMAGE="herddb/herddb-server:${BUILD_VERSION}"
+        if [[ "$SOURCE_IMAGE" != "${IMAGE_REPO}:${IMAGE_TAG}" ]]; then
+            echo "==> Tagging ${SOURCE_IMAGE} as ${IMAGE_REPO}:${IMAGE_TAG}..."
+            docker tag "$SOURCE_IMAGE" "${IMAGE_REPO}:${IMAGE_TAG}"
+        fi
+        echo "==> Pushing ${IMAGE_REPO}:${IMAGE_TAG}..."
+        docker push "${IMAGE_REPO}:${IMAGE_TAG}"
+    fi
+fi
+
+# ── 0c. Check / create GHCR image-pull secret ────────────────────
 if ! kubectl get secret ghcr-credentials >/dev/null 2>&1; then
-    echo "Secret 'ghcr-credentials' not found (needed to pull from ghcr.io)."
-    read -rp "Create it now? [Y/n] " create_ghcr
-    if [[ ! "$create_ghcr" =~ ^[Nn]$ ]]; then
-        read -rp "GitHub username: " GHCR_USER
-        read -rsp "GitHub Personal Access Token (with read:packages scope): " GHCR_TOKEN
-        echo ""
-        kubectl create secret docker-registry ghcr-credentials \
-            --docker-server=ghcr.io \
-            --docker-username="$GHCR_USER" \
-            --docker-password="$GHCR_TOKEN"
-        echo "Secret 'ghcr-credentials' created."
+    if $NON_INTERACTIVE; then
+        if $CREATE_PULL_SECRET; then
+            fatal "Secret 'ghcr-credentials' not found. In non-interactive mode you must create it yourself (or pass --no-create-pull-secret to proceed without one)."
+        else
+            echo "WARNING: Secret 'ghcr-credentials' not found; proceeding without it (--no-create-pull-secret)."
+        fi
     else
-        echo "WARNING: Without 'ghcr-credentials' pods may fail to pull from ghcr.io."
+        echo "Secret 'ghcr-credentials' not found (needed to pull from ghcr.io)."
+        read -rp "Create it now? [Y/n] " create_ghcr
+        if [[ ! "$create_ghcr" =~ ^[Nn]$ ]]; then
+            read -rp "GitHub username: " GHCR_USER
+            read -rsp "GitHub Personal Access Token (with read:packages scope): " GHCR_TOKEN
+            echo ""
+            kubectl create secret docker-registry ghcr-credentials \
+                --docker-server=ghcr.io \
+                --docker-username="$GHCR_USER" \
+                --docker-password="$GHCR_TOKEN"
+            echo "Secret 'ghcr-credentials' created."
+        else
+            echo "WARNING: Without 'ghcr-credentials' pods may fail to pull from ghcr.io."
+        fi
     fi
 else
     echo "==> Secret 'ghcr-credentials' found."
@@ -76,87 +142,105 @@ fi
 
 # ── 1. Verify cluster connectivity ────────────────────────────────
 echo "==> Verifying cluster connectivity..."
-if ! kubectl get nodes >/dev/null 2>&1; then
-    echo "ERROR: Cannot reach the Kubernetes cluster. Is KUBECONFIG set correctly?"
-    exit 1
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    fatal "Cannot reach the Kubernetes cluster. Is KUBECONFIG set correctly?"
 fi
 
 # ── 2. Check that the GCS bucket exists ───────────────────────────
 echo "==> Checking GCS bucket gs://${GCS_BUCKET}..."
 if ! gcloud storage buckets describe "gs://${GCS_BUCKET}" >/dev/null 2>&1; then
-    echo "Bucket 'gs://${GCS_BUCKET}' does not exist."
-    read -rp "Create it now? [Y/n] " create_bucket
-    if [[ ! "$create_bucket" =~ ^[Nn]$ ]]; then
-        read -rp "Bucket location [us-central1]: " BUCKET_LOCATION
-        BUCKET_LOCATION="${BUCKET_LOCATION:-us-central1}"
-        echo "==> Creating bucket gs://${GCS_BUCKET} in ${BUCKET_LOCATION}..."
-        gcloud storage buckets create "gs://${GCS_BUCKET}" --location="${BUCKET_LOCATION}"
+    if $NON_INTERACTIVE; then
+        if $CREATE_BUCKET; then
+            echo "==> Creating bucket gs://${GCS_BUCKET} in ${GCS_LOCATION}..."
+            gcloud storage buckets create "gs://${GCS_BUCKET}" --location="${GCS_LOCATION}"
+        else
+            fatal "Bucket gs://${GCS_BUCKET} does not exist and --no-create-bucket was set."
+        fi
     else
-        echo "WARNING: Proceeding without a bucket — the file server will fail to start."
+        echo "Bucket 'gs://${GCS_BUCKET}' does not exist."
+        read -rp "Create it now? [Y/n] " create_bucket
+        if [[ ! "$create_bucket" =~ ^[Nn]$ ]]; then
+            read -rp "Bucket location [${GCS_LOCATION}]: " in_loc
+            GCS_LOCATION="${in_loc:-$GCS_LOCATION}"
+            echo "==> Creating bucket gs://${GCS_BUCKET} in ${GCS_LOCATION}..."
+            gcloud storage buckets create "gs://${GCS_BUCKET}" --location="${GCS_LOCATION}"
+        else
+            echo "WARNING: Proceeding without a bucket — the file server will fail to start."
+        fi
     fi
 else
     echo "Bucket gs://${GCS_BUCKET} exists."
 fi
 
-# ── 2b. Optionally clean up the GCS bucket ───────────────────────
-read -rp "Clean up (delete all objects in) bucket gs://${GCS_BUCKET}? [y/N] " clean_bucket
-if [[ "$clean_bucket" =~ ^[Yy]$ ]]; then
-    echo "==> Deleting all objects in gs://${GCS_BUCKET}..."
-    gcloud storage rm "gs://${GCS_BUCKET}/**" --recursive 2>/dev/null || true
-    echo "Bucket cleaned."
+# ── 2b. Optional interactive bucket cleanup ─────────────────────
+if ! $NON_INTERACTIVE; then
+    read -rp "Clean up (delete all objects in) bucket gs://${GCS_BUCKET}? [y/N] " clean_bucket
+    if [[ "$clean_bucket" =~ ^[Yy]$ ]]; then
+        if [[ "$GCS_BUCKET" == "herddb-datasets" ]]; then
+            fatal "Refusing to wipe gs://herddb-datasets."
+        fi
+        echo "==> Deleting all objects in gs://${GCS_BUCKET}..."
+        gcloud storage rm "gs://${GCS_BUCKET}/**" --recursive 2>/dev/null || true
+    fi
 fi
 
 # ── 3. Check that the credentials Secret exists ──────────────────
 if ! kubectl get secret herddb-gcs-credentials >/dev/null 2>&1; then
-    echo "Secret 'herddb-gcs-credentials' not found."
-    read -rp "Create HMAC credentials and Secret now? [Y/n] " create_creds
-    if [[ ! "$create_creds" =~ ^[Nn]$ ]]; then
-        # HMAC keys require a GCP service account (not a user account).
-        GCP_PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
-        if [[ -z "$GCP_PROJECT" ]]; then
-            echo "ERROR: No GCP project configured. Run 'gcloud config set project PROJECT_ID'."
-            exit 1
+    if $NON_INTERACTIVE; then
+        if $CREATE_SECRET; then
+            fatal "Secret 'herddb-gcs-credentials' not found. In non-interactive mode you must create it yourself (or pass --no-create-secret)."
+        else
+            echo "WARNING: Secret 'herddb-gcs-credentials' not found; proceeding without it."
         fi
-        DEFAULT_SA="herddb-gcs@${GCP_PROJECT}.iam.gserviceaccount.com"
-        echo "HMAC keys require a GCP service account (not a personal Google account)."
-        read -rp "Service account email [${DEFAULT_SA}]: " SA_EMAIL
-        SA_EMAIL="${SA_EMAIL:-$DEFAULT_SA}"
-        # Create the service account if it does not exist yet
-        SA_NAME="${SA_EMAIL%%@*}"
-        if ! gcloud iam service-accounts describe "$SA_EMAIL" >/dev/null 2>&1; then
-            echo "==> Service account '${SA_EMAIL}' not found. Creating it..."
-            gcloud iam service-accounts create "$SA_NAME" \
-                --display-name="HerdDB GCS access"
-        fi
-        # Grant the service account objectAdmin on the bucket
-        echo "==> Granting roles/storage.objectAdmin on gs://${GCS_BUCKET} to ${SA_EMAIL}..."
-        gcloud storage buckets add-iam-policy-binding "gs://${GCS_BUCKET}" \
-            --member="serviceAccount:${SA_EMAIL}" \
-            --role="roles/storage.objectAdmin" --quiet
-        echo "==> Creating HMAC key for ${SA_EMAIL}..."
-        HMAC_OUTPUT="$(gcloud storage hmac create "$SA_EMAIL" --format=json)"
-        HMAC_ACCESS_ID="$(echo "$HMAC_OUTPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['metadata']['accessId'])")"
-        HMAC_SECRET="$(echo "$HMAC_OUTPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['secret'])")"
-        if [[ -z "$HMAC_ACCESS_ID" || -z "$HMAC_SECRET" ]]; then
-            echo "ERROR: Failed to parse HMAC credentials from gcloud output."
-            exit 1
-        fi
-        echo "==> Creating Kubernetes secret 'herddb-gcs-credentials'..."
-        kubectl create secret generic herddb-gcs-credentials \
-            --from-literal=S3_ACCESS_KEY="$HMAC_ACCESS_ID" \
-            --from-literal=S3_SECRET_KEY="$HMAC_SECRET"
-        echo "Secret created successfully."
     else
-        echo "WARNING: Secret 'herddb-gcs-credentials' is missing."
-        echo "The file server will fail to start without valid credentials."
-        echo "You can create it manually with:"
-        echo "  kubectl create secret generic herddb-gcs-credentials \\"
-        echo "    --from-literal=S3_ACCESS_KEY=<access-id> \\"
-        echo "    --from-literal=S3_SECRET_KEY=<secret>"
-        echo ""
-        read -rp "Continue anyway? [y/N] " answer
-        if [[ ! "$answer" =~ ^[Yy]$ ]]; then
-            exit 1
+        echo "Secret 'herddb-gcs-credentials' not found."
+        read -rp "Create HMAC credentials and Secret now? [Y/n] " create_creds
+        if [[ ! "$create_creds" =~ ^[Nn]$ ]]; then
+            GCP_PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+            if [[ -z "$GCP_PROJECT" ]]; then
+                fatal "No GCP project configured. Run 'gcloud config set project PROJECT_ID'."
+            fi
+            DEFAULT_SA="herddb-gcs@${GCP_PROJECT}.iam.gserviceaccount.com"
+            echo "HMAC keys require a GCP service account (not a personal Google account)."
+            read -rp "Service account email [${DEFAULT_SA}]: " SA_EMAIL
+            SA_EMAIL="${SA_EMAIL:-$DEFAULT_SA}"
+            SA_NAME="${SA_EMAIL%%@*}"
+            if ! gcloud iam service-accounts describe "$SA_EMAIL" >/dev/null 2>&1; then
+                echo "==> Service account '${SA_EMAIL}' not found. Creating it..."
+                gcloud iam service-accounts create "$SA_NAME" \
+                    --display-name="HerdDB GCS access"
+            fi
+            echo "==> Granting roles/storage.objectAdmin on gs://${GCS_BUCKET} to ${SA_EMAIL}..."
+            gcloud storage buckets add-iam-policy-binding "gs://${GCS_BUCKET}" \
+                --member="serviceAccount:${SA_EMAIL}" \
+                --role="roles/storage.objectAdmin" --quiet
+            echo "==> Granting roles/storage.objectViewer on gs://herddb-datasets to ${SA_EMAIL}..."
+            gcloud storage buckets add-iam-policy-binding "gs://herddb-datasets" \
+                --member="serviceAccount:${SA_EMAIL}" \
+                --role="roles/storage.objectViewer" --quiet || \
+                echo "WARNING: could not bind objectViewer on gs://herddb-datasets. Custom datasets may be inaccessible."
+            echo "==> Creating HMAC key for ${SA_EMAIL}..."
+            HMAC_OUTPUT="$(gcloud storage hmac create "$SA_EMAIL" --format=json)"
+            HMAC_ACCESS_ID="$(echo "$HMAC_OUTPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['metadata']['accessId'])")"
+            HMAC_SECRET="$(echo "$HMAC_OUTPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['secret'])")"
+            if [[ -z "$HMAC_ACCESS_ID" || -z "$HMAC_SECRET" ]]; then
+                fatal "Failed to parse HMAC credentials from gcloud output."
+            fi
+            echo "==> Creating Kubernetes secret 'herddb-gcs-credentials'..."
+            kubectl create secret generic herddb-gcs-credentials \
+                --from-literal=S3_ACCESS_KEY="$HMAC_ACCESS_ID" \
+                --from-literal=S3_SECRET_KEY="$HMAC_SECRET"
+            echo "Secret created successfully."
+        else
+            echo "WARNING: Secret 'herddb-gcs-credentials' is missing."
+            echo "You can create it manually with:"
+            echo "  kubectl create secret generic herddb-gcs-credentials \\"
+            echo "    --from-literal=S3_ACCESS_KEY=<access-id> \\"
+            echo "    --from-literal=S3_SECRET_KEY=<secret>"
+            read -rp "Continue anyway? [y/N] " answer
+            if [[ ! "$answer" =~ ^[Yy]$ ]]; then
+                exit 1
+            fi
         fi
     fi
 else
@@ -166,18 +250,31 @@ fi
 # ── 4. Install or upgrade the Helm chart ──────────────────────────
 if helm status herddb >/dev/null 2>&1; then
     echo "==> Helm release 'herddb' already exists, upgrading..."
-    helm upgrade herddb "$CHART_DIR" -f "$SCRIPT_DIR/values.yaml" "${EXTRA_ARGS[@]}"
+    helm upgrade herddb "$CHART_DIR" -f "$SCRIPT_DIR/values.yaml" "${HELM_EXTRA_ARGS[@]}"
 else
     echo "==> Installing Helm chart..."
-    helm install herddb "$CHART_DIR" -f "$SCRIPT_DIR/values.yaml" "${EXTRA_ARGS[@]}"
+    helm install herddb "$CHART_DIR" -f "$SCRIPT_DIR/values.yaml" "${HELM_EXTRA_ARGS[@]}"
 fi
 
 # ── 5. Wait for pods ─────────────────────────────────────────────
-echo "==> Waiting for all pods to become ready (timeout 3m)..."
-kubectl wait --for=condition=ready pod --all --timeout=180s
+if $WAIT_FOR_PODS; then
+    echo "==> Waiting for all pods to become ready (timeout 5m)..."
+    kubectl wait --for=condition=ready pod \
+        -l app.kubernetes.io/instance=herddb \
+        --all --timeout=300s || {
+        echo "WARNING: not all pods became ready within 5m; run scripts/check-cluster.sh" >&2
+        exit 1
+    }
+fi
 
-echo ""
-echo "==> HerdDB is ready!"
-echo ""
-echo "Connect with the CLI:"
-echo "  kubectl exec -it deploy/herddb-tools -- herddb-cli"
+cat <<EOF
+
+==> HerdDB is ready!
+
+Connect with the CLI:
+  kubectl exec -it sts/herddb-tools -- herddb-cli
+
+Run a vector benchmark:
+  ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \\
+      --ingest-max-ops 1000 --checkpoint
+EOF

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/check-cluster.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/check-cluster.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Health check for a HerdDB deployment on a GKE cluster.
+# Prints pod status and exits non-zero if any HerdDB pod is not Ready.
+#
+# Usage: ./scripts/check-cluster.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+section "HerdDB pods"
+kubectl -n default get pods -l app.kubernetes.io/instance=herddb \
+    -o wide
+
+unhealthy=0
+while read -r pod; do
+    [[ -z "$pod" ]] && continue
+    ready=$(kubectl -n default get pod "$pod" \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+    phase=$(kubectl -n default get pod "$pod" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+    if [[ "$ready" != "True" ]]; then
+        echo "  [NOT READY] $pod (phase=$phase, ready=$ready)" >&2
+        unhealthy=$((unhealthy + 1))
+    fi
+done < <(herddb_pods)
+
+if [[ $unhealthy -gt 0 ]]; then
+    echo ""
+    echo "ERROR: $unhealthy pod(s) not Ready." >&2
+    exit 1
+fi
+
+echo ""
+echo "All HerdDB pods are Ready."

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/collect-logs.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/collect-logs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Dump logs from every HerdDB pod into reports/logs-<timestamp>/.
+# Includes --previous logs if a pod has restarted.
+#
+# Usage: ./scripts/collect-logs.sh [--tail N]
+#
+# On success: prints "LOGS_DIR=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+TAIL=2000
+if [[ "${1:-}" == "--tail" ]]; then
+    TAIL="$2"; shift 2
+fi
+
+TS="$(timestamp)"
+LOGS_DIR="$REPORTS_DIR/logs-$TS"
+mkdir -p "$LOGS_DIR"
+
+section "Collecting logs into $LOGS_DIR"
+
+kubectl -n default get pods -l app.kubernetes.io/instance=herddb \
+    -o wide > "$LOGS_DIR/pods.txt" 2>&1 || true
+kubectl -n default describe pods -l app.kubernetes.io/instance=herddb \
+    > "$LOGS_DIR/describe.txt" 2>&1 || true
+kubectl -n default get events --sort-by=.lastTimestamp \
+    > "$LOGS_DIR/events.txt" 2>&1 || true
+
+while read -r pod; do
+    [[ -z "$pod" ]] && continue
+    echo "  - $pod"
+    kubectl -n default logs "$pod" --all-containers --tail="$TAIL" \
+        > "$LOGS_DIR/$pod.log" 2>&1 || true
+    kubectl -n default logs "$pod" --all-containers --previous --tail="$TAIL" \
+        > "$LOGS_DIR/$pod.previous.log" 2>/dev/null || \
+        rm -f "$LOGS_DIR/$pod.previous.log"
+done < <(herddb_pods)
+
+echo ""
+echo "LOGS_DIR=$LOGS_DIR"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/common.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/common.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Shared helpers sourced by the other GKE scripts. Not meant to be
+# executed directly.
+#
+# Unlike the k3s-local variant, this file does NOT manage a local
+# .kubeconfig — it relies on the caller's ambient $KUBECONFIG (or
+# ~/.kube/config if unset) pointing at a reachable GKE cluster.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# If $HERDDB_TESTS_HOME is set, keep reports there (outside the chart
+# tree so they are never bundled into the Helm release Secret).
+# Otherwise fall back to the in-tree reports/ directory.
+REPORTS_DIR="${HERDDB_TESTS_HOME:-$EXAMPLE_DIR/reports}"
+mkdir -p "$REPORTS_DIR"
+
+# Honour ambient KUBECONFIG. A missing kubeconfig means the user hasn't
+# selected a GKE cluster yet — fail fast.
+if [[ -z "${KUBECONFIG:-}" && ! -f "$HOME/.kube/config" ]]; then
+    echo "ERROR: no kubeconfig available. Export KUBECONFIG or run 'gcloud container clusters get-credentials ...' first." >&2
+    exit 1
+fi
+
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "ERROR: kubectl cannot reach the cluster. Check KUBECONFIG / current context." >&2
+    exit 1
+fi
+
+timestamp() { date +%Y%m%d-%H%M%S; }
+
+herddb_pods() {
+    kubectl -n default get pods -l app.kubernetes.io/instance=herddb \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+}
+
+section() { printf '\n==> %s\n' "$1"; }

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/diagnostics.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/diagnostics.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Collect a JVM heap dump or async-profiler profiles from a running
+# HerdDB pod and optionally analyse the heap dump with Eclipse Memory
+# Analyser (MAT).
+#
+# Usage (heap dump):
+#   ./scripts/diagnostics.sh [--pod <pod>] [--analyze] [--mat-home <path>]
+#
+# Usage (async-profiler profiles):
+#   ./scripts/diagnostics.sh --pod <pod> --profile [--profile-duration <secs>]
+#
+# Defaults:
+#   --pod               herddb-file-server-0
+#   --analyze           disabled (pass --analyze to run MAT after download)
+#   --mat-home          $MAT_HOME or ~/mat
+#   --profile-duration  30  (seconds per event type)
+#
+# Output (heap dump):
+#   Prints  HEAP_DUMP=<local-path>  on the last line on success.
+#   If --analyze is passed also prints  MAT_REPORT=<dir>  pointing at
+#   the MAT "leak_suspects" report directory.
+#
+# Output (profiles):
+#   Collects cpu / wall / alloc / lock profiles (HTML flamegraphs via
+#   async-profiler at /opt/profiler/bin/asprof) and downloads them.
+#   Prints  PROFILES_DIR=<local-dir>  on the last line on success.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+POD="herddb-file-server-0"
+ANALYZE=false
+MAT_HOME="${MAT_HOME:-${HOME}/mat}"
+PROFILE=false
+PROFILE_DURATION=30
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pod)               POD="$2";               shift 2 ;;
+        --analyze)           ANALYZE=true;            shift   ;;
+        --mat-home)          MAT_HOME="$2";           shift 2 ;;
+        --profile)           PROFILE=true;            shift   ;;
+        --profile-duration)  PROFILE_DURATION="$2";  shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if $PROFILE; then
+    section "async-profiler profiles from pod $POD (${PROFILE_DURATION}s per event)"
+
+    echo "  Locating JVM PID..."
+    JVM_PID=$(kubectl -n default exec "$POD" -- sh -c \
+        'jps 2>/dev/null | grep -v "^[0-9]* Jps$" | head -1 | cut -d" " -f1')
+
+    if [[ -z "$JVM_PID" ]]; then
+        echo "ERROR: could not determine JVM PID in $POD (is jps available?)" >&2
+        exit 1
+    fi
+    echo "  JVM PID: $JVM_PID"
+
+    TS_POD="$(date +%Y%m%d-%H%M%S)"
+    REMOTE_DIR="/tmp/profile-${POD}-${TS_POD}"
+    kubectl -n default exec "$POD" -- mkdir -p "$REMOTE_DIR"
+
+    ASPROF="/opt/profiler/bin/asprof"
+
+    echo "  [1/4] CPU profile (${PROFILE_DURATION}s)..."
+    kubectl -n default exec "$POD" -- \
+        "$ASPROF" -d "$PROFILE_DURATION" "$JVM_PID" \
+        -f "${REMOTE_DIR}/profile_cpu.html"
+
+    echo "  [2/4] Wall-clock profile (${PROFILE_DURATION}s)..."
+    kubectl -n default exec "$POD" -- \
+        "$ASPROF" -d "$PROFILE_DURATION" -e wall "$JVM_PID" \
+        -f "${REMOTE_DIR}/profile_wall.html"
+
+    echo "  [3/4] Allocation profile (${PROFILE_DURATION}s)..."
+    kubectl -n default exec "$POD" -- \
+        "$ASPROF" -d "$PROFILE_DURATION" -e alloc "$JVM_PID" \
+        -f "${REMOTE_DIR}/profile_mem.html"
+
+    echo "  [4/4] Lock profile (${PROFILE_DURATION}s)..."
+    kubectl -n default exec "$POD" -- \
+        "$ASPROF" -d "$PROFILE_DURATION" -e lock "$JVM_PID" \
+        -f "${REMOTE_DIR}/profile_locks.html"
+
+    TS_LOCAL="$(timestamp)"
+    LOCAL_DIR="$REPORTS_DIR/profiles-${POD}-${TS_LOCAL}"
+    mkdir -p "$LOCAL_DIR"
+
+    echo "  Downloading profiles to $LOCAL_DIR ..."
+    kubectl -n default cp "${POD}:${REMOTE_DIR}/profile_cpu.html"   "${LOCAL_DIR}/profile_cpu.html"
+    kubectl -n default cp "${POD}:${REMOTE_DIR}/profile_wall.html"  "${LOCAL_DIR}/profile_wall.html"
+    kubectl -n default cp "${POD}:${REMOTE_DIR}/profile_mem.html"   "${LOCAL_DIR}/profile_mem.html"
+    kubectl -n default cp "${POD}:${REMOTE_DIR}/profile_locks.html" "${LOCAL_DIR}/profile_locks.html"
+
+    kubectl -n default exec "$POD" -- rm -rf "$REMOTE_DIR" || true
+
+    echo ""
+    echo "PROFILES_DIR=$LOCAL_DIR"
+    exit 0
+fi
+
+section "Heap dump from pod $POD"
+
+echo "  Locating JVM PID..."
+JVM_PID=$(kubectl -n default exec "$POD" -- sh -c \
+    'jcmd 2>/dev/null | grep -v "^[0-9]* Jcmd$" | awk "NR==1{print \$1}"')
+
+if [[ -z "$JVM_PID" ]]; then
+    echo "ERROR: could not determine JVM PID in $POD (is jcmd available?)" >&2
+    exit 1
+fi
+echo "  JVM PID: $JVM_PID"
+
+REMOTE_DUMP="/tmp/heapdump-$(date +%Y%m%d-%H%M%S).hprof"
+echo "  Writing heap dump to $POD:$REMOTE_DUMP ..."
+kubectl -n default exec "$POD" -- jcmd "$JVM_PID" GC.heap_dump "$REMOTE_DUMP"
+
+TS="$(timestamp)"
+LOCAL_DUMP="$REPORTS_DIR/heapdump-${POD}-${TS}.hprof"
+echo "  Downloading to $LOCAL_DUMP ..."
+kubectl -n default cp "${POD}:${REMOTE_DUMP}" "$LOCAL_DUMP"
+
+kubectl -n default exec "$POD" -- rm -f "$REMOTE_DUMP" || true
+
+echo ""
+echo "HEAP_DUMP=$LOCAL_DUMP"
+
+if $ANALYZE; then
+    MAT_PARSE="$MAT_HOME/ParseHeapDump.sh"
+    if [[ ! -x "$MAT_PARSE" ]]; then
+        echo "ERROR: MAT not found at $MAT_PARSE (set --mat-home or \$MAT_HOME)" >&2
+        exit 1
+    fi
+
+    section "Analyzing $LOCAL_DUMP with MAT"
+    "$MAT_PARSE" "$LOCAL_DUMP" org.eclipse.mat.api:suspects org.eclipse.mat.api:overview
+
+    MAT_REPORT_DIR="$(dirname "$LOCAL_DUMP")"
+    echo ""
+    echo "MAT_REPORT=$MAT_REPORT_DIR"
+fi

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/open-issue.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/open-issue.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Open a GitHub issue describing a failed gke-bench run.
+# Attaches logs from a directory (produced by collect-logs.sh) as
+# collapsible blocks in the issue body. Truncates each log to the last
+# 500 lines so the body stays under GitHub's 65k-character limit.
+#
+# Usage:
+#   ./scripts/open-issue.sh --title "<title>" --body-file <path> \
+#       [--logs-dir <path>] [--label <label>] [--dry-run]
+#
+# Requires `gh` to be installed and authenticated.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPORTS_DIR="${HERDDB_TESTS_HOME:-$EXAMPLE_DIR/reports}"
+mkdir -p "$REPORTS_DIR"
+
+TITLE=""
+BODY_FILE=""
+LOGS_DIR=""
+DRY_RUN=false
+LABEL="gke-bench"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)      TITLE="$2"; shift 2 ;;
+        --body-file)  BODY_FILE="$2"; shift 2 ;;
+        --logs-dir)   LOGS_DIR="$2"; shift 2 ;;
+        --label)      LABEL="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$TITLE" || -z "$BODY_FILE" || ! -f "$BODY_FILE" ]]; then
+    echo "Usage: $0 --title <title> --body-file <path> [--logs-dir <path>] [--dry-run]" >&2
+    exit 2
+fi
+
+if ! $DRY_RUN; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "ERROR: 'gh' CLI is not installed." >&2
+        exit 1
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "ERROR: 'gh' is not authenticated. Run 'gh auth login' first." >&2
+        exit 1
+    fi
+fi
+
+TS="$(date +%Y%m%d-%H%M%S)"
+FINAL_BODY="$REPORTS_DIR/issue-body-$TS.md"
+
+{
+    cat "$BODY_FILE"
+    if [[ -n "$LOGS_DIR" && -d "$LOGS_DIR" ]]; then
+        echo ""
+        echo "## Attached pod logs"
+        echo ""
+        echo "_Collected from \`$LOGS_DIR\`. Each log is truncated to the last 500 lines._"
+        echo ""
+        for f in "$LOGS_DIR"/*.txt "$LOGS_DIR"/*.log; do
+            [[ -f "$f" ]] || continue
+            name=$(basename "$f")
+            echo ""
+            echo "<details><summary><code>$name</code></summary>"
+            echo ""
+            echo '```'
+            tail -n 500 "$f"
+            echo '```'
+            echo ""
+            echo '</details>'
+        done
+    fi
+} > "$FINAL_BODY"
+
+echo "==> Issue body written to $FINAL_BODY"
+
+if $DRY_RUN; then
+    echo "==> --dry-run set, not creating GH issue."
+    echo "ISSUE_BODY=$FINAL_BODY"
+    exit 0
+fi
+
+echo "==> Creating GitHub issue..."
+gh label create "$LABEL" --description "Automated reports from the GKE vector-bench agent" --force >/dev/null 2>&1 || true
+
+URL=$(gh issue create --title "$TITLE" --body-file "$FINAL_BODY" --label "$LABEL")
+echo "ISSUE_URL=$URL"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/reset-cluster.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/reset-cluster.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# Reset the HerdDB cluster to an empty state between benchmark runs.
+#
+# Scales down every HerdDB StatefulSet except the tools pod, deletes
+# their PVCs, empties the file-server pages bucket in GCS, and then
+# scales the StatefulSets back up to their original replica count.
+# The Helm release, the datasets bucket, the tools pod, and the tools
+# dataset cache PVC are all preserved.
+#
+# Usage:
+#   ./scripts/reset-cluster.sh
+#   ./scripts/reset-cluster.sh --pages-bucket herddb-pages --yes
+#   ./scripts/reset-cluster.sh --keep-pvc herddb-tools --keep-pvc herddb-server --yes
+#
+# Flags:
+#   --pages-bucket <name>   GCS bucket to empty (default: read from
+#                           `helm get values herddb`, else env
+#                           PAGES_BUCKET, else herddb-pages).
+#   --keep-pvc <sts-name>   Do not delete PVCs belonging to this
+#                           StatefulSet (repeatable). herddb-tools is
+#                           always kept; add more here to preserve
+#                           additional state.
+#   --yes                   Skip the interactive confirmation prompt.
+#
+# On success prints RESET_STATE=<path> pointing at a small JSON-ish
+# file under reports/ recording the original replica counts.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+# The tools StatefulSet is always preserved — it holds the downloaded
+# dataset cache, which we want to reuse across runs.
+KEEP_PVCS=("herddb-tools")
+PAGES_BUCKET=""
+ASSUME_YES=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pages-bucket) PAGES_BUCKET="$2"; shift 2 ;;
+        --keep-pvc)     KEEP_PVCS+=("$2"); shift 2 ;;
+        --yes)          ASSUME_YES=true; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+fatal() { echo "ERROR: $*" >&2; exit 1; }
+
+# Resolve pages bucket. Priority: --pages-bucket > env > helm values
+# > literal default. We never want to accidentally hit the datasets
+# bucket, so guard against that at several layers.
+if [[ -z "$PAGES_BUCKET" && -n "${PAGES_BUCKET_ENV:-}" ]]; then
+    PAGES_BUCKET="$PAGES_BUCKET_ENV"
+fi
+if [[ -z "$PAGES_BUCKET" ]]; then
+    PAGES_BUCKET=$(helm get values herddb -a -o json 2>/dev/null \
+        | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("fileServer",{}).get("s3",{}).get("bucket","") or "")' 2>/dev/null || true)
+fi
+PAGES_BUCKET="${PAGES_BUCKET:-herddb-pages}"
+
+# ── Hard safety guards. ────────────────────────────────────────
+if [[ "$PAGES_BUCKET" == "herddb-datasets" || "$PAGES_BUCKET" == *datasets* ]]; then
+    fatal "refusing to reset with pages-bucket='$PAGES_BUCKET' — looks like a datasets bucket."
+fi
+if [[ -z "$PAGES_BUCKET" ]]; then
+    fatal "could not resolve the pages bucket name; pass --pages-bucket."
+fi
+
+# The StatefulSets that hold durable state and that we DO want to
+# wipe. Order matters for a clean shutdown (dependents first).
+ALL_STS=(
+    "herddb-server"
+    "herddb-indexing-service"
+    "herddb-file-server"
+    "herddb-bookkeeper"
+    "herddb-zookeeper"
+)
+
+# Helper: is $1 in the KEEP_PVCS array?
+is_kept() {
+    local name="$1" kept
+    for kept in "${KEEP_PVCS[@]}"; do
+        [[ "$name" == "$kept" ]] && return 0
+    done
+    return 1
+}
+
+# Filter targets so we never scale the tools pod or any --keep-pvc entry.
+TARGET_STS=()
+for s in "${ALL_STS[@]}"; do
+    if ! is_kept "$s"; then
+        if kubectl -n default get sts "$s" >/dev/null 2>&1; then
+            TARGET_STS+=("$s")
+        fi
+    fi
+done
+
+if [[ ${#TARGET_STS[@]} -eq 0 ]]; then
+    fatal "no StatefulSets to reset (are you pointed at the right cluster?)."
+fi
+
+section "Reset plan"
+echo "  Pages bucket:   gs://$PAGES_BUCKET   (will be emptied)"
+echo "  StatefulSets:   ${TARGET_STS[*]}"
+echo "  Keep PVCs for:  ${KEEP_PVCS[*]}"
+echo ""
+
+if ! $ASSUME_YES; then
+    read -rp "Proceed with reset? This will DELETE PVCs and EMPTY the pages bucket. [y/N] " ans
+    if [[ ! "$ans" =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+fi
+
+TS="$(timestamp)"
+STATE_FILE="$REPORTS_DIR/reset-$TS.state"
+: > "$STATE_FILE"
+
+# ── 1. Record the current replica counts so scale-up can restore
+#       them even if the script is interrupted and re-run.
+section "Recording current replica counts"
+for s in "${TARGET_STS[@]}"; do
+    r=$(kubectl -n default get sts "$s" -o jsonpath='{.spec.replicas}')
+    echo "$s=$r" >> "$STATE_FILE"
+    echo "  $s: $r replicas"
+done
+
+# ── 2. Scale StatefulSets to 0 and wait for pod termination.
+section "Scaling StatefulSets to 0"
+for s in "${TARGET_STS[@]}"; do
+    kubectl -n default scale sts "$s" --replicas=0
+done
+
+echo "  Waiting for pods to terminate (up to 5m)..."
+for s in "${TARGET_STS[@]}"; do
+    # Wait per-StatefulSet so a single slow shutdown doesn't mask the
+    # others. `--for=delete` watches for the pod objects to disappear.
+    kubectl -n default wait --for=delete pod \
+        -l "app.kubernetes.io/instance=herddb,statefulset.kubernetes.io/pod-name" \
+        --timeout=300s >/dev/null 2>&1 || true
+done
+kubectl -n default get pods -l app.kubernetes.io/instance=herddb -o wide || true
+
+# ── 3. Delete PVCs for the target StatefulSets.
+section "Deleting PVCs"
+for s in "${TARGET_STS[@]}"; do
+    # StatefulSet PVCs follow the pattern <volume-name>-<sts>-<ordinal>.
+    # We filter by sts-name substring so we never touch PVCs of the
+    # tools pod or anything else.
+    PVCS=$(kubectl -n default get pvc -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+        | grep -E -- "-${s}-[0-9]+$" || true)
+    if [[ -z "$PVCS" ]]; then
+        echo "  $s: no PVCs to delete"
+        continue
+    fi
+    while read -r pvc; do
+        [[ -z "$pvc" ]] && continue
+        # Double-check it doesn't belong to any --keep-pvc target.
+        skip=false
+        for kept in "${KEEP_PVCS[@]}"; do
+            if [[ "$pvc" == *"-${kept}-"* ]]; then
+                skip=true; break
+            fi
+        done
+        if $skip; then
+            echo "  SKIP $pvc (kept)"
+            continue
+        fi
+        echo "  delete pvc/$pvc"
+        kubectl -n default delete pvc "$pvc" --wait=true --timeout=120s
+    done <<< "$PVCS"
+done
+
+# ── 4. Empty the pages bucket (but keep the bucket itself so IAM
+#       bindings and HMAC keys remain valid).
+section "Emptying gs://$PAGES_BUCKET"
+# Re-assert the guard right before the destructive call.
+if [[ "$PAGES_BUCKET" == "herddb-datasets" || "$PAGES_BUCKET" == *datasets* ]]; then
+    fatal "BUG: pages bucket '$PAGES_BUCKET' looks like a datasets bucket — refusing."
+fi
+gcloud storage rm "gs://${PAGES_BUCKET}/**" --recursive --quiet 2>/dev/null || {
+    echo "  (bucket was already empty)"
+}
+
+# ── 5. Scale StatefulSets back up to the recorded replica counts.
+section "Scaling StatefulSets back up"
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    name="${line%%=*}"
+    replicas="${line##*=}"
+    echo "  $name -> $replicas"
+    kubectl -n default scale sts "$name" --replicas="$replicas"
+done < "$STATE_FILE"
+
+# ── 6. Wait for ready.
+section "Waiting for pods to become Ready (up to 5m)"
+kubectl -n default wait --for=condition=ready pod \
+    -l app.kubernetes.io/instance=herddb \
+    --all --timeout=300s || {
+    echo "WARNING: not all pods became Ready within 5m; run scripts/check-cluster.sh" >&2
+}
+
+echo ""
+echo "RESET_STATE=$STATE_FILE"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/run-bench.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/run-bench.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Run a vector-bench workload against the HerdDB cluster on GKE.
+# All arguments are forwarded to /opt/herddb/bin/vector-bench.sh inside
+# the tools pod.
+#
+# The Java client is always driven with --no-progress so that the
+# captured run log is \n-terminated line-per-sample output (rather than
+# \r-overwritten spinner frames), making the log tail-friendly for
+# supervision agents and much smaller on long runs.
+#
+# Usage:
+#   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
+#       --ingest-max-ops 1000 --checkpoint
+#   ./scripts/run-bench.sh --dataset-url "$VECTORBENCH_DATASETS_BUCKET/mycorpus.fvecs.gz" \
+#       -n 100000 --checkpoint
+#
+# On success: writes reports/run-<timestamp>.log and prints its path
+# on the last line (prefixed "RUN_LOG="). Exits non-zero on failure.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <vector-bench args>" >&2
+    echo "Example: $0 --dataset sift10k -n 10000 -k 100 --ingest-max-ops 1000 --checkpoint" >&2
+    exit 2
+fi
+
+TS="$(timestamp)"
+RUN_LOG="$REPORTS_DIR/run-$TS.log"
+
+section "Running vector-bench inside sts/herddb-tools"
+echo "  args: $*"
+echo "  log:  $RUN_LOG"
+echo ""
+
+{
+    echo "# vector-bench run $TS"
+    echo "# args: $*"
+    echo "# start: $(date -Iseconds)"
+    echo ""
+} > "$RUN_LOG"
+
+set +e
+kubectl -n default exec sts/herddb-tools -- \
+    /opt/herddb/bin/vector-bench.sh --no-progress "$@" 2>&1 | tee -a "$RUN_LOG"
+status=${PIPESTATUS[0]}
+set -e
+
+{
+    echo ""
+    echo "# end: $(date -Iseconds)"
+    echo "# exit: $status"
+} >> "$RUN_LOG"
+
+echo ""
+echo "RUN_LOG=$RUN_LOG"
+exit "$status"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/write-report.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/write-report.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Turn a vector-bench run log into a markdown report.
+#
+# Usage: ./scripts/write-report.sh <run-log-path>
+#
+# On success: prints "REPORT=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+RUN_LOG="${1:-}"
+if [[ -z "$RUN_LOG" || ! -f "$RUN_LOG" ]]; then
+    echo "Usage: $0 <run-log-path>" >&2
+    echo "Run log not found: $RUN_LOG" >&2
+    exit 2
+fi
+
+TS="$(timestamp)"
+REPORT="$REPORTS_DIR/report-$TS.md"
+
+ARGS_LINE=$(grep -m1 '^# args:' "$RUN_LOG" || echo "# args: (unknown)")
+START_LINE=$(grep -m1 '^# start:' "$RUN_LOG" || echo "# start: (unknown)")
+END_LINE=$(grep -m1 '^# end:' "$RUN_LOG" || echo "# end: (unknown)")
+EXIT_LINE=$(grep -m1 '^# exit:' "$RUN_LOG" || echo "# exit: (unknown)")
+EXIT_CODE=$(echo "$EXIT_LINE" | awk '{print $NF}')
+
+SUMMARY=$(awk '
+    /^========================================$/ && !seen { seen=1; in_summary=1 }
+    in_summary { print }
+    /^Benchmark complete/ { in_summary=0 }
+' "$RUN_LOG" || true)
+
+PHASE_LINES=$(grep -E '^phase=' "$RUN_LOG" || true)
+
+CLUSTER_STATE=$("$SCRIPT_DIR/check-cluster.sh" 2>&1 || true)
+
+LOG_TAIL=$(tail -n 200 "$RUN_LOG")
+
+{
+    echo "# HerdDB vector-bench report (GKE) — $TS"
+    echo ""
+    echo "**Status:** $([[ "$EXIT_CODE" == "0" ]] && echo ":white_check_mark: success" || echo ":x: failed (exit=$EXIT_CODE)")"
+    echo ""
+    echo "## Workload"
+    echo ""
+    echo '```'
+    echo "${ARGS_LINE#\# args: }"
+    echo "${START_LINE#\# }"
+    echo "${END_LINE#\# }"
+    echo "${EXIT_LINE#\# }"
+    echo '```'
+    echo ""
+    echo "## Cluster state"
+    echo ""
+    echo '```'
+    echo "$CLUSTER_STATE"
+    echo '```'
+    echo ""
+    if [[ -n "$PHASE_LINES" ]]; then
+        echo "## Phase metrics"
+        echo ""
+        echo '```'
+        echo "$PHASE_LINES"
+        echo '```'
+        echo ""
+    fi
+    if [[ -n "$SUMMARY" ]]; then
+        echo "## Benchmark summary"
+        echo ""
+        echo '```'
+        echo "$SUMMARY"
+        echo '```'
+        echo ""
+    fi
+    echo "## Run log (last 200 lines)"
+    echo ""
+    echo '<details><summary>expand</summary>'
+    echo ""
+    echo '```'
+    echo "$LOG_TAIL"
+    echo '```'
+    echo ""
+    echo '</details>'
+    echo ""
+    echo "---"
+    echo ""
+    echo "_Full log: \`$RUN_LOG\`_"
+} > "$REPORT"
+
+echo ""
+echo "REPORT=$REPORT"

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -22,6 +22,9 @@
 #     --set fileServer.s3.bucket=<your-bucket-name>
 
 image:
+  # Always re-pull so that re-pushed tags (common during active
+  # benchmark iteration) are picked up on every pod restart.
+  pullPolicy: Always
   pullSecrets:
     - name: ghcr-credentials
 
@@ -124,12 +127,19 @@ tools:
   enabled: true
   gcs:
     credentialsSecret: "herddb-gcs-credentials"
+    # Shared bucket of reusable benchmark datasets. The tools pod
+    # gets VECTORBENCH_DATASETS_BUCKET=gs://herddb-datasets, which
+    # run-bench.sh and the herddb-gke-bench agent use as the default
+    # prefix for custom --dataset-url values. Standard presets
+    # (sift1m, gist1m, …) still resolve through DatasetLoader's
+    # built-in public URLs.
+    datasetsBucket: "herddb-datasets"
   storage:
     datasets:
       size: 200Gi
 
 prometheus:
-  enabled: true
+  enabled: false
 
 grafana:
-  enabled: true
+  enabled: false

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
@@ -44,6 +44,10 @@ spec:
               value: {{ .Values.tools.javaOpts | default "-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true" | quote }}
             - name: VECTORBENCH_DATASET_DIR
               value: /opt/herddb/vector-datasets
+            {{- if .Values.tools.gcs.datasetsBucket }}
+            - name: VECTORBENCH_DATASETS_BUCKET
+              value: "gs://{{ .Values.tools.gcs.datasetsBucket }}"
+            {{- end }}
             {{- if .Values.tools.gcs.credentialsSecret }}
             - name: GCS_ACCESS_KEY
               valueFrom:

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -180,6 +180,11 @@ tools:
     # Kubernetes Secret containing GCS HMAC credentials (keys: S3_ACCESS_KEY, S3_SECRET_KEY).
     # When set, the tools pod can download datasets from gs:// URLs using the S3-compatible API.
     credentialsSecret: ""
+    # Optional default datasets bucket. When set, the tools pod gets
+    # VECTORBENCH_DATASETS_BUCKET=gs://<name> so scripts and the
+    # benchmark can default custom --dataset-url prefixes without
+    # hard-coding the bucket name.
+    datasetsBucket: ""
   storage:
     datasets:
       size: 30Gi


### PR DESCRIPTION
## Summary
- Adds a **`herddb-gke-bench`** Claude Code agent that mirrors the k3s-local benchmark flow on an existing GKE cluster (install → health check → supervised `run-bench.sh` → markdown report, or GH issue on failure).
- Drops the supporting scripts under `herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/`: `common.sh`, `check-cluster.sh`, `run-bench.sh`, `collect-logs.sh`, `write-report.sh`, `open-issue.sh`, `diagnostics.sh`, and a brand-new `reset-cluster.sh` for between-runs cleanup.
- Makes `examples/gke/install.sh` agent-friendly via a `--non-interactive` flag (image repo/tag, bucket, location, and `--no-create-*` guards). Interactive prompts are preserved for humans.
- Teaches the tools StatefulSet to export `VECTORBENCH_DATASETS_BUCKET` when `tools.gcs.datasetsBucket` is set, so `vector-bench` can resolve custom datasets from `gs://herddb-datasets` directly through its existing HMAC credentials path.
- Updates `examples/gke/values.yaml` to disable Prometheus/Grafana, set `image.pullPolicy: Always`, and point `datasetsBucket` at `gs://herddb-datasets`.

### `reset-cluster.sh` safety invariants
- Never touches `gs://herddb-datasets` (hard guards on the bucket name, checked twice).
- Never deletes the tools pod or its dataset cache PVC — downloaded datasets persist across runs.
- Scales `herddb-server`, `-indexing-service`, `-file-server`, `-bookkeeper`, `-zookeeper` to 0 → deletes their PVCs → empties the pages bucket → scales back up to the recorded replica counts → waits for Ready.
- Records replica counts in `reports/reset-<ts>.state` before scaling so a re-run can restore them.

### Chart-level change
`tools.gcs.datasetsBucket` is an additive, backwards-compatible value (default `""`). When empty, the tools StatefulSet is unchanged; verified with `helm template` against the existing `k3s-local/values.yaml`.

## Test plan
- [x] `helm lint herddb-kubernetes/src/main/helm/herddb` — clean.
- [x] `helm template herddb ... -f examples/gke/values.yaml | grep VECTORBENCH_DATASETS_BUCKET` shows `gs://herddb-datasets` in the tools pod.
- [x] `helm template ... -f examples/k3s-local/values.yaml` does **not** render the new env var (backwards compatible).
- [x] `helm template ... -f examples/gke/values.yaml` renders `imagePullPolicy: Always` for every workload and emits no `prometheus` / `grafana` resources.
- [x] `mvn -B checkstyle:check apache-rat:check -pl herddb-kubernetes -am -DskipTests` — BUILD SUCCESS.
- [x] `bash -n` passes on all new scripts and on the refactored `install.sh`.
- [ ] End-to-end agent dry run on a real GKE cluster (to be done once a staging cluster is available): `install.sh --non-interactive` → `scripts/run-bench.sh --dataset sift10k …` → `write-report.sh`.
- [ ] `reset-cluster.sh --yes` on a real GKE cluster; confirm the tools dataset cache PVC and `gs://herddb-datasets` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)