### PR TITLE
Streaming HNSW search with lazy loading and global page cache (issue #113)

### DIFF
--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -105,6 +105,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.bookkeeper.stats</groupId>
             <artifactId>bookkeeper-stats-api</artifactId>
         </dependency>

--- a/herddb-core/src/main/java/herddb/index/vector/PageStoreReader.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PageStoreReader.java
@@ -203,25 +203,33 @@ final class PageStoreReader implements RandomAccessReader {
         final long totalLength;
         private final int maxCachedPages;
         private final LinkedHashMap<Integer, byte[]> cache;
+        private final SharedSegmentPageCache sharedCache;
         /** Observability: number of page loads that hit the cache. */
         final AtomicLong cacheHits = new AtomicLong(0);
         /** Observability: number of page loads that missed and read from the page store. */
         final AtomicLong cacheMisses = new AtomicLong(0);
 
         /**
-         * Builds the PageSource by reading each page once to learn its length.
-         * This is a single linear pass over {@code pageIds}; after it returns
-         * the cache may be warmed with up to {@code maxCachedPages} entries.
+         * Builds the PageSource with lazy loading. Page sizes must be provided up-front
+         * (from segment metadata), so the prefix-sum table can be built without reading
+         * any page content. Pages are fetched on-demand during search.
+         *
+         * @param pageIds logical page IDs in DataStorageManager
+         * @param pageSizes payload size (in bytes) for each page, pre-computed at write time
+         * @param expectedChunkType type tag to validate when reading pages
+         * @param maxCachedPages per-segment LRU page cache size
+         * @param sharedCache optional global page cache; if non-null, pages are stored here first
          */
         PageSource(DataStorageManager dsm, String tableSpace, String indexName,
-                   long[] pageIds, int expectedChunkType, int maxCachedPages)
-                throws IOException, DataStorageManagerException {
+                   long[] pageIds, int[] pageSizes, int expectedChunkType, int maxCachedPages,
+                   SharedSegmentPageCache sharedCache) {
             this.dsm = dsm;
             this.tableSpace = tableSpace;
             this.indexName = indexName;
             this.pageIds = pageIds;
             this.expectedChunkType = expectedChunkType;
-            this.pageSizes = new int[pageIds.length];
+            this.pageSizes = pageSizes;
+            this.sharedCache = sharedCache;
             this.prefixSum = new long[pageIds.length + 1];
             this.maxCachedPages = Math.max(1, maxCachedPages);
             this.cache = new LinkedHashMap<Integer, byte[]>(maxCachedPages + 1, 0.75f, true) {
@@ -231,16 +239,10 @@ final class PageStoreReader implements RandomAccessReader {
                 }
             };
 
-            // First pass: read every page once to discover its length. We keep
-            // the last `maxCachedPages` in the cache as a warm start — no extra
-            // reads required if the caller immediately iterates forward.
+            // Build prefix-sum table from pre-computed page sizes (no I/O).
+            // Pages are fetched lazily in loadPage() only when accessed during search.
             for (int i = 0; i < pageIds.length; i++) {
-                byte[] payload = readPayload(pageIds[i], expectedChunkType);
-                pageSizes[i] = payload.length;
-                prefixSum[i + 1] = prefixSum[i] + payload.length;
-                synchronized (cache) {
-                    cache.put(i, payload);
-                }
+                prefixSum[i + 1] = prefixSum[i] + pageSizes[i];
             }
             this.totalLength = prefixSum[pageIds.length];
         }
@@ -273,6 +275,9 @@ final class PageStoreReader implements RandomAccessReader {
         }
 
         byte[] loadPage(int pageIndex) {
+            long pageId = pageIds[pageIndex];
+
+            // Check per-segment LRU first
             byte[] page;
             synchronized (cache) {
                 page = cache.get(pageIndex);
@@ -281,15 +286,35 @@ final class PageStoreReader implements RandomAccessReader {
                     return page;
                 }
             }
+
+            // Check shared global cache (if enabled)
+            if (sharedCache != null) {
+                page = sharedCache.get(pageId);
+                if (page != null) {
+                    // Store in per-segment LRU too for locality
+                    synchronized (cache) {
+                        cache.put(pageIndex, page);
+                        cacheHits.incrementAndGet();
+                    }
+                    return page;
+                }
+            }
+
+            // Cache miss: fetch from storage
             try {
-                page = readPayload(pageIds[pageIndex], expectedChunkType);
+                page = readPayload(pageId, expectedChunkType);
             } catch (IOException | DataStorageManagerException e) {
                 throw new RuntimeException(
-                        "failed to read page " + pageIds[pageIndex] + " for index " + indexName, e);
+                        "failed to read page " + pageId + " for index " + indexName, e);
             }
+
+            // Store in both caches
             synchronized (cache) {
                 cache.put(pageIndex, page);
                 cacheMisses.incrementAndGet();
+            }
+            if (sharedCache != null) {
+                sharedCache.put(pageId, page);
             }
             return page;
         }
@@ -329,10 +354,11 @@ final class PageStoreReader implements RandomAccessReader {
         private final PageSource source;
 
         Supplier(DataStorageManager dsm, String tableSpace, String indexName,
-                 long[] pageIds, int expectedChunkType, int maxCachedPages)
-                throws IOException, DataStorageManagerException {
+                 long[] pageIds, int[] pageSizes, int expectedChunkType, int maxCachedPages,
+                 SharedSegmentPageCache sharedCache) {
             this.source = new PageSource(
-                    dsm, tableSpace, indexName, pageIds, expectedChunkType, maxCachedPages);
+                    dsm, tableSpace, indexName, pageIds, pageSizes, expectedChunkType,
+                    maxCachedPages, sharedCache);
         }
 
         @Override
@@ -342,9 +368,15 @@ final class PageStoreReader implements RandomAccessReader {
 
         @Override
         public void close() {
-            // Drop cached pages to free memory promptly.
+            // Drop cached pages to free memory promptly
             synchronized (source.cache) {
                 source.cache.clear();
+            }
+            // Also invalidate entries from shared cache
+            if (source.sharedCache != null) {
+                for (long pageId : source.pageIds) {
+                    source.sharedCache.invalidate(pageId);
+                }
             }
         }
 

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -267,6 +267,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** Optional stats logger for recording per-segment size distribution. */
     private volatile OpStatsLogger segmentSizeStats;
 
+    /** Global shared page cache for all segments of this store. */
+    private final SharedSegmentPageCache segmentPageCache;
+
     // -------------------------------------------------------------------------
     // In-memory state -- LIVE inserts (new since last checkpoint)
     // -------------------------------------------------------------------------
@@ -593,6 +596,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.maxVectorMemoryBytes = maxVectorMemoryBytes;
         this.memoryBudget = memoryBudget;
         this.maxLiveBytesPerCheckpoint = maxLiveBytesPerCheckpoint > 0 ? maxLiveBytesPerCheckpoint : 10L * 1024 * 1024 * 1024;
+
+        // Initialize global shared page cache for lazy-loaded segments
+        long segmentPageCacheBytes = Long.getLong("herddb.vectorindex.segmentPageCacheMaxBytes",
+                SharedSegmentPageCache.DEFAULT_MAX_BYTES);
+        this.segmentPageCache = new SharedSegmentPageCache(segmentPageCacheBytes);
     }
 
     /**
@@ -682,6 +690,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.maxVectorMemoryBytes = maxVectorMemoryBytes;
         this.memoryBudget = memoryBudget;
         this.maxLiveBytesPerCheckpoint = maxLiveBytesPerCheckpoint > 0 ? maxLiveBytesPerCheckpoint : 10L * 1024 * 1024 * 1024;
+
+        // Initialize global shared page cache for lazy-loaded segments
+        long segmentPageCacheBytes = Long.getLong("herddb.vectorindex.segmentPageCacheMaxBytes",
+                SharedSegmentPageCache.DEFAULT_MAX_BYTES);
+        this.segmentPageCache = new SharedSegmentPageCache(segmentPageCacheBytes);
     }
 
     // -------------------------------------------------------------------------
@@ -747,6 +760,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
         final int segmentId;
         final List<Long> graphPageIds;
         final List<Long> mapPageIds;
+        final List<Integer> graphPageSizes;
+        final List<Integer> mapPageSizes;
         final long estimatedSizeBytes;
         // Multipart mode (non-null when the storage manager supports multipart writes)
         final String graphFilePath;
@@ -756,10 +771,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         /** Page-based constructor. */
         SegmentWriteResult(int segmentId, List<Long> graphPageIds, List<Long> mapPageIds,
+                           List<Integer> graphPageSizes, List<Integer> mapPageSizes,
                            long estimatedSizeBytes) {
             this.segmentId = segmentId;
             this.graphPageIds = graphPageIds;
             this.mapPageIds = mapPageIds;
+            this.graphPageSizes = graphPageSizes;
+            this.mapPageSizes = mapPageSizes;
             this.estimatedSizeBytes = estimatedSizeBytes;
             this.graphFilePath = null;
             this.graphFileSize = 0;
@@ -773,6 +791,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.segmentId = segmentId;
             this.graphPageIds = Collections.emptyList();
             this.mapPageIds = Collections.emptyList();
+            this.graphPageSizes = Collections.emptyList();
+            this.mapPageSizes = Collections.emptyList();
             this.estimatedSizeBytes = estimatedSizeBytes;
             this.graphFilePath = graphFilePath;
             this.graphFileSize = graphFileSize;
@@ -782,6 +802,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         boolean isMultipart() {
             return graphFilePath != null;
+        }
+    }
+
+    /** Holds the result of writing chunks (pageIds + their payload sizes). */
+    private static class ChunkWriteResult {
+        final List<Long> pageIds;
+        final List<Integer> payloadSizes;
+
+        ChunkWriteResult(List<Long> pageIds, List<Integer> payloadSizes) {
+            this.pageIds = pageIds;
+            this.payloadSizes = payloadSizes;
         }
     }
 
@@ -1022,6 +1053,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
             seg.close();
         }
         segments = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+        // Clear the global shared page cache
