### PR TITLE
Remove jenkins profile docker-build from herddb-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: 'Build jvector'
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector
       - name: 'Build with Maven (with checkstyle, rat, spotbugs)'
-        run: mvn -B checkstyle:check apache-rat:check install -DskipTests spotbugs:check -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins
+        run: mvn -B checkstyle:check apache-rat:check install -DskipTests spotbugs:check -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pci
       - name: 'Upload build artifacts'
         uses: actions/upload-artifact@v4
         with:
@@ -84,7 +84,7 @@ jobs:
           name: maven-build-artifacts
           path: ~/.m2/repository
       - name: 'Test herddb-core (non-cluster)'
-        run: mvn -B verify -DforkCount=2 -Dtest.excludedGroups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pjenkins
+        run: mvn -B verify -DforkCount=2 -Dtest.excludedGroups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pci
       - name: 'Upload surefire reports'
         if: failure()
         uses: actions/upload-artifact@v4
@@ -119,7 +119,7 @@ jobs:
           name: maven-build-artifacts
           path: ~/.m2/repository
       - name: 'Test herddb-core (cluster)'
-        run: mvn -B verify -DforkCount=2 -Dtest.groups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pjenkins
+        run: mvn -B verify -DforkCount=2 -Dtest.groups=herddb.core.ClusterTest -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -pl herddb-core -Pci
       - name: 'Upload surefire reports'
         if: failure()
         uses: actions/upload-artifact@v4
@@ -154,7 +154,7 @@ jobs:
           name: maven-build-artifacts
           path: ~/.m2/repository
       - name: 'Test other modules'
-        run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins -pl !herddb-core,!herddb-remote-file-service,!herddb-indexing-service
+        run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pci -pl !herddb-core,!herddb-remote-file-service,!herddb-indexing-service
       - name: 'Upload surefire reports'
         if: failure()
         uses: actions/upload-artifact@v4
@@ -189,7 +189,7 @@ jobs:
           name: maven-build-artifacts
           path: ~/.m2/repository
       - name: 'Test herddb-remote-file-service'
-        run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins -pl herddb-remote-file-service
+        run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pci -pl herddb-remote-file-service
       - name: 'Upload surefire reports'
         if: failure()
         uses: actions/upload-artifact@v4
@@ -224,7 +224,7 @@ jobs:
           name: maven-build-artifacts
           path: ~/.m2/repository
       - name: 'Test herddb-indexing-service'
-        run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pjenkins -pl herddb-indexing-service
+        run: mvn -B verify -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml -Pci -pl herddb-indexing-service
       - name: 'Upload surefire reports'
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: 'Build jvector'
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector
       - name: 'Build with Maven'
-        run: mvn -B install -DskipTests --file pom.xml -Pjenkins
+        run: mvn -B install -DskipTests --file pom.xml -Pci
       - name: 'Build docker images'
         run: mvn -B -pl herddb-docker --file pom.xml package -Ddocker
       - name: 'Install Helm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ open a pull request so that CI runs and changes can be reviewed before merging.
 ## Before Sending a PR
 Run the code validation checks locally before opening a pull request:
 ```
-mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pjenkins
+mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci
 ```
 This matches what `.github/workflows/pr-validation.yml` runs in CI (checkstyle, Apache RAT license headers, SpotBugs).
 

--- a/herddb-docker/pom.xml
+++ b/herddb-docker/pom.xml
@@ -198,38 +198,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>jenkins</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>3.1.0</version>
-            <executions>
-              <execution>
-                <id>docker-build</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>docker</executable>
-                  <workingDirectory>${project.build.directory}/workdir</workingDirectory>
-                  <arguments>
-                    <argument>build</argument>
-                    <argument>-t</argument>
-                    <argument>${image.server.image.name}</argument>
-                    <argument>-f</argument>
-                    <argument>Dockerfile</argument>
-                    <argument>.</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -881,7 +881,7 @@
             </build>
         </profile>
         <profile>
-            <id>jenkins</id>
+            <id>ci</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>


### PR DESCRIPTION
## Summary

Removes legacy Jenkins profile references and renames the Maven CI profile to `ci` for clarity.

### Changes

1. **Remove jenkins profile from herddb-docker**: Eliminated unnecessary docker image builds triggered by `-Pjenkins`
   - ci.yml: Docker images no longer built unnecessarily
   - kubernetes-tests.yml: Docker images built exactly once via explicit `-Ddocker`

2. **Rename jenkins → ci profile**: Updated root pom.xml and all workflow references
   - Root `pom.xml`: Renamed profile id from `jenkins` to `ci`
   - `ci.yml`: Updated all 6 `-Pjenkins` references to `-Pci`
   - `kubernetes-tests.yml`: Updated `-Pjenkins` to `-Pci`
   - `CLAUDE.md`: Updated developer instructions

### Why

The `jenkins` profile was a legacy artifact from when CI ran on Jenkins. The profile actually configures the CI build (JVM args for JDK 25, code coverage, static analysis, module expansion), so renaming it to `ci` makes its purpose clear.

## Testing

✓ Validated with: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`
- All checks pass (checkstyle, rat, spotbugs)
- Docker image NOT built as side effect
- New profile name works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)