### PR TITLE
Drain newPages before checkpoint Phase C to unblock commits

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -207,6 +207,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private volatile Runnable duringPhaseBAction;
 
     /**
+     * Test-only counter incremented once per page flushed by {@link #drainPendingNewPages()}
+     * <strong>outside</strong> the checkpoint write lock. Lets tests assert that the drain path
+     * absorbed the backlog that accumulated during Phase B + {@code indexManager.checkpoint}.
+     */
+    private final java.util.concurrent.atomic.AtomicLong drainedNewPagesOutsideLock =
+            new java.util.concurrent.atomic.AtomicLong();
+
+    /**
      * Allow checkpoint
      */
     private final StampedLock checkpointLock = new StampedLock();
@@ -1020,7 +1028,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 recordsFlushed += page.size();
             }
         }
+        drainedNewPagesOutsideLock.addAndGet(snapshot.size());
         return new long[]{pagesFlushed, recordsFlushed};
+    }
+
+    /**
+     * @return number of pages that {@link #drainPendingNewPages()} has flushed outside the
+     *         checkpoint write lock since this {@code TableManager} was instantiated.
+     *         Visible for tests.
+     */
+    long getDrainedNewPagesOutsideLock() {
+        return drainedNewPagesOutsideLock.get();
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -966,6 +966,64 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     /**
+     * Flush whatever is in {@link #newPages} outside the checkpoint write lock.
+     *
+     * <p>The checkpoint write lock is acquired briefly, only long enough to snapshot
+     * {@code newPages} and rotate {@link #currentDirtyRecordsPage} to a fresh mutable
+     * page via {@link #createNewPage(long)} — same pattern as Phase A. After the rotate,
+     * every page in the snapshot is immutable (no DML can target them because
+     * {@link #allocateLivePage} checks against the new current page id), so
+     * {@link #flushNewPageForCheckpoint} can safely run outside {@code checkpointLock}.
+     * Concurrent commits proceed while the potentially I/O-heavy flush runs.
+     *
+     * <p>Used by Phase C to absorb the backlog of pages accumulated while Phase B and
+     * {@link AbstractIndexManager#checkpoint} ran (the latter can spend minutes in
+     * {@code waitForCatchUp}). Without this drain, Phase C's write-lock window grows
+     * proportionally to ingest throughput × checkpoint duration and starves commits on
+     * {@link #CHECKPOINT_LOCK_READ_TIMEOUT}.
+     *
+     * <p>This does NOT guarantee {@code newPages} is empty on return: concurrent DML
+     * after the rotate can create new pages. Phase C still performs a final flush pass
+     * under the write lock to preserve the issue #46 invariant
+     * ({@code newPages} must be empty before {@code keyToPage.checkpoint()}).
+     *
+     * @return {@code { pagesFlushed, recordsFlushed }} for non-empty pages in the
+     *         snapshot, so the caller can add them to the checkpoint stats.
+     */
+    private long[] drainPendingNewPages() throws DataStorageManagerException {
+        List<DataPage> snapshot;
+        boolean lockAcquired;
+        try {
+            lockAcquired = checkpointLock.asWriteLock().tryLock(CHECKPOINT_LOCK_WRITE_TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException err) {
+            throw new DataStorageManagerException("interrupted while waiting for checkpoint lock (drain newPages)", err);
+        }
+        if (!lockAcquired) {
+            throw new DataStorageManagerException("timed out while waiting for checkpoint lock (drain newPages), write lock "
+                    + checkpointLock.writeLock());
+        }
+        try {
+            if (newPages.isEmpty()) {
+                return new long[]{0, 0};
+            }
+            snapshot = new ArrayList<>(newPages.values());
+            createNewPage(nextPageId++);
+        } finally {
+            checkpointLock.asWriteLock().unlock();
+        }
+        long pagesFlushed = 0;
+        long recordsFlushed = 0;
+        for (DataPage page : snapshot) {
+            flushNewPageForCheckpoint(page, null);
+            if (!page.isEmpty()) {
+                ++pagesFlushed;
+                recordsFlushed += page.size();
+            }
+        }
+        return new long[]{pagesFlushed, recordsFlushed};
+    }
+
+    /**
      * Remove the page from {@link #newPages}, set it as "unloaded" and write it to disk
      * <p>
      * Add as much spare data as possible to fillup the page. If added must change key to page pointers
@@ -3601,6 +3659,22 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
         indexcheckpoint = System.currentTimeMillis();
 
+        /*
+         * Drain the backlog of pages that accumulated in newPages during Phase B and
+         * indexManager.checkpoint (which can spend minutes in VectorIndexManager's
+         * waitForCatchUp). This flushes them outside the Phase C write lock, preventing
+         * commits from timing out on CHECKPOINT_LOCK_READ_TIMEOUT while Phase C serially
+         * writes hundreds or thousands of pages to remote storage.
+         *
+         * The residual (pages created between this drain and the Phase C tryLock below) is
+         * bounded by DML rate × lock acquisition latency, normally one partially-filled
+         * page. Phase C's final flush loop still runs under the write lock to preserve the
+         * issue #46 invariant.
+         */
+        long[] drainedCounts = drainPendingNewPages();
+        flushedNewPages += (int) drainedCounts[0];
+        flushedRecords += drainedCounts[1];
+
 
         /* ================================================================== */
         /* === PHASE C: Brief write lock — finalize metadata and PK index === */
@@ -3631,12 +3705,15 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
 
             /*
-             * Flush any remaining newPages (the current DML page created by Phase A plus any
-             * additional pages allocated by allocateLivePage during Phase B). Without this, keys
-             * that were inserted/updated during Phase B live on a page whose content was never
-             * persisted, and keyToPage.checkpoint below would record a mapping to that unflushed
-             * page — a recovery scan would then fail with "no record in memory for K" because
-             * the page is missing from activePages and from storage (issue #46).
+             * Flush any residual newPages. drainPendingNewPages() just before Phase C already
+             * flushed the bulk of what accumulated during Phase B + indexManager.checkpoint.
+             * What remains here is the small tail: the fresh current page created by the last
+             * drain, plus any pages concurrent DML allocated between unlock-of-drain and
+             * acquire-of-Phase-C-write-lock (typically one partially-filled page).
+             *
+             * We still MUST run this pass: keyToPage.checkpoint() below requires newPages
+             * empty, else it records mappings to pages missing from activePages and storage,
+             * and recovery fails with "no record in memory for K" (issue #46).
              *
              * Phase C holds checkpointLock.asWriteLock(), so no concurrent DML can reach
              * applyInsert/applyUpdate/applyDelete while we flush these pages. After the flush,

--- a/herddb-core/src/test/java/herddb/core/CheckpointDrainNewPagesTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointDrainNewPagesTest.java
@@ -1,0 +1,220 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.server.ServerConfiguration;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression tests for the Phase C newPages drain introduced to unblock commits during
+ * long checkpoints (follow-up to issue #148).
+ *
+ * <p>Before the fix, {@link TableManager#checkpoint(boolean, long)} Phase C held
+ * {@code checkpointLock.asWriteLock()} while flushing every page that had accumulated in
+ * {@link TableManager#newPages} during Phase B and {@code indexManager.checkpoint} — which
+ * in production grew to thousands of pages during a long {@code waitForCatchUp}. Concurrent
+ * commits timed out on {@link TableManager#onTransactionCommit(herddb.model.Transaction, boolean)}'s
+ * read-side {@code tryLock}.
+ *
+ * <p>The fix adds {@link TableManager#drainPendingNewPages()}: a brief write-lock snapshot
+ * + rotate of {@code currentDirtyRecordsPage}, followed by a flush of the snapshot
+ * <strong>outside</strong> the checkpoint write lock.
+ *
+ * <p>These tests use the test-only {@link TableManager#setDuringPhaseBAction(Runnable)}
+ * hook to deterministically accumulate newPages during Phase B, then verify:
+ *
+ * <ul>
+ *   <li>the drain actually fires and flushes pages outside the lock
+ *       (via {@link TableManager#getDrainedNewPagesOutsideLock()});</li>
+ *   <li>the issue #46 invariant still holds: {@code newPages} is empty before
+ *       {@code keyToPage.checkpoint()} so every recovered row is in {@code activePages}
+ *       and on disk (a broken drain would resurface as recovery failures);</li>
+ *   <li>Phase C's final flush pass still handles the residual (pages created between
+ *       the drain unlock and Phase C's lock acquire).</li>
+ * </ul>
+ */
+public class CheckpointDrainNewPagesTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Many autocommit INSERTs during Phase B fill newPages beyond a single DML page. The
+     * drain must absorb them outside the write lock — visible via the test-only counter —
+     * and every row must still be readable after restart.
+     */
+    @Test
+    public void testDrainFlushesPagesAccumulatedDuringPhaseB() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmoDir").toPath();
+        String nodeId = "localhost";
+
+        // Small page size so a handful of inserts force allocateLivePage to roll a page.
+        ServerConfiguration config = new ServerConfiguration();
+        config.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, 1024);
+
+        final int preRows = 10;
+        final int hookInserts = 50;
+        long drainedPages;
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null, config, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, s1 string, n1 int)",
+                    Collections.emptyList());
+            for (int i = 0; i < preRows; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,s1,n1) values(?,?,?)",
+                        Arrays.asList("pre" + i, "payload-padding-to-inflate-page-size", i));
+            }
+            manager.checkpoint();
+
+            // Capture TableManager so we can arm the hook + read the drain counter.
+            TableManager t1Manager = (TableManager) manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+            long drainedBefore = t1Manager.getDrainedNewPagesOutsideLock();
+
+            AtomicReference<Throwable> hookError = new AtomicReference<>();
+            t1Manager.setDuringPhaseBAction(() -> {
+                try {
+                    // Keep the hook one-shot; if we fire during every per-table phase-B
+                    // the recursion gets confusing.
+                    t1Manager.setDuringPhaseBAction(null);
+                    for (int i = 0; i < hookInserts; i++) {
+                        execute(manager, "INSERT INTO tblspace1.t1(k1,s1,n1) values(?,?,?)",
+                                Arrays.asList("during" + i, "payload-padding-to-inflate-page-size",
+                                        1000 + i));
+                    }
+                } catch (Throwable t) {
+                    hookError.set(t);
+                }
+            });
+
+            manager.checkpoint();
+            if (hookError.get() != null) {
+                throw new AssertionError("insert-during-Phase-B hook failed", hookError.get());
+            }
+
+            drainedPages = t1Manager.getDrainedNewPagesOutsideLock() - drainedBefore;
+        }
+
+        // The drain must have fired: with 50 inserts at ~1KB page size, at least a couple of
+        // pages must have ended up in newPages between Phase A's rotate and the drain call.
+        assertTrue("expected drainPendingNewPages() to have flushed at least one page "
+                + "outside the write lock, saw " + drainedPages, drainedPages > 0);
+
+        // Recovery must find every row — the drain would be worthless if it broke
+        // the issue #46 invariant (keyToPage pointing at unflushed pages).
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null, config, null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10000);
+
+            long total;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1",
+                    Collections.emptyList())) {
+                total = s.consume().size();
+            }
+            assertEquals(preRows + hookInserts, total);
+
+            long duringRows;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1 WHERE n1>=1000",
+                    Collections.emptyList())) {
+                duringRows = s.consume().size();
+            }
+            assertEquals(hookInserts, duringRows);
+        }
+    }
+
+    /**
+     * The drain must be a no-op when {@code newPages} is already empty at the drain call.
+     * Using a memory-only setup with no Phase-B DML: Phase A rotates a fresh current page
+     * into {@code newPages} so the drain snapshot always contains at least that one page —
+     * but nothing should be left behind for Phase C to flush.
+     */
+    @Test
+    public void testDrainIsHarmlessWithoutPhaseBActivity() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager(nodeId,
+                new MemoryMetadataStorageManager(), new MemoryDataStorageManager(),
+                new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)",
+                    Collections.emptyList());
+            for (int i = 0; i < 5; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)",
+                        Arrays.asList("k" + i, i));
+            }
+
+            // Two back-to-back checkpoints with no DML in between. The second must be a
+            // clean no-op: if drain or the final-flush pass double-flushed or corrupted
+            // newPages the row count would diverge or recovery would fail.
+            manager.checkpoint();
+            manager.checkpoint();
+
+            long total;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1",
+                    Collections.emptyList())) {
+                total = s.consume().size();
+            }
+            assertEquals(5, total);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Move the large new-pages flush that currently runs under Phase C's write lock
  into a pre-Phase-C drain that acquires the write lock only long enough to
  snapshot and rotate `currentDirtyRecordsPage`, then flushes outside the lock.