+        if (segmentPageCache != null) {
+            segmentPageCache.clear();
+        }
 
         LOGGER.log(Level.INFO, "PersistentVectorStore {0} closed", indexName);
     }
@@ -1525,25 +1561,28 @@ public class PersistentVectorStore extends AbstractVectorStore {
         newShard.builder.cleanup();
         this.liveShards = new ArrayList<>(Collections.singletonList(newShard));
 
-        List<Long> graphPageIds;
+        ChunkWriteResult graphResult;
         Path graphTmpFile = Files.createTempFile(tmpDirectory, "herddb-vector-graph-", ".tmp");
         try {
             try (java.io.DataOutputStream graphDos = new java.io.DataOutputStream(
                     new BufferedOutputStream(new FileOutputStream(graphTmpFile.toFile()), CHUNK_SIZE))) {
                 ((OnHeapGraphIndex) newShard.builder.getGraph()).save(graphDos);
             }
-            graphPageIds = writeChunks(graphTmpFile, TYPE_VECTOR_GRAPHCHUNK);
+            graphResult = writeChunks(graphTmpFile, TYPE_VECTOR_GRAPHCHUNK);
         } finally {
             Files.deleteIfExists(graphTmpFile);
         }
 
-        List<Long> mapPageIds;
+        ChunkWriteResult mapResult;
         Path mapTmpFile = serializeMapDataToFile(vectorStorage, newShard.nodeToPk);
         try {
-            mapPageIds = writeChunks(mapTmpFile, TYPE_VECTOR_MAPCHUNK);
+            mapResult = writeChunks(mapTmpFile, TYPE_VECTOR_MAPCHUNK);
         } finally {
             Files.deleteIfExists(mapTmpFile);
         }
+
+        List<Long> graphPageIds = graphResult.pageIds;
+        List<Long> mapPageIds = mapResult.pageIds;
 
         int totalNodes = newShard.nodeToPk.size();
         persistIndexStatusSimple(graphPageIds, mapPageIds, totalNodes, false, sequenceNumber);
@@ -1706,6 +1745,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     seg.estimatedSizeBytes = swr.estimatedSizeBytes;
                     seg.graphPageIds = swr.graphPageIds;
                     seg.mapPageIds = swr.mapPageIds;
+                    seg.graphPageSizes = swr.graphPageSizes;
+                    seg.mapPageSizes = swr.mapPageSizes;
                     seg.graphFilePath = swr.graphFilePath;
                     seg.graphFileSize = swr.graphFileSize;
                     seg.mapFilePath = swr.mapFilePath;
@@ -2011,24 +2052,27 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 }
                 poolBuilder.cleanup();
 
-                List<Long> graphPageIds;
+                ChunkWriteResult graphResult;
                 Path graphTmpFile = Files.createTempFile(tmpDirectory, "herddb-vector-graph-", ".tmp");
                 try {
                     try (java.io.DataOutputStream graphDos = new java.io.DataOutputStream(
                             new BufferedOutputStream(new FileOutputStream(graphTmpFile.toFile()), CHUNK_SIZE))) {
                         ((OnHeapGraphIndex) poolBuilder.getGraph()).save(graphDos);
                     }
-                    graphPageIds = writeChunks(graphTmpFile, TYPE_VECTOR_GRAPHCHUNK);
+                    graphResult = writeChunks(graphTmpFile, TYPE_VECTOR_GRAPHCHUNK);
                 } finally {
                     Files.deleteIfExists(graphTmpFile);
                 }
-                List<Long> mapPageIds;
+                ChunkWriteResult mapResult;
                 Path mapTmpFile = serializeMapDataToFile(poolStorage, poolNodeToPk);
                 try {
-                    mapPageIds = writeChunks(mapTmpFile, TYPE_VECTOR_MAPCHUNK);
+                    mapResult = writeChunks(mapTmpFile, TYPE_VECTOR_MAPCHUNK);
                 } finally {
                     Files.deleteIfExists(mapTmpFile);
                 }
