### PR TITLE
Fix dropOldLedgers ignoring checkpoint LSN (#146)

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -539,7 +539,7 @@ Persists log entries to Apache BookKeeper ledgers in a distributed cluster.
 | Aspect | Behaviour |
 |--------|-----------|
 | `getLastSequenceNumber()` | Returns `(currentLedgerId, currentEntryId)` from the active BK ledger |
-| `dropOldLedgers(lsn)` | Calls `BookKeeper.deleteLedger()` for ledgers with `ledgerId < lsn.ledgerId` |
+| `dropOldLedgers(lsn)` | Calls `BookKeeper.deleteLedger()` for ledgers with `ledgerId < lsn.ledgerId` **and** older than the wall-clock retention period (`server.bookkeeper.ledgers.retention.period`). Both conditions must hold: the LSN floor guarantees replay from the last checkpoint is always possible, the retention gives external tailers a minimum time budget to catch up. |
 | Ledger rotation | A new BK ledger is created on fencing (leadership change) or explicit rotation |
 | Recovery | Reads all ledger entries from the stored first-ledger ID through the last written entry |
 | Checkpoint role | Enables deletion of old BK ledgers, freeing storage quota in the BK cluster |

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -35,6 +35,7 @@ import io.netty.buffer.ByteBufInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -784,14 +785,33 @@ public class BookkeeperCommitLog extends CommitLog {
         if (ledgersRetentionPeriod <= 0) {
             return;
         }
+        // Ledgers at or after the last checkpoint LSN are still needed to replay the log
+        // during recovery (see recovery() — it starts reading at lastCheckPoint.ledgerId).
+        // Time-based retention must never delete them. When no checkpoint has happened yet
+        // (START_OF_TIME, ledgerId = -1) the floor is -1 and every active ledger is kept.
+        final long ledgerLimit = Math.min(lastCheckPointSequenceNumber.ledgerId, currentLedgerId);
         LOGGER.log(Level.INFO,
-                "dropOldLedgers lastCheckPointSequenceNumber: {0}, ledgersRetentionPeriod: {1} ,lastLedgerId: {2}, currentLedgerId: {3}, tablespace {4}, actualLedgersList {5}",
-                new Object[]{lastCheckPointSequenceNumber, ledgersRetentionPeriod, lastLedgerId, currentLedgerId, tableSpaceDescription(), actualLedgersList});
+                "dropOldLedgers lastCheckPointSequenceNumber: {0}, ledgersRetentionPeriod: {1}, ledgerLimit: {2}, lastLedgerId: {3}, currentLedgerId: {4}, tablespace {5}, actualLedgersList {6}",
+                new Object[]{lastCheckPointSequenceNumber, ledgersRetentionPeriod, ledgerLimit,
+                        lastLedgerId, currentLedgerId, tableSpaceDescription(), actualLedgersList});
         long min_timestamp = System.currentTimeMillis() - ledgersRetentionPeriod;
         List<Long> oldLedgers = actualLedgersList.getOldLedgers(min_timestamp);
         LOGGER.log(Level.INFO,
                 "dropOldLedgers currentLedgerId: {0}, lastLedgerId: {1}, dropping ledgers before {2}: {3} tablespace {4}",
                 new Object[]{currentLedgerId, lastLedgerId, new java.sql.Timestamp(min_timestamp), oldLedgers, tableSpaceDescription()});
+        List<Long> keptForRecovery = new ArrayList<>();
+        oldLedgers.removeIf(id -> {
+            if (id >= ledgerLimit) {
+                keptForRecovery.add(id);
+                return true;
+            }
+            return false;
+        });
+        if (!keptForRecovery.isEmpty()) {
+            LOGGER.log(Level.INFO,
+                    "dropOldLedgers keeping {0} retention-expired ledger(s) still needed for recovery from checkpoint {1}: {2} tablespace {3}",
+                    new Object[]{keptForRecovery.size(), lastCheckPointSequenceNumber, keptForRecovery, tableSpaceDescription()});
+        }
         oldLedgers.remove(this.currentLedgerId);
         oldLedgers.remove(this.lastLedgerId);
         if (oldLedgers.isEmpty()) {

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -559,6 +559,150 @@ public class BookKeeperCommitLogTest {
         return result;
     }
 
+    /**
+     * Regression test for issue #146.
+     *
+     * <p>{@code dropOldLedgers} must never delete ledgers whose id is at or
+     * after the last successful checkpoint LSN, no matter how aggressive
+     * wall-clock retention is. Before the fix, the method ignored
+     * {@code lastCheckPointSequenceNumber} entirely and deleted every ledger
+     * past time-based retention, leaving the server (and any tailer) unable
+     * to recover.
+     */
+    @Test
+    public void testDropOldLedgersHonorsCheckpointLsn() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = newServerConfigurationWithAutoPort();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            // tiny retention so every ledger we backdate is considered "old"
+            logManager.setLedgersRetentionPeriod(1);
+            man.start();
+            logManager.start();
+
+            LogSequenceNumber checkpointLsn;
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting(1);
+                // Produce several ledgers. The BK writer auto-rolls on each sync
+                // write in this test setup (small ledger handle), so a handful
+                // of log calls plus explicit rolls is enough to guarantee at
+                // least 4 distinct ledgers.
+                writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(4), true).getLogSequenceNumber();
+
+                List<Long> ledgerIds = new ArrayList<>(writer.getActualLedgersList().getActiveLedgers());
+                assertTrue("expected at least four ledgers to exist, got " + ledgerIds,
+                        ledgerIds.size() >= 4);
+                // Pick a checkpoint ledger somewhere in the middle, so some
+                // ledgers are below the checkpoint (safe to drop) and some are
+                // at-or-after (must be kept).
+                long checkpointLedger = ledgerIds.get(ledgerIds.size() / 2);
+                checkpointLsn = new LogSequenceNumber(checkpointLedger, 0);
+                List<Long> below = new ArrayList<>();
+                List<Long> atOrAfter = new ArrayList<>();
+                for (Long id : ledgerIds) {
+                    if (id < checkpointLedger) {
+                        below.add(id);
+                    } else {
+                        atOrAfter.add(id);
+                    }
+                }
+                assertFalse("need at least one ledger below the checkpoint LSN", below.isEmpty());
+                assertFalse("need at least one ledger at or after the checkpoint LSN", atOrAfter.isEmpty());
+
+                // Backdate all timestamps so every ledger looks old enough to
+                // expire. Without this, freshly-created ledgers have current
+                // timestamps and the time filter keeps them regardless of LSN.
+                LedgersInfo info = writer.getActualLedgersList();
+                List<Long> backdated = new ArrayList<>();
+                for (int i = 0; i < ledgerIds.size(); i++) {
+                    backdated.add(0L);
+                }
+                info.setLedgersTimestamps(backdated);
+                man.saveActualLedgersList(tableSpaceUUID, info);
+
+                writer.dropOldLedgers(checkpointLsn);
+
+                List<Long> remaining = writer.getActualLedgersList().getActiveLedgers();
+                for (Long id : below) {
+                    assertFalse("ledger " + id + " (below checkpoint " + checkpointLedger
+                                    + ") must be dropped, remaining=" + remaining,
+                            remaining.contains(id));
+                }
+                for (Long id : atOrAfter) {
+                    assertTrue("ledger " + id + " (at or after checkpoint " + checkpointLedger
+                                    + ") must be kept, remaining=" + remaining,
+                            remaining.contains(id));
+                }
+
+                // ZK view must match what the writer sees.
+                List<Long> fromZk = man.getActualLedgersList(tableSpaceUUID).getActiveLedgers();
+                assertEquals(remaining, fromZk);
+            }
+
+            // Recovery from the checkpoint LSN must succeed using the ledgers
+            // that were kept (i.e. the core correctness property this bug
+            // broke: replay from the last checkpoint).
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                reader.recovery(checkpointLsn, (lsn, entry) -> { }, false);
+            }
+        }
+    }
+
+    /**
+     * Without any successful checkpoint yet ({@code START_OF_TIME}), the entire
+     * log is still needed for recovery; {@code dropOldLedgers} must keep all
+     * active ledgers regardless of retention. Regression test for issue #146.
+     */
+    @Test
+    public void testDropOldLedgersKeepsAllWhenNoCheckpoint() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = newServerConfigurationWithAutoPort();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            logManager.setLedgersRetentionPeriod(1);
+            man.start();
+            logManager.start();
+
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting(1);
+                writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
+
+                List<Long> before = new ArrayList<>(writer.getActualLedgersList().getActiveLedgers());
+                assertTrue("expected at least three ledgers, got " + before, before.size() >= 3);
+
+                LedgersInfo info = writer.getActualLedgersList();
+                List<Long> backdated = new ArrayList<>();
+                for (int i = 0; i < before.size(); i++) {
+                    backdated.add(0L);
+                }
+                info.setLedgersTimestamps(backdated);
+                man.saveActualLedgersList(tableSpaceUUID, info);
+
+                writer.dropOldLedgers(LogSequenceNumber.START_OF_TIME);
+
+                List<Long> after = writer.getActualLedgersList().getActiveLedgers();
+                assertEquals("no ledgers may be dropped before any checkpoint has happened",
+                        before, after);
+            }
+        }
+    }
+
     @Test
     public void testFollowEmptyLedgerBookieDown() throws Exception {
         BookieId secondBookie = testEnv.startNewBookie();


### PR DESCRIPTION
## Summary

- `BookkeeperCommitLog.dropOldLedgers` ignored its `lastCheckPointSequenceNumber` argument and deleted every ledger past wall-clock retention. Recovery needs all ledgers from the last checkpoint forward, so this permanently broke any consumer lagging behind retention and would break server-side recovery under the same conditions.
- Fix: add an LSN floor on top of time-based retention — a ledger can be deleted only if it is both older than retention **and** strictly below the last checkpoint's ledger id. Matches what `FileCommitLog` already does and what `CHECKPOINT.md` §9 already documented.
- When no checkpoint has happened yet (`START_OF_TIME`, `ledgerId = -1`), the floor is -1 so every active ledger is kept — the log remains fully replayable.

External consumer (indexing-service tailer) watermark coordination is intentionally out of scope here; this PR restores the invariant that the log never deletes data still needed for the leader's own recovery from the last checkpoint. The tailer-lag scenario that originally surfaced the bug (#146) is fixed as a side effect when the tailer is at or after the checkpoint LSN; a further PR can add explicit tailer-watermark coordination for tailers that lag the checkpoint itself.

## Test plan

- [x] New `@Category(ClusterTest.class)` tests in `BookKeeperCommitLogTest`:
  - `testDropOldLedgersHonorsCheckpointLsn` — given multiple backdated ledgers and a checkpoint LSN in the middle, asserts only ledgers `< lsn.ledgerId` are dropped, ledgers `>= lsn.ledgerId` are kept, ZK state matches the writer view, and recovery from the checkpoint LSN succeeds.
  - `testDropOldLedgersKeepsAllWhenNoCheckpoint` — with `START_OF_TIME` and backdated ledgers, asserts no ledgers are dropped.
  - Both tests fail against the pre-fix `BookkeeperCommitLog` (verified by temporarily reverting the production change).
- [x] Neighbour regression checks still pass: `testSimpleReadWrite`, `testSimpleFence`, `testWriteAsync`, `testOpenNewLedgerRollbacksBkWhenZkWriteFails`.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` passes.

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)