### PR TITLE
Fix file-server read/write contention (issue #100)

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -3214,6 +3214,263 @@
       "showTitle": false,
       "title": "Status RPC",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "File-server lane executor queue depth. Under checkpoint pressure the write series should spike while the read series stays flat — that is the issue #100 fix working.",
+          "fill": 1,
+          "id": 100,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 3,
+          "targets": [
+            {
+              "expr": "rfs_read_executor_queue_size{instance=~\"$fs_instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} read",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_write_executor_queue_size{instance=~\"$fs_instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} write",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "File Server Executor Queue Size (read vs write)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "File-server lane executor active thread count.",
+          "fill": 1,
+          "id": 101,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 3,
+          "targets": [
+            {
+              "expr": "rfs_read_executor_active_count{instance=~\"$fs_instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} read",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_write_executor_active_count{instance=~\"$fs_instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} write",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "File Server Executor Active Threads (read vs write)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "File-server readFileRange p99 latency during contention. Should stay low even while writes are in flight.",
+          "fill": 1,
+          "id": 102,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 3,
+          "targets": [
+            {
+              "expr": "rfs_readrange_latency{success=\"true\",quantile=\"0.99\",instance=~\"$fs_instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} p99",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_readrange_latency{success=\"true\",quantile=\"0.5\",instance=~\"$fs_instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} p50",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "File Server Read-Range Latency (p50 / p99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "µs",
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "File-server request rate split by operation type — confirms which lane is under pressure.",
+          "fill": 1,
+          "id": 103,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 3,
+          "targets": [
+            {
+              "expr": "rate(rfs_readrange_requests{instance=~\"$fs_instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} read-range",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(rfs_writeblock_requests{instance=~\"$fs_instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} write-block",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "File Server Request Rate (read-range vs write-block)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "File Server I/O Isolation (issue #100)",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
@@ -3290,6 +3547,23 @@
         "refresh": 1,
         "regex": "/vidx_(.+?)_node_count/",
         "sort": 1,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "File Server",
+        "multi": true,
+        "name": "fs_instance",
+        "options": [],
+        "query": "label_values(rfs_read_requests, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
         "type": "query",
         "useTags": false
       }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -41,7 +41,9 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -81,6 +83,10 @@ public class RemoteFileServer implements AutoCloseable {
     public static final String CONFIG_BLOCK_CACHE_MAX_BYTES = "block.cache.max.bytes";
     /** Config key: enable/disable the in-heap block cache. */
     public static final String CONFIG_BLOCK_CACHE_ENABLED = "block.cache.enabled";
+    /** Config key: thread count for the dedicated read-lane executor (issue #100). */
+    public static final String CONFIG_READ_EXECUTOR_THREADS = "fileserver.read.executor.threads";
+    /** Config key: thread count for the dedicated write-lane executor (issue #100). */
+    public static final String CONFIG_WRITE_EXECUTOR_THREADS = "fileserver.write.executor.threads";
 
     private final String host;
     private final int port;
@@ -91,6 +97,8 @@ public class RemoteFileServer implements AutoCloseable {
     private NioEventLoopGroup bossGroup;
     private NioEventLoopGroup workerGroup;
     private ExecutorService metadataExecutor;
+    private ThreadPoolExecutor readExecutor;
+    private ThreadPoolExecutor writeExecutor;
     private int blockSize;
     private ObjectStorage objectStorage;
     private PrometheusMetricsProvider statsProvider;
@@ -126,6 +134,13 @@ public class RemoteFileServer implements AutoCloseable {
             return t;
         };
         metadataExecutor = Executors.newFixedThreadPool(ioThreads, threadFactory);
+
+        int readExecutorThreads = Integer.parseInt(
+                config.getProperty(CONFIG_READ_EXECUTOR_THREADS, String.valueOf(ioThreads)));
+        int writeExecutorThreads = Integer.parseInt(
+                config.getProperty(CONFIG_WRITE_EXECUTOR_THREADS, String.valueOf(ioThreads)));
+        readExecutor = buildLaneExecutor("remote-file-read-exec-", readExecutorThreads);
+        writeExecutor = buildLaneExecutor("remote-file-write-exec-", writeExecutorThreads);
 
         String storageMode = config.getProperty("storage.mode", "local");
         if ("s3".equals(storageMode)) {
@@ -169,7 +184,9 @@ public class RemoteFileServer implements AutoCloseable {
         workerGroup = new NioEventLoopGroup(ioThreads);
         workerGroup.setIoRatio(ioRatio);
 
-        RemoteFileServiceImpl serviceImpl = new RemoteFileServiceImpl(objectStorage, statsLogger);
+        RemoteFileServiceImpl serviceImpl = new RemoteFileServiceImpl(
+                objectStorage, statsLogger, readExecutor, writeExecutor);
+        registerLaneExecutorGauges(statsLogger);
         NettyServerBuilder grpcBuilder = NettyServerBuilder.forPort(port)
                 .bossEventLoopGroup(bossGroup)
                 .workerEventLoopGroup(workerGroup)
@@ -222,8 +239,66 @@ public class RemoteFileServer implements AutoCloseable {
         }
 
         LOGGER.log(Level.INFO,
-                "RemoteFileServer started on port {0}, storage: {1}, io threads: {2}, ioRatio: {3}, blockSize: {4}",
-                new Object[]{port, storageMode, ioThreads, ioRatio, this.blockSize});
+                "RemoteFileServer started on port {0}, storage: {1}, io threads: {2}, ioRatio: {3}, "
+                        + "blockSize: {4}, readLane: {5}, writeLane: {6}",
+                new Object[]{port, storageMode, ioThreads, ioRatio, this.blockSize,
+                        readExecutorThreads, writeExecutorThreads});
+    }
+
+    private ThreadPoolExecutor buildLaneExecutor(String namePrefix, int threads) {
+        AtomicInteger counter = new AtomicInteger();
+        ThreadFactory factory = r -> {
+            Thread t = new Thread(r, namePrefix + counter.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        };
+        return new ThreadPoolExecutor(
+                threads, threads,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                factory);
+    }
+
+    private void registerLaneExecutorGauges(StatsLogger root) {
+        registerExecutorGauges(root, "read_executor", readExecutor);
+        registerExecutorGauges(root, "write_executor", writeExecutor);
+    }
+
+    private static void registerExecutorGauges(StatsLogger root, String name, ThreadPoolExecutor exec) {
+        StatsLogger scope = root.scope("rfs").scope(name);
+        scope.registerGauge("queue_size", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return (long) exec.getQueue().size();
+            }
+        });
+        scope.registerGauge("active_count", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return (long) exec.getActiveCount();
+            }
+        });
+        scope.registerGauge("pool_size", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return (long) exec.getPoolSize();
+            }
+        });
     }
 
     private ObjectStorage buildS3ObjectStorage() throws IOException {
@@ -425,6 +500,14 @@ public class RemoteFileServer implements AutoCloseable {
         if (metadataExecutor != null) {
             metadataExecutor.shutdown();
             metadataExecutor.awaitTermination(30, TimeUnit.SECONDS);
+        }
+        if (readExecutor != null) {
+            readExecutor.shutdown();
+            readExecutor.awaitTermination(30, TimeUnit.SECONDS);
+        }
+        if (writeExecutor != null) {
+            writeExecutor.shutdown();
+            writeExecutor.awaitTermination(30, TimeUnit.SECONDS);
         }
         if (objectStorage != null) {
             try {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -88,11 +88,21 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     private static class ServerSnapshot {
         final ConsistentHashRouter router;
-        final Map<String, ManagedChannel> channels;
+        /**
+         * Read-plane channels, one per server. Keyed by server id. Separate from
+         * {@link #writeChannels} so read and write RPCs sit on independent TCP
+         * connections and cannot share HTTP/2 stream budgets (issue #100).
+         */
+        final Map<String, ManagedChannel> readChannels;
+        /** Write-plane channels. Same keys as {@link #readChannels}. */
+        final Map<String, ManagedChannel> writeChannels;
 
-        ServerSnapshot(ConsistentHashRouter router, Map<String, ManagedChannel> channels) {
+        ServerSnapshot(ConsistentHashRouter router,
+                       Map<String, ManagedChannel> readChannels,
+                       Map<String, ManagedChannel> writeChannels) {
             this.router = router;
-            this.channels = Collections.unmodifiableMap(new HashMap<>(channels));
+            this.readChannels = Collections.unmodifiableMap(new HashMap<>(readChannels));
+            this.writeChannels = Collections.unmodifiableMap(new HashMap<>(writeChannels));
         }
     }
 
@@ -130,11 +140,13 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
             return t;
         });
 
-        Map<String, ManagedChannel> channels = new HashMap<>();
+        Map<String, ManagedChannel> readChannels = new HashMap<>();
+        Map<String, ManagedChannel> writeChannels = new HashMap<>();
         for (String server : servers) {
-            channels.put(server, buildChannel(server));
+            readChannels.put(server, buildChannel(server));
+            writeChannels.put(server, buildChannel(server));
         }
-        this.snapshot = new ServerSnapshot(new ConsistentHashRouter(servers), channels);
+        this.snapshot = new ServerSnapshot(new ConsistentHashRouter(servers), readChannels, writeChannels);
         if (!servers.isEmpty()) {
             this.serversReadyLatch.countDown();
         }
@@ -172,11 +184,21 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         return path + "#block" + blockIndex;
     }
 
-    private RemoteFileServiceGrpc.RemoteFileServiceStub asyncStubForBlock(String path, long blockIndex) {
+    /** Read-plane stub for a specific block (issue #100). */
+    private RemoteFileServiceGrpc.RemoteFileServiceStub readStubForBlock(String path, long blockIndex) {
         String key = blockRoutingKey(path, blockIndex);
         ServerSnapshot s = this.snapshot;
         String server = s.router.getServer(key);
-        return RemoteFileServiceGrpc.newStub(s.channels.get(server))
+        return RemoteFileServiceGrpc.newStub(s.readChannels.get(server))
+                .withDeadlineAfter(clientTimeoutSeconds, TimeUnit.SECONDS);
+    }
+
+    /** Write-plane stub for a specific block (issue #100). */
+    private RemoteFileServiceGrpc.RemoteFileServiceStub writeStubForBlock(String path, long blockIndex) {
+        String key = blockRoutingKey(path, blockIndex);
+        ServerSnapshot s = this.snapshot;
+        String server = s.router.getServer(key);
+        return RemoteFileServiceGrpc.newStub(s.writeChannels.get(server))
                 .withDeadlineAfter(clientTimeoutSeconds, TimeUnit.SECONDS);
     }
 
@@ -190,34 +212,38 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         ServerSnapshot current = this.snapshot;
 
         Set<String> added = new LinkedHashSet<>(newServers);
-        added.removeAll(current.channels.keySet());
+        added.removeAll(current.readChannels.keySet());
 
-        Set<String> removed = new LinkedHashSet<>(current.channels.keySet());
+        Set<String> removed = new LinkedHashSet<>(current.readChannels.keySet());
         removed.removeAll(new HashSet<>(newServers));
 
-        Map<String, ManagedChannel> newChannels = new HashMap<>();
+        Map<String, ManagedChannel> newReadChannels = new HashMap<>();
+        Map<String, ManagedChannel> newWriteChannels = new HashMap<>();
         for (String server : newServers) {
-            ManagedChannel existing = current.channels.get(server);
-            if (existing != null) {
-                newChannels.put(server, existing);
-            } else {
-                newChannels.put(server, buildChannel(server));
-            }
+            ManagedChannel existingRead = current.readChannels.get(server);
+            ManagedChannel existingWrite = current.writeChannels.get(server);
+            newReadChannels.put(server, existingRead != null ? existingRead : buildChannel(server));
+            newWriteChannels.put(server, existingWrite != null ? existingWrite : buildChannel(server));
         }
 
-        this.snapshot = new ServerSnapshot(new ConsistentHashRouter(newServers), newChannels);
+        this.snapshot = new ServerSnapshot(new ConsistentHashRouter(newServers),
+                newReadChannels, newWriteChannels);
         serversReadyLatch.countDown();
 
         LOGGER.log(Level.INFO, "Updated remote file servers: {0} (added: {1}, removed: {2})",
                 new Object[]{newServers, added, removed});
 
-        // Gracefully shutdown removed channels in background
+        // Gracefully shutdown removed channel pairs in background
         if (!removed.isEmpty()) {
             List<ManagedChannel> toShutdown = new ArrayList<>();
             for (String server : removed) {
-                ManagedChannel ch = current.channels.get(server);
-                if (ch != null) {
-                    toShutdown.add(ch);
+                ManagedChannel readCh = current.readChannels.get(server);
+                if (readCh != null) {
+                    toShutdown.add(readCh);
+                }
+                ManagedChannel writeCh = current.writeChannels.get(server);
+                if (writeCh != null) {
+                    toShutdown.add(writeCh);
                 }
             }
             Thread shutdownThread = new Thread(() -> {
@@ -242,7 +268,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
      */
     public boolean hasServers() {
         ServerSnapshot s = this.snapshot;
-        return !s.channels.isEmpty();
+        return !s.readChannels.isEmpty();
     }
 
     /**
@@ -256,23 +282,33 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         return serversReadyLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
     }
 
-    private RemoteFileServiceGrpc.RemoteFileServiceBlockingStub blockingStubForPath(String path) {
+    /** Read-plane async stub for a path. */
+    private RemoteFileServiceGrpc.RemoteFileServiceStub readStubForPath(String path) {
         ServerSnapshot s = this.snapshot;
         String server = s.router.getServer(path);
-        return RemoteFileServiceGrpc.newBlockingStub(s.channels.get(server))
+        return RemoteFileServiceGrpc.newStub(s.readChannels.get(server))
                 .withDeadlineAfter(clientTimeoutSeconds, TimeUnit.SECONDS);
     }
 
-    private RemoteFileServiceGrpc.RemoteFileServiceStub asyncStubForPath(String path) {
+    /** Write-plane async stub for a path. */
+    private RemoteFileServiceGrpc.RemoteFileServiceStub writeStubForPath(String path) {
         ServerSnapshot s = this.snapshot;
         String server = s.router.getServer(path);
-        return RemoteFileServiceGrpc.newStub(s.channels.get(server))
+        return RemoteFileServiceGrpc.newStub(s.writeChannels.get(server))
                 .withDeadlineAfter(clientTimeoutSeconds, TimeUnit.SECONDS);
     }
 
-    private RemoteFileServiceGrpc.RemoteFileServiceStub asyncStubForServer(String server) {
+    /** Read-plane async stub targeting a specific server (used by listFiles fan-out). */
+    private RemoteFileServiceGrpc.RemoteFileServiceStub readStubForServer(String server) {
         ServerSnapshot s = this.snapshot;
-        return RemoteFileServiceGrpc.newStub(s.channels.get(server))
+        return RemoteFileServiceGrpc.newStub(s.readChannels.get(server))
+                .withDeadlineAfter(clientTimeoutSeconds, TimeUnit.SECONDS);
+    }
+
+    /** Write-plane async stub targeting a specific server (used by deleteByPrefix fan-out). */
+    private RemoteFileServiceGrpc.RemoteFileServiceStub writeStubForServer(String server) {
+        ServerSnapshot s = this.snapshot;
+        return RemoteFileServiceGrpc.newStub(s.writeChannels.get(server))
                 .withDeadlineAfter(clientTimeoutSeconds, TimeUnit.SECONDS);
     }
 
@@ -291,7 +327,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         CompletableFuture<Long> future = new CompletableFuture<>();
         RemoteFileServiceGrpc.RemoteFileServiceStub stub;
         try {
-            stub = asyncStubForPath(path);
+            stub = writeStubForPath(path);
         } catch (Exception e) {
             future.completeExceptionally(e);
             return future;
@@ -328,7 +364,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     private CompletableFuture<byte[]> doReadFileAsync(String path) {
         CompletableFuture<byte[]> future = new CompletableFuture<>();
-        asyncStubForPath(path).readFile(
+        readStubForPath(path).readFile(
                 ReadFileRequest.newBuilder().setPath(path).build(),
                 new StreamObserver<ReadFileResponse>() {
                     private byte[] result;
@@ -359,7 +395,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     private CompletableFuture<Boolean> doDeleteFileAsync(String path) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        asyncStubForPath(path).deleteFile(
+        writeStubForPath(path).deleteFile(
                 DeleteFileRequest.newBuilder().setPath(path).build(),
                 new StreamObserver<DeleteFileResponse>() {
                     private boolean deleted;
@@ -389,8 +425,8 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     private CompletableFuture<List<String>> doListFilesAsync(String prefix) {
         ServerSnapshot s = this.snapshot;
         List<CompletableFuture<List<String>>> futures = new ArrayList<>();
-        for (String server : s.channels.keySet()) {
-            RemoteFileServiceGrpc.RemoteFileServiceStub stub = asyncStubForServer(server);
+        for (String server : s.readChannels.keySet()) {
+            RemoteFileServiceGrpc.RemoteFileServiceStub stub = readStubForServer(server);
             CompletableFuture<List<String>> serverFuture = new CompletableFuture<>();
             List<String> paths = Collections.synchronizedList(new ArrayList<>());
             stub.listFiles(
@@ -431,7 +467,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
      */
     public CompletableFuture<Void> writeFileBlockAsync(String path, long blockIndex, byte[] content) {
         CompletableFuture<Void> future = new CompletableFuture<>();
-        asyncStubForBlock(path, blockIndex).writeFileBlock(
+        writeStubForBlock(path, blockIndex).writeFileBlock(
                 WriteFileBlockRequest.newBuilder()
                         .setPath(path)
                         .setBlockIndex(blockIndex)
@@ -494,7 +530,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         return retryAsync(() -> {
             long blockIndex = offset / blockSize;
             CompletableFuture<byte[]> future = new CompletableFuture<>();
-            asyncStubForBlock(path, blockIndex).readFileRange(
+            readStubForBlock(path, blockIndex).readFileRange(
                     ReadFileRangeRequest.newBuilder()
                             .setPath(path)
                             .setOffset(offset)
@@ -562,8 +598,8 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     private CompletableFuture<Integer> doDeleteByPrefixAsync(String prefix) {
         ServerSnapshot s = this.snapshot;
         List<CompletableFuture<Integer>> futures = new ArrayList<>();
-        for (String server : s.channels.keySet()) {
-            RemoteFileServiceGrpc.RemoteFileServiceStub stub = asyncStubForServer(server);
+        for (String server : s.writeChannels.keySet()) {
+            RemoteFileServiceGrpc.RemoteFileServiceStub stub = writeStubForServer(server);
             CompletableFuture<Integer> serverFuture = new CompletableFuture<>();
             stub.deleteByPrefix(
                     DeleteByPrefixRequest.newBuilder().setPrefix(prefix).build(),
@@ -652,12 +688,18 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     public void close() {
         retryScheduler.shutdownNow();
         ServerSnapshot s = this.snapshot;
-        for (Map.Entry<String, ManagedChannel> entry : s.channels.entrySet()) {
+        shutdownChannels(s.readChannels, "read");
+        shutdownChannels(s.writeChannels, "write");
+    }
+
+    private static void shutdownChannels(Map<String, ManagedChannel> channels, String planeName) {
+        for (Map.Entry<String, ManagedChannel> entry : channels.entrySet()) {
             try {
                 entry.getValue().shutdown().awaitTermination(5, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                LOGGER.log(Level.WARNING, "Interrupted while shutting down channel to " + entry.getKey(), e);
+                LOGGER.log(Level.WARNING,
+                        "Interrupted while shutting down " + planeName + " channel to " + entry.getKey(), e);
             }
         }
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceImpl.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceImpl.java
@@ -40,7 +40,10 @@ import herddb.remote.storage.ObjectStorage;
 import herddb.remote.storage.ReadResult;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.Counter;
@@ -58,6 +61,8 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
     private static final Logger LOGGER = Logger.getLogger(RemoteFileServiceImpl.class.getName());
 
     private final ObjectStorage storage;
+    private final Executor readExecutor;
+    private final Executor writeExecutor;
 
     private final Counter writeRequests;
     private final Counter writeErrors;
@@ -94,11 +99,28 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
     private final OpStatsLogger readRangeLatency;
 
     public RemoteFileServiceImpl(ObjectStorage storage) {
-        this(storage, NullStatsLogger.INSTANCE);
+        this(storage, NullStatsLogger.INSTANCE, null, null);
     }
 
     public RemoteFileServiceImpl(ObjectStorage storage, StatsLogger statsLogger) {
+        this(storage, statsLogger, null, null);
+    }
+
+    /**
+     * Creates the service with dedicated read/write execution lanes (issue #100).
+     * Each RPC handler dispatches its storage call and its completion callback onto
+     * {@code readExecutor} or {@code writeExecutor} according to operation type, so
+     * slow write-path callbacks cannot starve read-path responses.
+     *
+     * <p>If either executor is {@code null}, handlers fall back to
+     * {@code whenComplete} on the storage future's default thread, preserving the
+     * legacy behavior.
+     */
+    public RemoteFileServiceImpl(ObjectStorage storage, StatsLogger statsLogger,
+                                 Executor readExecutor, Executor writeExecutor) {
         this.storage = storage;
+        this.readExecutor = readExecutor;
+        this.writeExecutor = writeExecutor;
 
         StatsLogger scope = statsLogger.scope("rfs");
 
@@ -139,11 +161,15 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
 
     @Override
     public void writeFile(WriteFileRequest request, StreamObserver<WriteFileResponse> responseObserver) {
+        runOnLane(writeExecutor, () -> writeFileImpl(request, responseObserver));
+    }
+
+    private void writeFileImpl(WriteFileRequest request, StreamObserver<WriteFileResponse> responseObserver) {
         long start = System.nanoTime();
         writeRequests.inc();
         byte[] content = request.getContent().toByteArray();
-        storage.write(request.getPath(), content)
-                .whenComplete((v, t) -> {
+        attachCallback(storage.write(request.getPath(), content), writeExecutor,
+                (v, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         writeErrors.inc();
@@ -166,10 +192,14 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
 
     @Override
     public void readFile(ReadFileRequest request, StreamObserver<ReadFileResponse> responseObserver) {
+        runOnLane(readExecutor, () -> readFileImpl(request, responseObserver));
+    }
+
+    private void readFileImpl(ReadFileRequest request, StreamObserver<ReadFileResponse> responseObserver) {
         long start = System.nanoTime();
         readRequests.inc();
-        storage.read(request.getPath())
-                .whenComplete((result, t) -> {
+        attachCallback(storage.read(request.getPath()), readExecutor,
+                (result, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         readErrors.inc();
@@ -202,11 +232,16 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
     @Override
     public void writeFileBlock(WriteFileBlockRequest request,
                                StreamObserver<WriteFileBlockResponse> responseObserver) {
+        runOnLane(writeExecutor, () -> writeFileBlockImpl(request, responseObserver));
+    }
+
+    private void writeFileBlockImpl(WriteFileBlockRequest request,
+                                    StreamObserver<WriteFileBlockResponse> responseObserver) {
         long start = System.nanoTime();
         writeBlockRequests.inc();
         byte[] content = request.getContent().toByteArray();
-        storage.writeBlock(request.getPath(), request.getBlockIndex(), content)
-                .whenComplete((v, t) -> {
+        attachCallback(storage.writeBlock(request.getPath(), request.getBlockIndex(), content), writeExecutor,
+                (v, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         writeBlockErrors.inc();
@@ -232,10 +267,17 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
     @Override
     public void readFileRange(ReadFileRangeRequest request,
                               StreamObserver<ReadFileRangeResponse> responseObserver) {
+        runOnLane(readExecutor, () -> readFileRangeImpl(request, responseObserver));
+    }
+
+    private void readFileRangeImpl(ReadFileRangeRequest request,
+                                   StreamObserver<ReadFileRangeResponse> responseObserver) {
         long start = System.nanoTime();
         readRangeRequests.inc();
-        storage.readRange(request.getPath(), request.getOffset(), request.getLength(), request.getBlockSize())
-                .whenComplete((result, t) -> {
+        attachCallback(
+                storage.readRange(request.getPath(), request.getOffset(), request.getLength(), request.getBlockSize()),
+                readExecutor,
+                (result, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         readRangeErrors.inc();
@@ -266,10 +308,14 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
 
     @Override
     public void deleteFile(DeleteFileRequest request, StreamObserver<DeleteFileResponse> responseObserver) {
+        runOnLane(writeExecutor, () -> deleteFileImpl(request, responseObserver));
+    }
+
+    private void deleteFileImpl(DeleteFileRequest request, StreamObserver<DeleteFileResponse> responseObserver) {
         long start = System.nanoTime();
         deleteRequests.inc();
-        storage.deleteLogical(request.getPath())
-                .whenComplete((deleted, t) -> {
+        attachCallback(storage.deleteLogical(request.getPath()), writeExecutor,
+                (deleted, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         deleteErrors.inc();
@@ -289,10 +335,14 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
 
     @Override
     public void listFiles(ListFilesRequest request, StreamObserver<ListFilesEntry> responseObserver) {
+        runOnLane(readExecutor, () -> listFilesImpl(request, responseObserver));
+    }
+
+    private void listFilesImpl(ListFilesRequest request, StreamObserver<ListFilesEntry> responseObserver) {
         long start = System.nanoTime();
         listRequests.inc();
-        storage.listLogical(request.getPrefix())
-                .whenComplete((paths, t) -> {
+        attachCallback(storage.listLogical(request.getPrefix()), readExecutor,
+                (paths, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         listErrors.inc();
@@ -329,10 +379,15 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
     @Override
     public void deleteByPrefix(DeleteByPrefixRequest request,
                                StreamObserver<DeleteByPrefixResponse> responseObserver) {
+        runOnLane(writeExecutor, () -> deleteByPrefixImpl(request, responseObserver));
+    }
+
+    private void deleteByPrefixImpl(DeleteByPrefixRequest request,
+                                    StreamObserver<DeleteByPrefixResponse> responseObserver) {
         long start = System.nanoTime();
         deleteByPrefixRequests.inc();
-        storage.deleteByPrefix(request.getPrefix())
-                .whenComplete((count, t) -> {
+        attachCallback(storage.deleteByPrefix(request.getPrefix()), writeExecutor,
+                (count, t) -> {
                     long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
                     if (t != null) {
                         deleteByPrefixErrors.inc();
@@ -354,5 +409,33 @@ public class RemoteFileServiceImpl extends RemoteFileServiceGrpc.RemoteFileServi
 
     private static long elapsedMs(long startNanos) {
         return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    /**
+     * Executes {@code task} on the given lane executor, or inline if the executor is
+     * {@code null} (legacy single-lane mode). Lane executors hop handler work off the
+     * Netty worker thread so checkpoint and search paths cannot block each other.
+     */
+    private static void runOnLane(Executor lane, Runnable task) {
+        if (lane != null) {
+            lane.execute(task);
+        } else {
+            task.run();
+        }
+    }
+
+    /**
+     * Attaches {@code callback} to {@code future} using {@code executor} when non-null
+     * ({@code whenCompleteAsync}), otherwise falls back to {@code whenComplete}. Keeps
+     * the existing legacy path byte-for-byte when lanes are disabled.
+     */
+    private static <T> void attachCallback(CompletableFuture<T> future,
+                                           Executor executor,
+                                           BiConsumer<? super T, ? super Throwable> callback) {
+        if (executor != null) {
+            future.whenCompleteAsync(callback, executor);
+        } else {
+            future.whenComplete(callback);
+        }
     }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/ReadWriteIsolationTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/ReadWriteIsolationTest.java
@@ -1,0 +1,207 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Integration test for issue #100: separate read/write execution lanes.
+ *
+ * <p>The test starts a {@link RemoteFileServer} with small, dedicated
+ * read/write executor pools, pre-writes a multipart file, then measures
+ * read-path latency in two phases:
+ * <ol>
+ *   <li>baseline reads, no writes in flight</li>
+ *   <li>contention reads concurrent with a sustained stream of
+ *       {@code writeFileBlockAsync} uploads</li>
+ * </ol>
+ *
+ * <p>Under the lane split the read path must survive the contention phase
+ * without timing out. We assert:
+ * <ul>
+ *   <li>zero read-path failures during contention,</li>
+ *   <li>contention-phase p99 read latency stays within a reasonable
+ *       multiple of the baseline (protects against regressions that
+ *       re-couple the two lanes).</li>
+ * </ul>
+ */
+public class ReadWriteIsolationTest {
+
+    private static final int BLOCK_SIZE = 64 * 1024;         // 64 KB
+    private static final int FILE_BLOCKS = 128;              // 8 MB target file
+    private static final int READ_LENGTH = 4096;             // 4 KB per read
+    private static final int BASELINE_READ_COUNT = 200;
+    private static final int CONTENTION_READ_COUNT = 200;
+    private static final long CONTENTION_WINDOW_MS = 10_000;
+    private static final long READ_P99_CEILING_MS = 2_000;
+
+    private static final String TARGET_PATH = "ts1/isolation/graph.bin";
+    private static final String WRITE_NOISE_PATH = "ts1/isolation/noise.bin";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(RemoteFileServer.CONFIG_READ_EXECUTOR_THREADS, "4");
+        props.setProperty(RemoteFileServer.CONFIG_WRITE_EXECUTOR_THREADS, "4");
+        props.setProperty("block.size", String.valueOf(BLOCK_SIZE));
+        server = new RemoteFileServer("localhost", 0, folder.newFolder("data").toPath(), 2, props);
+        server.start();
+        client = new RemoteFileServiceClient(Arrays.asList("localhost:" + server.getPort()));
+
+        // Pre-write a multipart target file so the read phase has something
+        // to fetch. Written block-by-block via writeFileBlockAsync so it
+        // lands on the server in the same layout we'll read from.
+        byte[] block = new byte[BLOCK_SIZE];
+        for (int i = 0; i < FILE_BLOCKS; i++) {
+            for (int j = 0; j < block.length; j++) {
+                block[j] = (byte) ((i + j) & 0xff);
+            }
+            client.writeFileBlockAsync(TARGET_PATH, i, block).get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void readsNotStarvedByConcurrentWrites() throws Exception {
+        long[] baseline = runReadWorkload(BASELINE_READ_COUNT);
+        long baselineP99 = percentile(baseline, 0.99);
+
+        AtomicBoolean stopWrites = new AtomicBoolean(false);
+        AtomicInteger writeCount = new AtomicInteger();
+        AtomicInteger writeErrors = new AtomicInteger();
+        byte[] writeBlock = new byte[BLOCK_SIZE];
+        new Random(42).nextBytes(writeBlock);
+
+        Thread writer = new Thread(() -> {
+            long nextBlock = 0;
+            while (!stopWrites.get()) {
+                try {
+                    CompletableFuture<Void> f =
+                            client.writeFileBlockAsync(WRITE_NOISE_PATH, nextBlock, writeBlock);
+                    f.get(30, TimeUnit.SECONDS);
+                    writeCount.incrementAndGet();
+                    nextBlock++;
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                } catch (java.util.concurrent.ExecutionException
+                        | java.util.concurrent.TimeoutException ex) {
+                    writeErrors.incrementAndGet();
+                }
+            }
+        }, "write-noise");
+        writer.setDaemon(true);
+        writer.start();
+
+        // Give the writer a head start so its I/O is actually in flight when
+        // the read workload begins — otherwise the baseline and contention
+        // phases are indistinguishable.
+        Thread.sleep(500);
+
+        long contentionStart = System.currentTimeMillis();
+        long[] contention = runReadWorkload(CONTENTION_READ_COUNT);
+        long contentionElapsed = System.currentTimeMillis() - contentionStart;
+
+        // Keep the writer going for the full window so every read overlaps.
+        long remaining = CONTENTION_WINDOW_MS - contentionElapsed;
+        if (remaining > 0) {
+            Thread.sleep(remaining);
+        }
+        stopWrites.set(true);
+        writer.join(TimeUnit.SECONDS.toMillis(60));
+
+        long contentionP99 = percentile(contention, 0.99);
+
+        assertTrue("writer must have driven some writes to exercise the write lane, got "
+                + writeCount.get(), writeCount.get() > 0);
+        assertEquals("writer saw errors: " + writeErrors.get(), 0, writeErrors.get());
+        // Every read must complete successfully — no timeouts, no exceptions.
+        // (runReadWorkload throws on any failure, so reaching this point already
+        // proves it; the assertion below guards against future silent-failure refactors.)
+        assertEquals(CONTENTION_READ_COUNT, contention.length);
+
+        long ceiling = Math.max(4 * baselineP99, TimeUnit.MILLISECONDS.toNanos(READ_P99_CEILING_MS));
+        assertTrue(
+                "read p99 under contention regressed: baseline_p99=" + (baselineP99 / 1_000_000) + "ms"
+                        + ", contention_p99=" + (contentionP99 / 1_000_000) + "ms"
+                        + ", ceiling=" + (ceiling / 1_000_000) + "ms"
+                        + ", writes_completed=" + writeCount.get(),
+                contentionP99 <= ceiling);
+    }
+
+    private long[] runReadWorkload(int n) throws Exception {
+        long[] latencies = new long[n];
+        Random rng = new Random(12345);
+        for (int i = 0; i < n; i++) {
+            long offset = (long) rng.nextInt(FILE_BLOCKS * BLOCK_SIZE - READ_LENGTH);
+            long t0 = System.nanoTime();
+            byte[] data = client.readFileRange(TARGET_PATH, offset, READ_LENGTH, BLOCK_SIZE);
+            long t1 = System.nanoTime();
+            assertNotNull("read returned null at offset " + offset, data);
+            assertEquals("read returned short data at offset " + offset, READ_LENGTH, data.length);
+            latencies[i] = t1 - t0;
+        }
+        return latencies;
+    }
+
+    private static long percentile(long[] samples, double p) {
+        long[] sorted = samples.clone();
+        java.util.Arrays.sort(sorted);
+        int idx = (int) Math.ceil(p * sorted.length) - 1;
+        if (idx < 0) {
+            idx = 0;
+        }
+        if (idx >= sorted.length) {
+            idx = sorted.length - 1;
+        }
+        return sorted[idx];
+    }
+
+}


### PR DESCRIPTION
## Summary

- Split file-server gRPC execution into two dedicated lanes: `readExecutor` handles `readFile` / `readFileRange` / `listFiles`; `writeExecutor` handles `writeFile` / `writeFileBlock` / `deleteFile` / `deleteByPrefix`. Each RPC handler dispatches both the storage call and its completion callback onto its lane via `whenCompleteAsync`, so a slow S3 upload blocking the AWS SDK pool can no longer delay a read-path `onNext`.
- `RemoteFileServiceClient` now opens **two `ManagedChannel`s per server** (one for reads, one for writes) so the two planes sit on independent TCP connections and cannot share HTTP/2 stream budgets. No wire-format or service-discovery change; both channels point at the same `host:port`.
- Added `fileserver.read.executor.threads` and `fileserver.write.executor.threads` config keys (default `ioThreads` each) plus `rfs_{read,write}_executor_{queue_size,active_count,pool_size}` gauges via the existing `registerBlockCacheGauges` pattern.
- New integration test `ReadWriteIsolationTest` pre-writes a multipart file, measures baseline read latency, then re-runs the read workload concurrent with a sustained stream of `writeFileBlockAsync` uploads, and asserts the contention-phase p99 stays within a reasonable multiple of the baseline with zero read failures.
- Added a new **File Server I/O Isolation (issue #100)** row to the Indexing Service Grafana dashboard with four panels (executor queue size, active threads, read-range latency p50/p99, request rate split) plus a new `$fs_instance` template variable.

Fixes #100.

## Context

On GKE with GIST1M (1M vectors, dim=960, FusedPQ) two consecutive vector-bench runs saw **all 1,000 queries fail** with `IndexingServiceClient.search` hitting its hardcoded 30 s deadline. Root cause: during Phase B checkpoints the IS streams ~2.1 GB of segment files to GCS via `writeFileBlockAsync`. Concurrent search requests needed to stream graph pages back via `readFileRange`, but both flows shared the same storage-backend completion pool — so read callbacks queued behind write callbacks and the 30 s client deadline fired before any response arrived.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins` (all 22 modules green)
- [x] `mvn -pl herddb-remote-file-service test` — 121 tests pass (includes S3 testcontainers coverage)
- [x] `mvn -pl herddb-remote-file-service -Dtest=ReadWriteIsolationTest test` — new isolation test passes
- [x] `mvn -pl herddb-indexing-service -Dtest='RemoteFile*Test,*IndexingServer*Test' test` — 15 smoke tests pass
- [ ] GKE re-run of the GIST1M vector-bench scenario from the issue, with `fileserver.{read,write}.executor.threads` sized appropriately, to confirm zero `IndexingService/Search` deadline errors during the query phase (end-to-end validation)

## Risks / follow-ups

- **S3AsyncClient pool is still shared.** The server-side `whenCompleteAsync` hop gets gRPC callbacks off the AWS SDK pool as soon as a future completes, but the initial submission of a read into the SDK still queues against writes inside the SDK's HTTP client. If a GKE re-run shows residual starvation, a follow-up should build two `S3AsyncClient` instances with independent `NettyNioAsyncHttpClient` connection pools.
- **Hardcoded 30 s search deadline** at `IndexingServiceClient.java:71` is orthogonal to this fix (tracked in #99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)