+
+                List<Long> graphPageIds = graphResult.pageIds;
+                List<Long> mapPageIds = mapResult.pageIds;
                 try {
                     poolBuilder.close();
                 } catch (IOException e) {
@@ -2310,11 +2354,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 } else {
                     // Fallback to page-based write if multipart not supported
                     ConcurrentHashMap<Integer, Bytes> ordinalToPk = buildOrdinalToPk(shard);
-                    List<Long> graphPages = writeChunks(tempFile, TYPE_VECTOR_GRAPHCHUNK);
-                    List<Long> mapPages = writeFusedPQMapData(shardView, ordinalToPk);
+                    ChunkWriteResult graphResult = writeChunks(tempFile, TYPE_VECTOR_GRAPHCHUNK);
+                    ChunkWriteResult mapResult = writeFusedPQMapData(shardView, ordinalToPk);
                     compactionNodesDone.addAndGet(shardSize);
-                    return new SegmentWriteResult(segmentId, graphPages, mapPages,
-                            (long) (graphPages.size() + mapPages.size()) * CHUNK_SIZE);
+                    return new SegmentWriteResult(segmentId, graphResult.pageIds, mapResult.pageIds,
+                            graphResult.payloadSizes, mapResult.payloadSizes,
+                            (long) (graphResult.pageIds.size() + mapResult.pageIds.size()) * CHUNK_SIZE);
                 }
             } finally {
                 // Always delete temp file - it's been uploaded/written to persistent storage
@@ -2642,16 +2687,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 try {
                     int numGraphChunks = dis.readInt();
                     long[] graphChunkPageIds = new long[numGraphChunks];
+                    int[] graphChunkPageSizes = new int[numGraphChunks];
                     for (int i = 0; i < numGraphChunks; i++) {
                         graphChunkPageIds[i] = dis.readLong();
+                        graphChunkPageSizes[i] = dis.readInt();
                     }
                     int numMapChunks = dis.readInt();
                     long[] mapChunkPageIds = new long[numMapChunks];
+                    int[] mapChunkPageSizes = new int[numMapChunks];
                     for (int i = 0; i < numMapChunks; i++) {
                         mapChunkPageIds[i] = dis.readLong();
+                        mapChunkPageSizes[i] = dis.readInt();
                     }
                     seg.graphPageIds = toLongList(graphChunkPageIds);
                     seg.mapPageIds = toLongList(mapChunkPageIds);
+                    seg.graphPageSizes = toIntList(graphChunkPageSizes);
+                    seg.mapPageSizes = toIntList(mapChunkPageSizes);
                     Path mapFile = readChunksToTempFile(mapChunkPageIds, TYPE_VECTOR_MAPCHUNK);
                     loadFusedPQSegment(seg, mapFile, dim, savedNextNodeId);
                 } catch (IOException e) {
@@ -2769,13 +2820,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         } else {
             long[] graphPageIds = new long[seg.graphPageIds.size()];
+            int[] graphPageSizes = new int[seg.graphPageSizes.size()];
             for (int i = 0; i < graphPageIds.length; i++) {
                 graphPageIds[i] = seg.graphPageIds.get(i);
+                graphPageSizes[i] = seg.graphPageSizes.get(i);
             }
             readerSupplier = new PageStoreReader.Supplier(
                     dataStorageManager, tableSpaceUUID, indexUUID,
-                    graphPageIds, TYPE_VECTOR_GRAPHCHUNK,
-                    PageStoreReader.DEFAULT_LRU_PAGES);
+                    graphPageIds, graphPageSizes, TYPE_VECTOR_GRAPHCHUNK,
+                    PageStoreReader.DEFAULT_LRU_PAGES, segmentPageCache);
         }
         seg.onDiskGraph = OnDiskGraphIndex.load(readerSupplier);
         seg.onDiskReaderSupplier = readerSupplier;
@@ -2856,17 +2909,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
 
         // Fallback: page-based writes
-        List<Long> graphPageIds = writeFusedPQGraph(partVectors, partNodeToPk, snapshotDimension);
-        List<Long> mapPageIds = writeFusedPQMapData(
+        ChunkWriteResult graphResult = writeFusedPQGraph(partVectors, partNodeToPk, snapshotDimension);
+        ChunkWriteResult mapResult = writeFusedPQMapData(
                 new VectorStorageRandomAccessVectorValues(partStorage, snapshotDimension), partNodeToPk);
-        long estimatedSize = (long) (graphPageIds.size() + mapPageIds.size()) * CHUNK_SIZE;
-        return new SegmentWriteResult(s.segmentId, graphPageIds, mapPageIds, estimatedSize);
+        long estimatedSize = (long) (graphResult.pageIds.size() + mapResult.pageIds.size()) * CHUNK_SIZE;
+        return new SegmentWriteResult(s.segmentId, graphResult.pageIds, mapResult.pageIds,
+                graphResult.payloadSizes, mapResult.payloadSizes, estimatedSize);
     }
 
     /**
-     * Writes the merged graph as FusedPQ on-disk format.
+     * Writes the merged graph as FusedPQ on-disk format. Returns both page IDs and their payload sizes.
      */
-    private List<Long> writeFusedPQGraph(ConcurrentHashMap<Integer, VectorFloat<?>> allVectors,
+    private ChunkWriteResult writeFusedPQGraph(ConcurrentHashMap<Integer, VectorFloat<?>> allVectors,
                                           ConcurrentHashMap<Integer, Bytes> allNodeToPk,
                                           int dim) throws IOException, DataStorageManagerException {
         if (allNodeToPk.isEmpty()) {
@@ -2955,12 +3009,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         ordinal -> new InlineVectors.State(allMravv.getVector(ordinal)));
                 writer.write(suppliers);
             }
-            List<Long> pages = writeChunks(tempFile, TYPE_VECTOR_GRAPHCHUNK);
+            ChunkWriteResult result = writeChunks(tempFile, TYPE_VECTOR_GRAPHCHUNK);
             long writeElapsedMs = System.currentTimeMillis() - writeStartMs;
             LOGGER.log(Level.INFO,
                     "writeFusedPQGraph {0}: disk write completed in {1} ms ({2} pages)",
-                    new Object[]{indexName, writeElapsedMs, pages.size()});
-            return pages;
+                    new Object[]{indexName, writeElapsedMs, result.pageIds.size()});
+            return result;
         } finally {
             Files.deleteIfExists(tempFile);
             try {
@@ -2972,9 +3026,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
-     * Writes map data for FusedPQ format.
+     * Writes map data for FusedPQ format. Returns both page IDs and their payload sizes.
      */
-    private List<Long> writeFusedPQMapData(RandomAccessVectorValues allVectors,
+    private ChunkWriteResult writeFusedPQMapData(RandomAccessVectorValues allVectors,
                                             ConcurrentHashMap<Integer, Bytes> allNodeToPk)
             throws IOException, DataStorageManagerException {
         List<Integer> sortedNodeIds = new ArrayList<>(allNodeToPk.keySet());
@@ -3234,12 +3288,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     /**
      * Streams a file into CHUNK_SIZE pieces and writes each as an index page.
+     * Returns both page IDs and the payload size for each page (used for building prefix-sum table).
      * <p>Every allocated pageId is recorded in {@link #provisionalPageIds} (if non-null)
      * <em>before</em> the corresponding {@code writeIndexPage} call, so that a failure
      * mid-write still leaves a rollback record for the caller to reclaim the page.
      */
-    private List<Long> writeChunks(Path file, int chunkType) throws DataStorageManagerException, IOException {
+    private ChunkWriteResult writeChunks(Path file, int chunkType) throws DataStorageManagerException, IOException {
         List<Long> pageIds = new ArrayList<>();
+        List<Integer> payloadSizes = new ArrayList<>();
         long fileSize = Files.size(file);
         if (fileSize == 0) {
             long pageId = newPageId.getAndIncrement();
@@ -3249,7 +3305,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 out.writeVInt(0);
             });
             pageIds.add(pageId);
-            return pageIds;
+            payloadSizes.add(0);
+            return new ChunkWriteResult(pageIds, payloadSizes);
         }
         try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file.toFile()), CHUNK_SIZE)) {
             byte[] buf = new byte[CHUNK_SIZE];
@@ -3264,9 +3321,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     out.write(buf, 0, len);
                 });
                 pageIds.add(pageId);
