### PR TITLE
Fix issue #122: Reduce lock contention in indexing service

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -1496,8 +1496,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private void doCheckpointSimpleUnderLock(LogSequenceNumber sequenceNumber)
             throws IOException, DataStorageManagerException {
         // Collect all vectors from all live shards + on-disk segments
-        ConcurrentHashMap<Integer, VectorFloat<?>> allVectors = new ConcurrentHashMap<>();
-        ConcurrentHashMap<Integer, Bytes> allNodeToPk = new ConcurrentHashMap<>();
+        int estimatedSize = liveShards.stream().mapToInt(s -> s.nodeToPk.size()).sum() + segments.size() * 10000;
+        ConcurrentHashMap<Integer, VectorFloat<?>> allVectors = new ConcurrentHashMap<>(estimatedSize);
+        ConcurrentHashMap<Integer, Bytes> allNodeToPk = new ConcurrentHashMap<>(estimatedSize);
         int seqId = 0;
         for (LiveGraphShard shard : liveShards) {
             for (Map.Entry<Integer, Bytes> e : shard.nodeToPk.entrySet()) {
@@ -3039,7 +3040,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             throws IOException, DataStorageManagerException {
         List<Integer> sortedNodeIds = new ArrayList<>(allNodeToPk.keySet());
         java.util.Collections.sort(sortedNodeIds);
-        Map<Integer, Integer> oldToNew = new java.util.HashMap<>();
+        Map<Integer, Integer> oldToNew = new java.util.HashMap<>(sortedNodeIds.size() * 2);  // avoid rehashing (issue #122)
         for (int i = 0; i < sortedNodeIds.size(); i++) {
             oldToNew.put(sortedNodeIds.get(i), i);
         }
@@ -3174,7 +3175,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             ConcurrentHashMap<Integer, Bytes> allNodeToPk) throws IOException {
         List<Integer> sortedNodeIds = new ArrayList<>(allNodeToPk.keySet());
         java.util.Collections.sort(sortedNodeIds);
-        Map<Integer, Integer> oldToNew = new java.util.HashMap<>();
+        Map<Integer, Integer> oldToNew = new java.util.HashMap<>(sortedNodeIds.size() * 2);  // avoid rehashing (issue #122)
         for (int i = 0; i < sortedNodeIds.size(); i++) {
             oldToNew.put(sortedNodeIds.get(i), i);
         }
@@ -3759,8 +3760,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * Use this when the global nodeId space has already been remapped (e.g., simple checkpoint rebuild).
      */
     private LiveGraphShard createEmptyLiveShard(int dim, int bw, float no, float a, int startNodeId) {
-        ConcurrentHashMap<Bytes, Integer> p2n = new ConcurrentHashMap<>();
-        ConcurrentHashMap<Integer, Bytes> n2p = new ConcurrentHashMap<>();
+        int cap = computeEffectiveMaxLiveGraphSize();  // preallocate to avoid rehashing during inserts (issue #122)
+        ConcurrentHashMap<Bytes, Integer> p2n = new ConcurrentHashMap<>(cap);
+        ConcurrentHashMap<Integer, Bytes> n2p = new ConcurrentHashMap<>(cap);
         VectorStorageRandomAccessVectorValues ravv =
                 new VectorStorageRandomAccessVectorValues(vectorStorage, dim, -1, startNodeId);
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, similarityFunction);

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -115,6 +115,7 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
     private ManagedChannel buildChannel(String server) {
         ManagedChannelBuilder<?> b = ManagedChannelBuilder.forTarget(server)
                 .usePlaintext()
+                .disableRetry()  // eliminate UncommittedRetriableStreamsRegistry lock contention (issue #122)
                 .keepAliveTime(300, TimeUnit.SECONDS)
                 .keepAliveTimeout(20, TimeUnit.SECONDS);
         if (clientInterceptor != null) {

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -113,7 +113,7 @@ indexingService:
   enabled: true
   storageMode: remote
   replicaCount: 2
-  javaOpts: "-Xms24g -Xmx24g -Djava.net.preferIPv4Stack=true"
+  javaOpts: "-Xms24g -Xmx24g -Djava.net.preferIPv4Stack=true -Dio.netty.maxDirectMemory=0 -XX:MaxDirectMemorySize=512m -Dio.netty.allocator.numDirectArenas=16"
   storage:
     data:
       size: 20Gi

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -148,7 +148,10 @@ indexingService:
   # ~25s/query. 9 g allows more segments resident in memory simultaneously,
   # which should significantly reduce query latency.
   # 9 g heap + 1 GiB JVM overhead → 10 GiB container memory.
-  javaOpts: "-Xms9g -Xmx9g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector"
+  # Netty memory tuning: io.netty.maxDirectMemory=0 respects -XX:MaxDirectMemorySize cap
+  # instead of defaulting to heap size; 512m cap is sufficient for gRPC messages.
+  # numDirectArenas=16 spreads Netty allocations to reduce lock contention (issue #122).
+  javaOpts: "-Xms9g -Xmx9g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector -Dio.netty.maxDirectMemory=0 -XX:MaxDirectMemorySize=512m -Dio.netty.allocator.numDirectArenas=16"
   storage:
     data:
       size: 5Gi

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -171,6 +171,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         int port = Integer.parseInt(parts[1]);
         ManagedChannelBuilder<?> b = ManagedChannelBuilder.forAddress(host, port)
                 .usePlaintext()
+                .disableRetry()  // eliminate UncommittedRetriableStreamsRegistry lock contention (issue #122)
                 .keepAliveTime(300, TimeUnit.SECONDS)
                 .keepAliveTimeout(20, TimeUnit.SECONDS)
                 .keepAliveWithoutCalls(false)


### PR DESCRIPTION
## Summary

Addresses lock contention observed in bigann 10M vector search profiling (issue #122).
Query latency degraded to ~20s/query due to three distinct lock contention sources in the
indexing service, file service clients, and vector storage layer.

## Changes

### 1. Netty memory tuning (Helm: k3s-local & GKE values)
- Add `-Dio.netty.maxDirectMemory=0` to respect JVM's direct memory cap instead of defaulting to heap size
- Add `-XX:MaxDirectMemorySize=512m` to limit gRPC Netty direct buffers (sufficient for message payloads)
- Add `-Dio.netty.allocator.numDirectArenas=16` to spread allocations across 16 arenas, reducing per-arena lock contention

Eliminates `PoolArena.allocate` and `PoolSubpage.lock` serialization in gRPC Netty transport.

### 2. Disable gRPC retries in client channels
- IndexingServiceClient: add `.disableRetry()`
- RemoteFileServiceClient: add `.disableRetry()`

Eliminates `UncommittedRetriableStreamsRegistry` lock contention that was serializing every RPC call.
Callers already have timeout/retry logic; failed calls should surface immediately rather than silently retry.

### 3. Pre-allocate ConcurrentHashMap capacity in hot paths
- `createEmptyLiveShard`: pass `computeEffectiveMaxLiveGraphSize()` to both `pkToNode` and `nodeToPk` maps
- `doCheckpointSimpleUnderLock`: estimate total capacity from live shards and on-disk segments
- `writeFusedPQMapData` variants: pass `sortedNodeIds.size() * 2` to HashMap

Eliminates rehashing overhead during vector insertion and checkpoint serialization phases.

## Testing

✅ All code validation checks pass (checkstyle, apache-rat, spotbugs)
✅ All PersistentVectorStore tests pass (36 tests)

## Expected impact

Profiling data should show significant reduction in:
- `PoolArena.allocate` and `PoolSubpage.lock` samples
- `UncommittedRetriableStreamsRegistry.add/remove` samples
- HashMap/ConcurrentHashMap rehashing overhead

Query latency on bigann 10M should improve substantially during both index construction and query phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)