### PR TITLE
Fix stale TableStatus.sequenceNumber exposing duplicate-key on recovery (#145)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -199,6 +199,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private volatile boolean checkPointRunning = false;
 
     /**
+     * Test-only hook fired inside {@link #checkpoint(double, double, long, long, long, boolean, long)}
+     * after Phase A releases the checkpoint write lock and before Phase B starts flushing pages.
+     * Used by the regression tests for issue #145 to deterministically drive DML that commits
+     * during Phase B. {@code null} in production.
+     */
+    private volatile Runnable duringPhaseBAction;
+
+    /**
      * Allow checkpoint
      */
     private final StampedLock checkpointLock = new StampedLock();
@@ -3464,6 +3472,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         /* === PHASE B: No checkpoint lock — DML proceeds concurrently === */
         /* ============================================================== */
 
+        /*
+         * Test-only hook that fires AFTER Phase A releases the checkpoint write lock
+         * but BEFORE Phase B starts flushing pages. Used by the regression tests for
+         * issue #145 to deterministically drive DML that commits during Phase B so
+         * its effects end up in pages flushed by Phase C's remainingNewPages loop.
+         * Production code leaves {@code duringPhaseBAction} null.
+         */
+        if (duringPhaseBAction != null) {
+            duringPhaseBAction.run();
+        }
+
         /* **************************** */
         /* *** Dirty pages handling *** */
         /* **************************** */
@@ -3662,11 +3681,30 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
 
             /*
+             * Re-read the log position AFTER all page flushes (Phase B + Phase C remaining newPages)
+             * completed, under the Phase C write lock. This LSN is an upper bound on the LSN of any
+             * entry whose effect is in a flushed page for THIS table — Phase C just flushed every
+             * remaining dirty page, so at this moment every entry with LSN ≤ postFlushSequenceNumber
+             * that affects this table is persisted.
+             *
+             * Persisting this LSN (rather than the Phase-A snapshot) as TableStatus.sequenceNumber
+             * makes the per-table recovery filter in {@code apply(...)} and
+             * {@code onTransactionCommit(...)} correctly skip entries/commits that were applied to
+             * flushed pages during Phase B — previously those entries could be replayed and
+             * re-applied, tripping duplicate-key {@code IllegalStateException} during recovery of
+             * the tablespace (issue #145).
+             *
+             * Phase C holds checkpointLock.asWriteLock(), so no concurrent DML on this table can
+             * advance the log between this read and the tableStatus write.
+             */
+            final LogSequenceNumber postFlushSequenceNumber = log.getLastSequenceNumber();
+
+            /*
              * Checkpoint the primary key index (BLink tree).
              * The write lock guarantees no threads are modifying the index concurrently,
              * which is required by BLink's checkpoint() contract.
              */
-            actions.addAll(keyToPage.checkpoint(sequenceNumber, pin));
+            actions.addAll(keyToPage.checkpoint(postFlushSequenceNumber, pin));
             maybeWarnOnActionAccumulation(actions);
             keytopagecheckpoint = System.currentTimeMillis();
 
@@ -3678,7 +3716,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
              * entire lifetime of `tableStatus` (it is consumed by
              * dataStorageManager.tableCheckpoint below and discarded).
              */
-            TableStatus tableStatus = new TableStatus(table.name, sequenceNumber,
+            TableStatus tableStatus = new TableStatus(table.name, postFlushSequenceNumber,
                     Bytes.longToByteArray(nextPrimaryKeyValue.get()), nextPageId,
                     pageSet.getActivePagesView());
 
@@ -3697,7 +3735,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             checkPointRunning = false;
 
-            result = new TableCheckpoint(table.name, sequenceNumber, actions);
+            result = new TableCheckpoint(table.name, postFlushSequenceNumber, actions);
 
             end = System.currentTimeMillis();
             if (flushedRecords > 0) {
@@ -4468,6 +4506,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     @Override
     public boolean isStarted() {
         return started;
+    }
+
+    /**
+     * Test-only: install a {@link Runnable} that fires inside
+     * {@link #checkpoint(double, double, long, long, long, boolean, long)} after
+     * Phase A releases the checkpoint write lock and before Phase B begins flushing.
+     * Used by the regression tests for issue #145 to deterministically drive DML
+     * that commits during Phase B.
+     */
+    public void setDuringPhaseBAction(Runnable duringPhaseBAction) {
+        this.duringPhaseBAction = duringPhaseBAction;
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/core/CheckpointConcurrentDdlTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointConcurrentDdlTest.java
@@ -1,0 +1,206 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Guards the tables-metadata snapshot written during checkpoint against concurrent DDL.
+ *
+ * <p>The Phase-B loop in {@link TableSpaceManager#checkpoint(boolean, boolean, boolean, long)}
+ * iterates a snapshot of tables taken in Phase A and tolerates a table being dropped mid-iteration
+ * (the per-table checkpoint throws and the loop logs a warning). These tests verify end-to-end
+ * recovery after CREATE TABLE / DROP TABLE that races a checkpoint.
+ */
+public class CheckpointConcurrentDdlTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * CREATE TABLE during Phase B: the new table is not iterated by the Phase-B loop for this
+     * checkpoint. The checkpoint for the newly-created table happens at the next checkpoint;
+     * the table's state must survive a DBManager restart in both cases.
+     */
+    @Test
+    public void testCreateTableDuringPhaseB() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmoDir").toPath();
+        String nodeId = "localhost";
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)", Collections.emptyList());
+            for (int i = 0; i < 10; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)",
+                        Arrays.asList("a" + i, i));
+            }
+            manager.checkpoint();
+
+            AtomicReference<Throwable> hookError = new AtomicReference<>();
+            manager.getTableSpaceManager("tblspace1").setAfterTableCheckPointAction(() -> {
+                try {
+                    execute(manager, "CREATE TABLE tblspace1.t2 (k2 string primary key, n2 int)",
+                            Collections.emptyList());
+                    for (int i = 0; i < 5; i++) {
+                        execute(manager, "INSERT INTO tblspace1.t2(k2,n2) values(?,?)",
+                                Arrays.asList("b" + i, 100 + i));
+                    }
+                } catch (Throwable t) {
+                    hookError.set(t);
+                }
+            });
+
+            manager.checkpoint();
+            if (hookError.get() != null) {
+                throw new AssertionError("CREATE TABLE during Phase B failed", hookError.get());
+            }
+
+            manager.getTableSpaceManager("tblspace1").setAfterTableCheckPointAction(null);
+            manager.checkpoint();
+        }
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10000);
+
+            long t1Rows;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1", Collections.emptyList())) {
+                t1Rows = s.consume().size();
+            }
+            assertEquals(10, t1Rows);
+
+            long t2Rows;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t2", Collections.emptyList())) {
+                t2Rows = s.consume().size();
+            }
+            assertEquals(5, t2Rows);
+        }
+    }
+
+    /**
+     * DROP TABLE during Phase B: the Phase-B loop's existing try/catch must swallow the
+     * DataStorageManagerException for the dropped table and let the checkpoint continue.
+     * On restart only the surviving table must be present.
+     */
+    @Test
+    public void testDropTableDuringPhaseB() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmoDir").toPath();
+        String nodeId = "localhost";
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)", Collections.emptyList());
+            execute(manager, "CREATE TABLE tblspace1.t2 (k2 string primary key, n2 int)", Collections.emptyList());
+            for (int i = 0; i < 10; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)", Arrays.asList("a" + i, i));
+                execute(manager, "INSERT INTO tblspace1.t2(k2,n2) values(?,?)", Arrays.asList("b" + i, 100 + i));
+            }
+            manager.checkpoint();
+
+            AtomicReference<Throwable> hookError = new AtomicReference<>();
+            manager.getTableSpaceManager("tblspace1").setAfterTableCheckPointAction(() -> {
+                try {
+                    // Drop t2 once, via the first firing of the hook.
+                    manager.getTableSpaceManager("tblspace1").setAfterTableCheckPointAction(null);
+                    execute(manager, "DROP TABLE tblspace1.t2", Collections.emptyList());
+                } catch (Throwable t) {
+                    hookError.set(t);
+                }
+            });
+
+            manager.checkpoint();
+            if (hookError.get() != null) {
+                throw new AssertionError("DROP TABLE during Phase B failed", hookError.get());
+            }
+        }
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10000);
+
+            long t1Rows;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1", Collections.emptyList())) {
+                t1Rows = s.consume().size();
+            }
+            assertEquals(10, t1Rows);
+
+            // t2 must not exist any more.
+            try {
+                try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t2", Collections.emptyList())) {
+                    s.consume();
+                }
+                throw new AssertionError("t2 should have been dropped");
+            } catch (Exception expected) {
+                // table does not exist — expected
+            }
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/core/CheckpointStaleLsnRecoveryBookKeeperTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointStaleLsnRecoveryBookKeeperTest.java
@@ -1,0 +1,109 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.beginTransaction;
+import static herddb.core.TestUtils.commitTransaction;
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Cluster-mode regression test for issue #145 — the same race as
+ * {@link CheckpointStaleLsnRecoveryTest} but with
+ * {@link herddb.cluster.BookkeeperCommitLogManager} (ZooKeeper + embedded BookKeeper from
+ * {@link ReplicatedLogtestcase}).
+ */
+@Category(ClusterTest.class)
+public class CheckpointStaleLsnRecoveryBookKeeperTest extends ReplicatedLogtestcase {
+
+    /**
+     * Transaction committed during Phase B must survive a restart against the BookKeeper
+     * commit log without a duplicate-key recovery error.
+     */
+    @Test
+    public void testRecoveryAfterCommitDuringPhaseB_BookKeeper() throws Exception {
+        try (DBManager manager = startDBManager("node1")) {
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton("node1"), "node1", 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)", Collections.emptyList());
+            for (int i = 0; i < 30; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)", Arrays.asList("pre" + i, i));
+            }
+            manager.checkpoint();
+
+            long tx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < 5; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)",
+                        Arrays.asList("tx" + i, 100 + i),
+                        new TransactionContext(tx));
+            }
+
+            AtomicReference<Throwable> hookError = new AtomicReference<>();
+            AbstractTableManager t1Manager = manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+            ((TableManager) t1Manager).setDuringPhaseBAction(() -> {
+                try {
+                    commitTransaction(manager, "tblspace1", tx);
+                } catch (Throwable t) {
+                    hookError.set(t);
+                }
+            });
+
+            manager.checkpoint();
+            if (hookError.get() != null) {
+                throw new AssertionError("commit-during-Phase-B hook failed", hookError.get());
+            }
+        }
+
+        // Restart on the same node directory: ZK + BK state persists in testEnv, so the
+        // BookkeeperCommitLog sees the same ledgers. Recovery must complete cleanly.
+        try (DBManager manager = startDBManager("node1")) {
+            manager.waitForTablespace("tblspace1", 10000);
+
+            long total;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1", Collections.emptyList())) {
+                total = s.consume().size();
+            }
+            assertEquals(35, total);
+
+            long txRows;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1 WHERE n1>=100",
+                    Collections.emptyList())) {
+                txRows = s.consume().size();
+            }
+            assertEquals(5, txRows);
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/core/CheckpointStaleLsnRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointStaleLsnRecoveryTest.java
@@ -1,0 +1,217 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.beginTransaction;
+import static herddb.core.TestUtils.commitTransaction;
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression tests for issue #145.
+ *
+ * <p>Before the fix in {@link TableManager#checkpoint(double, double, long, long, long, boolean, long)},
+ * {@link herddb.storage.TableStatus#sequenceNumber} was captured at Phase A and persisted as the
+ * per-table {@code bootSequenceNumber}. When a transaction committed during Phase B its pending
+ * changes landed in pages flushed by Phase C (the "remainingNewPages" loop), so the on-disk page
+ * state reflected entries with LSN &gt; Phase-A — but {@code bootSequenceNumber} still pointed at
+ * Phase-A. On recovery, the per-table filter in
+ * {@link TableManager#apply(herddb.log.CommitLogResult, herddb.log.LogEntry, boolean)} and
+ * {@link TableManager#onTransactionCommit(herddb.model.Transaction, boolean)} did not recognise
+ * those entries as already-applied, the COMMIT was replayed, and
+ * {@link herddb.core.TableManager#applyInsert(herddb.utils.Bytes, herddb.utils.Bytes, boolean)}
+ * threw {@code IllegalStateException: corrupted transaction log: key already present}.
+ *
+ * <p>These tests use the test-only {@link TableManager#setDuringPhaseBAction(Runnable)} hook to
+ * deterministically run DML (including a {@code COMMIT} of an in-flight transaction) while the
+ * {@link TableManager#checkpoint(boolean, long)} is between Phase A and Phase B, so the resulting
+ * entries end up in pages flushed by Phase C.
+ */
+public class CheckpointStaleLsnRecoveryTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * A transaction committed during Phase B must not produce a duplicate-key error on restart.
+     */
+    @Test
+    public void testRecoveryAfterCommitDuringPhaseB() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmoDir").toPath();
+        String nodeId = "localhost";
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)", Collections.emptyList());
+            for (int i = 0; i < 30; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)", Arrays.asList("pre" + i, i));
+            }
+            manager.checkpoint();
+
+            // Start a transaction with pending inserts BEFORE the checkpoint. During Phase B the
+            // transaction commits, applies its inserts to main state (which go into newPages), and
+            // Phase C flushes those pages to disk. Without the fix, TableStatus.sequenceNumber is
+            // the Phase-A snapshot so the flushed-page state disagrees with bootSequenceNumber.
+            long tx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < 5; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)",
+                        Arrays.asList("tx" + i, 100 + i),
+                        new TransactionContext(tx));
+            }
+
+            AtomicReference<Throwable> hookError = new AtomicReference<>();
+            AbstractTableManager t1Manager = manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+            ((TableManager) t1Manager).setDuringPhaseBAction(() -> {
+                try {
+                    commitTransaction(manager, "tblspace1", tx);
+                } catch (Throwable t) {
+                    hookError.set(t);
+                }
+            });
+
+            manager.checkpoint();
+            if (hookError.get() != null) {
+                throw new AssertionError("commit-during-Phase-B hook failed", hookError.get());
+            }
+        }
+
+        // Restart: recovery must complete cleanly (no IllegalStateException) and every row must be
+        // visible. Without the fix the replay of the COMMIT during recovery re-applies the pending
+        // inserts on top of the flushed pages and trips duplicate-key IllegalStateException.
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10000);
+
+            long total;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1", Collections.emptyList())) {
+                total = s.consume().size();
+            }
+            assertEquals(35, total);
+
+            long txRows;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1 WHERE n1>=100",
+                    Collections.emptyList())) {
+                txRows = s.consume().size();
+            }
+            assertEquals(5, txRows);
+        }
+    }
+
+    /**
+     * Autocommit INSERTs executed during Phase B must survive a restart with no duplicate-key
+     * errors. The INSERTs land in new pages flushed by Phase C, so their LSN is &gt; Phase-A; on
+     * recovery the per-table filter must skip the corresponding log entries.
+     */
+    @Test
+    public void testRecoveryAfterAutocommitDuringPhaseB() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmoDir").toPath();
+        String nodeId = "localhost";
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)", Collections.emptyList());
+            for (int i = 0; i < 30; i++) {
+                execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)", Arrays.asList("pre" + i, i));
+            }
+            manager.checkpoint();
+
+            AtomicReference<Throwable> hookError = new AtomicReference<>();
+            AbstractTableManager t1Manager = manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+            ((TableManager) t1Manager).setDuringPhaseBAction(() -> {
+                try {
+                    for (int i = 0; i < 5; i++) {
+                        execute(manager, "INSERT INTO tblspace1.t1(k1,n1) values(?,?)",
+                                Arrays.asList("during" + i, 200 + i));
+                    }
+                } catch (Throwable t) {
+                    hookError.set(t);
+                }
+            });
+
+            manager.checkpoint();
+            if (hookError.get() != null) {
+                throw new AssertionError("autocommit-during-Phase-B hook failed", hookError.get());
+            }
+        }
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10000);
+
+            long total;
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1", Collections.emptyList())) {
+                total = s.consume().size();
+            }
+            assertEquals(35, total);
+        }
+    }
+}

