### PR TITLE
Decouple RemoteRandomAccessReader buffer size from write block size (#104)

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
@@ -106,11 +106,13 @@ public class ReadReplicaDataStorageManager extends DataStorageManager {
             String tableSpace, String uuid, String fileType, long fileSize)
             throws DataStorageManagerException {
         String logicalPath = remoteMultipartPath(tableSpace, uuid, fileType);
-        int blockSize = client.getBlockSize();
+        int writeBlockSize = client.getBlockSize();
+        int bufferSize = RemoteFileDataStorageManager.READ_BUFFER_SIZE;
         LOGGER.log(Level.FINE,
-                "multipartIndexReaderSupplier: {0} fileSize={1} blockSize={2}",
-                new Object[]{logicalPath, fileSize, blockSize});
-        return new RemoteRandomAccessReader.Supplier(client, logicalPath, fileSize, blockSize);
+                "multipartIndexReaderSupplier: {0} fileSize={1} writeBlockSize={2} bufferSize={3}",
+                new Object[]{logicalPath, fileSize, writeBlockSize, bufferSize});
+        return new RemoteRandomAccessReader.Supplier(
+                client, logicalPath, fileSize, writeBlockSize, bufferSize);
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -278,6 +278,17 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     private static final int MULTIPART_BLOCK_SIZE =
             Integer.getInteger(MULTIPART_BLOCK_SIZE_PROPERTY, 4 * 1024 * 1024);
 
+    /**
+     * System property to override the read-buffer size used by
+     * {@link RemoteRandomAccessReader} when serving vector-index searches over
+     * remote multipart graph files. Default: 4096 bytes. See issue #104 —
+     * this buffer is intentionally decoupled from {@link #MULTIPART_BLOCK_SIZE}
+     * so that HNSW graph traversals do not fetch multi-MiB windows per miss.
+     */
+    public static final String READ_BUFFER_SIZE_PROPERTY = "herddb.vector.remote.read.bufferSize";
+    static final int READ_BUFFER_SIZE =
+            Integer.getInteger(READ_BUFFER_SIZE_PROPERTY, 4096);
+
     private static String remoteMultipartPath(String tableSpace, String uuid, String fileType) {
         return tableSpace + "/" + uuid + "/multipart/" + fileType;
     }
@@ -521,8 +532,9 @@ public class RemoteFileDataStorageManager extends DataStorageManager
             String tableSpace, String uuid, String fileType, long fileSize)
             throws DataStorageManagerException {
         String logicalPath = remoteMultipartPath(tableSpace, uuid, fileType);
-        int blockSize = Math.max(client.getBlockSize(), MULTIPART_BLOCK_SIZE);
-        return new RemoteRandomAccessReader.Supplier(client, logicalPath, fileSize, blockSize);
+        int writeBlockSize = Math.max(client.getBlockSize(), MULTIPART_BLOCK_SIZE);
+        return new RemoteRandomAccessReader.Supplier(
+                client, logicalPath, fileSize, writeBlockSize, READ_BUFFER_SIZE);
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -281,13 +281,24 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     /**
      * System property to override the read-buffer size used by
      * {@link RemoteRandomAccessReader} when serving vector-index searches over
-     * remote multipart graph files. Default: 4096 bytes. See issue #104 —
-     * this buffer is intentionally decoupled from {@link #MULTIPART_BLOCK_SIZE}
-     * so that HNSW graph traversals do not fetch multi-MiB windows per miss.
+     * remote multipart graph files. Default: 16384 bytes (16 KiB). See
+     * issue #104 — this buffer is intentionally decoupled from
+     * {@link #MULTIPART_BLOCK_SIZE} so that HNSW graph traversals do not fetch
+     * multi-MiB windows per miss.
+     *
+     * <p>The 16 KiB default is sized to absorb a single jvector logical read in
+     * one gRPC call. The dominant per-node read during search is the full-
+     * resolution vector fetched by {@code OnDiskGraphIndex.getVectorInto}
+     * for re-ranking, which reads {@code dimension * 4} bytes in a single
+     * {@code readFloatVector} call — 3840 bytes for GIST1M (dim=960), 6144 bytes
+     * for 1536-dim embeddings. A 4 KiB buffer would split those reads across
+     * two gRPC round-trips whenever the position is unaligned; 16 KiB keeps a
+     * raw vector up to ~4096 dimensions in a single fetch while still being
+     * 256× smaller than the 4 MiB write block and an exact divisor of it.
      */
     public static final String READ_BUFFER_SIZE_PROPERTY = "herddb.vector.remote.read.bufferSize";
     static final int READ_BUFFER_SIZE =
-            Integer.getInteger(READ_BUFFER_SIZE_PROPERTY, 4096);
+            Integer.getInteger(READ_BUFFER_SIZE_PROPERTY, 16 * 1024);
 
     private static String remoteMultipartPath(String tableSpace, String uuid, String fileType) {
         return tableSpace + "/" + uuid + "/multipart/" + fileType;

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -34,12 +34,14 @@ import java.nio.ByteOrder;
  *
  * <p>The buffer size is intentionally decoupled from the multipart write block
  * size (which is a GCS multipart-upload requirement and is typically 4 MiB).
- * For vector-index searches the buffer should be small (e.g. 4 KiB) so that
- * each cache miss only transfers a few KiB instead of several MiB — see
- * issue #104. {@code writeBlockSize} is still passed to the server because it
- * is what {@code LocalObjectStorage.readRange} uses to locate the on-disk
- * chunk file ({@code blockIndex = offset / writeBlockSize}); changing it would
- * break chunk lookup.
+ * For vector-index searches the buffer should be small — see issue #104 —
+ * but still large enough to absorb a single jvector logical read (notably
+ * {@code OnDiskGraphIndex.getVectorInto}, which reads {@code dimension * 4}
+ * bytes for the re-rank raw vector) in one gRPC call. The default is 16 KiB.
+ * {@code writeBlockSize} is still passed to the server because it is what
+ * {@code LocalObjectStorage.readRange} uses to locate the on-disk chunk file
+ * ({@code blockIndex = offset / writeBlockSize}); changing it would break
+ * chunk lookup.
  *
  * <p>Instances are NOT thread-safe (one per reader thread as expected by jvector).
  *

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -28,8 +28,18 @@ import java.nio.ByteOrder;
 
 /**
  * A {@link RandomAccessReader} that reads from a remote multipart file via
- * {@link RemoteFileServiceClient}. Buffers one block at a time to avoid
- * redundant network round-trips when jvector reads sequentially within a block.
+ * {@link RemoteFileServiceClient}. Buffers one {@code bufferSize}-sized window
+ * at a time to avoid redundant network round-trips when jvector reads
+ * sequentially within that window.
+ *
+ * <p>The buffer size is intentionally decoupled from the multipart write block
+ * size (which is a GCS multipart-upload requirement and is typically 4 MiB).
+ * For vector-index searches the buffer should be small (e.g. 4 KiB) so that
+ * each cache miss only transfers a few KiB instead of several MiB — see
+ * issue #104. {@code writeBlockSize} is still passed to the server because it
+ * is what {@code LocalObjectStorage.readRange} uses to locate the on-disk
+ * chunk file ({@code blockIndex = offset / writeBlockSize}); changing it would
+ * break chunk lookup.
  *
  * <p>Instances are NOT thread-safe (one per reader thread as expected by jvector).
  *
@@ -40,18 +50,52 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     private final RemoteFileServiceClient client;
     private final String path;
     private final long totalSize;
-    private final int blockSize;
+    private final int writeBlockSize;
+    private final int bufferSize;
 
     private long position;
     private byte[] blockBuffer;
     private long bufferedBlockIndex = -1;
 
+    /**
+     * Full constructor with separate write block size (routing / chunk lookup)
+     * and read buffer size (internal window for sequential reads).
+     *
+     * @param writeBlockSize the multipart chunk size used by the writer; must
+     *                       be a multiple of the effective buffer size so that
+     *                       a buffer window never crosses a chunk boundary
+     * @param bufferSize     the read-side buffer window; capped to
+     *                       {@code writeBlockSize} if larger
+     */
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
-                                    long totalSize, int blockSize) {
+                                    long totalSize, int writeBlockSize, int bufferSize) {
+        if (writeBlockSize <= 0) {
+            throw new IllegalArgumentException("writeBlockSize must be > 0, got " + writeBlockSize);
+        }
+        if (bufferSize <= 0) {
+            throw new IllegalArgumentException("bufferSize must be > 0, got " + bufferSize);
+        }
+        int effective = Math.min(bufferSize, writeBlockSize);
+        if (writeBlockSize % effective != 0) {
+            throw new IllegalArgumentException(
+                    "bufferSize (" + bufferSize + ") must divide writeBlockSize ("
+                            + writeBlockSize + ")");
+        }
         this.client = client;
         this.path = path;
         this.totalSize = totalSize;
-        this.blockSize = blockSize;
+        this.writeBlockSize = writeBlockSize;
+        this.bufferSize = effective;
+    }
+
+    /**
+     * Convenience constructor for the case where the caller has no distinct
+     * read-buffer size. Equivalent to
+     * {@code RemoteRandomAccessReader(client, path, totalSize, blockSize, blockSize)}.
+     */
+    public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
+                                    long totalSize, int blockSize) {
+        this(client, path, totalSize, blockSize, blockSize);
     }
 
     @Override
