### PR TITLE
Make addEntryTimeoutSec=30 / addEntryQuorumTimeoutSec=60 BK client defaults (#152)

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -20,6 +20,7 @@
 
 package herddb.cluster;
 
+import com.google.common.annotations.VisibleForTesting;
 import herddb.log.CommitLogManager;
 import herddb.log.LogEntry;
 import herddb.log.LogNotAvailableException;
@@ -51,6 +52,20 @@ import org.apache.bookkeeper.stats.StatsLogger;
  */
 public class BookkeeperCommitLogManager extends CommitLogManager {
 
+    /**
+     * Default BK client {@code addEntryTimeoutSec} applied by HerdDB. Overrides the
+     * BookKeeper built-in default of 5s, which is too short to survive simultaneous
+     * entry-log rotation + journal roll bursts on a single bookie (issue #152).
+     */
+    static final int DEFAULT_ADD_ENTRY_TIMEOUT_SEC = 30;
+
+    /**
+     * Default BK client {@code addEntryQuorumTimeoutSec} applied by HerdDB. Caps the
+     * overall wall-clock of a single add-entry quorum at 2x the per-bookie timeout
+     * so a genuinely stuck bookie eventually surfaces as a hard error (issue #152).
+     */
+    static final int DEFAULT_ADD_ENTRY_QUORUM_TIMEOUT_SEC = 60;
+
     private final ZookeeperMetadataStorageManager metadataStorageManager;
     private int ensemble = 1;
     private int writeQuorumSize = 1;
@@ -78,6 +93,16 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
                 ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT));
         config.setEnableParallelRecoveryRead(true);
         config.setEnableDigestTypeAutodetection(true);
