### PR TITLE
Wire bookie stats provider into EmbeddedServer (#142)

### DIFF
--- a/herddb-services/src/main/java/herddb/server/BookKeeperMainWrapper.java
+++ b/herddb-services/src/main/java/herddb/server/BookKeeperMainWrapper.java
@@ -269,7 +269,9 @@ public class BookKeeperMainWrapper implements AutoCloseable {
         }
 
         BookieConfiguration bkConf = new BookieConfiguration(conf);
-        this.embeddedServer = EmbeddedServer.builder(bkConf).build();
+        this.embeddedServer = EmbeddedServer.builder(bkConf)
+                .statsProvider(statsProvider)
+                .build();
         embeddedServer.getLifecycleComponentStack().start();
 
         if (waitForBookieServiceState(Lifecycle.State.STARTED)) {

--- a/herddb-services/src/test/java/herddb/server/BookKeeperMainWrapperTest.java
+++ b/herddb-services/src/test/java/herddb/server/BookKeeperMainWrapperTest.java
@@ -57,6 +57,8 @@ public class BookKeeperMainWrapperTest {
             config.put("ledgerDirNames", folder.newFolder("bk-ledgers").getAbsolutePath());
             config.put("journalDirName", folder.newFolder("bk-journal").getAbsolutePath());
             config.put("httpServerPort", String.valueOf(httpPort));
+            // Required for CI / dev hosts whose advertised hostname resolves to a loopback address.
+            config.put("allowLoopback", "true");
 
             BookKeeperMainWrapper wrapper = new BookKeeperMainWrapper(config);
             Thread runner = new Thread(() -> {
@@ -70,11 +72,15 @@ public class BookKeeperMainWrapperTest {
             runner.start();
 
             try {
-                // Wait for metrics HTTP endpoint to become available
+                // Wait for metrics HTTP endpoint to become available AND for the bookie's
+                // internal stats provider to have registered its metrics. Both must be
+                // present: JVM metrics come from PrometheusMetricsProvider.start(), and
+                // bookkeeper_server_* counters come from the embedded bookie once its
+                // stats provider is wired via EmbeddedServer.builder(...).statsProvider(...).
+                URL metricsUrl = new URL("http://localhost:" + httpPort + "/metrics");
                 String metricsBody = null;
-                for (int i = 0; i < 60; i++) {
+                for (int i = 0; i < 120; i++) {
                     try {
-                        URL metricsUrl = new URL("http://localhost:" + httpPort + "/metrics");
                         HttpURLConnection conn = (HttpURLConnection) metricsUrl.openConnection();
                         conn.setRequestMethod("GET");
                         conn.setConnectTimeout(1000);
@@ -88,18 +94,29 @@ public class BookKeeperMainWrapperTest {
                                     body.append(line).append("\n");
                                 }
                             }
-                            metricsBody = body.toString();
-                            break;
+                            String snapshot = body.toString();
+                            if (snapshot.contains("jvm_") && snapshot.contains("bookkeeper_server_")) {
+                                metricsBody = snapshot;
+                                break;
+                            }
                         }
-                    } catch (Exception e) {
-                        Thread.sleep(500);
+                    } catch (Exception ignored) {
+                        // endpoint not ready yet
                     }
+                    Thread.sleep(500);
                 }
 
-                assertTrue("Metrics endpoint did not become available in time", metricsBody != null);
+                assertTrue("Metrics endpoint did not expose the expected counters in time",
+                        metricsBody != null);
                 // JVM metrics should be present
                 assertTrue("Metrics should contain JVM info, got: " + metricsBody,
                         metricsBody.contains("jvm_"));
+                // BookKeeper server metrics should be present — regression guard for #142:
+                // if the embedded bookie's stats provider is not passed to the Jetty-served
+                // PrometheusMetricsProvider, BK counters accumulate in a hidden provider
+                // and only jvm_ metrics appear here.
+                assertTrue("Metrics should contain bookkeeper_server_* counters, got: " + metricsBody,
+                        metricsBody.contains("bookkeeper_server_"));
             } finally {
                 wrapper.close();
             }


### PR DESCRIPTION
## Summary

Fixes eolivelli/herddb#142 — the standalone bookie's Prometheus
`/metrics` endpoint served only JVM / Jetty metrics; none of the
`bookkeeper_server_*` counters surfaced.

`BookKeeperMainWrapper` created its own `PrometheusMetricsProvider`
and mounted it on Jetty but did not hand it to `EmbeddedServer.builder(...)`.
`EmbeddedServer$Builder#build()` saw a `null` stats provider and
instantiated a *second* `PrometheusMetricsProvider` internally via
`StatsProviderService`, so every BK-internal counter (journal queue
depth, `ADD_ENTRY_BLOCKED`, skiplist throttling, force-write queue,
`DbLedgerStorage` stats) accumulated in a hidden provider while the
served endpoint returned only JVM samples.

This gap masked the onset of the #141 bigann-100M ingest stall on
single-bookie topologies (bookie quietly disabled autoread on the
server→bookie channel; no metric surfaced it).

## Fix

One-liner in `BookKeeperMainWrapper.run()` — pass the existing
`statsProvider` to the builder, matching the pattern already used by
the in-server embedded bookie at `EmbeddedBookie.java:160-162`:

```java
this.embeddedServer = EmbeddedServer.builder(bkConf)
        .statsProvider(statsProvider)
        .build();
```

No config, no new plumbing.

## Metrics this unlocks

Counters are already produced by the bookie — the fix just makes them
scrapeable on `:httpServerPort/metrics`:

- Add-path backpressure: `ADD_ENTRY_BLOCKED` (gauge),
  `ADD_ENTRY_BLOCKED_WAIT`, `ADD_ENTRY_IN_PROGRESS`,
  `ADD_ENTRY_REJECTED`, `WRITE_THREAD_QUEUED_LATENCY`.
- Journal / pending-adds: `journal_JOURNAL_QUEUE_SIZE`,
  `journal_JOURNAL_FORCE_WRITE_QUEUE_SIZE`, queue/process/flush/sync
  latencies, `journal_JOURNAL_MEMORY_USED`/`_MAX`,
  `journal_JOURNAL_WRITE_BYTES`, force-write batch sizes.
- Skip-list memtable throttle: `SKIP_LIST_THROTTLING`,
  `SKIP_LIST_THROTTLING_LATENCY`, `SKIP_LIST_FLUSH_BYTES`.
- DbLedgerStorage: add / flush / compaction latencies, entry-log
  rotation counters.

The `ADD_ENTRY_BLOCKED` gauge is the primary signal for #141-class
stalls — non-zero means autoread has been disabled on ≥1 server
channel.

## Scope note

Audit of the other wrappers confirmed the gap was isolated:
- `EmbeddedBookie.java:160-162` already passes `.statsProvider(...)`.
- `ServerMain.java` / `ZooKeeperMainWrapper.java` don't embed a bookie.
- `BookkeeperCommitLogManager.java:126-130` already passes a
  `statsLogger` to the BK *client*.

## Test plan

- [x] `mvn -pl herddb-services -Dtest=BookKeeperMainWrapperTest test`
      passes with the fix.
- [x] Same command fails after reverting the one-line fix — the
      extended `testBootAndMetrics` asserts `bookkeeper_server_` is
      present, which is absent when the wrapper's provider is not
      wired. (True regression guard.)
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` passes.
- [ ] Optional post-merge smoke: `kubectl exec herddb-bookkeeper-0 -- curl -s http://localhost:8000/metrics | grep -E 'JOURNAL|ADD_ENTRY_BLOCKED|SKIP_LIST_'` returns rows on the k3s-local example chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)