### PR TITLE
Migrate vector page caches to Caffeine LoadingCache + expose stats

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PageStoreReader.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PageStoreReader.java
@@ -19,33 +19,35 @@
 
 package herddb.index.vector;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.CompletionException;
 
 /**
  * A {@link RandomAccessReader} that reads a logical byte stream assembled from
  * index pages stored in a {@link DataStorageManager}. This is the non-mmap
  * alternative to {@link SegmentedMappedReader} — the graph data is <em>not</em>
  * kept as a resident temp file on disk, and the memory footprint is explicitly
- * bounded by a small LRU page cache.
+ * bounded by a small Caffeine LRU page cache.
  *
  * <p>Rationale: mmapped regions are not counted against the process heap, so
  * holding an mmap reader per loaded vector-store segment can silently explode
  * resident memory at scale. This reader uses on-demand page fetches plus a
- * bounded LRU of decoded page bytes, so the cost is both observable and
- * configurable.
+ * bounded Caffeine LRU of decoded page bytes, so the cost is both observable
+ * and configurable.
  *
  * <p>Thread-safety: each {@code PageStoreReader} instance has its own mutable
  * position and is <em>not</em> safe for concurrent use. Multiple readers
- * obtained from the same {@link Supplier} share a single cache that is
- * internally synchronised.
+ * obtained from the same {@link Supplier} share a single {@link LoadingCache}
+ * that is lock-free on the read path and deduplicates concurrent misses on
+ * the same page.
  */
 final class PageStoreReader implements RandomAccessReader {
 
@@ -187,8 +189,8 @@ final class PageStoreReader implements RandomAccessReader {
 
     /**
      * Shared state used by all readers for one logical file. Holds the
-     * page-id list, the prefix-sum table of page sizes, and a bounded LRU
-     * cache of decoded page bytes.
+     * page-id list, the prefix-sum table of page sizes, and a bounded Caffeine
+     * {@link LoadingCache} of decoded page bytes.
      */
     static final class PageSource {
 
@@ -202,12 +204,8 @@ final class PageStoreReader implements RandomAccessReader {
         final long[] prefixSum;
         final long totalLength;
         private final int maxCachedPages;
-        private final LinkedHashMap<Integer, byte[]> cache;
+        private final LoadingCache<Integer, byte[]> cache;
         private final SharedSegmentPageCache sharedCache;
-        /** Observability: number of page loads that hit the cache. */
-        final AtomicLong cacheHits = new AtomicLong(0);
-        /** Observability: number of page loads that missed and read from the page store. */
-        final AtomicLong cacheMisses = new AtomicLong(0);
 
         /**
          * Builds the PageSource with lazy loading. Page sizes must be provided up-front
@@ -218,7 +216,8 @@ final class PageStoreReader implements RandomAccessReader {
          * @param pageSizes payload size (in bytes) for each page, pre-computed at write time
          * @param expectedChunkType type tag to validate when reading pages
          * @param maxCachedPages per-segment LRU page cache size
-         * @param sharedCache optional global page cache; if non-null, pages are stored here first
+         * @param sharedCache optional global page cache; if non-null, pages are
+         *        fetched through it so concurrent segment readers dedup DSM reads
          */
         PageSource(DataStorageManager dsm, String tableSpace, String indexName,
                    long[] pageIds, int[] pageSizes, int expectedChunkType, int maxCachedPages,
@@ -232,12 +231,10 @@ final class PageStoreReader implements RandomAccessReader {
             this.sharedCache = sharedCache;
             this.prefixSum = new long[pageIds.length + 1];
             this.maxCachedPages = Math.max(1, maxCachedPages);
-            this.cache = new LinkedHashMap<Integer, byte[]>(maxCachedPages + 1, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<Integer, byte[]> eldest) {
-                    return size() > PageSource.this.maxCachedPages;
-                }
-            };
+            this.cache = Caffeine.newBuilder()
+                    .maximumSize(this.maxCachedPages)
+                    .recordStats()
+                    .build(this::loadPageViaStorage);
 
             // Build prefix-sum table from pre-computed page sizes (no I/O).
             // Pages are fetched lazily in loadPage() only when accessed during search.
@@ -275,48 +272,38 @@ final class PageStoreReader implements RandomAccessReader {
         }
 
         byte[] loadPage(int pageIndex) {
-            long pageId = pageIds[pageIndex];
-
-            // Check per-segment LRU first
-            byte[] page;
-            synchronized (cache) {
-                page = cache.get(pageIndex);
-                if (page != null) {
-                    cacheHits.incrementAndGet();
-                    return page;
-                }
-            }
-
-            // Check shared global cache (if enabled)
-            if (sharedCache != null) {
-                page = sharedCache.get(pageId);
-                if (page != null) {
-                    // Store in per-segment LRU too for locality
-                    synchronized (cache) {
-                        cache.put(pageIndex, page);
-                        cacheHits.incrementAndGet();
-                    }
-                    return page;
-                }
-            }
-
-            // Cache miss: fetch from storage
             try {
-                page = readPayload(pageId, expectedChunkType);
-            } catch (IOException | DataStorageManagerException e) {
-                throw new RuntimeException(
+                return cache.get(pageIndex);
+            } catch (CompletionException ce) {
+                Throwable cause = ce.getCause() != null ? ce.getCause() : ce;
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                throw new RuntimeException("failed to load page index " + pageIndex
+                        + " for index " + indexName, cause);
+            }
+        }
+
+        /**
+         * Caffeine CacheLoader body. Either delegates to the shared cache (which has
+         * its own LoadingCache and dedups across segments) or falls back to a direct
+         * DSM read.
+         */
+        private byte[] loadPageViaStorage(Integer pageIndex) throws DataStorageManagerException {
+            long pageId = pageIds[pageIndex];
+            if (sharedCache != null && sharedCache.isActive()) {
+                return sharedCache.load(
+                        new SharedSegmentPageCache.PageKey(tableSpace, indexName, pageId));
+            }
+            try {
+                return readPayload(pageId, expectedChunkType);
+            } catch (IOException e) {
+                throw new DataStorageManagerException(
                         "failed to read page " + pageId + " for index " + indexName, e);
             }
-
-            // Store in both caches
-            synchronized (cache) {
-                cache.put(pageIndex, page);
-                cacheMisses.incrementAndGet();
-            }
-            if (sharedCache != null) {
-                sharedCache.put(pageId, page);
-            }
-            return page;
         }
 
         private byte[] readPayload(long pageId, int expectedType)
@@ -337,15 +324,24 @@ final class PageStoreReader implements RandomAccessReader {
         }
 
         int cachedPages() {
-            synchronized (cache) {
-                return cache.size();
-            }
+            // Caffeine counts may lag on pending writes; force cleanup for tests.
+            cache.cleanUp();
+            return (int) cache.estimatedSize();
+        }
+
+        CacheStats stats() {
+            return cache.stats();
+        }
+
+        void clearCache() {
+            cache.invalidateAll();
+            cache.cleanUp();
         }
     }
 
     /**
      * A {@link ReaderSupplier} backed by a single shared {@link PageSource}.
-     * All returned readers share the LRU page cache but each has its own
+     * All returned readers share the Caffeine cache but each has its own
      * {@code position}, so concurrent search traffic on one segment does not
      * multiply the cached footprint.
      */
@@ -369,25 +365,40 @@ final class PageStoreReader implements RandomAccessReader {
         @Override
         public void close() {
             // Drop cached pages to free memory promptly
-            synchronized (source.cache) {
-                source.cache.clear();
-            }
-            // Also invalidate entries from shared cache
+            source.clearCache();
+            // Also invalidate entries from shared cache, so a subsequent segment
+            // load does not reuse stale bytes after an index has been dropped.
             if (source.sharedCache != null) {
                 for (long pageId : source.pageIds) {
-                    source.sharedCache.invalidate(pageId);
+                    source.sharedCache.invalidate(new SharedSegmentPageCache.PageKey(
+                            source.tableSpace, source.indexName, pageId));
                 }
             }
         }
 
         /** Visible for tests. */
         long getCacheHits() {
-            return source.cacheHits.get();
+            return source.stats().hitCount();
         }
 
         /** Visible for tests. */
         long getCacheMisses() {
-            return source.cacheMisses.get();
+            return source.stats().missCount();
+        }
+
+        /** Visible for tests. */
+        long getCacheLoadSuccess() {
+            return source.stats().loadSuccessCount();
+        }
+
+        /** Visible for tests. */
+        long getCacheLoadFailure() {
+            return source.stats().loadFailureCount();
+        }
+
+        /** Visible for tests. */
+        long getCacheLoadTimeNanos() {
+            return source.stats().totalLoadTime();
         }
 
         /** Visible for tests. */
@@ -398,6 +409,11 @@ final class PageStoreReader implements RandomAccessReader {
         /** Visible for tests. */
         long getTotalLength() {
             return source.totalLength;
+        }
+
+        /** Snapshot of Caffeine stats for metrics publishing. */
+        CacheStats snapshot() {
+            return source.stats();
         }
     }
 }

--- a/herddb-core/src/main/java/herddb/index/vector/PageStoreReader.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PageStoreReader.java
@@ -324,13 +324,21 @@ final class PageStoreReader implements RandomAccessReader {
         }
 
         int cachedPages() {
-            // Caffeine counts may lag on pending writes; force cleanup for tests.
-            cache.cleanUp();
             return (int) cache.estimatedSize();
         }
 
         CacheStats stats() {
             return cache.stats();
+        }
+
+        /**
+         * Forces any pending Caffeine maintenance (eviction, reference-expiration)
+         * to run on the caller's thread. Visible for tests that assert on an
+         * exact post-eviction count; never call from the hot read path — cleanUp
+         * walks the write buffer under a lock and is not cheap.
+         */
+        void drainMaintenance() {
+            cache.cleanUp();
         }
 
         void clearCache() {
@@ -404,6 +412,15 @@ final class PageStoreReader implements RandomAccessReader {
         /** Visible for tests. */
         int getCachedPages() {
             return source.cachedPages();
+        }
+
+        /**
+         * Visible for tests: forces the Caffeine maintenance pass to run so that
+         * {@link #getCachedPages()} and {@code eviction}-related stats reflect a
+         * converged state. Not cheap — never call from production code paths.
+         */
+        void drainCacheMaintenance() {
+            source.drainMaintenance();
         }
 
         /** Visible for tests. */

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -700,7 +700,34 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // Initialize global shared page cache for lazy-loaded segments
         // If segmentPageCacheMaxBytes is 0, use the default (1/4 of JVM heap)
         long cacheBytes = segmentPageCacheMaxBytes > 0 ? segmentPageCacheMaxBytes : SharedSegmentPageCache.DEFAULT_MAX_BYTES;
-        this.segmentPageCache = new SharedSegmentPageCache(cacheBytes);
+        this.segmentPageCache = new SharedSegmentPageCache(cacheBytes, this::loadGraphChunkPage);
+    }
+
+    /**
+     * {@link SharedSegmentPageCache.PageLoader} implementation used for all
+     * {@link #TYPE_VECTOR_GRAPHCHUNK} pages written by this store's segments.
+     * The cache guarantees single-flight loading across concurrent segment
+     * readers that miss on the same {@code pageId}.
+     */
+    private byte[] loadGraphChunkPage(SharedSegmentPageCache.PageKey key)
+            throws DataStorageManagerException {
+        // DSM.readIndexPage() wraps any IOException from the reader lambda
+        // into DataStorageManagerException (see e.g. MemoryDataStorageManager /
+        // FileDataStorageManager), so we only need the one checked throws here.
+        return dataStorageManager.readIndexPage(
+                key.tableSpaceUUID(), key.indexUUID(), key.pageId(),
+                in -> {
+                    int type = in.readVInt();
+                    if (type != TYPE_VECTOR_GRAPHCHUNK) {
+                        throw new java.io.IOException(
+                                "page " + key.pageId() + ": expected type "
+                                        + TYPE_VECTOR_GRAPHCHUNK + " but got " + type);
+                    }
+                    int len = in.readVInt();
+                    byte[] data = new byte[len];
+                    in.readArray(len, data);
+                    return data;
+                });
     }
 
     // -------------------------------------------------------------------------
@@ -4055,6 +4082,101 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public void setSegmentSizeStats(OpStatsLogger segmentSizeStats) {
         this.segmentSizeStats = segmentSizeStats;
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache stats accessors — used by IndexingServiceEngine to register
+    // per-index gauges for the shared segment page cache and the aggregated
+    // per-segment page-reader caches.
+    // -------------------------------------------------------------------------
+
+    public long getSegmentPageCacheHitCount() {
+        return segmentPageCache == null ? 0L : segmentPageCache.hitCount();
+    }
+
+    public long getSegmentPageCacheMissCount() {
+        return segmentPageCache == null ? 0L : segmentPageCache.missCount();
+    }
+
+    public long getSegmentPageCacheEvictionCount() {
+        return segmentPageCache == null ? 0L : segmentPageCache.evictionCount();
+    }
+
+    public long getSegmentPageCacheLoadSuccessCount() {
+        return segmentPageCache == null ? 0L : segmentPageCache.loadSuccessCount();
+    }
+
+    public long getSegmentPageCacheLoadFailureCount() {
+        return segmentPageCache == null ? 0L : segmentPageCache.loadFailureCount();
+    }
+
+    public long getSegmentPageCacheLoadTimeNanos() {
+        return segmentPageCache == null ? 0L : segmentPageCache.totalLoadTimeNanos();
+    }
+
+    public long getSegmentPageCacheEntries() {
+        return segmentPageCache == null ? 0L : segmentPageCache.estimatedSize();
+    }
+
+    public long getSegmentPageCacheSizeBytes() {
+        return segmentPageCache == null ? 0L : segmentPageCache.weightedSize();
+    }
+
+    public long getSegmentPageCacheMaxBytes() {
+        return segmentPageCache == null ? 0L : segmentPageCache.maxBytes();
+    }
+
+    /**
+     * Aggregates per-segment {@link PageStoreReader.Supplier} Caffeine stats across all
+     * currently-loaded segments that use page-based readers (the remote multipart path
+     * contributes zero). Each call walks the segment list once; values are totals since
+     * the segments were loaded.
+     */
+    private long aggregatePageReaderStats(
+            java.util.function.ToLongFunction<com.github.benmanes.caffeine.cache.stats.CacheStats> extract) {
+        long total = 0L;
+        for (VectorSegment seg : segments) {
+            io.github.jbellis.jvector.disk.ReaderSupplier rs = seg.onDiskReaderSupplier;
+            if (rs instanceof PageStoreReader.Supplier) {
+                total += extract.applyAsLong(((PageStoreReader.Supplier) rs).snapshot());
+            }
+        }
+        return total;
+    }
+
+    public long getPageReaderCacheHitCount() {
+        return aggregatePageReaderStats(com.github.benmanes.caffeine.cache.stats.CacheStats::hitCount);
+    }
+
+    public long getPageReaderCacheMissCount() {
+        return aggregatePageReaderStats(com.github.benmanes.caffeine.cache.stats.CacheStats::missCount);
+    }
+
+    public long getPageReaderCacheEvictionCount() {
+        return aggregatePageReaderStats(com.github.benmanes.caffeine.cache.stats.CacheStats::evictionCount);
+    }
+
+    public long getPageReaderCacheLoadSuccessCount() {
+        return aggregatePageReaderStats(com.github.benmanes.caffeine.cache.stats.CacheStats::loadSuccessCount);
+    }
+
+    public long getPageReaderCacheLoadFailureCount() {
+        return aggregatePageReaderStats(com.github.benmanes.caffeine.cache.stats.CacheStats::loadFailureCount);
+    }
+
+    public long getPageReaderCacheLoadTimeNanos() {
+        return aggregatePageReaderStats(com.github.benmanes.caffeine.cache.stats.CacheStats::totalLoadTime);
+    }
+
+    public long getPageReaderCacheEntries() {
+        long total = 0L;
+        for (VectorSegment seg : segments) {
+            io.github.jbellis.jvector.disk.ReaderSupplier rs = seg.onDiskReaderSupplier;
+            if (rs instanceof PageStoreReader.Supplier) {
+                total += ((PageStoreReader.Supplier) rs).getCachedPages();
+            }
+        }
+        return total;
     }
 
     private void recordSegmentSizeDistribution() {

--- a/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
+++ b/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
@@ -101,6 +101,11 @@ public class SharedSegmentPageCache {
                 return false;
             }
             PageKey k = (PageKey) o;
+            // Fast path: both fields are precomputed in the constructor, so a
+            // hash mismatch is a certain non-equal without touching the strings.
+            if (hash != k.hash) {
+                return false;
+            }
             return pageId == k.pageId
                     && tableSpaceUUID.equals(k.tableSpaceUUID)
                     && indexUUID.equals(k.indexUUID);

--- a/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
+++ b/herddb-core/src/main/java/herddb/index/vector/SharedSegmentPageCache.java
@@ -19,71 +19,173 @@
 
 package herddb.index.vector;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import herddb.storage.DataStorageManagerException;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
 
 /**
  * Global page cache for vector index segments. All segments of a {@link PersistentVectorStore}
- * share a single Caffeine-backed LRU cache bounded by total bytes.
+ * share a single Caffeine-backed {@link LoadingCache} bounded by total bytes.
  *
- * <p>Key = long pageId (globally unique per DataStorageManager).
- * Value = byte[] page payload (cached graph page data).
+ * <p>The cache owns the fetch-on-miss path: callers invoke {@link #load(PageKey)} and
+ * Caffeine either serves the cached page or invokes the supplied {@link PageLoader}
+ * exactly once per concurrent miss (single-flight). This replaces the older
+ * {@code get}/{@code put} API whose callers had to deduplicate themselves.
  *
- * <p>The cache uses a byte-weight function: each entry's weight is its byte[] length.
- * When the cache exceeds the byte budget, the least-recently-used entries are evicted.
+ * <p>Key = {@link PageKey} (tableSpaceUUID + indexUUID + pageId). Value = byte[] page
+ * payload. The cache uses a byte-weight function so entries are weighed by their
+ * {@code byte[]} length and the total cached-byte budget is honoured regardless of
+ * individual page sizes.
  *
- * <p>Default budget = 1/4 of JVM heap; configurable via
- * {@code herddb.vectorindex.segmentPageCacheMaxBytes} system property.
+ * <p>Default budget = 1/4 of JVM heap; the actual value is wired in by
+ * {@link PersistentVectorStore} via the {@code herddb.vectorindex.segmentPageCacheMaxBytes}
+ * system property.
  */
 public class SharedSegmentPageCache {
 
     /** Default cache budget: 1/4 of the JVM max heap. */
     public static final long DEFAULT_MAX_BYTES = Runtime.getRuntime().maxMemory() / 4;
 
-    private final Cache<Long, byte[]> cache;
+    /**
+     * Loads a page by its {@link PageKey}. Called by Caffeine on miss.
+     * Implementations are responsible for turning storage errors into
+     * {@link DataStorageManagerException}.
+     */
+    @FunctionalInterface
+    public interface PageLoader {
+        byte[] load(PageKey key) throws DataStorageManagerException;
+    }
 
     /**
-     * Creates a new shared page cache with the given byte budget.
-     *
-     * @param maxBytes maximum total bytes to cache. If <= 0, behaves as a no-op cache (always miss).
+     * Immutable identifier for a cached page. Three fields are enough to disambiguate
+     * across every active index in the JVM: {@code pageId} is unique per DSM, and
+     * {@code tableSpaceUUID + indexUUID} narrows the lookup to the right DSM call.
+     * Page type is intentionally not part of the key — only one type
+     * ({@code TYPE_VECTOR_GRAPHCHUNK}) is cached here today, and adding a field per
+     * entry just to carry a constant would waste heap for every cached page.
      */
-    public SharedSegmentPageCache(long maxBytes) {
+    public static final class PageKey {
+        private final String tableSpaceUUID;
+        private final String indexUUID;
+        private final long pageId;
+        private final int hash;
+
+        public PageKey(String tableSpaceUUID, String indexUUID, long pageId) {
+            this.tableSpaceUUID = Objects.requireNonNull(tableSpaceUUID, "tableSpaceUUID");
+            this.indexUUID = Objects.requireNonNull(indexUUID, "indexUUID");
+            this.pageId = pageId;
+            this.hash = Objects.hash(tableSpaceUUID, indexUUID, pageId);
+        }
+
+        public String tableSpaceUUID() {
+            return tableSpaceUUID;
+        }
+
+        public String indexUUID() {
+            return indexUUID;
+        }
+
+        public long pageId() {
+            return pageId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof PageKey)) {
+                return false;
+            }
+            PageKey k = (PageKey) o;
+            return pageId == k.pageId
+                    && tableSpaceUUID.equals(k.tableSpaceUUID)
+                    && indexUUID.equals(k.indexUUID);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "PageKey{ts=" + tableSpaceUUID + ", idx=" + indexUUID + ", page=" + pageId + "}";
+        }
+    }
+
+    private final LoadingCache<PageKey, byte[]> cache;
+    private final PageLoader loader;
+    private final long maxBytes;
+
+    /**
+     * Creates a new shared page cache with the given byte budget and loader.
+     *
+     * @param maxBytes maximum total bytes to cache. If {@code <= 0}, no caching is done —
+     *        every {@link #load(PageKey)} call delegates straight to the loader.
+     * @param loader fetches a page on miss. Never {@code null}.
+     */
+    public SharedSegmentPageCache(long maxBytes, PageLoader loader) {
+        this.maxBytes = maxBytes;
+        this.loader = Objects.requireNonNull(loader, "loader");
         if (maxBytes <= 0) {
             this.cache = null;
         } else {
             this.cache = Caffeine.newBuilder()
                     .maximumWeight(maxBytes)
-                    .weigher((Long pageId, byte[] data) -> data == null ? 0 : data.length)
+                    .weigher((PageKey k, byte[] v) -> v == null ? 0 : v.length)
                     .recordStats()
-                    .build();
+                    .build(loader::load);
         }
     }
 
     /**
-     * Retrieves a page from the cache, or null if not present (miss).
+     * Returns the page for {@code key}, loading it through the configured
+     * {@link PageLoader} if not already cached. Concurrent misses on the same key
+     * are deduplicated — the loader is invoked exactly once.
+     *
+     * @throws DataStorageManagerException if the loader fails
      */
-    public byte[] get(long pageId) {
+    public byte[] load(PageKey key) throws DataStorageManagerException {
+        Objects.requireNonNull(key, "key");
         if (cache == null) {
-            return null;
+            byte[] v = loader.load(key);
+            if (v == null) {
+                throw new DataStorageManagerException("loader returned null for " + key);
+            }
+            return v;
         }
-        return cache.getIfPresent(pageId);
+        try {
+            byte[] v = cache.get(key);
+            if (v == null) {
+                // Caffeine returns null only if the loader returned null — surface it.
+                throw new DataStorageManagerException("loader returned null for " + key);
+            }
+            return v;
+        } catch (CompletionException ce) {
+            Throwable cause = ce.getCause() != null ? ce.getCause() : ce;
+            if (cause instanceof DataStorageManagerException) {
+                throw (DataStorageManagerException) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new DataStorageManagerException(cause);
+        }
     }
 
     /**
-     * Stores a page in the cache. May trigger eviction of LRU entries.
+     * Invalidates (removes) a page from the cache. Safe to call with an unknown key.
      */
-    public void put(long pageId, byte[] data) {
-        if (cache != null) {
-            cache.put(pageId, data);
-        }
-    }
-
-    /**
-     * Invalidates (removes) a page from the cache.
-     */
-    public void invalidate(long pageId) {
-        if (cache != null) {
-            cache.invalidate(pageId);
+    public void invalidate(PageKey key) {
+        if (cache != null && key != null) {
+            cache.invalidate(key);
         }
     }
 
@@ -97,13 +199,26 @@ public class SharedSegmentPageCache {
     }
 
     /**
-     * Returns the number of entries currently in the cache.
+     * Forces any pending maintenance (eviction, reference-expiration) to run on
+     * the caller's thread. Useful in tests that assert on {@link #evictionCount()}
+     * immediately after an insertion burst, and for operators that want the
+     * exposed gauges to reflect in-flight evictions without waiting for the
+     * background maintenance pass.
+     */
+    public void cleanUp() {
+        if (cache != null) {
+            cache.cleanUp();
+        }
+    }
+
+    /**
+     * Returns the approximate number of entries currently in the cache.
      */
     public long size() {
         if (cache == null) {
             return 0;
         }
-        return cache.asMap().size();
+        return cache.estimatedSize();
     }
 
     /**
@@ -111,5 +226,58 @@ public class SharedSegmentPageCache {
      */
     public boolean isActive() {
         return cache != null;
+    }
+
+    // ---------------------------------------------------------------------
+    // Stats accessors — backed by Caffeine's recordStats().
+    // Return zero when the cache is disabled so callers don't need branches.
+    // ---------------------------------------------------------------------
+
+    public long hitCount() {
+        return cache == null ? 0 : cache.stats().hitCount();
+    }
+
+    public long missCount() {
+        return cache == null ? 0 : cache.stats().missCount();
+    }
+
+    public long evictionCount() {
+        return cache == null ? 0 : cache.stats().evictionCount();
+    }
+
+    public long loadSuccessCount() {
+        return cache == null ? 0 : cache.stats().loadSuccessCount();
+    }
+
+    public long loadFailureCount() {
+        return cache == null ? 0 : cache.stats().loadFailureCount();
+    }
+
+    public long totalLoadTimeNanos() {
+        return cache == null ? 0 : cache.stats().totalLoadTime();
+    }
+
+    public long estimatedSize() {
+        return cache == null ? 0 : cache.estimatedSize();
+    }
+
+    /** Approximate total bytes currently held in the cache. */
+    public long weightedSize() {
+        if (cache == null) {
+            return 0;
+        }
+        return cache.policy().eviction()
+                .map(e -> e.weightedSize().orElse(0L))
+                .orElse(0L);
+    }
+
+    /** Configured byte budget. Returns 0 when the cache is disabled. */
+    public long maxBytes() {
+        return cache == null ? 0 : maxBytes;
+    }
+
+    /** Returns a snapshot of the underlying Caffeine stats (or a zero snapshot if disabled). */
+    public CacheStats stats() {
+        return cache == null ? CacheStats.empty() : cache.stats();
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
@@ -177,6 +177,8 @@ public class PageStoreReaderTest {
             assertTrue("some pages must have missed, got "
                             + (missesAfter - missesBefore),
                     missesAfter - missesBefore >= 4);
+            // Caffeine eviction is async; drain it before asserting a strict count.
+            sup.drainCacheMaintenance();
             assertEquals("LRU must still be bounded", 2, sup.getCachedPages());
         }
     }
@@ -390,7 +392,9 @@ public class PageStoreReaderTest {
                 r.seek(0);
                 r.readFully(buf);
             }
-            // After streaming through all 40 pages with cache of 4, LRU should still be bounded
+            // After streaming through all 40 pages with cache of 4, LRU should still be bounded.
+            // Caffeine eviction is async — drain before asserting a strict count.
+            sup.drainCacheMaintenance();
             assertEquals("cache still bounded after streaming", 4, sup.getCachedPages());
         }
     }

--- a/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
@@ -28,6 +28,10 @@ import herddb.storage.DataStorageManagerException;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
@@ -419,6 +423,220 @@ public class PageStoreReaderTest {
         } catch (Exception unexpected) {
             fail("empty page list should be allowed: " + unexpected);
         }
+    }
+
+    // -----------------------------------------------------------------
+    // LoadingCache-specific tests (new behaviour after migration)
+    // -----------------------------------------------------------------
+
+    @Test
+    public void concurrentMissesOnSamePageDeduplicate() throws Exception {
+        // With the old LinkedHashMap LRU, two threads missing the same page
+        // would each issue a readIndexPage call. Caffeine's LoadingCache
+        // dedups these: the loader runs exactly once per concurrent miss.
+        final int threadCount = 16;
+        AtomicInteger reads = new AtomicInteger(0);
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager() {
+            @Override
+            public <X> X readIndexPage(String tableSpace, String uuid, Long pageId,
+                                       DataReader<X> reader) throws DataStorageManagerException {
+                reads.incrementAndGet();
+                try {
+                    Thread.sleep(10); // hold the load briefly so threads collide
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+                return super.readIndexPage(tableSpace, uuid, pageId, reader);
+            }
+        };
+        int pageSize = 64;
+        long[] ids = writeFixedSizePages(dsm, 4, pageSize, 4L * pageSize);
+        try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
+                dsm, TS, IDX, ids, calculatePageSizes(4, pageSize, 4L * pageSize),
+                CHUNK_TYPE, 4, null)) {
+            int before = reads.get();
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threadCount);
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+            try {
+                List<Throwable> errs = new ArrayList<>();
+                for (int i = 0; i < threadCount; i++) {
+                    pool.submit(() -> {
+                        try (RandomAccessReader r = sup.get()) {
+                            start.await();
+                            r.seek(0); // all threads hit page 0
+                            r.readInt();
+                        } catch (Throwable t) {
+                            synchronized (errs) {
+                                errs.add(t);
+                            }
+                        } finally {
+                            done.countDown();
+                        }
+                    });
+                }
+                start.countDown();
+                assertTrue("threads finished", done.await(10, TimeUnit.SECONDS));
+                if (!errs.isEmpty()) {
+                    throw new AssertionError("concurrent reads failed: " + errs.get(0),
+                            errs.get(0));
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+            int after = reads.get();
+            assertEquals("dedup must limit the loader to one invocation for page 0",
+                    1, after - before);
+        }
+    }
+
+    @Test
+    public void statsAccessorsTrackLoadsAndHits() throws Exception {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        int pageSize = 64;
+        long[] ids = writeFixedSizePages(dsm, 3, pageSize, 3L * pageSize);
+        try (PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
+                dsm, TS, IDX, ids, calculatePageSizes(3, pageSize, 3L * pageSize),
+                CHUNK_TYPE, 4, null)) {
+            assertEquals("fresh supplier has zero load-success count",
+                    0, sup.getCacheLoadSuccess());
+            assertEquals(0, sup.getCacheLoadFailure());
+            try (RandomAccessReader r = sup.get()) {
+                r.seek(0);
+                r.readInt();
+                r.seek(pageSize);
+                r.readInt();
+                r.seek(2L * pageSize);
+                r.readInt();
+            }
+            assertEquals("three pages loaded exactly once each",
+                    3, sup.getCacheLoadSuccess());
+            assertTrue("some load time recorded",
+                    sup.getCacheLoadTimeNanos() >= 0);
+        }
+    }
+
+    @Test
+    public void failedLoadsIncrementLoadFailureStat() throws Exception {
+        // Deleting a page after construction triggers a failed load;
+        // Caffeine's recordStats() must count it under loadFailure, not success.
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        int pageSize = 32;
+        long[] ids = writeFixedSizePages(dsm, 2, pageSize, 2L * pageSize);
+        PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
+                dsm, TS, IDX, ids, calculatePageSizes(2, pageSize, 2L * pageSize),
+                CHUNK_TYPE, 1, null);
+        dsm.deleteIndexPage(TS, IDX, ids[0]);
+        try (RandomAccessReader r = sup.get()) {
+            r.seek(pageSize); // page 1 first (succeeds)
+            r.readInt();
+            r.seek(0); // page 0 — cache miss on a deleted page
+            try {
+                r.readInt();
+                fail("expected failure when loading a deleted page");
+            } catch (RuntimeException expected) {
+            }
+        }
+        assertEquals("one load failed", 1, sup.getCacheLoadFailure());
+        assertTrue("at least one load succeeded (page 1)",
+                sup.getCacheLoadSuccess() >= 1);
+        sup.close();
+    }
+
+    @Test
+    public void sharedCacheReceivesLoadsFromPageReader() throws Exception {
+        // With a SharedSegmentPageCache present, the PageStoreReader loader
+        // delegates to it. Two readers on different PageStoreReader.Suppliers
+        // must share the same loaded bytes via the global cache.
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        int pageSize = 128;
+        long[] ids = writeFixedSizePages(dsm, 3, pageSize, 3L * pageSize);
+        AtomicInteger reads = new AtomicInteger(0);
+        MemoryDataStorageManager countingDsm = new MemoryDataStorageManager() {
+            @Override
+            public <X> X readIndexPage(String tableSpace, String uuid, Long pageId,
+                                       DataReader<X> reader) throws DataStorageManagerException {
+                reads.incrementAndGet();
+                return super.readIndexPage(tableSpace, uuid, pageId, reader);
+            }
+        };
+        // Re-populate the counting DSM (IDs on MemoryDataStorageManager are
+        // per-instance, so we must rewrite the pages).
+        long[] idsCounting = writeFixedSizePages(countingDsm, 3, pageSize, 3L * pageSize);
+
+        // Shared cache with a direct loader that reads through the counting DSM,
+        // mimicking what PersistentVectorStore.loadGraphChunkPage does.
+        SharedSegmentPageCache shared = new SharedSegmentPageCache(1L << 20, key ->
+                countingDsm.readIndexPage(key.tableSpaceUUID(), key.indexUUID(), key.pageId(),
+                        in -> {
+                            int type = in.readVInt();
+                            assertEquals(CHUNK_TYPE, type);
+                            int len = in.readVInt();
+                            byte[] data = new byte[len];
+                            in.readArray(len, data);
+                            return data;
+                        }));
+
+        try (PageStoreReader.Supplier supA = new PageStoreReader.Supplier(
+                countingDsm, TS, IDX, idsCounting,
+                calculatePageSizes(3, pageSize, 3L * pageSize), CHUNK_TYPE, 1, shared);
+             PageStoreReader.Supplier supB = new PageStoreReader.Supplier(
+                countingDsm, TS, IDX, idsCounting,
+                calculatePageSizes(3, pageSize, 3L * pageSize), CHUNK_TYPE, 1, shared)) {
+
+            int before = reads.get();
+            try (RandomAccessReader r = supA.get()) {
+                r.seek(0);
+                r.readInt();
+            }
+            try (RandomAccessReader r = supB.get()) {
+                r.seek(0);
+                r.readInt();
+            }
+            int after = reads.get();
+            assertEquals("second supplier must hit the shared cache — no extra DSM read",
+                    1, after - before);
+        }
+        // the DSM used to stage pages above (dsm) was not hit in this test; silence unused.
+        assertTrue("primary DSM unused for counting", ids.length == idsCounting.length);
+    }
+
+    @Test
+    public void closeInvalidatesSharedCacheEntries() throws Exception {
+        // When the segment is closed, its pages must be evicted from the
+        // shared cache so a subsequent segment with colliding pageIds does
+        // not accidentally serve stale bytes.
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        int pageSize = 16;
+        long[] ids = writeFixedSizePages(dsm, 2, pageSize, 2L * pageSize);
+        AtomicInteger loaderCalls = new AtomicInteger(0);
+        SharedSegmentPageCache shared = new SharedSegmentPageCache(1L << 20, key -> {
+            loaderCalls.incrementAndGet();
+            return dsm.readIndexPage(key.tableSpaceUUID(), key.indexUUID(), key.pageId(),
+                    in -> {
+                        in.readVInt(); // type
+                        int len = in.readVInt();
+                        byte[] data = new byte[len];
+                        in.readArray(len, data);
+                        return data;
+                    });
+        });
+        PageStoreReader.Supplier sup = new PageStoreReader.Supplier(
+                dsm, TS, IDX, ids, calculatePageSizes(2, pageSize, 2L * pageSize),
+                CHUNK_TYPE, 2, shared);
+        try (RandomAccessReader r = sup.get()) {
+            r.seek(0);
+            r.readInt();
+        }
+        int afterFirst = loaderCalls.get();
+        assertTrue("shared cache has a page for this segment",
+                shared.size() > 0);
+        sup.close();
+        // After close, loading the same pageId via the shared cache must
+        // re-invoke the loader because close() invalidated those keys.
+        shared.load(new SharedSegmentPageCache.PageKey(TS, IDX, ids[0]));
+        assertEquals("shared cache entry was invalidated by supplier.close()",
+                afterFirst + 1, loaderCalls.get());
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PageStoreReaderTest.java
@@ -633,6 +633,8 @@ public class PageStoreReaderTest {
             r.readInt();
         }
         int afterFirst = loaderCalls.get();
+        // Caffeine size accounting is async; drain maintenance before asserting.
+        shared.cleanUp();
         assertTrue("shared cache has a page for this segment",
                 shared.size() > 0);
         sup.close();

--- a/herddb-core/src/test/java/herddb/index/vector/SharedSegmentPageCacheTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/SharedSegmentPageCacheTest.java
@@ -1,0 +1,495 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.index.vector.SharedSegmentPageCache.PageKey;
+import herddb.storage.DataStorageManagerException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * Tests for {@link SharedSegmentPageCache} covering:
+ *  - the single-flight LoadingCache path (hits, misses, loader invocations),
+ *  - concurrent-miss deduplication (new behaviour over the old get/put API),
+ *  - failure propagation for every exception class the loader can throw,
+ *  - null safety,
+ *  - byte-weighted eviction,
+ *  - {@link PageKey} equality / hashing / null checks,
+ *  - stats accessors when the cache is active and when it is disabled.
+ */
+public class SharedSegmentPageCacheTest {
+
+    private static final String TS = "ts";
+    private static final String IDX = "idx";
+
+    private static byte[] payload(int size, int marker) {
+        byte[] b = new byte[size];
+        for (int i = 0; i < size; i++) {
+            b[i] = (byte) (marker + i);
+        }
+        return b;
+    }
+
+    // -----------------------------------------------------------------
+    // Happy path
+    // -----------------------------------------------------------------
+
+    @Test
+    public void firstLoadInvokesLoaderAndCachesResult() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            calls.incrementAndGet();
+            return payload(16, (int) k.pageId());
+        });
+
+        byte[] first = cache.load(new PageKey(TS, IDX, 1));
+        byte[] second = cache.load(new PageKey(TS, IDX, 1));
+
+        assertArrayEquals(payload(16, 1), first);
+        assertSame("hit must serve the cached array, not reload", first, second);
+        assertEquals("loader called exactly once", 1, calls.get());
+        assertEquals("one miss observed", 1L, cache.missCount());
+        assertEquals("one hit observed", 1L, cache.hitCount());
+        assertEquals("one successful load", 1L, cache.loadSuccessCount());
+        assertEquals(0L, cache.loadFailureCount());
+    }
+
+    @Test
+    public void distinctKeysCoexist() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            calls.incrementAndGet();
+            return payload(8, (int) k.pageId());
+        });
+
+        byte[] a = cache.load(new PageKey(TS, IDX, 1));
+        byte[] b = cache.load(new PageKey(TS, IDX, 2));
+        byte[] c = cache.load(new PageKey(TS, IDX, 1));
+
+        assertNotEquals("distinct keys must produce distinct payloads",
+                Byte.valueOf(a[0]), Byte.valueOf(b[0]));
+        assertSame(a, c);
+        assertEquals("two distinct keys -> two loads", 2, calls.get());
+    }
+
+    @Test
+    public void keysDifferOnTableSpaceAndIndex() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            calls.incrementAndGet();
+            // Encode all three key fields into the payload so we can verify isolation.
+            byte tag = (byte) (k.tableSpaceUUID().hashCode() ^ k.indexUUID().hashCode()
+                    ^ (int) k.pageId());
+            return new byte[]{tag};
+        });
+
+        cache.load(new PageKey("ts1", IDX, 1));
+        cache.load(new PageKey("ts2", IDX, 1));
+        cache.load(new PageKey(TS, "idx2", 1));
+        cache.load(new PageKey(TS, IDX, 1));
+
+        assertEquals("each distinct (ts, idx, pageId) triggers a fresh load",
+                4, calls.get());
+    }
+
+    // -----------------------------------------------------------------
+    // Concurrent miss deduplication — the headline LoadingCache benefit
+    // -----------------------------------------------------------------
+
+    @Test
+    public void concurrentMissesDeduplicateToOneLoaderInvocation() throws Exception {
+        final int threads = 32;
+        AtomicInteger calls = new AtomicInteger(0);
+        CountDownLatch start = new CountDownLatch(1);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            calls.incrementAndGet();
+            // Hold the loader briefly so concurrent calls collide on the same key.
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            return payload(64, 1);
+        });
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            Set<byte[]> observed = ConcurrentHashMap.newKeySet();
+            CountDownLatch done = new CountDownLatch(threads);
+            for (int i = 0; i < threads; i++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        observed.add(cache.load(new PageKey(TS, IDX, 42)));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue("all threads finished", done.await(10, TimeUnit.SECONDS));
+            assertEquals("all callers see the same cached byte[]", 1, observed.size());
+            assertEquals("loader invoked exactly once despite concurrent misses",
+                    1, calls.get());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Failure propagation
+    // -----------------------------------------------------------------
+
+    @Test
+    public void dataStorageManagerExceptionPropagatesUnwrapped() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            throw new DataStorageManagerException("boom: " + k.pageId());
+        });
+
+        DataStorageManagerException ex = assertThrows(DataStorageManagerException.class,
+                () -> cache.load(new PageKey(TS, IDX, 7)));
+        assertTrue("message must be preserved",
+                ex.getMessage() != null && ex.getMessage().contains("boom: 7"));
+        assertEquals("a failed load counts as loadFailure", 1L, cache.loadFailureCount());
+        assertEquals("a failed load does not count as success", 0L, cache.loadSuccessCount());
+    }
+
+    @Test
+    public void runtimeExceptionFromLoaderPropagatesAsIs() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            throw new IllegalStateException("explode");
+        });
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> cache.load(new PageKey(TS, IDX, 1)));
+        assertEquals("explode", ex.getMessage());
+    }
+
+    @Test
+    public void loaderReturningNullSurfacesAsException() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> null);
+        DataStorageManagerException ex = assertThrows(DataStorageManagerException.class,
+                () -> cache.load(new PageKey(TS, IDX, 1)));
+        assertTrue("error message names the key",
+                ex.getMessage() != null && ex.getMessage().contains("page=1"));
+    }
+
+    @Test
+    public void failedLoadIsNotMemoizedAsNegative() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            int n = calls.incrementAndGet();
+            if (n == 1) {
+                throw new DataStorageManagerException("transient");
+            }
+            return payload(4, 9);
+        });
+
+        assertThrows(DataStorageManagerException.class,
+                () -> cache.load(new PageKey(TS, IDX, 1)));
+        // Second call must re-invoke the loader rather than returning a cached failure.
+        byte[] b = cache.load(new PageKey(TS, IDX, 1));
+        assertArrayEquals(payload(4, 9), b);
+        assertEquals("loader invoked twice — retry after failure is allowed",
+                2, calls.get());
+    }
+
+    // -----------------------------------------------------------------
+    // Cache-disabled (no-op) mode
+    // -----------------------------------------------------------------
+
+    @Test
+    public void zeroMaxBytesBypassesCacheEntirely() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(0, k -> {
+            calls.incrementAndGet();
+            return payload(4, 0);
+        });
+        assertFalse("cache disabled", cache.isActive());
+        for (int i = 0; i < 5; i++) {
+            cache.load(new PageKey(TS, IDX, 1));
+        }
+        assertEquals("every call must hit the loader when caching is off",
+                5, calls.get());
+        assertEquals("stats report zero when disabled", 0L, cache.hitCount());
+        assertEquals(0L, cache.missCount());
+        assertEquals(0L, cache.maxBytes());
+    }
+
+    @Test
+    public void negativeMaxBytesAlsoDisablesCache() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(-1, k -> {
+            calls.incrementAndGet();
+            return payload(1, 0);
+        });
+        assertFalse(cache.isActive());
+        cache.load(new PageKey(TS, IDX, 1));
+        cache.load(new PageKey(TS, IDX, 1));
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    public void disabledCacheStillPropagatesLoaderFailures() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(0, k -> {
+            throw new DataStorageManagerException("nope");
+        });
+        assertThrows(DataStorageManagerException.class,
+                () -> cache.load(new PageKey(TS, IDX, 1)));
+    }
+
+    @Test
+    public void disabledCacheNullLoaderResultSurfacesAsException() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(0, k -> null);
+        assertThrows(DataStorageManagerException.class,
+                () -> cache.load(new PageKey(TS, IDX, 1)));
+    }
+
+    // -----------------------------------------------------------------
+    // Invalidation
+    // -----------------------------------------------------------------
+
+    @Test
+    public void invalidateForcesNextLoadToRefetch() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            calls.incrementAndGet();
+            return payload(4, calls.get());
+        });
+        PageKey k = new PageKey(TS, IDX, 1);
+        cache.load(k);
+        cache.load(k);
+        assertEquals("second call hit the cache", 1, calls.get());
+        cache.invalidate(k);
+        cache.load(k);
+        assertEquals("post-invalidate load re-invoked the loader", 2, calls.get());
+    }
+
+    @Test
+    public void invalidateNullKeyIsSafe() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> payload(1, 0));
+        cache.invalidate(null); // must not throw
+    }
+
+    @Test
+    public void invalidateUnknownKeyIsSafe() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> payload(1, 0));
+        cache.invalidate(new PageKey(TS, IDX, 999)); // never loaded
+    }
+
+    @Test
+    public void clearDropsEveryEntry() throws Exception {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> payload(4, (int) k.pageId()));
+        cache.load(new PageKey(TS, IDX, 1));
+        cache.load(new PageKey(TS, IDX, 2));
+        cache.load(new PageKey(TS, IDX, 3));
+        assertTrue(cache.size() > 0);
+        cache.clear();
+        assertEquals("clear leaves the cache empty", 0, cache.size());
+    }
+
+    // -----------------------------------------------------------------
+    // Byte-weighted eviction
+    // -----------------------------------------------------------------
+
+    @Test
+    public void byteWeightedEvictionEnforcesBudget() throws Exception {
+        long budget = 4096L;
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(budget, k -> {
+            calls.incrementAndGet();
+            return new byte[1024]; // each entry weighs 1 KiB
+        });
+
+        // Insert far more entries than fit, each 1 KiB; total budget is 4 KiB.
+        for (int i = 0; i < 20; i++) {
+            cache.load(new PageKey(TS, IDX, i));
+        }
+        // Caffeine eviction is async — force it to run so the assertions below
+        // observe a converged state rather than a snapshot mid-maintenance.
+        cache.cleanUp();
+        assertEquals("each distinct key triggers a load", 20, calls.get());
+        assertTrue("evictions happened once the budget was exhausted",
+                cache.evictionCount() > 0);
+        assertTrue("weighted size cannot exceed the budget (allowing small overshoot)",
+                cache.weightedSize() <= budget);
+        assertEquals("budget reported matches construction arg", budget, cache.maxBytes());
+    }
+
+    // -----------------------------------------------------------------
+    // PageKey value semantics
+    // -----------------------------------------------------------------
+
+    @Test
+    public void pageKeyEqualsAndHashCode() {
+        PageKey a = new PageKey("ts", "idx", 42);
+        PageKey b = new PageKey("ts", "idx", 42);
+        PageKey c = new PageKey("ts", "idx", 43);
+        PageKey d = new PageKey("ts2", "idx", 42);
+        PageKey e = new PageKey("ts", "idx2", 42);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a, d);
+        assertNotEquals(a, e);
+        assertNotEquals(a, null);
+        assertNotEquals(a, "not-a-pagekey");
+    }
+
+    @Test
+    public void pageKeyRejectsNullTableSpace() {
+        assertThrows(NullPointerException.class, () -> new PageKey(null, "idx", 1));
+    }
+
+    @Test
+    public void pageKeyRejectsNullIndex() {
+        assertThrows(NullPointerException.class, () -> new PageKey("ts", null, 1));
+    }
+
+    @Test
+    public void pageKeyAccessorsReflectConstructorArguments() {
+        PageKey k = new PageKey("ts-x", "idx-y", 17);
+        assertEquals("ts-x", k.tableSpaceUUID());
+        assertEquals("idx-y", k.indexUUID());
+        assertEquals(17L, k.pageId());
+        assertTrue("toString exposes pageId", k.toString().contains("page=17"));
+    }
+
+    @Test
+    public void pageKeysSpreadAcrossHashBuckets() {
+        // Sanity check: a handful of different keys shouldn't collide on hashCode.
+        // This also guards against using only one field in hashCode.
+        Set<Integer> hashes = new HashSet<>();
+        for (int i = 0; i < 16; i++) {
+            hashes.add(new PageKey("ts", "idx", i).hashCode());
+        }
+        assertTrue("distinct pageIds should mostly hash to distinct buckets: " + hashes.size(),
+                hashes.size() >= 12);
+    }
+
+    // -----------------------------------------------------------------
+    // Constructor contracts
+    // -----------------------------------------------------------------
+
+    @Test
+    public void constructorRejectsNullLoader() {
+        assertThrows(NullPointerException.class,
+                () -> new SharedSegmentPageCache(1 << 20, null));
+        assertThrows(NullPointerException.class,
+                () -> new SharedSegmentPageCache(0, null));
+    }
+
+    @Test
+    public void loadRejectsNullKey() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> payload(1, 0));
+        assertThrows(NullPointerException.class, () -> cache.load(null));
+    }
+
+    // -----------------------------------------------------------------
+    // Stats accessors
+    // -----------------------------------------------------------------
+
+    @Test
+    public void statsAccessorsTrackBasicActivity() throws Exception {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> payload(8, (int) k.pageId()));
+        assertEquals(0L, cache.hitCount());
+        assertEquals(0L, cache.missCount());
+        assertEquals(0L, cache.loadSuccessCount());
+        assertEquals(0L, cache.totalLoadTimeNanos());
+
+        cache.load(new PageKey(TS, IDX, 1));      // miss
+        cache.load(new PageKey(TS, IDX, 1));      // hit
+        cache.load(new PageKey(TS, IDX, 2));      // miss
+
+        assertEquals("two unique keys loaded", 2L, cache.missCount());
+        assertEquals(1L, cache.hitCount());
+        assertEquals(2L, cache.loadSuccessCount());
+        assertTrue("totalLoadTimeNanos should record some time",
+                cache.totalLoadTimeNanos() >= 0);
+        assertTrue("weightedSize tracks cached bytes", cache.weightedSize() > 0);
+        assertTrue(cache.estimatedSize() > 0);
+    }
+
+    @Test
+    public void statsSnapshotIsNonNullEvenWhenDisabled() {
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(0, k -> payload(1, 0));
+        assertEquals(0L, cache.stats().hitCount());
+    }
+
+    // -----------------------------------------------------------------
+    // Defensive: loader seeing the right key
+    // -----------------------------------------------------------------
+
+    @Test
+    public void loaderSeesExactPageKeyPassedByCaller() throws Exception {
+        AtomicReference<PageKey> seen = new AtomicReference<>();
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            seen.set(k);
+            return payload(2, 0);
+        });
+        PageKey requested = new PageKey(TS, IDX, 99);
+        cache.load(requested);
+        assertEquals(requested, seen.get());
+    }
+
+    // -----------------------------------------------------------------
+    // Regression: failure then success on the same key
+    // -----------------------------------------------------------------
+
+    @Test
+    public void interleavedFailuresAndSuccessesTrackedIndependently() {
+        AtomicInteger calls = new AtomicInteger(0);
+        SharedSegmentPageCache cache = new SharedSegmentPageCache(1 << 20, k -> {
+            int n = calls.incrementAndGet();
+            if ((n & 1) == 1) {
+                throw new DataStorageManagerException("odd call fails");
+            }
+            return payload(1, 0);
+        });
+
+        assertThrows(DataStorageManagerException.class,
+                () -> cache.load(new PageKey(TS, IDX, 1)));
+        try {
+            cache.load(new PageKey(TS, IDX, 1));
+        } catch (Exception e) {
+            fail("second load should succeed: " + e);
+        }
+        assertEquals("one failure recorded", 1L, cache.loadFailureCount());
+        assertEquals("one success recorded", 1L, cache.loadSuccessCount());
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/SharedSegmentPageCacheTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/SharedSegmentPageCacheTest.java
@@ -317,8 +317,10 @@ public class SharedSegmentPageCacheTest {
         cache.load(new PageKey(TS, IDX, 1));
         cache.load(new PageKey(TS, IDX, 2));
         cache.load(new PageKey(TS, IDX, 3));
+        cache.cleanUp();
         assertTrue(cache.size() > 0);
         cache.clear();
+        cache.cleanUp();
         assertEquals("clear leaves the cache empty", 0, cache.size());
     }
 
@@ -441,6 +443,10 @@ public class SharedSegmentPageCacheTest {
         assertEquals(2L, cache.loadSuccessCount());
         assertTrue("totalLoadTimeNanos should record some time",
                 cache.totalLoadTimeNanos() >= 0);
+        // Caffeine's weight/size accounting goes through an async write buffer;
+        // drain it before asserting on converged state, otherwise the test is
+        // flaky under CI scheduling.
+        cache.cleanUp();
         assertTrue("weightedSize tracks cached bytes", cache.weightedSize() > 0);
         assertTrue(cache.estimatedSize() > 0);
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1663,6 +1663,174 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 }
             });
             pvs.setSegmentSizeStats(indexStats.getOpStatsLogger("segment_size_bytes"));
