### PR TITLE
Fix issue #129: Race condition in concurrent search and checkpoint Phase C

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -1217,44 +1217,53 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
 
-        // Search frozen shards (during Phase B of checkpoint)
-        List<LiveGraphShard> frozen = frozenShards;
-        if (frozen != null) {
-            Set<Bytes> pending = pendingCheckpointDeletes;
-            for (LiveGraphShard shard : frozen) {
-                if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
-                    int k = Math.min(perSourceK, shard.nodeToPk.size());
-                    ImmutableGraphIndex graph = shard.builder.getGraph();
-                    SearchResult result = GraphSearcher.search(
-                            qv, k, shard.mravv, similarityFunction, graph, Bits.ALL);
-                    for (SearchResult.NodeScore ns : result.getNodes()) {
-                        Bytes pk = shard.nodeToPk.get(ns.node + shard.startNodeId);
-                        if (pk != null && (pending == null || !pending.contains(pk))) {
-                            results.add(new AbstractMap.SimpleImmutableEntry<>(pk, ns.score));
+        // Search frozen shards (during Phase B of checkpoint) and deferred shards.
+        // Both are cleaned up by Phase C under the write lock, so we must hold the read lock
+        // to prevent concurrent vectorStorage.remove() (called in Phase C) from clearing vectors
+        // while GraphSearcher accesses them via shard.mravv. Without this lock, there is a race
+        // where vectorStorage.remove() nulls a vector slot while jvector's scorer is calling
+        // getVector() on it, leading to NullPointerException (issue #129).
+        stateLock.readLock().lock();
+        try {
+            List<LiveGraphShard> frozen = frozenShards;
+            if (frozen != null) {
+                Set<Bytes> pending = pendingCheckpointDeletes;
+                for (LiveGraphShard shard : frozen) {
+                    if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
+                        int k = Math.min(perSourceK, shard.nodeToPk.size());
+                        ImmutableGraphIndex graph = shard.builder.getGraph();
+                        SearchResult result = GraphSearcher.search(
+                                qv, k, shard.mravv, similarityFunction, graph, Bits.ALL);
+                        for (SearchResult.NodeScore ns : result.getNodes()) {
+                            Bytes pk = shard.nodeToPk.get(ns.node + shard.startNodeId);
+                            if (pk != null && (pending == null || !pending.contains(pk))) {
+                                results.add(new AbstractMap.SimpleImmutableEntry<>(pk, ns.score));
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // Search deferred shards (live shards held back by the shard cap during Phase B)
-        List<LiveGraphShard> deferred = deferredShards;
-        if (deferred != null) {
-            Set<Bytes> pending = pendingCheckpointDeletes;
-            for (LiveGraphShard shard : deferred) {
-                if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
-                    int k = Math.min(perSourceK, shard.nodeToPk.size());
-                    ImmutableGraphIndex graph = shard.builder.getGraph();
-                    SearchResult result = GraphSearcher.search(
-                            qv, k, shard.mravv, similarityFunction, graph, Bits.ALL);
-                    for (SearchResult.NodeScore ns : result.getNodes()) {
-                        Bytes pk = shard.nodeToPk.get(ns.node + shard.startNodeId);
-                        if (pk != null && (pending == null || !pending.contains(pk))) {
-                            results.add(new AbstractMap.SimpleImmutableEntry<>(pk, ns.score));
+            List<LiveGraphShard> deferred = deferredShards;
+            if (deferred != null) {
+                Set<Bytes> pending = pendingCheckpointDeletes;
+                for (LiveGraphShard shard : deferred) {
+                    if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
+                        int k = Math.min(perSourceK, shard.nodeToPk.size());
+                        ImmutableGraphIndex graph = shard.builder.getGraph();
+                        SearchResult result = GraphSearcher.search(
+                                qv, k, shard.mravv, similarityFunction, graph, Bits.ALL);
+                        for (SearchResult.NodeScore ns : result.getNodes()) {
+                            Bytes pk = shard.nodeToPk.get(ns.node + shard.startNodeId);
+                            if (pk != null && (pending == null || !pending.contains(pk))) {
+                                results.add(new AbstractMap.SimpleImmutableEntry<>(pk, ns.score));
+                            }
                         }
                     }
                 }
             }
+        } finally {
+            stateLock.readLock().unlock();
         }
 
         // Merge and sort by score descending, take top-K

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreConcurrentCheckpointTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreConcurrentCheckpointTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
@@ -341,6 +342,84 @@ public class PersistentVectorStoreConcurrentCheckpointTest {
             assertEquals("a real Phase B should have run after the bound",
                     afterBootstrap + 1, store.getTotalFusedPQCheckpointCount());
             assertEquals(400, store.size());
+        }
+    }
+
+    /**
+     * Verifies that concurrent search and checkpoint do not corrupt the
+     * vector store state. This is a regression test for issue #129, which
+     * manifested as NullPointerException in GraphSearcher when Phase C
+     * cleared vectorStorage while searches were accessing frozen shards.
+     */
+    @Test
+    public void testConcurrentSearchAndCheckpoint() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("concurrent-search-cp-simple").toPath();
+        int dim = 128;
+        Random rng = new Random(42);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Insert and checkpoint multiple times concurrently with searches
+            // This exercises the race condition where Phase C clears vectorStorage
+            // while searches might be accessing frozen shards.
+            for (int cycle = 0; cycle < 3; cycle++) {
+                // Insert a batch of vectors
+                int batchSize = 256;
+                for (int i = 0; i < batchSize; i++) {
+                    store.addVector(Bytes.from_int(cycle * 1000 + i), randomVector(rng, dim));
+                }
+
+                // Launch search threads that will run concurrently
+                // with checkpoint Phase C (which clears vectorStorage).
+                int numSearchThreads = 3;
+                CountDownLatch searchStart = new CountDownLatch(numSearchThreads);
+                CountDownLatch searchDone = new CountDownLatch(numSearchThreads);
+                AtomicInteger searchCount = new AtomicInteger(0);
+                AtomicReference<Throwable> searchError = new AtomicReference<>();
+
+                for (int t = 0; t < numSearchThreads; t++) {
+                    new Thread(() -> {
+                        try {
+                            searchStart.countDown();
+                            searchStart.await();
+                            float[] query = randomVector(rng, dim);
+                            for (int iter = 0; iter < 5; iter++) {
+                                store.search(query, 5);
+                                searchCount.incrementAndGet();
+                            }
+                        } catch (Throwable t1) {
+                            searchError.compareAndSet(null, t1);
+                        } finally {
+                            searchDone.countDown();
+                        }
+                    }).start();
+                }
+
+                // Run checkpoint while searches are happening
+                searchStart.await();
+                store.checkpoint();
+
+                // Wait for searches to complete
+                assertTrue("searches should complete within 120s",
+                        searchDone.await(120, TimeUnit.SECONDS));
+                if (searchError.get() != null) {
+                    throw new AssertionError("search thread encountered exception",
+                            searchError.get());
+                }
+                assertTrue("search threads should have executed some queries",
+                        searchCount.get() > 0);
+            }
+
+            // Verify data integrity
+            int expectedVectors = 3 * 256;
+            assertEquals("all vectors should be present after concurrent ops",
+                    expectedVectors, store.size());
+
+            // Verify searches still work
+            float[] query = randomVector(rng, dim);
+            var results = store.search(query, 10);
+            assertFalse("final search should return results", results.isEmpty());
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a critical race condition (NullPointerException) in `PersistentVectorStore` that occurs during concurrent vector search and checkpoint Phase C cleanup.

### Root Cause

During checkpoint Phase C, `vectorStorage.remove()` is called under the write lock to clear vectors for checkpointed shards. Concurrently, `search()` threads can read `frozenShards` and call `GraphSearcher.search()` **without holding any lock**, creating a race:

1. Search thread reads `frozenShards` (volatile, non-null)
2. Phase C acquires write lock, calls `vectorStorage.remove(nodeId)` for all frozen nodes
3. GraphSearcher tries to call `getVector(node)` → returns **null**
4. jvector's `VectorUtil.squareL2Distance(vec, null)` throws NPE

Error: `java.lang.NullPointerException: Cannot invoke "VectorFloat.length()" because "b" is null`

### Solution

Hold `stateLock.readLock()` while searching frozen/deferred shards. Since Phase C holds the write lock during cleanup, this ensures mutual exclusion: Phase C cannot clear vectors while a search thread is using them.

### Implementation Details

- Wrapped frozen/deferred shard search blocks (lines ~1220-1268) in `stateLock.readLock()`
- Live shard search does NOT need the lock (live shards are not cleared in Phase C)
- Added regression test: `testConcurrentSearchAndCheckpoint()` with concurrent search+checkpoint cycles
- Minimal performance impact: read lock held only during graph search (~milliseconds per checkpoint)

### Test Plan

- [x] Unit test: concurrent search + checkpoint (3 cycles, 3 search threads)
- [x] Existing tests: all 6 concurrent checkpoint tests pass
- [ ] To verify before merge: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins`

### Workload Command (from issue)

```bash
./scripts/run-bench.sh --dataset bigann -n 10000000 -k 10 \
    --ingest-max-ops 50000 --ingest-threads 8 --batch-size 10000 --checkpoint
```

Should no longer fail with NPE during query phase.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)