### PR TITLE
Fix bench agent default: --ingest-max-ops 20000 (not 10000)

### DIFF
--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -170,12 +170,12 @@ invariants.
 
 ```
 ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
-    --ingest-max-ops 10000 --ingest-threads 8 --batch-size 10000 --checkpoint
+    --ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000 --checkpoint
 ```
 
 Rules that apply to every workload, including user-specified ones:
 
-- **Ingest defaults to `--ingest-max-ops 10000 --ingest-threads 8 --batch-size 10000`**
+- **Ingest defaults to `--ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000`**
   unless the user explicitly overrides them. These values were validated on
   bigann 10M (k3s-local): 13,870 ops/s sustained, p99=0.43 ms, batch latency
   max=73 ms. If the user's command omits any of these flags, add them and tell
@@ -458,7 +458,7 @@ preserve existing `section` / `timestamp` helpers, and add `--help`
   traces and SEVERE log lines **verbatim**.
 - Never attempt to recover a faulty cluster. Collect, file, stop.
 - Never run recall / query phases before a successful checkpoint.
-- Default ingest uses `--ingest-max-ops 10000 --ingest-threads 8 --batch-size 10000`
+- Default ingest uses `--ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000`
   unless the user overrides them.
 - Escalate checkpoint timeout from 300 s to 600 s after any timeout
   is observed in the session.

--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -155,15 +155,14 @@ forbidden.
 
 ```
 ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
-    --ingest-max-ops 10000 --ingest-threads 8 --batch-size 10000 --checkpoint
+    --ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000 --checkpoint
 ```
 
 Rules that apply to every workload, including user-specified ones:
 
-- **Ingest is always throttled to `--ingest-max-ops 10000`** unless the user
-  explicitly overrides it. We are never in a hurry; a stable 10000 op/s load
-  with 8 threads and batch-size 10000 keeps results comparable across runs
-  (validated on bigann 10M: 13,870 ops/s sustained, p99=0.43 ms).
+- **Ingest defaults to `--ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000`**
+  unless the user explicitly overrides them. These values were validated on
+  bigann 10M (k3s-local): 13,870 ops/s sustained, p99=0.43 ms, max=73 ms.
   If the user's command omits any of these flags, add them and tell the user
   you added them.
 - **Recall / query phases (`-k`, recall tests) must only run AFTER a
@@ -435,7 +434,7 @@ any new flag.
   stack traces and SEVERE log lines **verbatim** in the body.
 - Never attempt to recover a faulty cluster. Collect, file, stop.
 - Never run recall / query phases before a successful checkpoint.
-- Default ingest uses `--ingest-max-ops 10000 --ingest-threads 8 --batch-size 10000`
+- Default ingest uses `--ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000`
   unless the user overrides them.
 - Escalate checkpoint timeout from 300 s to 600 s after any timeout is
   observed in the session.


### PR DESCRIPTION
## Summary

Corrects `--ingest-max-ops` in both `herddb-k3s-bench` and `herddb-gke-bench` agent defaults to **`20000`**.

The full set of new defaults (combining with #120):

```
--ingest-max-ops 20000 --ingest-threads 8 --batch-size 10000
```

These were validated during the 2026-04-16 bigann 10M benchmark session:

| Metric | Value |
|---|---|
| Throughput | 13,870 ops/s |
| Wall time (10M rows) | 721s |
| p99 latency | 0.43 ms |
| max latency | 73 ms |

Note: this PR includes all changes from #120 plus the `--ingest-max-ops` correction. If #120 is merged first, only the max-ops line will show as a diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)