+                payloadSizes.add(len);
             }
         }
-        return pageIds;
+        return new ChunkWriteResult(pageIds, payloadSizes);
     }
 
     /**
@@ -3285,9 +3343,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     /**
      * Splits data into CHUNK_SIZE pieces and writes each as an index page.
+     * Returns both page IDs and the payload size for each page.
      */
-    private List<Long> writeChunks(byte[] data, int chunkType) throws DataStorageManagerException {
+    private ChunkWriteResult writeChunks(byte[] data, int chunkType) throws DataStorageManagerException {
         List<Long> pageIds = new ArrayList<>();
+        List<Integer> payloadSizes = new ArrayList<>();
         if (data.length == 0) {
             long pageId = newPageId.getAndIncrement();
             trackProvisionalPageId(pageId);
@@ -3296,7 +3356,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 out.writeVInt(0);
             });
             pageIds.add(pageId);
-            return pageIds;
+            payloadSizes.add(0);
+            return new ChunkWriteResult(pageIds, payloadSizes);
         }
         for (int offset = 0; offset < data.length; offset += CHUNK_SIZE) {
             final int off = offset;
@@ -3309,8 +3370,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 out.write(data, off, len);
             });
             pageIds.add(pageId);
+            payloadSizes.add(len);
         }
-        return pageIds;
+        return new ChunkWriteResult(pageIds, payloadSizes);
     }
 
     // -------------------------------------------------------------------------
@@ -3382,6 +3444,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 writeSegmentMeta(dos, activePages,
                         seg.segmentId, seg.estimatedSizeBytes,
                         seg.graphPageIds, seg.mapPageIds,
+                        seg.graphPageSizes, seg.mapPageSizes,
                         seg.graphFilePath, seg.graphFileSize,
                         seg.mapFilePath, seg.mapFileSize);
             }
@@ -3389,6 +3452,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 writeSegmentMeta(dos, activePages,
                         seg.segmentId, seg.estimatedSizeBytes,
                         seg.graphPageIds, seg.mapPageIds,
+                        seg.graphPageSizes, seg.mapPageSizes,
                         seg.graphFilePath, seg.graphFileSize,
                         seg.mapFilePath, seg.mapFileSize);
             }
@@ -3396,6 +3460,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 writeSegmentMeta(dos, activePages,
                         swr.segmentId, swr.estimatedSizeBytes,
                         swr.graphPageIds, swr.mapPageIds,
+                        swr.graphPageSizes, swr.mapPageSizes,
                         swr.graphFilePath, swr.graphFileSize,
                         swr.mapFilePath, swr.mapFileSize);
             }
@@ -3414,6 +3479,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             java.io.DataOutputStream dos, Set<Long> activePages,
             int segmentId, long estimatedSizeBytes,
             List<Long> graphPageIds, List<Long> mapPageIds,