@@ -101,7 +145,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         int destOffset = 0;
         while (remaining > 0) {
             ensureBlockLoaded();
-            int offsetInBlock = (int) (position % blockSize);
+            int offsetInBlock = (int) (position % bufferSize);
             int available = blockBuffer.length - offsetInBlock;
             int toCopy = Math.min(available, remaining);
             System.arraycopy(blockBuffer, offsetInBlock, dest, destOffset, toCopy);
@@ -148,22 +192,22 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     }
 
     private void ensureBlockLoaded() throws IOException {
-        long blockIndex = position / blockSize;
-        if (blockIndex == bufferedBlockIndex && blockBuffer != null) {
+        long bufferIndex = position / bufferSize;
+        if (bufferIndex == bufferedBlockIndex && blockBuffer != null) {
             return;
         }
-        long blockOffset = blockIndex * (long) blockSize;
-        int requestLength = (int) Math.min(blockSize, totalSize - blockOffset);
+        long bufferOffset = bufferIndex * (long) bufferSize;
+        int requestLength = (int) Math.min(bufferSize, totalSize - bufferOffset);
         if (requestLength <= 0) {
             throw new IOException("Read past end of file: position=" + position
                     + " totalSize=" + totalSize);
         }
-        byte[] data = client.readFileRange(path, blockOffset, requestLength, blockSize);
+        byte[] data = client.readFileRange(path, bufferOffset, requestLength, writeBlockSize);
         if (data == null) {
-            throw new IOException("Block not found: path=" + path + " blockIndex=" + blockIndex);
+            throw new IOException("Block not found: path=" + path + " bufferIndex=" + bufferIndex);
         }
         blockBuffer = data;
-        bufferedBlockIndex = blockIndex;
+        bufferedBlockIndex = bufferIndex;
     }
 
     /**
@@ -175,19 +219,30 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         private final RemoteFileServiceClient client;
         private final String path;
         private final long totalSize;
-        private final int blockSize;
+        private final int writeBlockSize;
+        private final int bufferSize;
 
         public Supplier(RemoteFileServiceClient client, String path,
-                        long totalSize, int blockSize) {
+                        long totalSize, int writeBlockSize, int bufferSize) {
             this.client = client;
             this.path = path;
             this.totalSize = totalSize;
-            this.blockSize = blockSize;
+            this.writeBlockSize = writeBlockSize;
+            this.bufferSize = bufferSize;
+        }
+
+        /**
+         * Convenience constructor that uses the same value for the write block
+         * size and the read-buffer size.
+         */
+        public Supplier(RemoteFileServiceClient client, String path,
+                        long totalSize, int blockSize) {
+            this(client, path, totalSize, blockSize, blockSize);
         }
 
         @Override
         public RandomAccessReader get() throws IOException {
-            return new RemoteRandomAccessReader(client, path, totalSize, blockSize);
+            return new RemoteRandomAccessReader(client, path, totalSize, writeBlockSize, bufferSize);
         }
 
         @Override

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
@@ -175,13 +175,14 @@ public class RemoteRandomAccessReaderTest {
     /**
      * Issue #104 — the vector-search read-buffer size is configurable via the
      * {@code herddb.vector.remote.read.bufferSize} system property and defaults
-     * to 4096 bytes.
+     * to 16 KiB (sized to absorb a single jvector raw-vector re-rank read for
+     * up to ~4096 dimensions in one gRPC call).
      */
     @Test
     public void testReadBufferSizeDefault() {
         assertEquals("herddb.vector.remote.read.bufferSize",
                 RemoteFileDataStorageManager.READ_BUFFER_SIZE_PROPERTY);
-        assertEquals(4096, RemoteFileDataStorageManager.READ_BUFFER_SIZE);
+        assertEquals(16 * 1024, RemoteFileDataStorageManager.READ_BUFFER_SIZE);
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import java.io.ByteArrayInputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
@@ -169,6 +170,127 @@ public class RemoteRandomAccessReaderTest {
 
         RemoteRandomAccessReader reader = new RemoteRandomAccessReader(client, "ts/idx/len", data.length, BLOCK_SIZE);
         assertEquals(150, reader.length());
+    }
+
+    /**
+     * Issue #104 — the vector-search read-buffer size is configurable via the
+     * {@code herddb.vector.remote.read.bufferSize} system property and defaults
+     * to 4096 bytes.
+     */
+    @Test
+    public void testReadBufferSizeDefault() {
+        assertEquals("herddb.vector.remote.read.bufferSize",
+                RemoteFileDataStorageManager.READ_BUFFER_SIZE_PROPERTY);
+        assertEquals(4096, RemoteFileDataStorageManager.READ_BUFFER_SIZE);
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #104 — readFully across buffer boundaries
+    //
+    // These tests pin the reader behaviour when the internal buffer window is
+    // smaller than the write block, which is the configuration the vector-search
+    // path will use in production (writeBlockSize=4MiB, bufferSize=4KiB).
+    // They use writeBlockSize=64 and bufferSize=16 so that 4 buffer windows fit
+    // in one write block. Every test reads the same underlying sequence and
+    // asserts that the bytes returned exactly match the expected slice.
+    // -------------------------------------------------------------------------
+
+    private static final int READFULLY_WRITE_BLOCK = 64;
+    private static final int READFULLY_BUFFER = 16;
+
+    /** Write a single file used by the {@code testReadFully_*} group. */
+    private byte[] writeReadFullyFile(String path) throws Exception {
+        // 3 write blocks + partial tail ⇒ 200 bytes, spans >>= 2 buffer windows.
+        byte[] data = seqBytes(READFULLY_WRITE_BLOCK * 3 + 8);
+        client.writeMultipartFile(path, new ByteArrayInputStream(data), READFULLY_WRITE_BLOCK);
+        return data;
+    }
+
+    private RemoteRandomAccessReader openReadFullyReader(String path, long totalSize) {
+        return new RemoteRandomAccessReader(
+                client, path, totalSize, READFULLY_WRITE_BLOCK, READFULLY_BUFFER);
+    }
+
+    /** Read fewer bytes than one buffer window. */
+    @Test
+    public void testReadFully_lessThanOneBuffer() throws Exception {
+        byte[] data = writeReadFullyFile("ts/idx/rf-less");
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/rf-less", data.length)) {
+            reader.seek(0);
+            byte[] buf = new byte[READFULLY_BUFFER - 5]; // 11 bytes
+            reader.readFully(buf);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, buf.length), buf);
+            assertEquals(buf.length, reader.getPosition());
+        }
+    }
+
+    /** Read exactly one full buffer window. */
+    @Test
+    public void testReadFully_exactlyOneBuffer() throws Exception {
+        byte[] data = writeReadFullyFile("ts/idx/rf-exact1");
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/rf-exact1", data.length)) {
+            reader.seek(0);
+            byte[] buf = new byte[READFULLY_BUFFER]; // 16 bytes
+            reader.readFully(buf);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, READFULLY_BUFFER), buf);
+            assertEquals(READFULLY_BUFFER, reader.getPosition());
+        }
+    }
+
+    /** Read more than one but less than two buffer windows — forces a second load mid-read. */
+    @Test
+    public void testReadFully_moreThanOneBuffer() throws Exception {
+        byte[] data = writeReadFullyFile("ts/idx/rf-more1");
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/rf-more1", data.length)) {
+            reader.seek(0);
+            byte[] buf = new byte[READFULLY_BUFFER + 5]; // 21 bytes
+            reader.readFully(buf);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, buf.length), buf);
+            assertEquals(buf.length, reader.getPosition());
+        }
+    }
+
+    /** Read exactly two back-to-back full buffer windows. */
+    @Test
+    public void testReadFully_exactlyTwoBuffers() throws Exception {
+        byte[] data = writeReadFullyFile("ts/idx/rf-exact2");
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/rf-exact2", data.length)) {
+            reader.seek(0);
+            byte[] buf = new byte[READFULLY_BUFFER * 2]; // 32 bytes
+            reader.readFully(buf);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, buf.length), buf);
+            assertEquals(buf.length, reader.getPosition());
+        }
+    }
+
+    /** Read two full buffer windows plus a partial third window. */
+    @Test
+    public void testReadFully_twoBuffersAndMore() throws Exception {
+        byte[] data = writeReadFullyFile("ts/idx/rf-more2");
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/rf-more2", data.length)) {
+            reader.seek(0);
+            byte[] buf = new byte[READFULLY_BUFFER * 2 + 7]; // 39 bytes
+            reader.readFully(buf);
+            assertArrayEquals(Arrays.copyOfRange(data, 0, buf.length), buf);
+            assertEquals(buf.length, reader.getPosition());
+        }
+    }
+
+    /** Start mid-buffer so the first copy is a partial-tail of the first window. */
+    @Test
+    public void testReadFully_startingMidBuffer() throws Exception {
+        byte[] data = writeReadFullyFile("ts/idx/rf-mid");
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/rf-mid", data.length)) {
+            // Seek 3 bytes before the end of the first buffer window, read across the boundary.
+            long start = READFULLY_BUFFER - 3L;
+            reader.seek(start);
+            byte[] buf = new byte[READFULLY_BUFFER + 10]; // 26 bytes → spans 3 windows
+            reader.readFully(buf);
+            assertArrayEquals(
+                    Arrays.copyOfRange(data, (int) start, (int) start + buf.length),
+                    buf);
+            assertEquals(start + buf.length, reader.getPosition());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #104 — `RemoteRandomAccessReader` used the multipart **write** block size (4 MiB) as its read-buffer granularity, so every HNSW cache miss fetched a full 4 MiB chunk and GIST1M searches timed out against `IndexingService/Search` (30 s deadline).

### Split `blockSize` into two concepts

- **`writeBlockSize`** — still forwarded as the 4th arg to `readFileRange`, because `LocalObjectStorage.readRange` computes `blockIndex = offset / blockSize` to locate the on-disk chunk file. Changing it would break chunk lookup.
- **`bufferSize`** — a new, smaller parameter that drives the reader's internal window in `ensureBlockLoaded`. Capped to `writeBlockSize` and required to divide it, so a buffer window never straddles a chunk boundary.

A single-arg convenience constructor forwards `writeBlockSize = bufferSize = blockSize` to keep existing call sites compiling.

### New system property

`herddb.vector.remote.read.bufferSize` — default **16 KiB**, exposed as `RemoteFileDataStorageManager.READ_BUFFER_SIZE_PROPERTY`. Both `RemoteFileDataStorageManager` and `ReadReplicaDataStorageManager` pass this value to the reader supplier for multipart vector indexes.

### Why 16 KiB and not 4 KiB

The dominant per-node disk read during HNSW search is **not** FusedPQ's neighbor codes (a few hundred bytes) but the full-resolution raw vector fetched by `OnDiskGraphIndex.getVectorInto` for re-ranking. That call reads `dimension * 4` bytes in a single `readFloatVector`, so a 4 KiB buffer is too tight:

| Dataset | Raw vector read | At 4 KiB buffer |
|---|---|---|
| GIST1M (dim=960) | 3840 B | unaligned positions split across 2 RPCs |
| 1024-dim | 4096 B | every unaligned position splits |
| 1536-dim (OpenAI ada) | 6144 B | always splits |

A 16 KiB default absorbs a single raw-vector re-rank read for vectors up to ~4096 dimensions in one gRPC call while still being 256× smaller than the 4 MiB multipart write block and an exact divisor of it. FusedPQ's own `getPackedNeighbors` read (`compressedVectorSize * maxDegree` ≈ 512 B for M=16, maxDegree=32) fits easily.

## Test plan

- [x] `mvn -pl herddb-remote-file-service -Dtest=RemoteRandomAccessReaderTest test` — 15/15 pass
- [x] `mvn -pl herddb-remote-file-service test` — 128/128 pass
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins` — green on the full reactor
- [x] New `readFully` coverage across buffer boundaries: `< 1 buffer`, `== 1 buffer`, `> 1 buffer`, `== 2 buffers`, `> 2 buffers`, mid-buffer start
- [x] New assertion that the default `READ_BUFFER_SIZE` is 16384 and the property name is `herddb.vector.remote.read.bufferSize`
- [ ] Re-run GKE GIST1M vector bench and confirm `IndexingService/Search` no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)