- Follow-up to #148: the timeout bump (commit `9435833c`) was a mitigation; this
  PR addresses the root cause so Phase C holds `checkpointLock.asWriteLock()`
  for a bounded time even under heavy ingest.

## Background

In the issue #148 run, Phase C held the write lock for 15-20 s while it
sequentially flushed **1,719 new pages** to `RemoteFileDataStorageManager`.
Those pages accumulated in `newPages` during Phase B and, dominantly, during
the 80 s `VectorIndexManager.waitForCatchUp` that runs between Phase B and
Phase C. Concurrent commits hit `checkpointLock.asReadLock().tryLock(30s)` at
`TableManager.onTransactionCommit` and timed out, so the server effectively
froze at 2.7 % of the target ingest.

## Design

- New private helper `drainPendingNewPages()` (`TableManager.java`, next to
  `flushNewPageForCheckpoint`). It briefly acquires `checkpointLock.asWriteLock()`
  only to snapshot `newPages.values()` and rotate `currentDirtyRecordsPage` via
  `createNewPage(nextPageId++)` — the same shape as Phase A, takes microseconds.
  Outside the lock it calls `flushNewPageForCheckpoint(page, null)` on each
  snapshot entry.
- One call site in `checkpoint()` just after `indexManager.checkpoint(...)` and
  before Phase C's `tryLock`, so it drains the pages that accumulated during
  Phase B + `waitForCatchUp`.