--- a/herddb-services/src/test/java/herddb/server/CheckpointStaleLsnRemoteStorageTest.java
+++ b/herddb-services/src/test/java/herddb/server/CheckpointStaleLsnRemoteStorageTest.java
@@ -1,0 +1,177 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import static org.junit.Assert.assertEquals;
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.client.HDBConnection;
+import herddb.client.ScanResultSet;
+import herddb.client.ZookeeperClientSideMetadataProvider;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.core.AbstractTableManager;
+import herddb.core.TableManager;
+import herddb.model.TableSpace;
+import herddb.remote.RemoteFileServer;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.test.TestingServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Cluster + remote-storage regression test for issue #145. Exercises the same
+ * Phase-B COMMIT race as
+ * {@link herddb.core.CheckpointStaleLsnRecoveryTest} but with a full HerdDB
+ * {@link Server} in cluster mode ({@link herddb.cluster.BookkeeperCommitLog})
+ * backed by a {@link RemoteFileServer} registered via ZooKeeper.
+ */
+public class CheckpointStaleLsnRemoteStorageTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testRecoveryAfterCommitDuringPhaseB_RemoteStorage() throws Exception {
+        Path zkDir = folder.newFolder("zk").toPath();
+        try (TestingServer zookeeperServer = new TestingServer(-1, zkDir.toFile(), true)) {
+            String zkAddress = zookeeperServer.getConnectString();
+            String zkPath = "/herddb";
+
+            Path fileServerDataDir = folder.newFolder("fileserver").toPath();
+            RemoteFileServer fileServer = new RemoteFileServer("localhost", 0, fileServerDataDir);
+            fileServer.start();
+            try {
+                ZookeeperMetadataStorageManager registrationManager =
+                        new ZookeeperMetadataStorageManager(zkAddress, 40000, zkPath);
+                registrationManager.start();
+                try {
+                    String addr = "localhost:" + fileServer.getPort();
+                    registrationManager.registerFileServer("fs1", addr);
+
+                    String baseDir = folder.newFolder("herddb").getAbsolutePath();
+
+                    Properties serverProps = new Properties();
+                    try (InputStream in = SimpleClusterTest.class.getResourceAsStream(
+                            "/conf/test.server_cluster.properties")) {
+                        serverProps.load(in);
+                    }
+                    serverProps.put(ServerConfiguration.PROPERTY_BASEDIR, baseDir);
+                    serverProps.put(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkAddress);
+                    serverProps.put(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, zkPath);
+                    serverProps.put("http.enable", "false");
+                    serverProps.put(ServerConfiguration.PROPERTY_STORAGE_MODE,
+                            ServerConfiguration.PROPERTY_STORAGE_MODE_REMOTE);
+                    serverProps.put(ServerConfiguration.PROPERTY_REMOTE_FILE_SERVERS, addr);
+
+                    // ---- First boot: load data and run the checkpoint with the Phase-B hook ----
+                    try (Server server = new Server(new ServerConfiguration(serverProps))) {
+                        server.start();
+                        server.waitForStandaloneBoot();
+
+                        try (HDBClient hdbClient = new HDBClient(
+                                new ClientConfiguration(folder.newFolder().toPath()))) {
+                            hdbClient.setClientSideMetadataProvider(
+                                    new ZookeeperClientSideMetadataProvider(
+                                            zkAddress, 40000, zkPath));
+                            try (HDBConnection con = hdbClient.openConnection()) {
+                                con.executeUpdate(TableSpace.DEFAULT,
+                                        "CREATE TABLE t1 (k string primary key, n int)",
+                                        0, false, true, Collections.emptyList());
+                                for (int i = 0; i < 30; i++) {
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "INSERT INTO t1(k,n) VALUES(?, ?)",
+                                            0, false, true, Arrays.asList("pre" + i, i));
+                                }
+                                server.getManager().checkpoint();
+
+                                long tx = con.beginTransaction(TableSpace.DEFAULT);
+                                for (int i = 0; i < 5; i++) {
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "INSERT INTO t1(k,n) VALUES(?, ?)",
+                                            tx, false, true, Arrays.asList("tx" + i, 100 + i));
+                                }
+
+                                AtomicReference<Throwable> hookError = new AtomicReference<>();
+                                AbstractTableManager t1Manager = server.getManager()
+                                        .getTableSpaceManager(TableSpace.DEFAULT)
+                                        .getTableManager("t1");
+                                ((TableManager) t1Manager).setDuringPhaseBAction(() -> {
+                                    try {
+                                        con.commitTransaction(TableSpace.DEFAULT, tx);
+                                    } catch (Throwable t) {
+                                        hookError.set(t);
+                                    }
+                                });
+
+                                server.getManager().checkpoint();
+                                if (hookError.get() != null) {
+                                    throw new AssertionError("commit-during-Phase-B hook failed",
+                                            hookError.get());
+                                }
+                            }
+                        }
+                    }
+
+                    // ---- Second boot: recovery must succeed and all rows must be visible ----
+                    try (Server server = new Server(new ServerConfiguration(serverProps))) {
+                        server.start();
+                        server.waitForStandaloneBoot();
+
+                        try (HDBClient hdbClient = new HDBClient(
+                                new ClientConfiguration(folder.newFolder().toPath()))) {
+                            hdbClient.setClientSideMetadataProvider(
+                                    new ZookeeperClientSideMetadataProvider(
+                                            zkAddress, 40000, zkPath));
+                            try (HDBConnection con = hdbClient.openConnection()) {
+                                try (ScanResultSet s = con.executeScan(TableSpace.DEFAULT,
+                                        "SELECT count(*) as cnt FROM t1",
+                                        false, Collections.emptyList(), 0, 10, 10, false)) {
+                                    List<Map<String, Object>> rows = s.consume();
+                                    assertEquals(1, rows.size());
+                                    assertEquals(35, ((Number) rows.get(0).get("cnt")).intValue());
+                                }
+
+                                try (ScanResultSet s = con.executeScan(TableSpace.DEFAULT,
+                                        "SELECT count(*) as cnt FROM t1 WHERE n>=100",
+                                        false, Collections.emptyList(), 0, 10, 10, false)) {
+                                    List<Map<String, Object>> rows = s.consume();
+                                    assertEquals(5, ((Number) rows.get(0).get("cnt")).intValue());
+                                }
+                            }
+                        }
+                    }
+                } finally {
+                    registrationManager.close();
+                }
+            } finally {
+                fileServer.stop();
+            }
+        }
+    }
+}

