### PR TITLE
Incremental-checkpoint BLink primary-key index

### DIFF
--- a/BLINK.md
+++ b/BLINK.md
@@ -1,0 +1,373 @@
+# HerdDB BLink Primary-Key Index
+
+HerdDB stores every table's primary-key → page-id map in a B-link tree (see
+Lanin & Shasha, "A Symmetric Concurrent B-Tree Algorithm"). This document
+describes the two on-disk formats currently supported, how each checkpoints
+itself, and how recovery works.
+
+Checkpointing at large is described in [CHECKPOINT.md](./CHECKPOINT.md); this
+file zooms into the BLink-specific parts referenced from §5 there.
+
+---
+
+## 1. Two implementations, one interface
+
+Two `KeyToPageIndex` implementations ship with HerdDB:
+
+| Class | On-disk format | Selected when |
+|-------|----------------|---------------|
+| `herddb.index.blink.BLinkKeyToPageIndex` | legacy (single metadata blob) | `-Dherddb.index.pk.mode=legacy` |
+| `herddb.index.blink.IncrementalBLinkKeyToPageIndex` | incremental (snapshot + delta chain) | `-Dherddb.index.pk.mode=incremental` — **default** |
+
+The factory seam is `herddb.index.KeyToPageIndexFactory.create(...)`, called
+from every persistent `DataStorageManager.createKeyToPageMap` implementation
+(File, BookKeeper, RemoteFile, ReadReplica). `MemoryDataStorageManager` is
+not affected — it returns `ConcurrentMapKeyToPageIndex` unconditionally
+because it is used only in tests that don't exercise index persistence.
+
+Both implementations share:
+
+- The same BLink tree algorithm (Lanin–Shasha) and the same in-memory node
+  objects (`herddb.index.blink.BLink`).
+- The same **node-page byte layout** — the bytes stored by
+  `writeIndexPage(pageId, …)` for an inner or a leaf node are
+  byte-identical between the two implementations. A node page written by
+  the legacy implementation can be read by the incremental one and vice
+  versa.
+
+They differ only in the **checkpoint metadata** — what gets serialised into
+`IndexStatus.indexData` and which sidecar pages the index keeps.
+
+---
+
+## 2. Node-page layout (shared)
+
+Every inner or leaf node is persisted as a single index page via
+`DataStorageManager.writeIndexPage(tableSpace, indexName, pageId, writer)`:
+
+```
+vlong  version            = 1
+vlong  flags              = 0
+byte   kind               = 1 (INNER) | 2 (LEAF)
+
+repeat until END:
+  byte  block
+  case KEY_VALUE_BLOCK (1):
+    array key              // variable-length byte array (length-prefixed)
+    vlong value            // leaf: data-page-id ; inner: child-node-id
+  case INF_BLOCK (2):
+    vlong value            // value bound to the +∞ separator (rightmost)
+  case END_BLOCK (0):
+    break
+```
+
+`vlong` is the ZigZag-free variable-length long encoding used throughout
+HerdDB; `array` is the length-prefixed byte array (see
+`herddb.utils.ExtendedDataOutputStream.writeArray`).
+
+Neither implementation currently embeds per-node metadata (keys count,
+outlink, rightlink, rightsep, leaf flag) inside the page. That metadata
+lives in the checkpoint sidecar described below.
+
+---
+
+## 3. Legacy format (`BLinkKeyToPageIndex`)
+
+### 3.1 Checkpoint metadata
+
+On every checkpoint the legacy implementation:
+
+1. Calls `BLink.checkpoint()` which returns a `BLinkMetadata<K>` with one
+   `BLinkNodeMetadata` entry **per node in the tree**:
+   `(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep)`.
+2. Serialises the full `BLinkMetadata` into a single byte array using
+   `BLinkKeyToPageIndex.MetadataSerializer`.
+3. Collects every live `storeId` into a `Set<Long> activePages`.
+4. Builds an `IndexStatus(indexName, lsn, nextPageId, activePages,
+   serializedMetadata)` and calls
+   `DataStorageManager.indexCheckpoint(tableSpace, indexName, status, pin)`.
+
+The serialized blob starts with
+`writeVLong(CURRENT_VERSION=2); writeVLong(NO_FLAGS=0); writeByte(METADATA_PAGE=0);`
+followed by anchor pointers and the full node list.
+
+### 3.2 Cost model
+
+| Quantity | Size at checkpoint | Written to |
+|----------|--------------------|------------|
+| `indexData` (serialized metadata) | O(N) — ~80 bytes × every node in tree | `IndexStatus.indexData` (metadata file) |
+| `activePages` set | O(N) — ~8 bytes × every live page | `IndexStatus.activePages` (metadata file) |
+| Node pages | O(changes) | `writeIndexPage` (one file per page) |
+
+The **node pages** are already written incrementally — BLink only writes a
+node when it is dirty and otherwise reuses its existing `storeId`. The
+problem is the **metadata blob** and the **activePages set**, which are
+both fully rewritten on every checkpoint regardless of how little the tree
+changed. At 20 million nodes the metadata blob is ≈ 2 GB and the page-id
+set is ≈ 160 MB — rewritten at every checkpoint, this is why the legacy
+format does not scale.
+
+### 3.3 Recovery
+
+`getIndexStatus(lsn)` returns the full metadata blob; the legacy
+`BLinkKeyToPageIndex.start` deserialises it and passes the resulting
+`BLinkMetadata` to `new BLink<>(…, metadata)`, which rebuilds the in-memory
+node map (`ConcurrentMap<Long, Node>`) by creating one `Node` per entry in
+the metadata.
+
+Node-page data is loaded lazily on demand through the standard
+`BLinkIndexDataStorage` interface.
+
+---
+
+## 4. Incremental format (`IncrementalBLinkKeyToPageIndex`)
+
+### 4.1 Goal
+
+Make **per-checkpoint disk writes proportional to the number of node
+entries that changed since the previous checkpoint**, not to the total
+number of nodes in the tree.
+
+### 4.2 Pieces on disk
+
+The incremental format writes three kinds of content:
+
+| Kind | Written by | Where it lives |
+|------|------------|----------------|
+| Node pages (inner / leaf) | `BLinkIndexDataStorage` (same as legacy) | regular index pages (one per node, `writeIndexPage`) |
+| **Snapshot-chunk pages** (full node-metadata list) | `IncrementalBLinkPageCodec.writeSnapshotChunk` | regular index pages (chunked, one per chunk) |
+| **Delta pages** (per-checkpoint diffs) | `IncrementalBLinkPageCodec.writeDelta` | regular index pages (one per checkpoint) |
+| **Manifest** | `IncrementalBLinkManifest.serialize` | `IndexStatus.indexData` (metadata file) |
+
+Sidecar-page layout shares the same three-field header as the node pages
+(`vlong version; vlong flags; byte kind`) so the two formats coexist
+in the same index directory without confusion. The incremental kinds are
+`10 = SNAPSHOT_CHUNK` and `11 = DELTA`.
+
+### 4.3 Manifest (small, O(1) per checkpoint)
+
+Serialised into `IndexStatus.indexData`. Version marker **100** — well
+above the legacy range of 0–2, so the legacy reader throws
+`"Unknown BLink node metadata version 100"` and the incremental reader
+symmetrically refuses any version `< 100` with a
+`LegacyFormatDetectedException`. This is the format-mismatch safety net.
+
+```
+vlong  version             = 100
+vlong  flags               = 0
+vlong  epoch               // monotonically increasing
+vlong  values              // tree key count
+vlong  nextID              // BLink.nextID.get()
+zlong  anchorTop           // anchor pointers (copied verbatim from BLink)
+vint   anchorTopHeight
+zlong  anchorFast
+vint   anchorFastHeight
+zlong  anchorFirst
+vlong  snapshotEpoch       // epoch at which the current snapshot was taken
+vint   numSnapshotChunks
+repeat numSnapshotChunks × { vlong pageId ; vint chunkIndex ; vint totalChunks }
+vint   numDeltas
+repeat numDeltas × { vlong epoch ; vlong pageId }
+```
+
+Total size: a few hundred bytes plus ~16 bytes per sidecar-page reference.
+Always O(1) in tree size.
+
+### 4.4 Snapshot-chunk pages
+
+```
+vlong  version = 1  ;  vlong flags = 0  ;  byte kind = 10 (SNAPSHOT_CHUNK)
+vlong  epoch
+vint   chunkIndex        // 0-based
+vint   totalChunks       // total chunks for this snapshot
+vint   nodeCount
+repeat nodeCount × node-metadata
+```
+
+where each node-metadata record is:
+
+```
+boolean  leaf
+vlong    id               // BLink logical node id
+vlong    storeId          // BLink.storeId (data page id)
+vint     keys
+vlong    bytes
+zlong    outlink
+zlong    rightlink
+byte     rightSepKind     // 0 = +∞ , 1 = explicit key bytes
+[array]  rightSep         // only present when rightSepKind == 1
+```
+
+One snapshot is split across multiple chunk pages of at most
+`herddb.index.pk.incremental.snapshotChunkSize` (default 50 000) node
+entries. At recovery, all chunks for the manifest's `snapshotEpoch` are
+read and merged into a `Map<nodeId, BLinkNodeMetadata>` baseline.
+
+### 4.5 Delta pages
+
+```
+vlong  version = 1  ;  vlong flags = 0  ;  byte kind = 11 (DELTA)
+vlong  epoch
+vint   upsertedCount
+repeat upsertedCount × node-metadata             // full metadata, replaces prior entry with same id
+vint   removedCount
+repeat removedCount × vlong nodeId               // logical id (not storeId)
+vint   deadStoreIdCount
+repeat deadStoreIdCount × vlong storeId          // former storeIds now eligible for GC
+```
+
+At recovery, deltas from the manifest's `deltaChain` are applied in order
+on top of the snapshot baseline: each upserted entry replaces or inserts
+its `nodeId` in the map; each removed `nodeId` is deleted. The resulting
+map is converted to a list and passed to `new BLink<>(…, metadata)`
+exactly like the legacy recovery path — the in-memory BLink is unchanged.
+
+### 4.6 Checkpoint algorithm
+
+```
+epoch = (currentManifest == null) ? 1 : currentManifest.epoch + 1
+metadata = BLink.checkpoint()                         // returns full node list
+newByNodeId = metadata.nodes indexed by node id
+
+rewriteSnapshot = currentManifest == null
+               || currentManifest.deltaChain.size() >= SNAPSHOT_EVERY    // default 64
+
+if rewriteSnapshot:
+    snapshotChunks = writeSnapshotChunks(epoch, metadata.nodes)
+    deltaChain     = []
+    snapshotEpoch  = epoch
+else:
+    diff newByNodeId against previousByNodeId:
+        upserted      = nodes added or whose metadata changed
+        removedIds    = nodeIds in previous but not in new
+        deadStoreIds  = old storeIds of changed or removed nodes
+    if everything empty AND anchors unchanged:
+        # no-op checkpoint — reuse manifest, bump LSN only
+        (snapshotChunks, deltaChain, snapshotEpoch) = (prev.snapshotChunks,
+                                                       prev.deltaChain,
+                                                       prev.snapshotEpoch)
+    else:
+        deltaPageId = newPageId++
+        writeDelta(deltaPageId, epoch, upserted, removedIds, deadStoreIds)
+        snapshotChunks = prev.snapshotChunks
+        deltaChain     = prev.deltaChain ++ (epoch, deltaPageId)
+        snapshotEpoch  = prev.snapshotEpoch
+
+manifest = IncrementalBLinkManifest(epoch, …, snapshotChunks, deltaChain)
+preserve = { node storeIds } ∪ { snapshotChunks.pageIds } ∪ { deltaChain.pageIds }
+IndexStatus status = new IndexStatus(indexName, lsn, nextID, preserve,
+                                     manifest.serialize())
+postActions = dataStorageManager.indexCheckpoint(tableSpace, indexName,
+                                                  status, pin)
+currentManifest     = manifest
+previousByNodeId   := newByNodeId
+return postActions
+```
+
+Notes:
+
+- **Preserve set** — the `activePages` field of `IndexStatus` is the
+  **small** preserve set of "pages we must not delete this round":
+  the live node pages, plus our own manifest sidecars. This is
+  deliberately not the full activePages set of the tree; the existing
+  `FileDataStorageManager.indexCheckpoint` GC logic ([CHECKPOINT.md §10](./CHECKPOINT.md#10-datastorage-backend-differences))
+  already deletes any page file not in `activePages` and not pinned,
+  so feeding it only the preserve set is what makes GC of superseded
+  snapshots and consumed deltas happen automatically.
+- **Snapshot-refresh threshold** — tuned via
+  `-Dherddb.index.pk.incremental.snapshotEvery` (default 64). After N
+  deltas the next checkpoint rewrites a fresh snapshot, bounding the
+  recovery cost at snapshot-size + N-deltas.
+- **No DSM API change** — the incremental format rides on the same
+  `readIndexPage` / `writeIndexPage` / `deleteIndexPage` / `indexCheckpoint`
+  / `getIndexStatus` surface as the legacy format. All five
+  `DataStorageManager` implementations (File, BookKeeper, RemoteFile,
+  ReadReplica, Memory) support it without modification.
+
+### 4.7 Cost model
+
+| Quantity | Size at a non-snapshot checkpoint | Size at a snapshot-refresh checkpoint |
+|----------|-----------------------------------|----------------------------------------|
+| manifest (`indexData`) | ~O(1) + ~16 B × deltaChain length | ~O(1) + ~16 B × chunk count |
+| preserve set (`activePages`) | ~O(changes) + snapshot & delta page-ids | same |
+| delta page | O(changes) × node-metadata record size | **not written** |
+| snapshot-chunk pages | **not written** | O(N) × node-metadata record size |
+| node pages | O(dirty nodes) (same as legacy) | same |
+
+The normal case is a non-snapshot checkpoint: its dominant cost is the
+delta page, whose size grows with the number of nodes that actually
+changed since the previous checkpoint — not with the total tree size.
+
+### 4.8 Format-mismatch detection
+
+If the JVM is configured with `-Dherddb.index.pk.mode=incremental` (the
+default) but the existing on-disk metadata for an index was written by the
+legacy implementation, `IncrementalBLinkKeyToPageIndex.start` detects this
+inside `IncrementalBLinkManifest.deserialize` (version marker `< 100`) and
+throws a `DataStorageManagerException` with a message pointing the
+operator to either `-Dherddb.index.pk.mode=legacy` or a fresh tablespace.
+
+Symmetrically, the legacy reader throws a
+`"Unknown BLink node metadata version 100"` if fed an incremental
+manifest. No silent misreads are possible.
+
+Migration between the two formats is not implemented in this first
+iteration — set the mode once per tablespace and keep it.
+
+### 4.9 Garbage collection
+
+Dead store-page IDs are recorded explicitly in each delta's
+`deadStoreIds` list so that operators can reason about what was
+abandoned at what epoch. Actual file-level deletion happens at
+`dataStorageManager.indexCheckpoint` time through the standard
+`PostCheckpointAction` mechanism: any index page file whose id is
+`< maxPageId`, not pinned, and not in the preserve set is scheduled for
+deletion by the `FileDataStorageManager` / `RemoteFileDataStorageManager`
+cleanup code (see [CHECKPOINT.md §10](./CHECKPOINT.md#10-datastorage-backend-differences)).
+
+On a snapshot refresh the whole previous snapshot and delta chain become
+"not referenced" — the preserve set no longer contains them, so the DSM
+reclaims them in the same pass.
+
+---
+
+## 5. In-memory representation (common to both formats)
+
+Both implementations share the same in-memory `BLink` object:
+
+- `ConcurrentMap<Long, Node<K,V>> nodes` — one `Node` instance per live
+  tree node. **This is still O(N) in tree size** and is not addressed by
+  the incremental format: at 20 million nodes the heap still holds 20
+  million `Node` objects. The cost that the incremental format removes is
+  the **persisted** O(N), not the in-memory O(N).
+- `PageReplacementPolicy` — evicts **node page data** (keys + values) from
+  memory when the global PK memory budget fills up; the `Node` object
+  itself stays pinned.
+- `anchor` — the top / fast / first pointers for concurrent descents.
+
+Moving to true lazy-`Node` allocation (so the heap footprint is
+proportional to the working set, not to tree size) is a follow-up that
+requires changes to `BLink` itself and is deliberately out of scope for
+the first incremental checkpoint release.
+
+---
+
+## 6. Configuration summary
+
+| Property | Default | Effect |
+|----------|---------|--------|
+| `herddb.index.pk.mode` | `incremental` | `incremental` / `legacy` — which implementation runs |
+| `herddb.index.pk.incremental.snapshotEvery` | 64 | Rewrite a fresh snapshot after this many deltas |
+| `herddb.index.pk.incremental.snapshotChunkSize` | 50000 | Max node-metadata entries per snapshot-chunk page |
+
+---
+
+## 7. Cross-references
+
+- [CHECKPOINT.md](./CHECKPOINT.md) — overall checkpoint dynamics
+- [CHECKPOINT.md §5 BLink Primary-Key Index](./CHECKPOINT.md#blink-primary-key-index) — where the PK index fits into the checkpoint pipeline
+- `herddb.index.KeyToPageIndexMode` — property-driven mode selector
+- `herddb.index.KeyToPageIndexFactory` — single factory wired into every persistent DSM
+- `herddb.index.blink.IncrementalBLinkManifest` — manifest class + serializer
+- `herddb.index.blink.IncrementalBLinkPageCodec` — snapshot / delta page codec
+- `herddb.index.blink.IncrementalBLinkKeyToPageIndex` — the implementation

--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -276,23 +276,46 @@ A `DataPage` transitions:
 
 ### BLink Primary-Key Index
 
-The BLink tree (`BLinkKeyToPageIndex`) maps primary keys → page IDs. It is checkpointed in
-**Phase C** under the `checkpointLock` write lock.
+The BLink tree maps primary keys → page IDs and is checkpointed in **Phase C**
+under the `checkpointLock` write lock.
+
+Since release 0.30 there are **two** BLink implementations selected at boot by
+the `herddb.index.pk.mode` system property (default `incremental`):
+
+- **Legacy** — `BLinkKeyToPageIndex`. Serialises the full tree node list into
+  `IndexStatus.indexData` on every checkpoint. Cost per checkpoint is O(N) in
+  tree size.
+- **Incremental** — `IncrementalBLinkKeyToPageIndex`. Writes a small manifest
+  plus one delta-log page per checkpoint, with periodic snapshot refresh.
+  Cost per (non-snapshot) checkpoint is O(changes since the previous checkpoint).
+
+Both use the same in-memory `BLink` tree and the same node-page byte layout —
+they differ only in how checkpoint metadata is persisted. Full format details
+are in [BLINK.md](./BLINK.md).
 
 ```mermaid
 flowchart LR
-    PC[Phase C write lock] --> BL["BLink.checkpoint()\nserialises all tree nodes\nto BLinkMetadata"]
-    BL --> DS[DataStorageManager.indexCheckpoint\nIndexStatus = metadata + LSN]
-    DS --> POST[PostCheckpointAction:\ndelete old BLink pages]
+    PC[Phase C write lock] --> BL["BLink.checkpoint()\nproduces full node-metadata list"]
+    BL -->|legacy| LEG["BLinkKeyToPageIndex\nserialises all nodes\ninto IndexStatus.indexData"]
+    BL -->|incremental| INC["IncrementalBLinkKeyToPageIndex\ndiffs against previous state\nwrites small manifest + delta page\n(periodic snapshot refresh)"]
+    LEG --> DS[DataStorageManager.indexCheckpoint\nIndexStatus]
+    INC --> DS
+    DS --> POST[PostCheckpointAction:\ndelete pages not in preserve set]
 ```
 
-**Why Phase C?** The BLink checkpoint serialises the entire tree structure. It requires
-no concurrent structural modifications (key inserts/deletes during serialisation would
-invalidate the serialised state). The write lock guarantees this. Because BLink is a
-B-tree-like structure with per-node read/write locks, its checkpoint is relatively fast.
+**Why Phase C?** The BLink checkpoint iterates the tree structure. It requires
+no concurrent structural modifications (key inserts/deletes during serialisation
+would invalidate the returned state). The write lock guarantees this. Because
+BLink is a B-tree-like structure with per-node read/write locks, its checkpoint
+is relatively fast.
 
-**DML interaction**: Key inserts/deletes happen under the DML read lock on `checkpointLock`,
-so they cannot overlap with Phase C.
+**DML interaction**: Key inserts/deletes happen under the DML read lock on
+`checkpointLock`, so they cannot overlap with Phase C.
+
+**Format mismatch**: if on-disk metadata was written with one mode and the
+JVM is configured for the other, `start()` fails fast with a clear error
+message pointing to the `herddb.index.pk.mode` system property. See
+[BLINK.md §4.8](./BLINK.md#48-format-mismatch-detection).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,17 @@ mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci
 ```
 This matches what `.github/workflows/pr-validation.yml` runs in CI (checkstyle, Apache RAT license headers, SpotBugs).
 
+For any change related to indexes, checkpoints, or concurrency, also run every
+subclass of `DirectMultipleConcurrentUpdatesSuite` (in
+`herddb-core/src/test/java/herddb/server/hammer/`) and make sure they all pass:
+```
+mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test
+```
+These hammer tests exercise concurrent DML with periodic checkpoints and
+recovery, so they are the main regression gate for the primary-key index, the
+checkpoint pipeline, and transaction isolation. Run them multiple times when
+the first pass is green to reduce the chance of a flake masking a real bug.
+
 ## Test Categories
 Tests that require ZooKeeper/BookKeeper infrastructure (cluster mode) must be annotated with
 `@Category(ClusterTest.class)` (import `herddb.core.ClusterTest` and `org.junit.experimental.categories.Category`).

--- a/herddb-backward-compatibility/pom.xml
+++ b/herddb-backward-compatibility/pom.xml
@@ -54,10 +54,24 @@
         </resources>
         <plugins>
             <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>                
+                <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                      Backward-compatibility tests open databases written by older
+                      HerdDB releases whose primary-key index is in the legacy
+                      BLink format. Force the legacy mode so the on-disk format
+                      matches what those tests unpack from fixture zips.
+                    -->
+                    <systemPropertyVariables>
+                        <herddb.index.pk.mode>legacy</herddb.index.pk.mode>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -27,7 +27,7 @@ import herddb.core.PostCheckpointAction;
 import herddb.core.RecordSetFactory;
 import herddb.file.FileRecordSetFactory;
 import herddb.index.KeyToPageIndex;
-import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.index.KeyToPageIndexFactory;
 import herddb.log.LogSequenceNumber;
 import herddb.model.Index;
 import herddb.model.Record;
@@ -1634,7 +1634,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
     @Override
     public KeyToPageIndex createKeyToPageMap(String tablespace, String name, MemoryManager memoryManager) throws DataStorageManagerException {
-        return new BLinkKeyToPageIndex(tablespace, name, memoryManager, this);
+        return KeyToPageIndexFactory.create(tablespace, name, memoryManager, this);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -25,7 +25,7 @@ import herddb.core.MemoryManager;
 import herddb.core.PostCheckpointAction;
 import herddb.core.RecordSetFactory;
 import herddb.index.KeyToPageIndex;
-import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.index.KeyToPageIndexFactory;
 import herddb.log.LogSequenceNumber;
 import herddb.model.Index;
 import herddb.model.Record;
@@ -1745,7 +1745,7 @@ public class FileDataStorageManager extends DataStorageManager {
 
     @Override
     public KeyToPageIndex createKeyToPageMap(String tablespace, String name, MemoryManager memoryManager) throws DataStorageManagerException {
-        return new BLinkKeyToPageIndex(tablespace, name, memoryManager, this);
+        return KeyToPageIndexFactory.create(tablespace, name, memoryManager, this);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/KeyToPageIndexFactory.java
+++ b/herddb-core/src/main/java/herddb/index/KeyToPageIndexFactory.java
@@ -1,0 +1,59 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index;
+
+import herddb.core.MemoryManager;
+import herddb.index.KeyToPageIndexMode.Mode;
+import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.index.blink.IncrementalBLinkKeyToPageIndex;
+import herddb.storage.DataStorageManager;
+
+/**
+ * Central factory for the table primary-key {@link KeyToPageIndex}. Invoked
+ * from every {@code DataStorageManager.createKeyToPageMap} implementation
+ * that persists its data (File, BookKeeper, RemoteFile, ReadReplica). The
+ * in-memory {@code MemoryDataStorageManager} intentionally bypasses this
+ * factory and keeps its simpler {@code ConcurrentMapKeyToPageIndex}.
+ *
+ * @see KeyToPageIndexMode
+ */
+public final class KeyToPageIndexFactory {
+
+    private KeyToPageIndexFactory() {
+    }
+
+    /**
+     * Returns the {@link KeyToPageIndex} implementation configured for this
+     * JVM. Call sites must already have performed any on-disk format-mismatch
+     * check (or will rely on the implementation's own validation in
+     * {@link KeyToPageIndex#start}).
+     */
+    public static KeyToPageIndex create(String tableSpace, String tableName,
+                                        MemoryManager memoryManager,
+                                        DataStorageManager dataStorageManager) {
+        Mode mode = KeyToPageIndexMode.getResolved();
+        if (mode == Mode.INCREMENTAL) {
+            return new IncrementalBLinkKeyToPageIndex(tableSpace, tableName,
+                    memoryManager, dataStorageManager);
+        }
+        return new BLinkKeyToPageIndex(tableSpace, tableName, memoryManager, dataStorageManager);
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/KeyToPageIndexMode.java
+++ b/herddb-core/src/main/java/herddb/index/KeyToPageIndexMode.java
@@ -1,0 +1,96 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index;
+
+import herddb.utils.SystemProperties;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Selects which {@link KeyToPageIndex} implementation is used for table
+ * primary-key indexes.
+ *
+ * <p>The value is resolved once per JVM from the system property
+ * {@value #PROPERTY_NAME}. Allowed values are {@code incremental} (default —
+ * the new on-disk format whose checkpoint cost is proportional to the amount
+ * of change since the previous checkpoint) and {@code legacy} (the original
+ * {@code BLinkKeyToPageIndex} whose checkpoint rewrites a metadata entry for
+ * every node in the tree).</p>
+ *
+ * <p>Both implementations expose the same {@link KeyToPageIndex} surface and
+ * are interchangeable from the point of view of {@code TableManager}.
+ * Selection happens inside the {@code DataStorageManager.createKeyToPageMap}
+ * factory methods via {@link KeyToPageIndexFactory}.</p>
+ *
+ * @see KeyToPageIndexFactory
+ */
+public final class KeyToPageIndexMode {
+
+    private static final Logger LOGGER = Logger.getLogger(KeyToPageIndexMode.class.getName());
+
+    /**
+     * System property name used to configure the PK index implementation.
+     */
+    public static final String PROPERTY_NAME = "herddb.index.pk.mode";
+
+    /**
+     * Available PK index implementations.
+     */
+    public enum Mode {
+        /**
+         * New incremental format. Default.
+         */
+        INCREMENTAL,
+        /**
+         * Legacy {@code BLinkKeyToPageIndex} format.
+         */
+        LEGACY
+    }
+
+    private static final Mode RESOLVED = resolve();
+
+    private KeyToPageIndexMode() {
+    }
+
+    /**
+     * Returns the mode configured for this JVM.
+     */
+    public static Mode getResolved() {
+        return RESOLVED;
+    }
+
+    private static Mode resolve() {
+        String raw = SystemProperties.getStringSystemProperty(PROPERTY_NAME, "incremental");
+        String normalized = raw.trim().toLowerCase(Locale.ROOT);
+        switch (normalized) {
+            case "incremental":
+                return Mode.INCREMENTAL;
+            case "legacy":
+                return Mode.LEGACY;
+            default:
+                LOGGER.log(Level.WARNING,
+                        "unrecognised value {0}={1}; falling back to 'incremental'",
+                        new Object[]{PROPERTY_NAME, raw});
+                return Mode.INCREMENTAL;
+        }
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -1,0 +1,794 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import herddb.core.AbstractIndexManager;
+import herddb.core.HerdDBInternalException;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.index.IndexOperation;
+import herddb.index.KeyToPageIndex;
+import herddb.index.PrimaryIndexPrefixScan;
+import herddb.index.PrimaryIndexRangeScan;
+import herddb.index.PrimaryIndexSeek;
+import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.InvalidNullValueForKeyException;
+import herddb.model.RecordFunction;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.model.TableContext;
+import herddb.sql.SQLRecordKeyFunction;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.IndexStatus;
+import herddb.utils.Bytes;
+import herddb.utils.SystemProperties;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+/**
+ * Incremental {@link KeyToPageIndex} implementation backed by the existing
+ * {@link BLink} tree plus a new on-disk format whose checkpoint cost is
+ * proportional to the number of nodes that changed since the previous
+ * checkpoint — rather than to the total number of nodes in the tree.
+ *
+ * <p>The on-disk layout produced by this class is composed of three kinds of
+ * pages stored through the standard {@code DataStorageManager.writeIndexPage}
+ * entry point, plus one small manifest blob stored inside
+ * {@code IndexStatus.indexData}:
+ *
+ * <ul>
+ *   <li><b>Node pages</b> (inner / leaf) — identical format to the legacy
+ *       {@link BLinkKeyToPageIndex}, produced by a nested
+ *       {@link BLinkIndexDataStorage} implementation. This means node pages
+ *       are byte-compatible between the two implementations; only the
+ *       checkpoint-metadata pages differ.</li>
+ *   <li><b>Snapshot-chunk pages</b> — the full list of
+ *       {@link BLinkNodeMetadata} valid at some epoch, split across several
+ *       pages to avoid unbounded single-page growth.</li>
+ *   <li><b>Delta pages</b> — per-checkpoint deltas recording upserted node
+ *       metadata, logically-removed node ids, and the dead store-page ids
+ *       that the {@code DataStorageManager} garbage-collector may reclaim.</li>
+ * </ul>
+ *
+ * <p>A running {@link IncrementalBLinkManifest} tracks the latest snapshot
+ * reference and the chain of deltas applied on top of it. On recovery, the
+ * snapshot is read and deltas are replayed to rebuild the full
+ * {@link BLinkMetadata}, which is then passed to the normal {@code BLink}
+ * recovery constructor.</p>
+ *
+ * <p>This class is selected at factory time based on
+ * {@link herddb.index.KeyToPageIndexMode}.</p>
+ *
+ * @see BLinkKeyToPageIndex
+ * @see IncrementalBLinkManifest
+ * @see IncrementalBLinkPageCodec
+ */
+public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
+
+    private static final Logger LOGGER = Logger.getLogger(IncrementalBLinkKeyToPageIndex.class.getName());
+
+    /**
+     * Number of deltas after which the next checkpoint rewrites a fresh full
+     * snapshot instead of appending another delta. Bounded so recovery cost
+     * stays bounded even on very long-running indexes.
+     */
+    public static final String PROP_SNAPSHOT_EVERY =
+            "herddb.index.pk.incremental.snapshotEvery";
+
+    /**
+     * Target number of {@link BLinkNodeMetadata} entries per snapshot-chunk
+     * page. Snapshot pages are split into chunks of at most this size so that
+     * an individual snapshot write does not produce a single unbounded page.
+     */
+    public static final String PROP_SNAPSHOT_CHUNK_SIZE =
+            "herddb.index.pk.incremental.snapshotChunkSize";
+
+    private static final int DEFAULT_SNAPSHOT_EVERY =
+            SystemProperties.getIntSystemProperty(PROP_SNAPSHOT_EVERY, 64);
+
+    private static final int DEFAULT_SNAPSHOT_CHUNK_SIZE =
+            SystemProperties.getIntSystemProperty(PROP_SNAPSHOT_CHUNK_SIZE, 50_000);
+
+    private final String tableSpace;
+    private final String indexName;
+
+    private final MemoryManager memoryManager;
+    private final DataStorageManager dataStorageManager;
+
+    private final AtomicLong newPageId;
+
+    private final BLinkIndexDataStorage<Bytes, Long> indexDataStorage;
+
+    private volatile BLink<Bytes, Long> tree;
+
+    private final AtomicBoolean closed;
+
+    /**
+     * In-memory cache of the node metadata persisted at the previous
+     * checkpoint. Used to diff against the metadata produced by the next
+     * {@code tree.checkpoint()} call. Maintained in sync with the on-disk
+     * snapshot+delta chain.
+     */
+    private final Map<Long, BLinkNodeMetadata<Bytes>> previousByNodeId = new HashMap<>();
+
+    /**
+     * Latest committed manifest (or {@code null} if none has been committed
+     * yet for this index).
+     */
+    private volatile IncrementalBLinkManifest currentManifest;
+
+    /**
+     * Preserve set computed by {@link #checkpoint} and supplied to
+     * {@code DataStorageManager.indexCheckpoint} as {@code IndexStatus.activePages}.
+     * Intentionally small: node pages currently referenced, snapshot chunk
+     * pages, and active delta pages. Pages not in this set (and older than
+     * the largest known page id) are reclaimed by the standard DSM GC path.
+     */
+    private Set<Long> lastPreserveSet = Collections.emptySet();
+
+    public IncrementalBLinkKeyToPageIndex(String tableSpace, String tableName,
+                                          MemoryManager memoryManager,
+                                          DataStorageManager dataStorageManager) {
+        super();
+        this.tableSpace = tableSpace;
+        this.indexName = BLinkKeyToPageIndex.deriveIndexName(tableName);
+        this.memoryManager = memoryManager;
+        this.dataStorageManager = dataStorageManager;
+        this.newPageId = new AtomicLong(1);
+        this.indexDataStorage = new NodePageStorageImpl();
+        this.closed = new AtomicBoolean(false);
+    }
+
+    // ---------------- KeyToPageIndex tree ops ----------------
+
+    @Override
+    public long size() {
+        return getTree().size();
+    }
+
+    @Override
+    public void put(Bytes key, Long currentPage) {
+        try {
+            getTree().insert(key, currentPage);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
+    }
+
+    @Override
+    public boolean put(Bytes key, Long newPage, Long expectedPage) {
+        try {
+            return getTree().insert(key, newPage, expectedPage);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
+    }
+
+    @Override
+    public boolean containsKey(Bytes key) {
+        try {
+            return getTree().search(key) != null;
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
+    }
+
+    @Override
+    public Long get(Bytes key) {
+        try {
+            return getTree().search(key);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
+    }
+
+    @Override
+    public Long remove(Bytes key) {
+        try {
+            return getTree().delete(key);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
+    }
+
+    @Override
+    public boolean isSortedAscending(int[] pkTypes) {
+        if (pkTypes.length != 1) {
+            return false;
+        }
+        switch (pkTypes[0]) {
+            case ColumnTypes.NOTNULL_STRING:
+            case ColumnTypes.STRING:
+            case ColumnTypes.BYTEARRAY:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public Stream<Entry<Bytes, Long>> scanner(
+            IndexOperation operation, StatementEvaluationContext context,
+            TableContext tableContext, AbstractIndexManager index
+    ) throws DataStorageManagerException, StatementExecutionException {
+        if (operation instanceof PrimaryIndexSeek) {
+            PrimaryIndexSeek seek = (PrimaryIndexSeek) operation;
+            byte[] seekValue = computeKeyValue(seek.value, context, tableContext);
+            if (seekValue == null) {
+                return Stream.empty();
+            }
+            Bytes key = Bytes.from_array(seekValue);
+            Long pageId = getTree().search(key);
+            if (pageId == null) {
+                return Stream.empty();
+            }
+            return Stream.of(new AbstractMap.SimpleImmutableEntry<>(key, pageId));
+        }
+
+        if (operation instanceof PrimaryIndexPrefixScan) {
+            PrimaryIndexPrefixScan scan = (PrimaryIndexPrefixScan) operation;
+            byte[] refvalue = computeKeyValue(scan.value, context, tableContext);
+            if (refvalue == null) {
+                return Stream.empty();
+            }
+            Bytes firstKey = Bytes.from_array(refvalue);
+            Bytes lastKey = firstKey.next();
+            return getTree().scan(firstKey, lastKey);
+        }
+
+        if (index != null) {
+            return index.recordSetScanner(operation, context, tableContext, this);
+        }
+
+        if (operation == null) {
+            return getTree().scan(null, null);
+        } else if (operation instanceof PrimaryIndexRangeScan) {
+            Bytes refminvalue;
+            PrimaryIndexRangeScan sis = (PrimaryIndexRangeScan) operation;
+            SQLRecordKeyFunction minKey = sis.minValue;
+            if (minKey != null) {
+                refminvalue = Bytes.from_array(minKey.computeNewValue(null, context, tableContext));
+            } else {
+                refminvalue = null;
+            }
+            Bytes refmaxvalue;
+            SQLRecordKeyFunction maxKey = sis.maxValue;
+            if (maxKey != null) {
+                refmaxvalue = Bytes.from_array(maxKey.computeNewValue(null, context, tableContext));
+            } else {
+                refmaxvalue = null;
+            }
+            return getTree().scan(refminvalue, refmaxvalue, refmaxvalue != null);
+        }
+
+        throw new DataStorageManagerException("operation " + operation + " not implemented on " + this.getClass());
+    }
+
+    private static byte[] computeKeyValue(RecordFunction keyFun, StatementEvaluationContext context, TableContext tableContext)
+            throws StatementExecutionException {
+        try {
+            return keyFun.computeNewValue(null, context, tableContext);
+        } catch (InvalidNullValueForKeyException invalidKeyValueException) {
+            return null;
+        }
+    }
+
+    // ---------------- lifecycle ----------------
+
+    @Override
+    public void close() throws DataStorageManagerException {
+        if (closed.compareAndSet(false, true)) {
+            final BLink<Bytes, Long> t = this.tree;
+            this.tree = null;
+            if (t != null) {
+                t.close();
+            }
+            previousByNodeId.clear();
+        } else {
+            throw new DataStorageManagerException("Index " + indexName + " already closed");
+        }
+    }
+
+    @Override
+    public void truncate() {
+        getTree().truncate();
+        previousByNodeId.clear();
+        currentManifest = null;
+    }
+
+    @Override
+    public void dropData() {
+        truncate();
+        dataStorageManager.dropIndex(tableSpace, indexName);
+    }
+
+    @Override
+    public long getUsedMemory() {
+        return getTree().getUsedMemory();
+    }
+
+    @Override
+    public boolean requireLoadAtStartup() {
+        return false;
+    }
+
+    @Override
+    public void init() throws DataStorageManagerException {
+        dataStorageManager.initIndex(tableSpace, indexName);
+    }
+
+    @Override
+    public void start(LogSequenceNumber sequenceNumber, boolean created) throws DataStorageManagerException {
+        if (!created) {
+            LOGGER.log(Level.INFO, "start incremental index {0}", new Object[]{indexName});
+        }
+        final long pageSize = memoryManager.getMaxLogicalPageSize();
+
+        if (LogSequenceNumber.START_OF_TIME.equals(sequenceNumber)) {
+            tree = new BLink<>(pageSize, BytesLongSizeEvaluator.INSTANCE,
+                    memoryManager.getPKPageReplacementPolicy(), indexDataStorage);
+            currentManifest = null;
+            previousByNodeId.clear();
+            if (!created) {
+                LOGGER.log(Level.INFO, "loaded empty incremental index {0}", new Object[]{indexName});
+            }
+            return;
+        }
+
+        IndexStatus status = dataStorageManager.getIndexStatus(tableSpace, indexName, sequenceNumber);
+        IncrementalBLinkManifest manifest;
+        try {
+            manifest = IncrementalBLinkManifest.deserialize(status.indexData);
+        } catch (IncrementalBLinkManifest.LegacyFormatDetectedException err) {
+            throw new DataStorageManagerException(
+                    "Index " + indexName + " on-disk format is 'legacy' but JVM is configured"
+                            + " with herddb.index.pk.mode=incremental. Start the server with"
+                            + " -Dherddb.index.pk.mode=legacy, or rebuild the tablespace in the"
+                            + " desired mode. Original error: " + err.getMessage(), err);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        Map<Long, BLinkNodeMetadata<Bytes>> byNodeId = new HashMap<>();
+        for (IncrementalBLinkManifest.SnapshotChunkRef ref : manifest.snapshotChunks) {
+            IncrementalBLinkPageCodec.SnapshotChunkContents chunk =
+                    dataStorageManager.readIndexPage(tableSpace, indexName, ref.pageId,
+                            IncrementalBLinkPageCodec::readSnapshotChunk);
+            for (BLinkNodeMetadata<Bytes> node : chunk.nodes) {
+                byNodeId.put(node.id, node);
+            }
+        }
+        for (IncrementalBLinkManifest.DeltaRef deltaRef : manifest.deltaChain) {
+            IncrementalBLinkPageCodec.DeltaContents delta =
+                    dataStorageManager.readIndexPage(tableSpace, indexName, deltaRef.pageId,
+                            IncrementalBLinkPageCodec::readDelta);
+            applyDelta(byNodeId, delta);
+        }
+
+        BLinkMetadata<Bytes> metadata = IncrementalBLinkPageCodec.rebuild(
+                byNodeId,
+                status.newPageId,
+                manifest.anchorFast, manifest.anchorFastHeight,
+                manifest.anchorTop, manifest.anchorTopHeight,
+                manifest.anchorFirst, manifest.values);
+
+        try {
+            tree = new BLink<>(pageSize, BytesLongSizeEvaluator.INSTANCE,
+                    memoryManager.getPKPageReplacementPolicy(), indexDataStorage, metadata);
+        } catch (RuntimeException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        newPageId.set(status.newPageId);
+        currentManifest = manifest;
+        previousByNodeId.clear();
+        previousByNodeId.putAll(byNodeId);
+
+        LOGGER.log(Level.INFO, "loaded incremental index {0}: {1} keys (epoch {2}, {3} snapshot chunks + {4} deltas)",
+                new Object[]{indexName, tree.size(), manifest.epoch,
+                        manifest.snapshotChunks.size(), manifest.deltaChain.size()});
+    }
+
+    private static void applyDelta(Map<Long, BLinkNodeMetadata<Bytes>> byNodeId,
+                                   IncrementalBLinkPageCodec.DeltaContents delta) {
+        for (BLinkNodeMetadata<Bytes> node : delta.upserted) {
+            byNodeId.put(node.id, node);
+        }
+        for (long id : delta.removedNodeIds) {
+            byNodeId.remove(id);
+        }
+    }
+
+    // ---------------- checkpoint ----------------
+
+    @Override
+    public List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin)
+            throws DataStorageManagerException {
+        try {
+            final BLink<Bytes, Long> t = this.tree;
+            if (t == null) {
+                return Collections.emptyList();
+            }
+
+            BLinkMetadata<Bytes> metadata = t.checkpoint();
+
+            Map<Long, BLinkNodeMetadata<Bytes>> newByNodeId = new LinkedHashMap<>(metadata.nodes.size());
+            for (BLinkNodeMetadata<Bytes> node : metadata.nodes) {
+                newByNodeId.put(node.id, node);
+            }
+
+            long nextEpoch = (currentManifest == null) ? 1L : currentManifest.epoch + 1;
+
+            boolean rewriteSnapshot = currentManifest == null
+                    || currentManifest.deltaChain.size() >= DEFAULT_SNAPSHOT_EVERY;
+
+            List<IncrementalBLinkManifest.SnapshotChunkRef> newSnapshotChunks;
+            List<IncrementalBLinkManifest.DeltaRef> newDeltaChain;
+            long newSnapshotEpoch;
+            List<BLinkNodeMetadata<Bytes>> upserted = new ArrayList<>();
+            List<Long> removedIds = new ArrayList<>();
+            List<Long> deadStoreIds = new ArrayList<>();
+
+            if (rewriteSnapshot) {
+                // A full snapshot supersedes the previous one and all
+                // accumulated deltas. We must preserve-set only the new
+                // snapshot's pages plus the node pages still reachable;
+                // everything else (old snapshot chunks, old delta pages,
+                // abandoned node storeIds) is reclaimable.
+                newSnapshotChunks = writeSnapshotChunks(nextEpoch, metadata.nodes);
+                newDeltaChain = Collections.emptyList();
+                newSnapshotEpoch = nextEpoch;
+            } else {
+                // Diff against previousByNodeId and write a single delta page.
+                diff(metadata.nodes, newByNodeId, upserted, removedIds, deadStoreIds);
+                if (upserted.isEmpty() && removedIds.isEmpty() && deadStoreIds.isEmpty()
+                        && anchorsUnchanged(metadata)) {
+                    // Nothing changed; keep the previous manifest but refresh
+                    // its LSN/newPageId. We still call indexCheckpoint to make
+                    // a new metadata file that the DSM can pin at this LSN.
+                    newSnapshotChunks = currentManifest.snapshotChunks;
+                    newDeltaChain = currentManifest.deltaChain;
+                    newSnapshotEpoch = currentManifest.snapshotEpoch;
+                } else {
+                    long deltaPageId = allocatePageId();
+                    writeDeltaPage(deltaPageId, nextEpoch, upserted, removedIds, deadStoreIds);
+                    newSnapshotChunks = currentManifest.snapshotChunks;
+                    List<IncrementalBLinkManifest.DeltaRef> chain =
+                            new ArrayList<>(currentManifest.deltaChain.size() + 1);
+                    chain.addAll(currentManifest.deltaChain);
+                    chain.add(new IncrementalBLinkManifest.DeltaRef(nextEpoch, deltaPageId));
+                    newDeltaChain = chain;
+                    newSnapshotEpoch = currentManifest.snapshotEpoch;
+                }
+            }
+
+            IncrementalBLinkManifest nextManifest = new IncrementalBLinkManifest(
+                    nextEpoch, metadata.values, metadata.nextID,
+                    metadata.top, metadata.topheight,
+                    metadata.fast, metadata.fastheight,
+                    metadata.first,
+                    newSnapshotEpoch, newSnapshotChunks, newDeltaChain);
+
+            Set<Long> preserve = buildPreserveSet(metadata.nodes, newSnapshotChunks, newDeltaChain);
+
+            byte[] manifestBytes = nextManifest.serialize();
+            IndexStatus indexStatus = new IndexStatus(indexName, sequenceNumber,
+                    newPageId.get(), preserve, manifestBytes);
+
+            List<PostCheckpointAction> result = new ArrayList<>(
+                    dataStorageManager.indexCheckpoint(tableSpace, indexName, indexStatus, pin));
+
+            currentManifest = nextManifest;
+            lastPreserveSet = preserve;
+            previousByNodeId.clear();
+            previousByNodeId.putAll(newByNodeId);
+
+            LOGGER.log(Level.INFO,
+                    "incremental index {0} checkpoint: epoch {1}, nodes {2}, snapshot chunks {3},"
+                            + " deltas {4}, upserted {5}, removed {6}, dead pages {7}",
+                    new Object[]{indexName, nextEpoch, metadata.nodes.size(),
+                            newSnapshotChunks.size(), newDeltaChain.size(),
+                            upserted.size(), removedIds.size(), deadStoreIds.size()});
+
+            return result;
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    private boolean anchorsUnchanged(BLinkMetadata<Bytes> metadata) {
+        IncrementalBLinkManifest m = currentManifest;
+        return m != null
+                && m.anchorTop == metadata.top
+                && m.anchorTopHeight == metadata.topheight
+                && m.anchorFast == metadata.fast
+                && m.anchorFastHeight == metadata.fastheight
+                && m.anchorFirst == metadata.first
+                && m.values == metadata.values
+                && m.nextID == metadata.nextID;
+    }
+
+    private void diff(
+            List<BLinkNodeMetadata<Bytes>> currentNodes,
+            Map<Long, BLinkNodeMetadata<Bytes>> currentByNodeId,
+            List<BLinkNodeMetadata<Bytes>> upserted,
+            List<Long> removedIds,
+            List<Long> deadStoreIds
+    ) {
+        for (BLinkNodeMetadata<Bytes> current : currentNodes) {
+            BLinkNodeMetadata<Bytes> prev = previousByNodeId.get(current.id);
+            if (prev == null) {
+                upserted.add(current);
+            } else if (!sameMetadata(prev, current)) {
+                upserted.add(current);
+                if (prev.storeId != current.storeId
+                        && prev.storeId != BLinkIndexDataStorage.NEW_PAGE) {
+                    deadStoreIds.add(prev.storeId);
+                }
+            }
+        }
+        for (Map.Entry<Long, BLinkNodeMetadata<Bytes>> e : previousByNodeId.entrySet()) {
+            if (!currentByNodeId.containsKey(e.getKey())) {
+                removedIds.add(e.getKey());
+                long storeId = e.getValue().storeId;
+                if (storeId != BLinkIndexDataStorage.NEW_PAGE) {
+                    deadStoreIds.add(storeId);
+                }
+            }
+        }
+    }
+
+    private static boolean sameMetadata(BLinkNodeMetadata<Bytes> a, BLinkNodeMetadata<Bytes> b) {
+        if (a.leaf != b.leaf) {
+            return false;
+        }
+        if (a.storeId != b.storeId) {
+            return false;
+        }
+        if (a.keys != b.keys) {
+            return false;
+        }
+        if (a.bytes != b.bytes) {
+            return false;
+        }
+        if (a.outlink != b.outlink) {
+            return false;
+        }
+        if (a.rightlink != b.rightlink) {
+            return false;
+        }
+        return java.util.Objects.equals(a.rightsep, b.rightsep);
+    }
+
+    private List<IncrementalBLinkManifest.SnapshotChunkRef> writeSnapshotChunks(
+            long epoch, List<BLinkNodeMetadata<Bytes>> nodes
+    ) throws DataStorageManagerException {
+        if (nodes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        int chunkSize = Math.max(1, DEFAULT_SNAPSHOT_CHUNK_SIZE);
+        int totalChunks = (nodes.size() + chunkSize - 1) / chunkSize;
+        List<IncrementalBLinkManifest.SnapshotChunkRef> refs = new ArrayList<>(totalChunks);
+        for (int i = 0; i < totalChunks; i++) {
+            int from = i * chunkSize;
+            int to = Math.min(from + chunkSize, nodes.size());
+            List<BLinkNodeMetadata<Bytes>> slice = nodes.subList(from, to);
+            long pageId = allocatePageId();
+            final int chunkIndex = i;
+            dataStorageManager.writeIndexPage(tableSpace, indexName, pageId, out -> {
+                IncrementalBLinkPageCodec.writeSnapshotChunk(out, epoch, chunkIndex, totalChunks, slice);
+            });
+            refs.add(new IncrementalBLinkManifest.SnapshotChunkRef(pageId, i, totalChunks));
+        }
+        return refs;
+    }
+
+    private void writeDeltaPage(long pageId, long epoch,
+                                List<BLinkNodeMetadata<Bytes>> upserted,
+                                List<Long> removedIds, List<Long> deadStoreIds)
+            throws DataStorageManagerException {
+        long[] removedArr = toArray(removedIds);
+        long[] deadArr = toArray(deadStoreIds);
+        dataStorageManager.writeIndexPage(tableSpace, indexName, pageId, out -> {
+            IncrementalBLinkPageCodec.writeDelta(out, epoch, upserted, removedArr, deadArr);
+        });
+    }
+
+    private static long[] toArray(List<Long> list) {
+        long[] out = new long[list.size()];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = list.get(i);
+        }
+        return out;
+    }
+
+    private Set<Long> buildPreserveSet(
+            List<BLinkNodeMetadata<Bytes>> liveNodes,
+            List<IncrementalBLinkManifest.SnapshotChunkRef> snapshotChunks,
+            List<IncrementalBLinkManifest.DeltaRef> deltaChain
+    ) {
+        Set<Long> preserve = new HashSet<>();
+        for (BLinkNodeMetadata<Bytes> node : liveNodes) {
+            if (node.storeId != BLinkIndexDataStorage.NEW_PAGE) {
+                preserve.add(node.storeId);
+            }
+        }
+        for (IncrementalBLinkManifest.SnapshotChunkRef ref : snapshotChunks) {
+            preserve.add(ref.pageId);
+        }
+        for (IncrementalBLinkManifest.DeltaRef ref : deltaChain) {
+            preserve.add(ref.pageId);
+        }
+        return preserve;
+    }
+
+    private long allocatePageId() {
+        return newPageId.getAndIncrement();
+    }
+
+    @Override
+    public void unpinCheckpoint(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+        dataStorageManager.unPinIndexCheckpoint(tableSpace, indexName, sequenceNumber);
+    }
+
+    private BLink<Bytes, Long> getTree() {
+        final BLink<Bytes, Long> t = this.tree;
+        if (t == null) {
+            if (closed.get()) {
+                throw new DataStorageManagerException("Index " + indexName + " already closed");
+            } else {
+                throw new DataStorageManagerException("Index " + indexName + " still not started");
+            }
+        }
+        return t;
+    }
+
+    // ---------------- node-page storage (same byte layout as legacy) ----------------
+
+    private static final byte INNER_NODE_PAGE = BLinkKeyToPageIndex.INNER_NODE_PAGE;
+    private static final byte LEAF_NODE_PAGE = BLinkKeyToPageIndex.LEAF_NODE_PAGE;
+    private static final byte NODE_PAGE_END_BLOCK = 0;
+    private static final byte NODE_PAGE_KEY_VALUE_BLOCK = 1;
+    private static final byte NODE_PAGE_INF_BLOCK = 2;
+
+    private final class NodePageStorageImpl implements BLinkIndexDataStorage<Bytes, Long> {
+
+        @Override
+        public void loadNodePage(long pageId, Map<Bytes, Long> data) throws IOException {
+            loadPage(pageId, INNER_NODE_PAGE, data);
+        }
+
+        @Override
+        public void loadLeafPage(long pageId, Map<Bytes, Long> data) throws IOException {
+            loadPage(pageId, LEAF_NODE_PAGE, data);
+        }
+
+        private void loadPage(long pageId, byte type, Map<Bytes, Long> map) throws IOException {
+            dataStorageManager.readIndexPage(tableSpace, indexName, pageId, in -> {
+                long version = in.readVLong();
+                long flags = in.readVLong();
+                if (version != 1 || flags != 0) {
+                    throw new IOException("Corrupted index page " + pageId);
+                }
+                byte rtype = in.readByte();
+                if (rtype != type) {
+                    throw new IOException("Wrong page type " + rtype + " expected " + type);
+                }
+                byte block;
+                while ((block = in.readByte()) != NODE_PAGE_END_BLOCK) {
+                    switch (block) {
+                        case NODE_PAGE_KEY_VALUE_BLOCK:
+                            map.put(in.readBytes(), in.readVLong());
+                            break;
+                        case NODE_PAGE_INF_BLOCK:
+                            map.put(Bytes.POSITIVE_INFINITY, in.readVLong());
+                            break;
+                        default:
+                            throw new IOException("Wrong node block type " + block);
+                    }
+                }
+                return map;
+            });
+        }
+
+        @Override
+        public long createNodePage(Map<Bytes, Long> data) throws IOException {
+            return createPage(NEW_PAGE, data, INNER_NODE_PAGE);
+        }
+
+        @Override
+        public long createLeafPage(Map<Bytes, Long> data) throws IOException {
+            return createPage(NEW_PAGE, data, LEAF_NODE_PAGE);
+        }
+
+        @Override
+        public void overwriteNodePage(long pageId, Map<Bytes, Long> data) throws IOException {
+            createPage(pageId, data, INNER_NODE_PAGE);
+        }
+
+        @Override
+        public void overwriteLeafPage(long pageId, Map<Bytes, Long> data) throws IOException {
+            createPage(pageId, data, LEAF_NODE_PAGE);
+        }
+
+        private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
+            long pid = (pageId == NEW_PAGE) ? allocatePageId() : pageId;
+            dataStorageManager.writeIndexPage(tableSpace, indexName, pid, out -> {
+                out.writeVLong(1);
+                out.writeVLong(0);
+                out.writeByte(type);
+                data.forEach((x, y) -> {
+                    try {
+                        if (x == Bytes.POSITIVE_INFINITY) {
+                            out.writeByte(NODE_PAGE_INF_BLOCK);
+                            out.writeVLong(y);
+                        } else {
+                            out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
+                            out.writeArray(x.to_array());
+                            out.writeVLong(y);
+                        }
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(
+                                "Unexpected IOException during node page write preparation", e);
+                    }
+                });
+                out.writeByte(NODE_PAGE_END_BLOCK);
+            });
+            return pid;
+        }
+    }
+
+    // ---------------- test accessors ----------------
+
+    /**
+     * Returns a defensive copy of the most recent preserve set sent to
+     * {@code DataStorageManager.indexCheckpoint}. Exposed for tests.
+     */
+    Set<Long> getLastPreserveSet() {
+        return new HashSet<>(lastPreserveSet);
+    }
+
+    /**
+     * Returns the most recently committed manifest, or {@code null} if
+     * {@link #checkpoint} has never succeeded.
+     */
+    IncrementalBLinkManifest getCurrentManifest() {
+        return currentManifest;
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkManifest.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkManifest.java
@@ -1,0 +1,255 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import herddb.utils.ByteArrayCursor;
+import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.VisibleByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Small per-checkpoint manifest for the incremental BLink format.
+ *
+ * <p>Stored as the opaque {@code indexData} byte array inside the standard
+ * {@code IndexStatus} returned by
+ * {@code DataStorageManager.indexCheckpoint}. The manifest contains only
+ * constant-size data plus small references to sidecar pages (the snapshot
+ * chunks and the delta-log entries) — never the full node list. The full node
+ * list lives in the snapshot chunk pages and is rebuilt at recovery by
+ * reading the snapshot and replaying the delta chain.</p>
+ *
+ * <p>The format starts with a version marker large enough that the legacy
+ * {@code BLinkKeyToPageIndex.MetadataSerializer.read} will immediately throw
+ * {@code "Unknown BLink node metadata version 100"} when it encounters an
+ * incremental manifest. Symmetrically, the incremental reader rejects any
+ * version &lt; {@value #INCREMENTAL_VERSION_MIN} as a legacy format.</p>
+ */
+public final class IncrementalBLinkManifest {
+
+    /**
+     * Lowest version number reserved for the incremental format. Kept well
+     * above the legacy version numbers (0, 1, 2) so crossing the streams is
+     * detected deterministically.
+     */
+    public static final long INCREMENTAL_VERSION_MIN = 100L;
+
+    /**
+     * Current version of the incremental manifest.
+     */
+    public static final long CURRENT_VERSION = 100L;
+
+    private static final long NO_FLAGS = 0L;
+
+    /**
+     * Monotonically increasing epoch counter. Incremented on every
+     * checkpoint. Used to order snapshot / delta writes and to drive
+     * tombstone-based garbage collection.
+     */
+    public final long epoch;
+
+    /**
+     * Value count mirrored from {@code BLink.size()}.
+     */
+    public final long values;
+
+    /**
+     * {@code BLink.nextID.get()} at checkpoint time — the next page id to
+     * allocate on recovery.
+     */
+    public final long nextID;
+
+    /**
+     * Anchor pointers captured from the {@code BLink} tree.
+     */
+    public final long anchorTop;
+    public final int anchorTopHeight;
+    public final long anchorFast;
+    public final int anchorFastHeight;
+    public final long anchorFirst;
+
+    /**
+     * Epoch at which the snapshot was written. A snapshot is an unordered
+     * collection of {@link SnapshotChunkRef}s; together they contain the full
+     * {@code BLinkMetadata} valid at {@link #snapshotEpoch}.
+     */
+    public final long snapshotEpoch;
+
+    public final List<SnapshotChunkRef> snapshotChunks;
+
+    /**
+     * Delta-chain entries to apply on top of the snapshot to rebuild the
+     * current {@code BLinkMetadata}.
+     */
+    public final List<DeltaRef> deltaChain;
+
+    public IncrementalBLinkManifest(
+            long epoch, long values, long nextID,
+            long anchorTop, int anchorTopHeight,
+            long anchorFast, int anchorFastHeight,
+            long anchorFirst,
+            long snapshotEpoch, List<SnapshotChunkRef> snapshotChunks,
+            List<DeltaRef> deltaChain
+    ) {
+        this.epoch = epoch;
+        this.values = values;
+        this.nextID = nextID;
+        this.anchorTop = anchorTop;
+        this.anchorTopHeight = anchorTopHeight;
+        this.anchorFast = anchorFast;
+        this.anchorFastHeight = anchorFastHeight;
+        this.anchorFirst = anchorFirst;
+        this.snapshotEpoch = snapshotEpoch;
+        this.snapshotChunks = Collections.unmodifiableList(new ArrayList<>(snapshotChunks));
+        this.deltaChain = Collections.unmodifiableList(new ArrayList<>(deltaChain));
+    }
+
+    /**
+     * Reference to one snapshot chunk page.
+     */
+    public static final class SnapshotChunkRef {
+        public final long pageId;
+        public final int chunkIndex;
+        public final int totalChunks;
+
+        public SnapshotChunkRef(long pageId, int chunkIndex, int totalChunks) {
+            this.pageId = pageId;
+            this.chunkIndex = chunkIndex;
+            this.totalChunks = totalChunks;
+        }
+    }
+
+    /**
+     * Reference to one delta-log page.
+     */
+    public static final class DeltaRef {
+        public final long epoch;
+        public final long pageId;
+
+        public DeltaRef(long epoch, long pageId) {
+            this.epoch = epoch;
+            this.pageId = pageId;
+        }
+    }
+
+    public byte[] serialize() throws IOException {
+        VisibleByteArrayOutputStream bos = new VisibleByteArrayOutputStream();
+        try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(bos)) {
+            out.writeVLong(CURRENT_VERSION);
+            out.writeVLong(NO_FLAGS);
+
+            out.writeVLong(epoch);
+            out.writeVLong(values);
+            out.writeVLong(nextID);
+
+            out.writeZLong(anchorTop);
+            out.writeVInt(anchorTopHeight);
+            out.writeZLong(anchorFast);
+            out.writeVInt(anchorFastHeight);
+            out.writeZLong(anchorFirst);
+
+            out.writeVLong(snapshotEpoch);
+            out.writeVInt(snapshotChunks.size());
+            for (SnapshotChunkRef ref : snapshotChunks) {
+                out.writeVLong(ref.pageId);
+                out.writeVInt(ref.chunkIndex);
+                out.writeVInt(ref.totalChunks);
+            }
+
+            out.writeVInt(deltaChain.size());
+            for (DeltaRef ref : deltaChain) {
+                out.writeVLong(ref.epoch);
+                out.writeVLong(ref.pageId);
+            }
+        }
+        return bos.toByteArray();
+    }
+
+    public static IncrementalBLinkManifest deserialize(byte[] data) throws IOException {
+        try (ByteArrayCursor cur = ByteArrayCursor.wrap(data)) {
+            long version = cur.readVLong();
+            if (version < INCREMENTAL_VERSION_MIN) {
+                throw new LegacyFormatDetectedException(
+                        "data appears to be in legacy BLink format (version marker "
+                                + version + "); incremental reader refuses to parse it");
+            }
+            if (version != CURRENT_VERSION) {
+                throw new IOException("unsupported incremental BLink manifest version " + version);
+            }
+
+            long flags = cur.readVLong();
+            if (flags != NO_FLAGS) {
+                throw new IOException("unsupported incremental BLink manifest flags " + flags);
+            }
+
+            long epoch = cur.readVLong();
+            long values = cur.readVLong();
+            long nextID = cur.readVLong();
+
+            long anchorTop = cur.readZLong();
+            int anchorTopHeight = cur.readVInt();
+            long anchorFast = cur.readZLong();
+            int anchorFastHeight = cur.readVInt();
+            long anchorFirst = cur.readZLong();
+
+            long snapshotEpoch = cur.readVLong();
+            int numSnapshotChunks = cur.readVInt();
+            List<SnapshotChunkRef> snapshotChunks = new ArrayList<>(numSnapshotChunks);
+            for (int i = 0; i < numSnapshotChunks; i++) {
+                long pageId = cur.readVLong();
+                int chunkIndex = cur.readVInt();
+                int totalChunks = cur.readVInt();
+                snapshotChunks.add(new SnapshotChunkRef(pageId, chunkIndex, totalChunks));
+            }
+
+            int numDeltas = cur.readVInt();
+            List<DeltaRef> deltaChain = new ArrayList<>(numDeltas);
+            for (int i = 0; i < numDeltas; i++) {
+                long deltaEpoch = cur.readVLong();
+                long pageId = cur.readVLong();
+                deltaChain.add(new DeltaRef(deltaEpoch, pageId));
+            }
+
+            return new IncrementalBLinkManifest(
+                    epoch, values, nextID,
+                    anchorTop, anchorTopHeight,
+                    anchorFast, anchorFastHeight,
+                    anchorFirst,
+                    snapshotEpoch, snapshotChunks, deltaChain);
+        }
+    }
+
+    /**
+     * Thrown when the incremental manifest reader encounters a legacy-format
+     * payload. Callers convert this into a user-visible
+     * {@code DataStorageManagerException} with guidance on switching the
+     * {@code herddb.index.pk.mode} system property.
+     */
+    public static final class LegacyFormatDetectedException extends IOException {
+        private static final long serialVersionUID = 1L;
+
+        public LegacyFormatDetectedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
@@ -1,0 +1,257 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
+import herddb.utils.ByteBufCursor;
+import herddb.utils.Bytes;
+import herddb.utils.ExtendedDataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serialisation helpers for the incremental BLink sidecar pages.
+ *
+ * <p>Two kinds of sidecar pages are written via
+ * {@code DataStorageManager.writeIndexPage}:
+ * <ul>
+ *   <li>{@link #PAGE_KIND_SNAPSHOT_CHUNK} — one chunk of the full node-metadata
+ *       list; on recovery all chunks for a snapshot epoch are read and merged.</li>
+ *   <li>{@link #PAGE_KIND_DELTA} — the per-checkpoint delta recording upserted
+ *       node metadata, logically-removed node ids, and dead store-page ids for
+ *       garbage collection.</li>
+ * </ul>
+ *
+ * <p>The legacy {@code BLinkKeyToPageIndex} index-page codec writes pages with
+ * a {@code vlong version, vlong flags, byte kind} header where {@code kind} is
+ * {@code 1} (INNER) or {@code 2} (LEAF). The incremental codec uses the same
+ * three-field header with distinct {@code kind} values so the two formats can
+ * coexist in the same index directory without ambiguity.</p>
+ */
+final class IncrementalBLinkPageCodec {
+
+    static final long PAGE_VERSION = 1L;
+
+    static final byte PAGE_KIND_SNAPSHOT_CHUNK = 10;
+    static final byte PAGE_KIND_DELTA = 11;
+
+    private static final long PAGE_FLAGS = 0L;
+
+    // Shared markers for the rightSep encoding (matches BLinkKeyToPageIndex style)
+    private static final byte RIGHTSEP_INF = 0;
+    private static final byte RIGHTSEP_BYTES = 1;
+
+    private IncrementalBLinkPageCodec() {
+    }
+
+    // ---------------- snapshot chunk ----------------
+
+    static void writeSnapshotChunk(
+            ExtendedDataOutputStream out,
+            long epoch, int chunkIndex, int totalChunks,
+            List<BLinkNodeMetadata<Bytes>> nodes
+    ) throws IOException {
+        out.writeVLong(PAGE_VERSION);
+        out.writeVLong(PAGE_FLAGS);
+        out.writeByte(PAGE_KIND_SNAPSHOT_CHUNK);
+
+        out.writeVLong(epoch);
+        out.writeVInt(chunkIndex);
+        out.writeVInt(totalChunks);
+
+        out.writeVInt(nodes.size());
+        for (BLinkNodeMetadata<Bytes> node : nodes) {
+            writeNodeMetadata(out, node);
+        }
+    }
+
+    static SnapshotChunkContents readSnapshotChunk(ByteBufCursor in) throws IOException {
+        long version = in.readVLong();
+        long flags = in.readVLong();
+        byte kind = in.readByte();
+        if (version != PAGE_VERSION || flags != PAGE_FLAGS || kind != PAGE_KIND_SNAPSHOT_CHUNK) {
+            throw new IOException("not a snapshot-chunk page (version=" + version
+                    + ", flags=" + flags + ", kind=" + kind + ")");
+        }
+        long epoch = in.readVLong();
+        int chunkIndex = in.readVInt();
+        int totalChunks = in.readVInt();
+        int count = in.readVInt();
+        BLinkNodeMetadata<Bytes>[] nodes = newArray(count);
+        for (int i = 0; i < count; i++) {
+            nodes[i] = readNodeMetadata(in);
+        }
+        return new SnapshotChunkContents(epoch, chunkIndex, totalChunks, nodes);
+    }
+
+    static final class SnapshotChunkContents {
+        final long epoch;
+        final int chunkIndex;
+        final int totalChunks;
+        final BLinkNodeMetadata<Bytes>[] nodes;
+
+        SnapshotChunkContents(long epoch, int chunkIndex, int totalChunks,
+                              BLinkNodeMetadata<Bytes>[] nodes) {
+            this.epoch = epoch;
+            this.chunkIndex = chunkIndex;
+            this.totalChunks = totalChunks;
+            this.nodes = nodes;
+        }
+    }
+
+    // ---------------- delta ----------------
+
+    static void writeDelta(
+            ExtendedDataOutputStream out,
+            long epoch,
+            List<BLinkNodeMetadata<Bytes>> upserted,
+            long[] removedNodeIds,
+            long[] deadStoreIds
+    ) throws IOException {
+        out.writeVLong(PAGE_VERSION);
+        out.writeVLong(PAGE_FLAGS);
+        out.writeByte(PAGE_KIND_DELTA);
+
+        out.writeVLong(epoch);
+
+        out.writeVInt(upserted.size());
+        for (BLinkNodeMetadata<Bytes> node : upserted) {
+            writeNodeMetadata(out, node);
+        }
+
+        out.writeVInt(removedNodeIds.length);
+        for (long id : removedNodeIds) {
+            out.writeVLong(id);
+        }
+
+        out.writeVInt(deadStoreIds.length);
+        for (long id : deadStoreIds) {
+            out.writeVLong(id);
+        }
+    }
+
+    static DeltaContents readDelta(ByteBufCursor in) throws IOException {
+        long version = in.readVLong();
+        long flags = in.readVLong();
+        byte kind = in.readByte();
+        if (version != PAGE_VERSION || flags != PAGE_FLAGS || kind != PAGE_KIND_DELTA) {
+            throw new IOException("not a delta page (version=" + version
+                    + ", flags=" + flags + ", kind=" + kind + ")");
+        }
+        long epoch = in.readVLong();
+
+        int upsertedCount = in.readVInt();
+        BLinkNodeMetadata<Bytes>[] upserted = newArray(upsertedCount);
+        for (int i = 0; i < upsertedCount; i++) {
+            upserted[i] = readNodeMetadata(in);
+        }
+
+        int removedCount = in.readVInt();
+        long[] removedNodeIds = new long[removedCount];
+        for (int i = 0; i < removedCount; i++) {
+            removedNodeIds[i] = in.readVLong();
+        }
+
+        int deadCount = in.readVInt();
+        long[] deadStoreIds = new long[deadCount];
+        for (int i = 0; i < deadCount; i++) {
+            deadStoreIds[i] = in.readVLong();
+        }
+
+        return new DeltaContents(epoch, upserted, removedNodeIds, deadStoreIds);
+    }
+
+    static final class DeltaContents {
+        final long epoch;
+        final BLinkNodeMetadata<Bytes>[] upserted;
+        final long[] removedNodeIds;
+        final long[] deadStoreIds;
+
+        DeltaContents(long epoch, BLinkNodeMetadata<Bytes>[] upserted,
+                      long[] removedNodeIds, long[] deadStoreIds) {
+            this.epoch = epoch;
+            this.upserted = upserted;
+            this.removedNodeIds = removedNodeIds;
+            this.deadStoreIds = deadStoreIds;
+        }
+    }
+
+    // ---------------- shared node-metadata codec ----------------
+
+    private static void writeNodeMetadata(ExtendedDataOutputStream out, BLinkNodeMetadata<Bytes> node)
+            throws IOException {
+        out.writeBoolean(node.leaf);
+        out.writeVLong(node.id);
+        out.writeVLong(node.storeId);
+        out.writeVInt(node.keys);
+        out.writeVLong(node.bytes);
+        out.writeZLong(node.outlink);
+        out.writeZLong(node.rightlink);
+        if (node.rightsep == Bytes.POSITIVE_INFINITY) {
+            out.writeByte(RIGHTSEP_INF);
+        } else {
+            out.writeByte(RIGHTSEP_BYTES);
+            out.writeArray(node.rightsep.to_array());
+        }
+    }
+
+    private static BLinkNodeMetadata<Bytes> readNodeMetadata(ByteBufCursor in) throws IOException {
+        boolean leaf = in.readBoolean();
+        long id = in.readVLong();
+        long storeId = in.readVLong();
+        int keys = in.readVInt();
+        long bytes = in.readVLong();
+        long outlink = in.readZLong();
+        long rightlink = in.readZLong();
+        byte sepKind = in.readByte();
+        Bytes rightsep;
+        if (sepKind == RIGHTSEP_INF) {
+            rightsep = Bytes.POSITIVE_INFINITY;
+        } else if (sepKind == RIGHTSEP_BYTES) {
+            rightsep = Bytes.from_array(in.readArray());
+        } else {
+            throw new IOException("unknown rightsep marker " + sepKind);
+        }
+        return new BLinkNodeMetadata<>(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static BLinkNodeMetadata<Bytes>[] newArray(int size) {
+        return (BLinkNodeMetadata<Bytes>[]) new BLinkNodeMetadata[size];
+    }
+
+    /**
+     * Rebuild a full {@link BLinkMetadata} from a snapshot's node list plus a
+     * sequence of deltas. The returned metadata also carries the anchor data
+     * supplied by the caller (read from the manifest, not from the snapshot
+     * page itself — the snapshot only carries node metadata).
+     */
+    static BLinkMetadata<Bytes> rebuild(
+            Map<Long, BLinkNodeMetadata<Bytes>> byNodeId,
+            long nextID, long fast, int fastHeight, long top, int topHeight,
+            long first, long values
+    ) {
+        List<BLinkNodeMetadata<Bytes>> list = new ArrayList<>(byNodeId.values());
+        return new BLinkMetadata<>(nextID, fast, fastHeight, top, topHeight, first, values, list);
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/IncrementalBLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/IncrementalBLinkKeyToPageIndexTest.java
@@ -1,0 +1,161 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+*/
+
+package herddb.index;
+
+import herddb.core.MemoryManager;
+import herddb.index.blink.IncrementalBLinkKeyToPageIndex;
+import herddb.mem.MemoryDataStorageManager;
+
+/**
+ * Runs the shared {@link KeyToPageIndexTest} contract against the
+ * {@link IncrementalBLinkKeyToPageIndex} — the new default PK index
+ * implementation.
+ */
+public class IncrementalBLinkKeyToPageIndexTest extends KeyToPageIndexTest {
+
+    @Override
+    KeyToPageIndex createIndex() {
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        MemoryDataStorageManager ds = new MemoryDataStorageManager();
+        IncrementalBLinkKeyToPageIndex idx =
+                new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        return new ResourceCloseKeyToPageIndex(idx, ds);
+    }
+
+    private final class ResourceCloseKeyToPageIndex implements KeyToPageIndex {
+
+        private final KeyToPageIndex delegate;
+        private final AutoCloseable[] closeables;
+
+        ResourceCloseKeyToPageIndex(KeyToPageIndex index, AutoCloseable... closeables) {
+            this.delegate = index;
+            this.closeables = closeables;
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+            IllegalStateException exception = null;
+            for (AutoCloseable c : closeables) {
+                try {
+                    c.close();
+                } catch (Exception e) {
+                    if (exception == null) {
+                        exception = new IllegalStateException("Failed to properly close resources", e);
+                    } else {
+                        exception.addSuppressed(e);
+                    }
+                }
+            }
+            if (exception != null) {
+                throw exception;
+            }
+        }
+
+        @Override
+        public long getUsedMemory() {
+            return delegate.getUsedMemory();
+        }
+
+        @Override
+        public boolean requireLoadAtStartup() {
+            return delegate.requireLoadAtStartup();
+        }
+
+        @Override
+        public long size() {
+            return delegate.size();
+        }
+
+        @Override
+        public void init() throws herddb.storage.DataStorageManagerException {
+            delegate.init();
+        }
+
+        @Override
+        public void start(herddb.log.LogSequenceNumber sequenceNumber, boolean created)
+                throws herddb.storage.DataStorageManagerException {
+            delegate.start(sequenceNumber, created);
+        }
+
+        @Override
+        public java.util.List<herddb.core.PostCheckpointAction> checkpoint(
+                herddb.log.LogSequenceNumber sequenceNumber, boolean pin)
+                throws herddb.storage.DataStorageManagerException {
+            return delegate.checkpoint(sequenceNumber, pin);
+        }
+
+        @Override
+        public void unpinCheckpoint(herddb.log.LogSequenceNumber sequenceNumber)
+                throws herddb.storage.DataStorageManagerException {
+            delegate.unpinCheckpoint(sequenceNumber);
+        }
+
+        @Override
+        public void truncate() {
+            delegate.truncate();
+        }
+
+        @Override
+        public void dropData() {
+            delegate.dropData();
+        }
+
+        @Override
+        public java.util.stream.Stream<java.util.Map.Entry<herddb.utils.Bytes, Long>> scanner(
+                IndexOperation operation, herddb.model.StatementEvaluationContext context,
+                herddb.model.TableContext tableContext, herddb.core.AbstractIndexManager index)
+                throws herddb.storage.DataStorageManagerException,
+                       herddb.model.StatementExecutionException {
+            return delegate.scanner(operation, context, tableContext, index);
+        }
+
+        @Override
+        public void put(herddb.utils.Bytes key, Long currentPage) {
+            delegate.put(key, currentPage);
+        }
+
+        @Override
+        public boolean put(herddb.utils.Bytes key, Long newPage, Long expectedPage) {
+            return delegate.put(key, newPage, expectedPage);
+        }
+
+        @Override
+        public boolean containsKey(herddb.utils.Bytes key) {
+            return delegate.containsKey(key);
+        }
+
+        @Override
+        public Long get(herddb.utils.Bytes key) {
+            return delegate.get(key);
+        }
+
+        @Override
+        public Long remove(herddb.utils.Bytes key) {
+            return delegate.remove(key);
+        }
+
+        @Override
+        public boolean isSortedAscending(int[] pkTypes) {
+            return delegate.isSortedAscending(pkTypes);
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkCheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkCheckpointTest.java
@@ -1,0 +1,178 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+*/
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import org.junit.Test;
+
+/**
+ * Focused tests for {@link IncrementalBLinkKeyToPageIndex} covering
+ * checkpoint / recovery behaviour, format-mismatch detection, and the basic
+ * manifest contents after each checkpoint.
+ */
+public class IncrementalBLinkCheckpointTest {
+
+    private static MemoryManager newMem() {
+        return new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+    }
+
+    @Test
+    public void checkpointThenRecoverRestoresAllKeys() throws Exception {
+        MemoryManager mem = newMem();
+        MemoryDataStorageManager ds = new MemoryDataStorageManager();
+        IncrementalBLinkKeyToPageIndex idx = new IncrementalBLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+        for (int i = 0; i < 200; i++) {
+            idx.put(Bytes.from_int(i), (long) i);
+        }
+        LogSequenceNumber lsn1 = new LogSequenceNumber(1, 100);
+        idx.checkpoint(lsn1, false);
+
+        IncrementalBLinkManifest m1 = idx.getCurrentManifest();
+        assertNotNull(m1);
+        assertEquals(1L, m1.epoch);
+        assertFalse("first checkpoint should have written a snapshot",
+                m1.snapshotChunks.isEmpty());
+        assertTrue("first checkpoint should have no delta chain",
+                m1.deltaChain.isEmpty());
+
+        // Reopen and verify every key is still there.
+        idx.close();
+        IncrementalBLinkKeyToPageIndex idx2 = new IncrementalBLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        idx2.start(lsn1, false);
+        assertEquals(200L, idx2.size());
+        for (int i = 0; i < 200; i++) {
+            assertEquals(Long.valueOf(i), idx2.get(Bytes.from_int(i)));
+        }
+        idx2.close();
+    }
+
+    @Test
+    public void secondCheckpointProducesDeltaNotSnapshot() throws Exception {
+        MemoryManager mem = newMem();
+        MemoryDataStorageManager ds = new MemoryDataStorageManager();
+        IncrementalBLinkKeyToPageIndex idx = new IncrementalBLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+
+        for (int i = 0; i < 50; i++) {
+            idx.put(Bytes.from_int(i), (long) i);
+        }
+        idx.checkpoint(new LogSequenceNumber(1, 1), false);
+        IncrementalBLinkManifest m1 = idx.getCurrentManifest();
+
+        // Another mutation + checkpoint — delta path.
+        idx.put(Bytes.from_int(9999), 9999L);
+        idx.checkpoint(new LogSequenceNumber(1, 2), false);
+
+        IncrementalBLinkManifest m2 = idx.getCurrentManifest();
+        assertEquals(m1.epoch + 1, m2.epoch);
+        // Snapshot reused — same chunk references.
+        assertEquals(m1.snapshotChunks.size(), m2.snapshotChunks.size());
+        if (!m1.snapshotChunks.isEmpty()) {
+            assertEquals(m1.snapshotChunks.get(0).pageId, m2.snapshotChunks.get(0).pageId);
+        }
+        // Delta chain grew by one.
+        assertEquals(m1.deltaChain.size() + 1, m2.deltaChain.size());
+
+        idx.close();
+    }
+
+    @Test
+    public void recoveryReplaysDeltasOverSnapshot() throws Exception {
+        MemoryManager mem = newMem();
+        MemoryDataStorageManager ds = new MemoryDataStorageManager();
+        IncrementalBLinkKeyToPageIndex idx = new IncrementalBLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+
+        for (int i = 0; i < 30; i++) {
+            idx.put(Bytes.from_int(i), (long) i);
+        }
+        idx.checkpoint(new LogSequenceNumber(1, 1), false);
+
+        // Insertions → delta 1
+        for (int i = 30; i < 60; i++) {
+            idx.put(Bytes.from_int(i), (long) i);
+        }
+        idx.checkpoint(new LogSequenceNumber(1, 2), false);
+
+        // Delete some keys → delta 2
+        for (int i = 10; i < 20; i++) {
+            idx.remove(Bytes.from_int(i));
+        }
+        LogSequenceNumber last = new LogSequenceNumber(1, 3);
+        idx.checkpoint(last, false);
+        idx.close();
+
+        // Recover from the last LSN and verify final state.
+        IncrementalBLinkKeyToPageIndex r = new IncrementalBLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        r.start(last, false);
+        assertEquals(50L, r.size()); // 60 inserted - 10 deleted
+        for (int i = 0; i < 10; i++) {
+            assertEquals(Long.valueOf(i), r.get(Bytes.from_int(i)));
+        }
+        for (int i = 10; i < 20; i++) {
+            assertEquals("key " + i + " should have been removed", null, r.get(Bytes.from_int(i)));
+        }
+        for (int i = 20; i < 60; i++) {
+            assertEquals(Long.valueOf(i), r.get(Bytes.from_int(i)));
+        }
+        r.close();
+    }
+
+    @Test
+    public void legacyFormatTriggersClearError() throws Exception {
+        MemoryManager mem = newMem();
+        MemoryDataStorageManager ds = new MemoryDataStorageManager();
+
+        // Write data with the legacy impl.
+        BLinkKeyToPageIndex legacy = new BLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        legacy.start(LogSequenceNumber.START_OF_TIME, true);
+        for (int i = 0; i < 10; i++) {
+            legacy.put(Bytes.from_int(i), (long) i);
+        }
+        LogSequenceNumber lsn = new LogSequenceNumber(1, 1);
+        legacy.checkpoint(lsn, false);
+        legacy.close();
+
+        // Now attempt to open with the incremental impl at the same LSN.
+        IncrementalBLinkKeyToPageIndex incr =
+                new IncrementalBLinkKeyToPageIndex("ts", "tbl", mem, ds);
+        try {
+            incr.start(lsn, false);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException expected) {
+            String msg = expected.getMessage();
+            assertNotNull(msg);
+            assertTrue("message should mention 'legacy': " + msg, msg.contains("legacy"));
+            assertTrue("message should mention the system property: " + msg,
+                    msg.contains("herddb.index.pk.mode"));
+        }
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/ReadReplicaDataStorageManager.java
@@ -25,7 +25,7 @@ import herddb.core.PostCheckpointAction;
 import herddb.core.RecordSetFactory;
 import herddb.file.FileRecordSetFactory;
 import herddb.index.KeyToPageIndex;
-import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.index.KeyToPageIndexFactory;
 import herddb.log.LogSequenceNumber;
 import herddb.model.Index;
 import herddb.model.Record;
@@ -329,7 +329,7 @@ public class ReadReplicaDataStorageManager extends DataStorageManager {
     @Override
     public KeyToPageIndex createKeyToPageMap(String tableSpace, String uuid,
             MemoryManager memoryManager) throws DataStorageManagerException {
-        return new BLinkKeyToPageIndex(tableSpace, uuid, memoryManager, this);
+        return KeyToPageIndexFactory.create(tableSpace, uuid, memoryManager, this);
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -26,7 +26,7 @@ import herddb.core.RecordSetFactory;
 import herddb.file.FileDataStorageManager;
 import herddb.file.FileRecordSetFactory;
 import herddb.index.KeyToPageIndex;
-import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.index.KeyToPageIndexFactory;
 import herddb.log.LogSequenceNumber;
 import herddb.model.Index;
 import herddb.model.Record;
@@ -954,7 +954,7 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     @Override
     public KeyToPageIndex createKeyToPageMap(String tableSpace, String uuid,
             MemoryManager memoryManager) throws DataStorageManagerException {
-        return new BLinkKeyToPageIndex(tableSpace, uuid, memoryManager, this);
+        return KeyToPageIndexFactory.create(tableSpace, uuid, memoryManager, this);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds a second PK-index implementation, `IncrementalBLinkKeyToPageIndex`, whose
normal-case checkpoint writes only a small manifest plus a delta page covering
nodes that changed since the previous checkpoint — instead of rewriting the full
tree metadata and the full activePages set like the legacy `BLinkKeyToPageIndex`
does today. Selection is driven by the `herddb.index.pk.mode` system property
(`incremental` is the new default; `legacy` opts out).

Motivation: 20B-row tables mean ~20M BLink nodes; the legacy checkpoint
serialises a per-node metadata entry plus every live page id every time, so
disk writes grow O(tree size). The incremental format collapses this to
O(nodes changed since previous checkpoint), with a periodic snapshot refresh
that bounds recovery cost.

- New on-disk format: self-contained manifest + sidecar snapshot chunks + delta
  pages. Full spec in `BLINK.md` (new); `CHECKPOINT.md` §5 cross-links to it.
- Old node-page bytes are unchanged, so both impls share the BLink tree and the
  `BLinkIndexDataStorage` surface.
- Factory `KeyToPageIndexFactory` wired into every persistent
  `DataStorageManager` (File, BookKeeper, RemoteFile, ReadReplica);
  `MemoryDataStorageManager` keeps its `ConcurrentMapKeyToPageIndex`.
- Format-mismatch is detected via a version-marker skew (legacy versions 0–2,
  incremental version 100) and surfaces as a `DataStorageManagerException`
  pointing at the system property.

## Scope

This PR delivers **on-disk** incremental checkpoint — disk writes become
O(changes). The in-memory representation (`BLink.nodes` holds one `Node`
object per tree node) is unchanged in this iteration; making it lazy is a
separate follow-up that requires changes to `BLink` itself. `BLINK.md §5`
flags this explicitly.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [x] `IncrementalBLinkKeyToPageIndexTest` — the shared `KeyToPageIndexTest`
      contract run against the new impl (the existing `BLinkKeyToPageIndexTest`
      still runs against the legacy impl; both pass)
- [x] `IncrementalBLinkCheckpointTest` — new tests for:
      checkpoint→close→recover with all keys intact;
      second checkpoint produces a delta (not a snapshot);
      insert+delete replay across snapshot+multiple deltas;
      legacy-format-on-disk triggers a clear error message
- [x] `CheckpointTest` + `CheckpointRecoveryWithIndexTest` — all 13 pass with
      incremental default
- [x] `ConcurrentCheckpointTest` + `ConcurrentCheckpointWithIndexTest` +
      `CheckpointDrainNewPagesTest` + `CheckpointStaleLsnRecoveryTest` — all 13 pass
- [x] `FileDataStorageManagerRestartTest` + `AutocheckPointTest` +
      `AutoCheckpointMemoryTest` — all 13 pass
- [ ] Large-scale manual verification (100M keys × 100 checkpoints, assert
      manifest < a few KB per non-snapshot checkpoint) — recommended before
      enabling in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)