- Phase C is otherwise unchanged: it still flushes whatever residual exists in
  `newPages` (typically one partially-filled current page), checkpoints the
  B-Link PK index, and writes `TableStatus` — all under the write lock.

## Why this is safe

After the rotate inside the drain, every page in the snapshot is immutable:
`allocateLivePage` (in `TableManager.java:727-784`) compares `lastKnownPageId`
with `currentDirtyRecordsPage.get()` and will always see the new current page,
so DML is redirected there. The snapshot pages can never be written to again.
`flushNewPageForCheckpoint` already synchronizes on the page's own `pageLock`
and publishes to `pageSet.activePages` / removes from `newPages` atomically —
this is the same mechanism Phase B already uses for `frozenNewPages` without
holding `checkpointLock`.

Invariants preserved:

- **Issue #46 invariant** — `newPages` must be empty before `keyToPage.checkpoint()`.
  Phase C's final flush pass over the small residual still runs before the
  B-Link checkpoint under the write lock.
- **B-Link checkpoint atomicity** — `keyToPage.checkpoint(sequenceNumber, pin)`
  still runs with the write lock held.
- **`pageSet.checkpointDone` + `TableStatus` capture atomicity** — unchanged,
  still in one uninterrupted write-lock window.
- **Issue #129 concurrent-search safety** — untouched; secondary indexes keep
  their own per-index locking and run outside Phase C.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`
- [x] `mvn -pl herddb-core -Dtest='CheckpointTest,CheckpointRecoveryWithIndexTest,CheckpointExecuteTest,CheckpointMemoryBoundsTest' test` → 23/23 green
- [ ] CI cluster category (`ClusterTest`) — runs `BookKeeperCommitLogTest#testDropOldLedgers*` added in #147
- [ ] End-to-end: k3s-local vector bench (`./scripts/run-bench.sh --dataset bigann -n 100000000 -k 1 --ingest-max-ops 5000 --ingest-threads 4 --batch-size 1000 --checkpoint`). Expect no `timed out while acquiring checkpoint lock during a commit` errors and the gap between Phase C start and "checkpoint finished" reduced from ~15-20 s to a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)