+
+            // ---------------------------------------------------------------
+            // Segment page cache (shared Caffeine LoadingCache, byte-weighted)
+            // ---------------------------------------------------------------
+            indexStats.registerGauge("segment_cache_hits", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheHitCount();
+                }
+            });
+            indexStats.registerGauge("segment_cache_misses", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheMissCount();
+                }
+            });
+            indexStats.registerGauge("segment_cache_evictions", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheEvictionCount();
+                }
+            });
+            indexStats.registerGauge("segment_cache_load_success", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheLoadSuccessCount();
+                }
+            });
+            indexStats.registerGauge("segment_cache_load_failure", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheLoadFailureCount();
+                }
+            });
+            indexStats.registerGauge("segment_cache_load_time_nanos_total", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheLoadTimeNanos();
+                }
+            });
+            indexStats.registerGauge("segment_cache_entries", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheEntries();
+                }
+            });
+            indexStats.registerGauge("segment_cache_size_bytes", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheSizeBytes();
+                }
+            });
+            indexStats.registerGauge("segment_cache_max_bytes", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentPageCacheMaxBytes();
+                }
+            });
+
+            // ---------------------------------------------------------------
+            // Per-segment PageStoreReader caches (aggregated across segments)
+            // ---------------------------------------------------------------
+            indexStats.registerGauge("page_reader_cache_hits", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheHitCount();
+                }
+            });
+            indexStats.registerGauge("page_reader_cache_misses", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheMissCount();
+                }
+            });
+            indexStats.registerGauge("page_reader_cache_evictions", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheEvictionCount();
+                }
+            });
+            indexStats.registerGauge("page_reader_cache_load_success", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheLoadSuccessCount();
+                }
+            });
+            indexStats.registerGauge("page_reader_cache_load_failure", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheLoadFailureCount();
+                }
+            });
+            indexStats.registerGauge("page_reader_cache_load_time_nanos_total", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheLoadTimeNanos();
+                }
+            });
+            indexStats.registerGauge("page_reader_cache_entries", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getPageReaderCacheEntries();
+                }
+            });
         }
     }
 

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -1244,6 +1244,284 @@
       "height": 250,
       "panels": [
         {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 300,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hits/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_misses\",job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "misses/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Segment Cache Hits / Misses (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 301,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 2,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_misses\",job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hit ratio [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Segment Cache Hit Ratio (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "percentunit", "logBase": 1, "max": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 302,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_size_bytes\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "used [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_max_bytes\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "max [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Segment Cache Bytes (used vs max)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "bytes", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 303,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_evictions\",job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "evictions/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_entries\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "entries [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Segment Cache Evictions (1m) & Entries",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 304,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_load_time_nanos_total\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_load_success\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_cache_load_failure\",job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg load ns [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Segment Cache — Average Page Load Latency",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ns", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Vector Segment Cache",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 310,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hits/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_misses\",job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "misses/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Page Reader Cache Hits / Misses (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 311,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 2,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_misses\",job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hit ratio [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Page Reader Cache Hit Ratio (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "percentunit", "logBase": 1, "max": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 312,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_evictions\",job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "evictions/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_entries\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "entries [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Page Reader Cache Evictions (1m) & Entries",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 313,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_load_time_nanos_total\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_load_success\",job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_page_reader_cache_load_failure\",job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg load ns [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Page Reader Cache — Average Page Load Latency",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ns", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Vector Page Reader Cache",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/vector-search-latency-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/vector-search-latency-dashboard.json
@@ -1612,6 +1612,73 @@
       "showTitle": true,
       "title": "File Server S3 Reads",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 400,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 2,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "sum by (instance)(rate({__name__=~\".+_segment_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m])) / clamp_min(sum by (instance)(rate({__name__=~\".+_segment_cache_hits\",job=\"indexing-service\",instance=~\"$instance\"}[1m])) + sum by (instance)(rate({__name__=~\".+_segment_cache_misses\",job=\"indexing-service\",instance=~\"$instance\"}[1m])), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "segment-cache hit ratio [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregated Segment-Cache Hit Ratio (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "percentunit", "logBase": 1, "max": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 401,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "stack": false,
+          "targets": [
+            {
+              "expr": "sum by (instance)(rate({__name__=~\".+_segment_cache_misses\",job=\"indexing-service\",instance=~\"$instance\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "segment miss/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(rfs_client_read_requests{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "rfs client read/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Segment Miss vs File-Server Client Read Rate",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Vector Cache Correlation",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `LinkedHashMap` LRU in `PageStoreReader` and the passive `get`/`put` `SharedSegmentPageCache` with Caffeine `LoadingCache` instances. Exposes Caffeine stats as per-index gauges and adds Grafana panels for them.

### Why

- The old `PageStoreReader` LRU held a `synchronized(cache)` block on every hot-path lookup — serialising concurrent searches on the same segment.
- Neither cache deduplicated concurrent misses: two search threads missing the same `pageId` each issued a full DSM read.
- `SharedSegmentPageCache` already called `.recordStats()` but never exposed the results; there was no way to answer "is the segment cache doing anything useful?".
- The per-reader cache exposed custom `AtomicLong` hit/miss counters that duplicated Caffeine built-ins.

### What changed

- **`SharedSegmentPageCache`** — now a `LoadingCache<PageKey, byte[]>`. New `PageKey` value type (tableSpaceUUID + indexUUID + pageId — no `pageType` field, since only `TYPE_VECTOR_GRAPHCHUNK` flows through this cache today). Constructor takes a `PageLoader` functional interface; `load(PageKey)` is the single entry point. New `cleanUp()` forces async eviction maintenance to run synchronously.
- **`PageStoreReader`** — per-segment cache is now `LoadingCache<Integer, byte[]>`. The cache loader delegates to the shared cache (which has its own loader), so two tiers of single-flight loading stack cleanly. The hot read path is lock-free.
- **`PersistentVectorStore`** — constructs the shared cache with a `loadGraphChunkPage` loader that wraps `dsm.readIndexPage(...)`. Exposes 18 cache-stats accessors (nine for the shared cache, nine aggregated across per-segment `PageStoreReader` caches).
- **`IndexingServiceEngine.registerIndexMetrics`** — registers 16 new per-index gauges under scopes `{ts}_{table}_{vidx}_segment_cache_*` and `{ts}_{table}_{vidx}_page_reader_cache_*`: hits, misses, evictions, load\_success, load\_failure, load\_time\_nanos\_total, entries, size\_bytes (shared only), max\_bytes (shared only).
- **Grafana dashboards**
  - `indexing-service-dashboard.json`: two new rows (*Vector Segment Cache*, *Vector Page Reader Cache*), each with hits/misses rate, hit ratio, bytes used vs max / evictions & entries, and average page-load latency (ns).
  - `vector-search-latency-dashboard.json`: new trailing row *Vector Cache Correlation* showing aggregated segment-cache hit ratio and a stack of segment-cache miss rate vs file-server client read rate.

### Unit tests — edge cases and failure scenarios covered

**New file `SharedSegmentPageCacheTest` (28 tests):**
- Happy path: single load invokes loader once; repeated load is a hit; distinct keys coexist; the three `PageKey` fields are all part of identity.
- **Concurrent miss deduplication** — 32 threads racing on the same key; loader invoked exactly once.
- Failure modes: `DataStorageManagerException` propagates unwrapped; runtime exceptions propagate as-is; loader returning `null` surfaces as exception; failed loads are not negatively cached (retry succeeds); interleaved failures and successes are tracked independently.
- Cache-disabled (`maxBytes <= 0`): every load delegates to loader, failures still surface, null results still surface.
- Invalidation: `invalidate(PageKey)` forces refetch; null/unknown keys are safe; `clear()` drops every entry.
- Byte-weighted eviction: 20 × 1 KiB into a 4 KiB cache triggers evictions; `weightedSize()` stays under budget.
- `PageKey` value semantics: `equals`/`hashCode` match; null tableSpace/index rejected via NPE; hashes spread across buckets.
- Constructor: null loader rejected; `load(null)` rejected.
- Stats accessors: track basic activity; work when disabled.
- Loader visibility: sees exactly the `PageKey` passed by the caller.

**New `PageStoreReaderTest` cases (4 added, 17 preserved — 21 total):**
- Concurrent miss dedup within a single segment (16 threads on page 0 → one DSM read).
- Stats accessors track `loadSuccess` / `loadFailure` / `loadTimeNanos`.
- Failed loads increment the `loadFailure` stat.
- Shared cache deduplicates across `PageStoreReader.Supplier` instances.
- `close()` invalidates shared-cache entries for this segment's pages.

### Follow-up (not in this PR)

The existing `rfs_client_read_*` panels in `vector-search-latency-dashboard.json` will light up once `RemoteFileDataStorageManager.multipartIndexReaderSupplier` is threaded a real `StatsLogger` instead of the `null` passed today (line 573). That's a signature change across four implementations, deferred for a separate PR.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — BUILD SUCCESS
- [x] `mvn -pl herddb-core -Dtest='PageStoreReaderTest,SharedSegmentPageCacheTest' test` — 49 tests, 0 failures
- [x] All three Grafana dashboard JSON files validated
- [ ] End-to-end verification on k3s-local: curl the `/metrics` endpoint after a few searches and confirm `_segment_cache_hits` / `_page_reader_cache_hits` appear non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)