+            List<Integer> graphPageSizes, List<Integer> mapPageSizes,
             String graphFilePath, long graphFileSize,
             String mapFilePath, long mapFileSize) throws IOException {
         dos.writeInt(segmentId);
@@ -3427,14 +3493,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
             dos.writeLong(mapFileSize);
         } else {
             dos.writeInt(graphPageIds.size());
-            for (long id : graphPageIds) {
-                dos.writeLong(id);
-                activePages.add(id);
+            for (int i = 0; i < graphPageIds.size(); i++) {
+                dos.writeLong(graphPageIds.get(i));
+                dos.writeInt(graphPageSizes.get(i));
+                activePages.add(graphPageIds.get(i));
             }
             dos.writeInt(mapPageIds.size());
-            for (long id : mapPageIds) {
-                dos.writeLong(id);
-                activePages.add(id);
+            for (int i = 0; i < mapPageIds.size(); i++) {
+                dos.writeLong(mapPageIds.get(i));
+                dos.writeInt(mapPageSizes.get(i));
+                activePages.add(mapPageIds.get(i));
             }
         }
     }
@@ -3759,6 +3827,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private static List<Long> toLongList(long[] arr) {
         List<Long> list = new ArrayList<>(arr.length);
         for (long v : arr) {
+            list.add(v);
+        }
+        return list;
+    }
+
+    private static List<Integer> toIntList(int[] arr) {
+        List<Integer> list = new ArrayList<>(arr.length);
+        for (int v : arr) {
             list.add(v);
         }
         return list;

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -531,7 +531,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 indexName + "_" + tableName + "_" + System.nanoTime(), tmpDirectory,
                 dataStorageManager, memoryManager, m, beamWidth, neighborOverflow, alpha,
                 fusedPQ, maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
-                VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0);
+                VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0, 0);
     }
 
     public PersistentVectorStore(String indexName, String tableName, String tableSpaceUUID,
@@ -546,7 +546,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 indexName + "_" + tableName + "_" + System.nanoTime(), tmpDirectory,
                 dataStorageManager, memoryManager, m, beamWidth, neighborOverflow, alpha,
                 fusedPQ, maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
-                similarityFunction, Long.MAX_VALUE, null, 0);
+                similarityFunction, Long.MAX_VALUE, null, 0, 0);
     }
 
     public PersistentVectorStore(String indexName, String tableName, String tableSpaceUUID,
@@ -562,7 +562,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 indexName + "_" + tableName + "_" + System.nanoTime(), tmpDirectory,
                 dataStorageManager, memoryManager, m, beamWidth, neighborOverflow, alpha,
                 fusedPQ, maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
-                similarityFunction, maxVectorMemoryBytes, null, 0);
+                similarityFunction, maxVectorMemoryBytes, null, 0, 0);
     }
 
     public PersistentVectorStore(String indexName, String tableName, String tableSpaceUUID,
@@ -576,31 +576,36 @@ public class PersistentVectorStore extends AbstractVectorStore {
                                  long maxVectorMemoryBytes,
                                  VectorMemoryBudget memoryBudget,
                                  long maxLiveBytesPerCheckpoint) {
-        super(vectorColumnName);
-        this.indexName = indexName;
-        this.tableName = tableName;
-        this.tableSpaceUUID = tableSpaceUUID;
-        this.indexUUID = indexName + "_" + tableName + "_" + System.nanoTime();
-        this.tmpDirectory = tmpDirectory;
-        this.dataStorageManager = dataStorageManager;
-        this.memoryManager = memoryManager;
-        this.m = m;
-        this.beamWidth = beamWidth;
-        this.neighborOverflow = neighborOverflow;
-        this.alpha = alpha;
-        this.fusedPQ = fusedPQ;
-        this.similarityFunction = similarityFunction;
-        this.maxSegmentSize = maxSegmentSize;
-        this.maxLiveGraphSize = maxLiveGraphSize;
-        this.compactionIntervalMs = compactionIntervalMs;
-        this.maxVectorMemoryBytes = maxVectorMemoryBytes;
-        this.memoryBudget = memoryBudget;
-        this.maxLiveBytesPerCheckpoint = maxLiveBytesPerCheckpoint > 0 ? maxLiveBytesPerCheckpoint : 10L * 1024 * 1024 * 1024;
+        this(indexName, tableName, tableSpaceUUID, vectorColumnName,
+                indexName + "_" + tableName + "_" + System.nanoTime(),
+                tmpDirectory, dataStorageManager, memoryManager, m, beamWidth,
+                neighborOverflow, alpha, fusedPQ, maxSegmentSize, maxLiveGraphSize,
+                compactionIntervalMs, similarityFunction, maxVectorMemoryBytes,
+                memoryBudget, maxLiveBytesPerCheckpoint, 0);
+    }
 
-        // Initialize global shared page cache for lazy-loaded segments
-        long segmentPageCacheBytes = Long.getLong("herddb.vectorindex.segmentPageCacheMaxBytes",
-                SharedSegmentPageCache.DEFAULT_MAX_BYTES);
-        this.segmentPageCache = new SharedSegmentPageCache(segmentPageCacheBytes);
+    /**
+     * Constructor that accepts all parameters including segment page cache max bytes,
+     * for use by the IndexingServiceEngine factory.
+     */
+    public PersistentVectorStore(String indexName, String tableName, String tableSpaceUUID,
+                                 String vectorColumnName, Path tmpDirectory,
+                                 DataStorageManager dataStorageManager,
+                                 MemoryManager memoryManager,
+                                 int m, int beamWidth, float neighborOverflow, float alpha,
+                                 boolean fusedPQ, long maxSegmentSize, int maxLiveGraphSize,
+                                 long compactionIntervalMs,
+                                 VectorSimilarityFunction similarityFunction,
+                                 long maxVectorMemoryBytes,
+                                 VectorMemoryBudget memoryBudget,
+                                 long maxLiveBytesPerCheckpoint,
+                                 long segmentPageCacheMaxBytes) {
+        this(indexName, tableName, tableSpaceUUID, vectorColumnName,
+                indexName + "_" + tableName + "_" + System.nanoTime(),
+                tmpDirectory, dataStorageManager, memoryManager, m, beamWidth,
+                neighborOverflow, alpha, fusedPQ, maxSegmentSize, maxLiveGraphSize,
+                compactionIntervalMs, similarityFunction, maxVectorMemoryBytes,
+                memoryBudget, maxLiveBytesPerCheckpoint, segmentPageCacheMaxBytes);
     }
 
     /**
@@ -617,7 +622,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this(indexName, tableName, tableSpaceUUID, vectorColumnName, indexUUID, tmpDirectory,
                 dataStorageManager, memoryManager, m, beamWidth, neighborOverflow, alpha,
                 fusedPQ, maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
-                VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0);
+                VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0, 0);
     }
 
     /**
@@ -634,7 +639,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this(indexName, tableName, tableSpaceUUID, vectorColumnName, indexUUID, tmpDirectory,
                 dataStorageManager, memoryManager, m, beamWidth, neighborOverflow, alpha,
                 fusedPQ, maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
-                similarityFunction, Long.MAX_VALUE, null, 0);
+                similarityFunction, Long.MAX_VALUE, null, 0, 0);
     }
 
     /**
@@ -652,12 +657,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this(indexName, tableName, tableSpaceUUID, vectorColumnName, indexUUID, tmpDirectory,
                 dataStorageManager, memoryManager, m, beamWidth, neighborOverflow, alpha,
                 fusedPQ, maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
-                similarityFunction, maxVectorMemoryBytes, null, 0);
+                similarityFunction, maxVectorMemoryBytes, null, 0, 0);
     }
 
     /**
      * Constructor that accepts an explicit indexUUID, similarity function, memory limit,
-     * global memory budget, and live-shard snapshot byte cap.
+     * global memory budget, live-shard snapshot byte cap, and segment page cache max bytes.
      */
     public PersistentVectorStore(String indexName, String tableName, String tableSpaceUUID,
                                  String vectorColumnName, String indexUUID, Path tmpDirectory,
@@ -669,7 +674,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                                  VectorSimilarityFunction similarityFunction,
                                  long maxVectorMemoryBytes,
                                  VectorMemoryBudget memoryBudget,
-                                 long maxLiveBytesPerCheckpoint) {
+                                 long maxLiveBytesPerCheckpoint,
+                                 long segmentPageCacheMaxBytes) {
         super(vectorColumnName);
         this.indexName = indexName;
         this.tableName = tableName;
@@ -692,9 +698,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.maxLiveBytesPerCheckpoint = maxLiveBytesPerCheckpoint > 0 ? maxLiveBytesPerCheckpoint : 10L * 1024 * 1024 * 1024;
 
         // Initialize global shared page cache for lazy-loaded segments
-        long segmentPageCacheBytes = Long.getLong("herddb.vectorindex.segmentPageCacheMaxBytes",
-                SharedSegmentPageCache.DEFAULT_MAX_BYTES);
-        this.segmentPageCache = new SharedSegmentPageCache(segmentPageCacheBytes);
+        // If segmentPageCacheMaxBytes is 0, use the default (1/4 of JVM heap)
+        long cacheBytes = segmentPageCacheMaxBytes > 0 ? segmentPageCacheMaxBytes : SharedSegmentPageCache.DEFAULT_MAX_BYTES;
+        this.segmentPageCache = new SharedSegmentPageCache(cacheBytes);
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
+++ b/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
@@ -1,0 +1,118 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Global page cache for vector index segments. All segments of a {@link PersistentVectorStore}
+ * share a single Caffeine-backed LRU cache bounded by total bytes.
+ *
+ * <p>Key = long pageId (globally unique per DataStorageManager).
+ * Value = byte[] page payload (cached graph page data).
+ *
+ * <p>The cache uses a byte-weight function: each entry's weight is its byte[] length.
+ * When the cache exceeds the byte budget, the least-recently-used entries are evicted.
+ *
+ * <p>Default budget = 1/4 of JVM heap; configurable via
+ * {@code herddb.vectorindex.segmentPageCacheMaxBytes} system property.
+ */
+public class SharedSegmentPageCache {
+
+    /** Default cache budget: 1/4 of the JVM max heap. */
+    public static final long DEFAULT_MAX_BYTES = Runtime.getRuntime().maxMemory() / 4;
+
+    private final Cache<Long, byte[]> cache;
+
+    /**
+     * Creates a new shared page cache with the given byte budget.
+     *
+     * @param maxBytes maximum total bytes to cache. If <= 0, behaves as a no-op cache (always miss).
+     */
+    public SharedSegmentPageCache(long maxBytes) {
+        if (maxBytes <= 0) {
+            this.cache = null;
+        } else {
+            this.cache = Caffeine.newBuilder()
+                    .maximumWeight(maxBytes)
+                    .weigher((Long pageId, byte[] data) -> {
+                        long len = data == null ? 0L : data.length;
+                        return len > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) len;
+                    })
+                    .recordStats()
+                    .build();
+        }
+    }
+
+    /**
+     * Retrieves a page from the cache, or null if not present (miss).
+     */
+    public byte[] get(long pageId) {
+        if (cache == null) {
+            return null;
+        }
+        return cache.getIfPresent(pageId);
+    }
+
+    /**
+     * Stores a page in the cache. May trigger eviction of LRU entries.
+     */
+    public void put(long pageId, byte[] data) {
+        if (cache != null) {
+            cache.put(pageId, data);
+        }
+    }
+
+    /**
+     * Invalidates (removes) a page from the cache.
+     */
+    public void invalidate(long pageId) {
+        if (cache != null) {
+            cache.invalidate(pageId);
+        }
+    }
+
+    /**
+     * Invalidates all entries in the cache.
+     */
+    public void clear() {
+        if (cache != null) {
+            cache.invalidateAll();
+        }
+    }
+
+    /**
+     * Returns the number of entries currently in the cache.
+     */
+    public long size() {
+        if (cache == null) {
+            return 0;
+        }
+        return cache.asMap().size();
+    }
+
+    /**
+     * Checks if the cache is active (non-null).
+     */
+    public boolean isActive() {
+        return cache != null;
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
+++ b/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
@@ -53,10 +53,7 @@ public class SharedSegmentPageCache {
         } else {
             this.cache = Caffeine.newBuilder()
                     .maximumWeight(maxBytes)
-                    .weigher((Long pageId, byte[] data) -> {
-                        long len = data == null ? 0L : data.length;
-                        return len > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) len;
-                    })
+                    .weigher((Long pageId, byte[] data) -> data == null ? 0 : data.length)
                     .recordStats()
                     .build();
         }

--- a/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
@@ -92,6 +92,10 @@ class VectorSegment implements Closeable {
     List<Long> graphPageIds = java.util.Collections.emptyList();
     /** Page IDs for the map chunks (needed to re-persist sealed segments, page-based mode). */
     List<Long> mapPageIds = java.util.Collections.emptyList();
+    /** Payload sizes (in bytes) for each graph page, from segment metadata. */
+    List<Integer> graphPageSizes = java.util.Collections.emptyList();
+    /** Payload sizes (in bytes) for each map page, from segment metadata. */
+    List<Integer> mapPageSizes = java.util.Collections.emptyList();
 
     /** Logical path of the graph multipart file (non-null only in multipart mode). */
     String graphFilePath;

--- a/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -71,6 +70,21 @@ public class PageStoreReaderTest {
         return ids;
     }
 
+    /**
+     * Calculates page sizes for fixed-size pages (each page is {@code pageSize}
+     * bytes except the last one may be smaller).
+     */
+    private int[] calculatePageSizes(int pageCount, int pageSize, long totalLength) {
+        int[] sizes = new int[pageCount];
+        long bytesLeft = totalLength;
+        for (int i = 0; i < pageCount; i++) {
+            int len = (int) Math.min(pageSize, bytesLeft);
+            sizes[i] = len;
+            bytesLeft -= len;
+        }
+        return sizes;
+    }
+
     @Test
     public void roundTripMatchesByteStream() throws Exception {
         // Write a 7-page stream, each page 1024 bytes except the tail = 300.
@@ -80,7 +94,7 @@ public class PageStoreReaderTest {
         long[] ids = writeFixedSizePages(dsm, 7, pageSize, total);
 
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 3)) {
+                dsm, TS, IDX, ids, calculatePageSizes(7, pageSize, total), CHUNK_TYPE, 3, null)) {
             try (RandomAccessReader r = sup.get()) {
                 assertEquals(total, r.length());
                 // Read all bytes from position 0 and verify the deterministic
@@ -103,7 +117,7 @@ public class PageStoreReaderTest {
         long[] ids = writeFixedSizePages(dsm, 11, pageSize, total);
 
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 2)) {
+                dsm, TS, IDX, ids, calculatePageSizes(11, pageSize, total), CHUNK_TYPE, 2, null)) {
             try (RandomAccessReader r = sup.get()) {
                 // Probe crossing page boundaries; last position must leave at
                 // least 4 bytes (readInt consumes 4) before EOF.
@@ -123,7 +137,7 @@ public class PageStoreReaderTest {
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         long[] ids = writeFixedSizePages(dsm, 1, 8, 8);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 1)) {
+                dsm, TS, IDX, ids, calculatePageSizes(1, 8, 8), CHUNK_TYPE, 1, null)) {
             try (RandomAccessReader r = sup.get()) {
                 r.seek(7);
                 try {
@@ -138,17 +152,16 @@ public class PageStoreReaderTest {
     @Test
     public void lruEvictsOldestPages() throws Exception {
         // 6 pages, cache of 2 → touching all 6 in order forces at least 4 misses
-        // in addition to the initial priming pass that filled the cache.
+        // due to LRU eviction.
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         int pageSize = 64;
         long total = 6L * pageSize;
         long[] ids = writeFixedSizePages(dsm, 6, pageSize, total);
 
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 2)) {
-            // At construction, 6 pages were read to learn sizes; LRU now holds
-            // the last 2.
-            assertEquals(2, sup.getCachedPages());
+                dsm, TS, IDX, ids, calculatePageSizes(6, pageSize, total), CHUNK_TYPE, 2, null)) {
+            // With lazy loading, no pages cached at construction
+            assertEquals("no cache at construction", 0, sup.getCachedPages());
             long missesBefore = sup.getCacheMisses();
             try (RandomAccessReader r = sup.get()) {
                 for (int pageIdx = 0; pageIdx < 6; pageIdx++) {
@@ -166,24 +179,29 @@ public class PageStoreReaderTest {
 
     @Test
     public void wrongChunkTypeFails() throws Exception {
-        // Pages stored with type 99, reader expects CHUNK_TYPE = 12 → should
-        // throw when constructing the PageSource (priming pass).
+        // Pages stored with type 99, reader expects CHUNK_TYPE = 12.
+        // With lazy loading, the type check happens when a page is actually read.
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         dsm.writeIndexPage(TS, IDX, 42L, out -> {
             out.writeVInt(99);
             out.writeVInt(4);
             out.write(new byte[]{1, 2, 3, 4}, 0, 4);
         });
-        try {
-            new PageStoreReader.Supplier(dsm, TS, IDX,
-                    new long[]{42L}, CHUNK_TYPE, 2);
-            fail("expected failure on wrong chunk type");
-        } catch (IOException | DataStorageManagerException expected) {
-            assertTrue("message should surface the type mismatch, got: "
-                            + expected.getMessage() + " cause: " + expected.getCause(),
-                    expected.getMessage().contains("expected type")
-                            || (expected.getCause() != null
-                                && expected.getCause().getMessage().contains("expected type")));
+        // Supplier construction succeeds with lazy loading (no page reads yet)
+        PageStoreReader.Supplier sup = new PageStoreReader.Supplier(dsm, TS, IDX,
+                new long[]{42L}, new int[]{4}, CHUNK_TYPE, 2, null);
+        // Type mismatch is detected when the page is actually accessed
+        try (RandomAccessReader r = sup.get()) {
+            try {
+                r.readInt(); // This triggers the page load which should fail on type check
+                fail("expected failure on wrong chunk type");
+            } catch (RuntimeException expected) {
+                // The IOException with "expected type" is wrapped as the cause
+                String fullMessage = expected.toString() + " cause: "
+                        + (expected.getCause() != null ? expected.getCause().toString() : "null");
+                assertTrue("message should surface the type mismatch, got: " + fullMessage,
+                        fullMessage.contains("expected type"));
+            }
         }
     }
 
@@ -192,8 +210,14 @@ public class PageStoreReaderTest {
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         long[] ids = writeFixedSizePages(dsm, 3, 64, 3 * 64L);
         PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 3);
-        assertTrue(sup.getCachedPages() > 0);
+                dsm, TS, IDX, ids, calculatePageSizes(3, 64, 3 * 64L), CHUNK_TYPE, 3, null);
+        // With lazy loading, no pages are cached at construction
+        assertEquals("no pages cached at construction with lazy loading", 0, sup.getCachedPages());
+        // Access a page to populate the cache
+        try (RandomAccessReader r = sup.get()) {
+            r.readInt();
+        }
+        assertTrue("cache should have pages after access", sup.getCachedPages() > 0);
         sup.close();
         assertEquals("close must drop cached pages", 0, sup.getCachedPages());
     }
@@ -210,7 +234,7 @@ public class PageStoreReaderTest {
 
         // Very small cache so reading a different page evicts.
         PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 1);
+                dsm, TS, IDX, ids, calculatePageSizes(4, pageSize, 4L * pageSize), CHUNK_TYPE, 1, null);
         // Remove page 0 from the backing store.
         dsm.deleteIndexPage(TS, IDX, ids[0]);
         try (RandomAccessReader r = sup.get()) {
@@ -235,7 +259,7 @@ public class PageStoreReaderTest {
         int pageSize = 64;
         long[] ids = writeFixedSizePages(dsm, 4, pageSize, 4L * pageSize);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 4)) {
+                dsm, TS, IDX, ids, calculatePageSizes(4, pageSize, 4L * pageSize), CHUNK_TYPE, 4, null)) {
             long hitsBefore = sup.getCacheHits();
             RandomAccessReader a = sup.get();
             RandomAccessReader b = sup.get();
@@ -253,9 +277,8 @@ public class PageStoreReaderTest {
 
     @Test
     public void counterOfReadPayloadInvocations() throws Exception {
-        // Defensive: the priming-pass invokes readIndexPage exactly once per
-        // page. We simulate that by counting dsm.readIndexPage calls via a
-        // subclass.
+        // Defensive: with lazy loading, pages are read on-demand when accessed.
+        // Count dsm.readIndexPage calls via a subclass.
         AtomicInteger reads = new AtomicInteger(0);
         MemoryDataStorageManager dsm = new MemoryDataStorageManager() {
             @Override
@@ -268,11 +291,10 @@ public class PageStoreReaderTest {
         long[] ids = writeFixedSizePages(dsm, 5, 128, 5L * 128);
         int before = reads.get();
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 5)) {
-            assertEquals("priming pass must read each page exactly once",
-                    5, reads.get() - before);
-            // Second pass, reading all pages, should be ALL hits (no extra
-            // readIndexPage calls).
+                dsm, TS, IDX, ids, calculatePageSizes(5, 128, 5L * 128), CHUNK_TYPE, 5, null)) {
+            assertEquals("no reads at construction with lazy loading",
+                    0, reads.get() - before);
+            // First pass: reading all pages triggers lazy loads on demand
             int after = reads.get();
             try (RandomAccessReader r = sup.get()) {
                 for (int p = 0; p < 5; p++) {
@@ -280,7 +302,18 @@ public class PageStoreReaderTest {
                     r.readInt();
                 }
             }
-            assertEquals("all hits, no new reads", after, reads.get());
+            int firstPass = reads.get() - after;
+            assertTrue("first pass should read pages on demand", firstPass > 0);
+            // Second pass, reading all pages again, should be ALL hits (no extra readIndexPage calls).
+            int after2 = reads.get();
+            try (RandomAccessReader r = sup.get()) {
+                for (int p = 0; p < 5; p++) {
+                    r.seek((long) p * 128);
+                    r.readInt();
+                }
+            }
+            assertEquals("all second pass reads should hit the cache",
+                    0, reads.get() - after2);
         }
     }
 
@@ -291,7 +324,7 @@ public class PageStoreReaderTest {
         int pageSize = 32;
         long[] ids = writeFixedSizePages(dsm, 3, pageSize, 3L * pageSize);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 3)) {
+                dsm, TS, IDX, ids, calculatePageSizes(3, pageSize, 3L * pageSize), CHUNK_TYPE, 3, null)) {
             try (RandomAccessReader r = sup.get()) {
                 // Read full buffer and check alignment
                 byte[] buf = new byte[3 * pageSize];
@@ -314,7 +347,7 @@ public class PageStoreReaderTest {
         long total = 2L * pageSize + 7;
         long[] ids = writeFixedSizePages(dsm, 3, pageSize, total);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 3)) {
+                dsm, TS, IDX, ids, calculatePageSizes(3, pageSize, total), CHUNK_TYPE, 3, null)) {
             assertEquals(total, sup.getTotalLength());
         }
     }
@@ -325,7 +358,7 @@ public class PageStoreReaderTest {
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         long[] ids = writeFixedSizePages(dsm, 1, 16, 16);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 1)) {
+                dsm, TS, IDX, ids, calculatePageSizes(1, 16, 16), CHUNK_TYPE, 1, null)) {
             try (RandomAccessReader r = sup.get()) {
                 r.seek(0);
                 byte[] buf = new byte[16];
@@ -345,13 +378,15 @@ public class PageStoreReaderTest {
         int pageSize = 32;
         long[] ids = writeFixedSizePages(dsm, pageCount, pageSize, pageCount * (long) pageSize);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 4)) {
-            assertEquals("cache must saturate at its bound", 4, sup.getCachedPages());
+                dsm, TS, IDX, ids, calculatePageSizes(pageCount, pageSize, pageCount * (long) pageSize), CHUNK_TYPE, 4, null)) {
+            // With lazy loading, no cache at construction
+            assertEquals("no cache at construction", 0, sup.getCachedPages());
             try (RandomAccessReader r = sup.get()) {
                 byte[] buf = new byte[pageCount * pageSize];
                 r.seek(0);
                 r.readFully(buf);
             }
+            // After streaming through all 40 pages with cache of 4, LRU should still be bounded
             assertEquals("cache still bounded after streaming", 4, sup.getCachedPages());
         }
     }
@@ -362,7 +397,7 @@ public class PageStoreReaderTest {
         int pageSize = 8;
         long[] ids = writeFixedSizePages(dsm, 4, pageSize, 4L * pageSize);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 4)) {
+                dsm, TS, IDX, ids, calculatePageSizes(4, pageSize, 4L * pageSize), CHUNK_TYPE, 4, null)) {
             try (RandomAccessReader r = sup.get()) {
                 // Read a 12-byte buffer starting at position 4: spans pages 0 and 1.
                 byte[] buf = new byte[12];
@@ -379,7 +414,7 @@ public class PageStoreReaderTest {
     public void emptyPageListIsUnsupported() {
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         try {
-            new PageStoreReader.Supplier(dsm, TS, IDX, new long[0], CHUNK_TYPE, 2);
+            new PageStoreReader.Supplier(dsm, TS, IDX, new long[0], new int[0], CHUNK_TYPE, 2, null);
             // Empty list is valid construction; totalLength = 0.
         } catch (Exception unexpected) {
             fail("empty page list should be allowed: " + unexpected);
@@ -395,7 +430,7 @@ public class PageStoreReaderTest {
         long total = 16L * pageSize;
         long[] ids = writeFixedSizePages(dsm, 16, pageSize, total);
         try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
-                dsm, TS, IDX, ids, CHUNK_TYPE, 4)) {
+                dsm, TS, IDX, ids, calculatePageSizes(16, pageSize, total), CHUNK_TYPE, 4, null)) {
             List<Thread> threads = new ArrayList<>();
             List<Throwable> errors = new ArrayList<>();
             for (int t = 0; t < 4; t++) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -117,6 +117,10 @@ public final class IndexingServerConfiguration {
     public static final long PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT_DEFAULT =
             10L * 1024 * 1024 * 1024; // 10 GiB
 
+    public static final String PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES =
+            "indexing.vector.segmentPageCacheMaxBytes";
+    public static final long PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES_DEFAULT = 0; // 0 = compute as 1/4 of heap
+
     // Compaction
     public static final String PROPERTY_COMPACTION_INTERVAL = "indexing.compaction.interval";
     public static final long PROPERTY_COMPACTION_INTERVAL_DEFAULT = 60000L;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -326,9 +326,17 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     IndexingServerConfiguration.PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT_DEFAULT);
             LOGGER.log(Level.INFO, "vector index maxLiveBytesPerCheckpoint: {0} bytes",
                     maxLiveBytesPerCheckpoint);
+            final long segmentPageCacheMaxBytes = config.getLong(
+                    IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES,
+                    IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES_DEFAULT);
+            long effectiveCacheBytes = segmentPageCacheMaxBytes > 0 ? segmentPageCacheMaxBytes
+                    : herddb.index.vector.SharedSegmentPageCache.DEFAULT_MAX_BYTES;
+            LOGGER.log(Level.INFO, "vector index segmentPageCacheMaxBytes: {0} bytes (config: {1})",
+                    new Object[]{effectiveCacheBytes, segmentPageCacheMaxBytes});
 
             final long vectorMemLimit = maxVectorMemoryBytes;
             final VectorMemoryBudget budget = this;
+            final long finalSegmentPageCacheMaxBytes = segmentPageCacheMaxBytes;
             vectorStoreFactory = (indexName, tableName, vectorColumnName, dataDir, indexProperties) -> {
                 var similarityFunction = PersistentVectorStore.parseSimilarityFunction(
                         indexProperties != null ? indexProperties.get(VectorIndexManager.PROP_SIMILARITY) : null);
@@ -338,7 +346,8 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         m, beamWidth, neighborOverflow, alpha,
                         fusedPQ, maxSegmentSize, maxLiveGraphSize,
                         compactionInterval,
-                        similarityFunction, vectorMemLimit, budget, maxLiveBytesPerCheckpoint);
+                        similarityFunction, vectorMemLimit, budget, maxLiveBytesPerCheckpoint,
+                        finalSegmentPageCacheMaxBytes);
                 try {
                     store.start();
                 } catch (Exception e) {

--- a/herddb-services/src/main/resources/conf/indexingservice.properties
+++ b/herddb-services/src/main/resources/conf/indexingservice.properties
@@ -48,3 +48,8 @@ indexing.http.host=0.0.0.0
 # next cycle. Prevents pathologically large FusedPQ writes after OOM-recovery
 # catch-up (issue #107). 0 = no cap. Default: 10737418240 (10 GiB).
 # indexing.vector.maxLiveBytesPerCheckpoint=10737418240
+
+# Maximum bytes for the global page cache of lazy-loaded vector index segments.
+# The cache uses an LRU eviction strategy and is bounded by this byte budget.
+# 0 (default) = automatically compute as 1/4 of the JVM max heap.
+# indexing.vector.segmentPageCacheMaxBytes=0


### PR DESCRIPTION
## Summary

Implement streaming HNSW search across segments by introducing lazy page loading and a global shared page cache. This solves issue #113 where ANN queries were extremely slow due to constant page re-fetches from the remote file server when the indexing service heap was limited.

**Problem**: With 221 segments (~17 GB total) and only 5 GB heap, the indexing service experienced O(segment_bytes) loads at startup and 4.6 GB/query re-fetches, resulting in 20-25 second queries (0.04 qps).

**Solution**: 
- Eliminate forced eager reads of all pages during segment initialization
- Implement Caffeine-backed `SharedSegmentPageCache` bounded by bytes (default 1/4 heap)
- Lazy-load graph pages only when visited during HNSW traversal
- All segments share one global cache for better working-set utilization

**Technical Details**:
- Store page payload sizes in segment metadata (no version bump, format experimental)
- New `PageStoreReader.PageSource` constructor accepts pre-known page sizes
- `SharedSegmentPageCache` uses byte-weight LRU with configurable budget
- Updated segment write/read paths to persist and restore page sizes
- Cache integrated into `loadFusedPQSegment` and passed to all readers

**Test Results**: All 73 vector index tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)