+
+        // BookKeeper's built-in addEntryTimeoutSec default (5s) is too short for bursts of
+        // simultaneous entry-log rotation + journal roll on a single bookie, which has been
+        // observed to stall writes for 7-10s (issue #152). 30s gives ~6x headroom and
+        // addEntryQuorumTimeoutSec=60s caps the overall wall-clock so a genuinely stuck
+        // bookie surfaces as an error. Applied before the property passthrough loop so that
+        // explicit bookkeeper.addEntryTimeoutSec / bookkeeper.addEntryQuorumTimeoutSec values
+        // in the server configuration still win.
+        config.setAddEntryTimeout(DEFAULT_ADD_ENTRY_TIMEOUT_SEC);
+        config.setAddEntryQuorumTimeout(DEFAULT_ADD_ENTRY_QUORUM_TIMEOUT_SEC);
 
         /* Setups values from configuration */
         for (String key : serverConfiguration.keys()) {
@@ -112,6 +137,11 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
 
     public BookKeeper getBookKeeper() {
         return bookKeeper;
+    }
+
+    @VisibleForTesting
+    ClientConfiguration getClientConfiguration() {
+        return config;
     }
 
     private void forceLastAddConfirmed() {

--- a/herddb-core/src/test/java/herddb/cluster/BookkeeperCommitLogManagerConfigTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BookkeeperCommitLogManagerConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.cluster;
+
+import static org.junit.Assert.assertEquals;
+import herddb.server.ServerConfiguration;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link ClientConfiguration} built by
+ * {@link BookkeeperCommitLogManager}.
+ *
+ * <p>Focuses on the BK client timeout defaults introduced for issue #152.
+ */
+public class BookkeeperCommitLogManagerConfigTest {
+
+    private static ZookeeperMetadataStorageManager fakeMetadata() {
+        // The constructor of ZookeeperMetadataStorageManager does not open a ZK
+        // connection — it only stores the values. BookkeeperCommitLogManager's
+        // constructor likewise just reads these getters, so we can build the
+        // manager without any real infrastructure.
+        return new ZookeeperMetadataStorageManager("localhost:2181", 30_000, "/herddb-test");
+    }
+
+    @Test
+    public void appliesDefaultAddEntryTimeouts() {
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (BookkeeperCommitLogManager manager = new BookkeeperCommitLogManager(
+                fakeMetadata(), serverConfiguration, NullStatsLogger.INSTANCE)) {
+            ClientConfiguration config = manager.getClientConfiguration();
+            assertEquals(BookkeeperCommitLogManager.DEFAULT_ADD_ENTRY_TIMEOUT_SEC,
+                    config.getAddEntryTimeout());
+            assertEquals(BookkeeperCommitLogManager.DEFAULT_ADD_ENTRY_QUORUM_TIMEOUT_SEC,
+                    config.getAddEntryQuorumTimeout());
+        }
+    }
+
+    @Test
+    public void explicitBookkeeperPropertiesOverrideDefaults() {
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        serverConfiguration.set("bookkeeper.addEntryTimeoutSec", "11");
+        serverConfiguration.set("bookkeeper.addEntryQuorumTimeoutSec", "22");
+        try (BookkeeperCommitLogManager manager = new BookkeeperCommitLogManager(
+                fakeMetadata(), serverConfiguration, NullStatsLogger.INSTANCE)) {
+            ClientConfiguration config = manager.getClientConfiguration();
+            assertEquals(11, config.getAddEntryTimeout());
+            assertEquals(22, config.getAddEntryQuorumTimeout());
+        }
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -80,20 +80,9 @@ server:
     # also reduce the per-checkpoint catch-up backlog that was the root cause
     # of issue #145 (LSN mismatch after a 25-min waitForInstanceCatchUp).
     server.checkpoint.period: "60000"                          # 1 min (ms)
-    # --- BookKeeper client resilience tuning (issue #152) ---
-    # Default addEntryTimeoutSec=5 is too short: the single bookie can stall
-    # for 7-10 s during simultaneous entry-log rotation + journal roll (burst
-    # of 4 fsyncs observed at bigann 28% ingest). After 5 s the BK client
-    # fires handleBookieFailure() → ensembleChangeLoop() → with only one
-    # bookie available the ensemble change always fails with
-    # BKNotEnoughBookiesException → commitlog is permanently marked failed.
-    # 30 s gives 3-4× headroom over the worst observed stall with no risk of
-    # masking real bookie crashes (those take much longer or never recover).
-    # addEntryQuorumTimeoutSec caps the overall per-write wall-clock time;
-    # set to 2× addEntryTimeoutSec so a genuinely stuck bookie eventually
-    # surfaces as a hard error rather than hanging forever.
-    bookkeeper.addEntryTimeoutSec: "30"
-    bookkeeper.addEntryQuorumTimeoutSec: "60"
+    # BookKeeper client resilience tuning (addEntryTimeoutSec=30,
+    # addEntryQuorumTimeoutSec=60) is now the BookkeeperCommitLogManager
+    # default — see issue #152.
   resources:
     requests:
       memory: "23Gi"


### PR DESCRIPTION
## Summary
- Promote the BK client timeout values introduced in commit 97744ff4 (`addEntryTimeoutSec=30`, `addEntryQuorumTimeoutSec=60`) from the k3s-local Helm example to `BookkeeperCommitLogManager` defaults so every HerdDB deployment gets them out of the box (issue #152).
- Explicit `bookkeeper.addEntryTimeoutSec` / `bookkeeper.addEntryQuorumTimeoutSec` values in `server.properties` still win — the defaults are set before the existing `bookkeeper.*` passthrough loop.
- Drop the now-redundant explicit overrides from `herddb-kubernetes/.../k3s-local/values.yaml`.

## Why these values
BookKeeper's built-in `addEntryTimeoutSec=5` is too short to survive a simultaneous entry-log rotation + journal roll on a single bookie (7–10 s stalls observed at bigann 28% ingest, issue #152). With 5 s the BK client fires `handleBookieFailure` → `ensembleChangeLoop` → `BKNotEnoughBookiesException` and the commitlog is permanently failed. 30 s gives ~6× headroom; 60 s on the quorum timeout caps overall wall-clock at 2× the per-bookie timeout.

## Test plan
- [x] `mvn -pl herddb-core -Dtest=BookkeeperCommitLogManagerConfigTest test` — 2 new tests (defaults applied; explicit override wins) pass.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)