--- a/herddb-services/src/test/java/herddb/server/CheckpointStaleLsnSharedStorageFollowerTest.java
+++ b/herddb-services/src/test/java/herddb/server/CheckpointStaleLsnSharedStorageFollowerTest.java
@@ -1,0 +1,169 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import static org.junit.Assert.assertEquals;
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.client.HDBConnection;
+import herddb.client.ZookeeperClientSideMetadataProvider;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.core.AbstractTableManager;
+import herddb.core.TableManager;
+import herddb.log.LogSequenceNumber;
+import herddb.model.TableSpace;
+import herddb.remote.RemoteFileServer;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.test.TestingServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Guards the shared-storage follower bootstrap path after the
+ * issue-#145 Phase-B commit scenario.
+ *
+ * <p>Shared-storage read replicas bootstrap from the LSN the leader publishes
+ * to ZooKeeper metadata via
+ * {@code TableSpaceManager#publishCheckpointLsnToMetadata} — that LSN must
+ * match the LSN the leader persists to disk via
+ * {@code writeCheckpointSequenceNumber}, so the follower loads the same
+ * pages and transactions file as the leader would after a restart.
+ *
+ * <p>The fix for issue #145 lives in {@link TableManager#checkpoint} (it
+ * updates per-table {@code TableStatus.sequenceNumber}) and does not change
+ * the tablespace-level LSN; this test nails that invariant down so a future
+ * change that moves only one of the two LSNs cannot silently diverge the
+ * follower's view from the on-disk state.
+ */
+public class CheckpointStaleLsnSharedStorageFollowerTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testPublishedLsnMatchesStoredCheckpoint() throws Exception {
+        Path zkDir = folder.newFolder("zk").toPath();
+        try (TestingServer zookeeperServer = new TestingServer(-1, zkDir.toFile(), true)) {
+            String zkAddress = zookeeperServer.getConnectString();
+            String zkPath = "/herddb";
+
+            Path fileServerDataDir = folder.newFolder("fileserver").toPath();
+            RemoteFileServer fileServer = new RemoteFileServer("localhost", 0, fileServerDataDir);
+            fileServer.start();
+            try {
+                ZookeeperMetadataStorageManager registrationManager =
+                        new ZookeeperMetadataStorageManager(zkAddress, 40000, zkPath);
+                registrationManager.start();
+                try {
+                    String addr = "localhost:" + fileServer.getPort();
+                    registrationManager.registerFileServer("fs1", addr);
+
+                    String baseDir = folder.newFolder("herddb").getAbsolutePath();
+
+                    Properties serverProps = new Properties();
+                    try (InputStream in = SimpleClusterTest.class.getResourceAsStream(
+                            "/conf/test.server_cluster.properties")) {
+                        serverProps.load(in);
+                    }
+                    serverProps.put(ServerConfiguration.PROPERTY_BASEDIR, baseDir);
+                    serverProps.put(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkAddress);
+                    serverProps.put(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, zkPath);
+                    serverProps.put("http.enable", "false");
+                    serverProps.put(ServerConfiguration.PROPERTY_STORAGE_MODE,
+                            ServerConfiguration.PROPERTY_STORAGE_MODE_REMOTE);
+                    serverProps.put(ServerConfiguration.PROPERTY_REMOTE_FILE_SERVERS, addr);
+
+                    try (Server server = new Server(new ServerConfiguration(serverProps))) {
+                        server.start();
+                        server.waitForStandaloneBoot();
+
+                        try (HDBClient hdbClient = new HDBClient(
+                                new ClientConfiguration(folder.newFolder().toPath()))) {
+                            hdbClient.setClientSideMetadataProvider(
+                                    new ZookeeperClientSideMetadataProvider(
+                                            zkAddress, 40000, zkPath));
+                            try (HDBConnection con = hdbClient.openConnection()) {
+                                con.executeUpdate(TableSpace.DEFAULT,
+                                        "CREATE TABLE t1 (k string primary key, n int)",
+                                        0, false, true, Collections.emptyList());
+                                for (int i = 0; i < 30; i++) {
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "INSERT INTO t1(k,n) VALUES(?, ?)",
+                                            0, false, true, Arrays.asList("pre" + i, i));
+                                }
+                                server.getManager().checkpoint();
+
+                                long tx = con.beginTransaction(TableSpace.DEFAULT);
+                                for (int i = 0; i < 5; i++) {
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "INSERT INTO t1(k,n) VALUES(?, ?)",
+                                            tx, false, true, Arrays.asList("tx" + i, 100 + i));
+                                }
+
+                                AtomicReference<Throwable> hookError = new AtomicReference<>();
+                                AbstractTableManager t1Manager = server.getManager()
+                                        .getTableSpaceManager(TableSpace.DEFAULT)
+                                        .getTableManager("t1");
+                                ((TableManager) t1Manager).setDuringPhaseBAction(() -> {
+                                    try {
+                                        con.commitTransaction(TableSpace.DEFAULT, tx);
+                                    } catch (Throwable t) {
+                                        hookError.set(t);
+                                    }
+                                });
+
+                                server.getManager().checkpoint();
+                                if (hookError.get() != null) {
+                                    throw new AssertionError("commit-during-Phase-B hook failed",
+                                            hookError.get());
+                                }
+                            }
+
+                            String tableSpaceUUID = server.getManager()
+                                    .getTableSpaceManager(TableSpace.DEFAULT).getTableSpaceUUID();
+
+                            // The LSN the follower would read from ZooKeeper must match the LSN
+                            // the leader persisted to remote storage. Any drift between these two
+                            // would bootstrap a shared-storage follower at a different snapshot
+                            // than the leader itself would recover from.
+                            LogSequenceNumber publishedLsn = server.getMetadataStorageManager()
+                                    .getCheckpointLsn(tableSpaceUUID);
+                            LogSequenceNumber storedLsn = server.getManager()
+                                    .getDataStorageManager()
+                                    .getLastcheckpointSequenceNumber(tableSpaceUUID);
+                            assertEquals(storedLsn, publishedLsn);
+                        }
+                    }
+                } finally {
+                    registrationManager.close();
+                }
+            } finally {
+                fileServer.stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Re-read the log position inside `TableManager.checkpoint()` Phase C under the checkpoint write lock — after every dirty page has been flushed — and persist it as `TableStatus.sequenceNumber` (also used for the BLink primary-key-index checkpoint and the returned `TableCheckpoint`).
- Without this change, pages flushed by Phase C's \"remainingNewPages\" loop could reflect log entries with LSN > the Phase-A snapshot. On recovery the per-table filters in `TableManager.apply()` and `onTransactionCommit()` did not recognise those entries as already-applied, the replay re-applied them, and `TableManager.applyInsert` threw `IllegalStateException: corrupted transaction log: key already present`, bricking the tablespace (issue #145).

## Fix

`TableManager.checkpoint()` now captures `postFlushSequenceNumber = log.getLastSequenceNumber()` at the top of Phase C (write-lock held, all `frozenNewPages` / dirty / small / remaining-new pages flushed). This LSN is the upper bound of any entry whose effect is in a flushed page for this table, and it becomes `TableStatus.sequenceNumber`, so the per-table recovery filter correctly skips replayed commits of transactions whose changes already landed on disk during Phase B.

## Tests

A new test-only `TableManager.setDuringPhaseBAction(Runnable)` hook fires between Phase A and Phase B so a transaction COMMIT can be driven deterministically from tests — its effects end up in pages flushed by Phase C, which is exactly the bug scenario. Five new tests cover the fix:

- `CheckpointStaleLsnRecoveryTest` — local storage, in-memory metadata, two scenarios (tx COMMIT during Phase B; autocommit INSERTs during Phase B).
- `CheckpointStaleLsnRecoveryBookKeeperTest` — same scenario routed through `BookkeeperCommitLog` (`@Category(ClusterTest.class)`, extends `ReplicatedLogtestcase`).
- `CheckpointStaleLsnRemoteStorageTest` — cluster mode (ZK + embedded BK) with `PROPERTY_STORAGE_MODE=remote` backed by `RemoteFileServer`.
- `CheckpointStaleLsnSharedStorageFollowerTest` — invariant that the LSN published to ZooKeeper metadata equals the LSN persisted in the on-disk checkpoint file (shared-storage followers bootstrap from the published LSN).
- `CheckpointConcurrentDdlTest` — CREATE TABLE and DROP TABLE during Phase B survive a DBManager restart.

The three failure-mode tests fail on `master` with exactly the issue-#145 stack:

```
java.lang.IllegalStateException: corrupted transaction log: key … is already present in table tblspace1.t1
  at herddb.core.TableManager.applyInsert
  at herddb.core.TableManager.onTransactionCommit
  at herddb.core.TableSpaceManager.apply
  at herddb.core.TableSpaceManager$ApplyEntryOnRecovery.accept
```

All five new tests pass with the fix applied.

## Test plan

- [x] `mvn -pl herddb-core -Dtest=CheckpointStaleLsnRecoveryTest test`
- [x] `mvn -pl herddb-core -Dtest=CheckpointStaleLsnRecoveryBookKeeperTest -Dgroups=herddb.core.ClusterTest test`
- [x] `mvn -pl herddb-core -Dtest=CheckpointConcurrentDdlTest test`
- [x] `mvn -pl herddb-services -Dtest=CheckpointStaleLsnRemoteStorageTest test`
- [x] `mvn -pl herddb-services -Dtest=CheckpointStaleLsnSharedStorageFollowerTest test`
- [x] Regression suite against neighbouring tests: `ConcurrentCheckpointTest`, `ConcurrentCheckpointBookKeeperTest`, `ConcurrentCheckpointWithIndexTest`, `CheckpointRecoveryWithIndexTest` — all pass.
- [x] Pre-PR validation gate: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — BUILD SUCCESS across all 22 modules.

Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)