### PR TITLE
syslogstatus: expose last-checkpoint LSN; VectorBench [status] dump (#159)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -199,6 +199,20 @@ public class TableSpaceManager {
     private volatile boolean failed;
     private LogSequenceNumber actualLogSequenceNumber;
 
+    /**
+     * LSN durably flushed by the last completed checkpoint. {@code null} until the first checkpoint finishes.
+     * Populated in the {@code finally} block of {@link #checkpoint(boolean, boolean, boolean, long)}.
+     */
+    private volatile LogSequenceNumber lastCheckpointSequenceNumber;
+    /**
+     * Wall-clock timestamp (epoch millis) when the last checkpoint completed; {@code 0} until the first one.
+     */
+    private volatile long lastCheckpointTimestamp;
+    /**
+     * Duration in milliseconds of the last completed checkpoint; {@code 0} until the first one.
+     */
+    private volatile long lastCheckpointDurationMs;
+
     // only for tests
     private Runnable afterTableCheckPointAction;
 
@@ -2585,6 +2599,13 @@ public class TableSpaceManager {
             LOGGER.log(Level.INFO, "{0} checkpoint finish {1} started ad {2}, finished at {3}, total time {4} ms",
                     new Object[]{nodeId, tableSpaceName, logSequenceNumber, _logSequenceNumber, Long.toString(_stop - _start)});
             checkpointTimeStats.registerSuccessfulEvent(_stop, TimeUnit.MILLISECONDS);
+            // Record per-tablespace checkpoint status for syslogstatus. Only update when we actually
+            // persisted a checkpoint marker (logSequenceNumber is non-null and not start-of-time).
+            if (logSequenceNumber != null && !logSequenceNumber.isStartOfTime()) {
+                this.lastCheckpointSequenceNumber = logSequenceNumber;
+                this.lastCheckpointTimestamp = _stop;
+                this.lastCheckpointDurationMs = _stop - _start;
+            }
         }
     }
 
@@ -2879,6 +2900,29 @@ public class TableSpaceManager {
 
     public CommitLog getLog() {
         return log;
+    }
+
+    /**
+     * LSN durably flushed by the last completed checkpoint, or {@code null} if no checkpoint has
+     * completed yet on this node (fresh tablespace, empty log, or recovery still running).
+     */
+    public LogSequenceNumber getLastCheckpointSequenceNumber() {
+        return lastCheckpointSequenceNumber;
+    }
+
+    /**
+     * Wall-clock time (epoch millis) when the last checkpoint completed, or {@code 0} if no
+     * checkpoint has completed yet on this node.
+     */
+    public long getLastCheckpointTimestamp() {
+        return lastCheckpointTimestamp;
+    }
+
+    /**
+     * Duration (ms) of the last completed checkpoint, or {@code 0} if no checkpoint has completed.
+     */
+    public long getLastCheckpointDurationMs() {
+        return lastCheckpointDurationMs;
     }
 
     public ExecutorService getCallbacksExecutor() {

--- a/herddb-core/src/main/java/herddb/core/system/SyslogstatusManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SyslogstatusManager.java
@@ -28,11 +28,16 @@ import herddb.model.Record;
 import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.Transaction;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Table Manager for the SYSTABLESPACES virtual table
+ * Table Manager for the SYSLOGSTATUS virtual table.
+ *
+ * <p>Exposes the per-tablespace commit-log write head and the state of the
+ * last completed checkpoint, so the gap between them (recovery exposure) is
+ * directly readable with a single {@code SELECT}.
  *
  * @author enrico.olivelli
  */
@@ -47,6 +52,11 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
             .column("ledger", ColumnTypes.LONG)
             .column("offset", ColumnTypes.LONG)
             .column("status", ColumnTypes.STRING)
+            .column("checkpoint_ledger", ColumnTypes.LONG)
+            .column("checkpoint_offset", ColumnTypes.LONG)
+            .column("checkpoint_timestamp", ColumnTypes.TIMESTAMP)
+            .column("checkpoint_duration_ms", ColumnTypes.LONG)
+            .column("dirty_ledgers_count", ColumnTypes.INTEGER)
             .primaryKey("tablespace_uuid", false)
             .primaryKey("nodeid", false)
             .build();
@@ -60,15 +70,34 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
         boolean isVirtual = tableSpaceManager.isVirtual();
         boolean isLeader = tableSpaceManager.isLeader();
         LogSequenceNumber logSequenceNumber = isVirtual ? null : tableSpaceManager.getLog().getLastSequenceNumber();
+        LogSequenceNumber checkpointLsn = isVirtual ? null : tableSpaceManager.getLastCheckpointSequenceNumber();
+        long checkpointTimestamp = isVirtual ? 0L : tableSpaceManager.getLastCheckpointTimestamp();
+        long checkpointDurationMs = isVirtual ? 0L : tableSpaceManager.getLastCheckpointDurationMs();
+
+        Long ledger = isVirtual ? 0L : logSequenceNumber.ledgerId;
+        Long offset = isVirtual ? 0L : logSequenceNumber.offset;
+        Long cpLedger = checkpointLsn != null ? checkpointLsn.ledgerId : null;
+        Long cpOffset = checkpointLsn != null ? checkpointLsn.offset : null;
+        Timestamp cpTs = checkpointTimestamp > 0 ? new Timestamp(checkpointTimestamp) : null;
+        Long cpDuration = checkpointTimestamp > 0 ? checkpointDurationMs : null;
+        Integer dirtyLedgers = (!isVirtual && checkpointLsn != null)
+                ? (int) Math.max(0L, logSequenceNumber.ledgerId - checkpointLsn.ledgerId)
+                : null;
+
         List<Record> result = new ArrayList<>();
         result.add(RecordSerializer.makeRecord(
                 table,
                 "tablespace_uuid", tableSpaceManager.getTableSpaceUUID(),
                 "nodeid", tableSpaceManager.getDbmanager().getNodeId(),
                 "tablespace_name", tableSpaceManager.getTableSpaceName(),
-                "ledger", isVirtual ? 0L : logSequenceNumber.ledgerId,
-                "offset", isVirtual ? 0L : logSequenceNumber.offset,
-                "status", isVirtual ? "virtual" : isLeader ? "leader" : "follower"
+                "ledger", ledger,
+                "offset", offset,
+                "status", isVirtual ? "virtual" : isLeader ? "leader" : "follower",
+                "checkpoint_ledger", cpLedger,
+                "checkpoint_offset", cpOffset,
+                "checkpoint_timestamp", cpTs,
+                "checkpoint_duration_ms", cpDuration,
+                "dirty_ledgers_count", dirtyLedgers
         ));
         return result;
 

--- a/herddb-core/src/test/java/herddb/sql/SyslogstatusTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SyslogstatusTest.java
@@ -1,0 +1,160 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql;
+
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.utils.DataAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class SyslogstatusTest {
+
+    @Test
+    public void testSyslogstatusColumnsPresent() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager(nodeId,
+                new MemoryMetadataStorageManager(),
+                new MemoryDataStorageManager(),
+                new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement(
+                    "tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1,
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            try (DataScanner scan = scan(manager,
+                    "SELECT * FROM tblspace1.syslogstatus", Collections.emptyList())) {
+                List<DataAccessor> records = scan.consume();
+                assertEquals(1, records.size());
+                Map<String, Object> row = records.get(0).toMap();
+
+                // Existing columns still present
+                assertNotNull(row.get("tablespace_uuid"));
+                assertEquals(nodeId, row.get("nodeid").toString());
+                assertEquals("tblspace1", row.get("tablespace_name").toString());
+                assertNotNull(row.get("ledger"));
+                assertNotNull(row.get("offset"));
+                assertEquals("leader", row.get("status").toString());
+
+                // New checkpoint columns are null until the first checkpoint completes.
+                assertNull("checkpoint_ledger must be null before any checkpoint",
+                        row.get("checkpoint_ledger"));
+                assertNull("checkpoint_offset must be null before any checkpoint",
+                        row.get("checkpoint_offset"));
+                assertNull("checkpoint_timestamp must be null before any checkpoint",
+                        row.get("checkpoint_timestamp"));
+                assertNull("checkpoint_duration_ms must be null before any checkpoint",
+                        row.get("checkpoint_duration_ms"));
+                assertNull("dirty_ledgers_count must be null before any checkpoint",
+                        row.get("dirty_ledgers_count"));
+            }
+        }
+    }
+
+    @Test
+    public void testSyslogstatusAfterCheckpoint() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager(nodeId,
+                new MemoryMetadataStorageManager(),
+                new MemoryDataStorageManager(),
+                new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement(
+                    "tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1,
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager,
+                    "CREATE TABLE tblspace1.t1 (k1 string primary key, n1 int)",
+                    Collections.emptyList());
+            execute(manager,
+                    "INSERT INTO tblspace1.t1(k1, n1) VALUES('a', 1)",
+                    Collections.emptyList());
+
+            long beforeCheckpointMs = System.currentTimeMillis();
+            manager.checkpoint();
+
+            try (DataScanner scan = scan(manager,
+                    "SELECT * FROM tblspace1.syslogstatus", Collections.emptyList())) {
+                List<DataAccessor> records = scan.consume();
+                assertEquals(1, records.size());
+                Map<String, Object> row = records.get(0).toMap();
+
+                Object cpLedger = row.get("checkpoint_ledger");
+                Object cpOffset = row.get("checkpoint_offset");
+                Object cpTs = row.get("checkpoint_timestamp");
+                Object cpDuration = row.get("checkpoint_duration_ms");
+                Object dirtyLedgers = row.get("dirty_ledgers_count");
+
+                assertNotNull("checkpoint_ledger should be populated after checkpoint", cpLedger);
+                assertNotNull("checkpoint_offset should be populated after checkpoint", cpOffset);
+                assertNotNull("checkpoint_timestamp should be populated after checkpoint", cpTs);
+                assertNotNull("checkpoint_duration_ms should be populated after checkpoint", cpDuration);
+                assertNotNull("dirty_ledgers_count should be populated after checkpoint", dirtyLedgers);
+
+                // checkpoint_offset must be <= current log offset (checkpoint is behind or equal to write head)
+                long ledger = ((Number) row.get("ledger")).longValue();
+                long offset = ((Number) row.get("offset")).longValue();
+                long cpLedgerVal = ((Number) cpLedger).longValue();
+                long cpOffsetVal = ((Number) cpOffset).longValue();
+                assertTrue("checkpoint_ledger must not exceed current ledger",
+                        cpLedgerVal <= ledger);
+                if (cpLedgerVal == ledger) {
+                    assertTrue("checkpoint_offset must not exceed current offset on same ledger",
+                            cpOffsetVal <= offset);
+                }
+
+                // duration is non-negative
+                long durationMs = ((Number) cpDuration).longValue();
+                assertTrue("checkpoint_duration_ms should be >= 0", durationMs >= 0);
+
+                // timestamp falls in a sensible window around the checkpoint call
+                long cpTsMs = ((java.sql.Timestamp) cpTs).getTime();
+                assertTrue("checkpoint_timestamp must be >= before-checkpoint time",
+                        cpTsMs >= beforeCheckpointMs);
+                assertTrue("checkpoint_timestamp must not be in the future",
+                        cpTsMs <= System.currentTimeMillis() + 1000);
+
+                int dirtyLedgersVal = ((Number) dirtyLedgers).intValue();
+                assertTrue("dirty_ledgers_count must be >= 0", dirtyLedgersVal >= 0);
+            }
+        }
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/BenchOutput.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/BenchOutput.java
@@ -60,6 +60,14 @@ abstract class BenchOutput {
      */
     abstract void progress(String phase, double elapsedSecs, String statusLine, LinkedHashMap<String, Object> fields);
 
+    /**
+     * Emits a server-status snapshot, structurally similar to {@link #progress} but always
+     * visible (no rate-limiting, no spinner). Used by the dedicated status thread that
+     * dumps {@code syslogstatus} / {@code systablestats} / {@code sysindexstatus} during
+     * ingestion.
+     */
+    abstract void status(String phase, double elapsedSecs, LinkedHashMap<String, Object> fields);
+
     /** Prints the "done in NNs" line at the end of a phase. */
     abstract void phaseDone(String phase, double elapsedSecs);
 
@@ -151,6 +159,15 @@ abstract class BenchOutput {
         }
 
         @Override
+        void status(String phase, double elapsedSecs, LinkedHashMap<String, Object> fields) {
+            // Print on its own line so the spinner's \r-overwrite doesn't clobber it, and so
+            // the next spinner update redraws cleanly.
+            out.println();
+            out.println("  [status] " + PlainBenchOutput.formatStatusLine(phase, elapsedSecs, fields));
+            out.flush();
+        }
+
+        @Override
         void phaseEnd(String phase, LinkedHashMap<String, Object> fields) {
             out.println(PlainBenchOutput.formatPhaseLine(phase, fields));
         }
@@ -239,6 +256,11 @@ abstract class BenchOutput {
         }
 
         @Override
+        void status(String phase, double elapsedSecs, LinkedHashMap<String, Object> fields) {
+            out.println("  [status] " + formatStatusLine(phase, elapsedSecs, fields));
+        }
+
+        @Override
         void phaseEnd(String phase, LinkedHashMap<String, Object> fields) {
             out.println(formatPhaseLine(phase, fields));
         }
@@ -266,6 +288,35 @@ abstract class BenchOutput {
                 all.putAll(fields);
             }
             return renderKeyValues(all);
+        }
+
+        static String formatStatusLine(String phase, double elapsedSecs, LinkedHashMap<String, Object> fields) {
+            LinkedHashMap<String, Object> all = new LinkedHashMap<>();
+            all.put("phase", phase);
+            all.put("elapsed_s", roundOneDecimal(elapsedSecs));
+            if (fields != null) {
+                flattenInto(all, "", fields);
+            }
+            return renderKeyValues(all);
+        }
+
+        /**
+         * Flattens a potentially nested {@code fields} map into {@code target}, joining
+         * nested keys with {@code _}. Example: {@code {"commitlog":{"ledger":145}}} becomes
+         * {@code commitlog_ledger=145}. This keeps the status line's human-readable shape
+         * stable regardless of how callers nest data for the JSON event.
+         */
+        @SuppressWarnings("unchecked")
+        private static void flattenInto(LinkedHashMap<String, Object> target, String prefix, Map<String, Object> fields) {
+            for (Map.Entry<String, Object> e : fields.entrySet()) {
+                String key = prefix.isEmpty() ? e.getKey() : prefix + "_" + e.getKey();
+                Object v = e.getValue();
+                if (v instanceof Map) {
+                    flattenInto(target, key, (Map<String, Object>) v);
+                } else {
+                    target.put(key, v);
+                }
+            }
         }
 
         static String formatSummary(LinkedHashMap<String, Object> fields) {
@@ -412,6 +463,18 @@ abstract class BenchOutput {
         @Override
         void phaseDone(String phase, double elapsedSecs) {
             // phase_end carries the definitive metrics; a bare "done" is noise in NDJSON.
+        }
+
+        @Override
+        void status(String phase, double elapsedSecs, LinkedHashMap<String, Object> fields) {
+            LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+            m.put("event", "status");
+            m.put("phase", phase);
+            m.put("elapsed_s", elapsedSecs);
+            if (fields != null) {
+                m.putAll(fields);
+            }
+            write(m);
         }
 
         @Override

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -65,6 +65,13 @@ public class Config {
     int checkpointTimeoutSeconds = 300;
     boolean noProgress = false;
     OutputFormat outputFormat = OutputFormat.TEXT;
+    /**
+     * Interval in seconds between periodic {@code [status]} dumps during ingestion.
+     * A dedicated JDBC connection queries {@code syslogstatus}, {@code systablestats} and
+     * {@code sysindexstatus} every {@code N} seconds so checkpoint / index-tail lag is
+     * visible in the run log. {@code 0} disables the status thread entirely.
+     */
+    int statusIntervalSeconds = 60;
 
     private static Options buildOptions() {
         Options opts = new Options();
@@ -102,6 +109,8 @@ public class Config {
                         + "(implicitly enabled when VECTOR_BENCH_NO_PROGRESS=1 or --output-format=json)");
         opts.addOption(null, "output-format", true,
                 "Output format: text (default) or json (NDJSON, one object per line). json implies --no-progress.");
+        opts.addOption(null, "status-interval-seconds", true,
+                "Seconds between server-status dumps during ingestion; 0 disables (default: 60)");
         opts.addOption(null, "config", true, "Path to properties file");
         opts.addOption("h", "help", false, "Show help");
         return opts;
@@ -217,6 +226,9 @@ public class Config {
         }
         if (cmd.hasOption("output-format")) {
             cfg.outputFormat = parseOutputFormat(cmd.getOptionValue("output-format"));
+        }
+        if (cmd.hasOption("status-interval-seconds")) {
+            cfg.statusIntervalSeconds = Integer.parseInt(cmd.getOptionValue("status-interval-seconds"));
         }
 
         // Env var fallbacks (only applied when the CLI flag was not set).
@@ -339,6 +351,9 @@ public class Config {
         if (props.containsKey("output-format")) {
             outputFormat = parseOutputFormat(props.getProperty("output-format"));
         }
+        if (props.containsKey("status-interval-seconds")) {
+            statusIntervalSeconds = Integer.parseInt(props.getProperty("status-interval-seconds"));
+        }
     }
 
     private static OutputFormat parseOutputFormat(String raw) {
@@ -417,6 +432,7 @@ public class Config {
                 + ", clientTimeoutSeconds=" + clientTimeoutSeconds
                 + ", noProgress=" + noProgress
                 + ", outputFormat=" + outputFormat
+                + ", statusIntervalSeconds=" + statusIntervalSeconds
                 + '}';
     }
 }

--- a/vector-testings/src/main/java/herddb/vectortesting/MetricsCollector.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/MetricsCollector.java
@@ -33,10 +33,13 @@ public class MetricsCollector {
     private final LongAdder count = new LongAdder();
     private final long[] reservoir = new long[MAX_SAMPLES];
     private final AtomicLong samplesStored = new AtomicLong(0);
+    /** Nanoseconds of the most recently recorded event; 0 when none recorded yet. */
+    private final AtomicLong lastNanos = new AtomicLong(0);
 
     public void record(long nanos) {
         long n = count.longValue() + 1; // approximate position before increment
         count.increment();
+        lastNanos.set(nanos);
         long stored = samplesStored.get();
         if (stored < MAX_SAMPLES) {
             // Fill reservoir sequentially until full
@@ -55,6 +58,11 @@ public class MetricsCollector {
 
     public long getCount() {
         return count.sum();
+    }
+
+    /** Nanoseconds of the most recently recorded event; 0 when none recorded yet. */
+    public long getLastNanos() {
+        return lastNanos.get();
     }
 
     public Stats computeStats() {

--- a/vector-testings/src/main/java/herddb/vectortesting/ServerStatusSampler.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/ServerStatusSampler.java
@@ -1,0 +1,224 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Snapshots server-side state — commit-log head, last checkpoint, table dirty state, vector
+ * index progress — by querying {@code syslogstatus}, {@code systablestats} and
+ * {@code sysindexstatus}. Used by {@link VectorBench} during ingestion to emit periodic
+ * {@code [status]} lines that make checkpoint stalls and index-tail lag visible in the run log.
+ *
+ * <p>Robust to older servers missing the new checkpoint columns: the {@code SELECT *} query
+ * picks up whatever is available, and absent columns simply produce {@code null} fields.</p>
+ */
+final class ServerStatusSampler {
+
+    private static final DateTimeFormatter TS_FORMAT = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(ZoneOffset.UTC);
+
+    private static final Pattern VECTOR_COUNT = Pattern.compile("\"vectorCount\"\\s*:\\s*(\\d+)");
+    private static final Pattern SEGMENT_COUNT = Pattern.compile("\"segmentCount\"\\s*:\\s*(\\d+)");
+    private static final Pattern LAST_LSN_LEDGER = Pattern.compile("\"lastLsnLedger\"\\s*:\\s*(-?\\d+)");
+    private static final Pattern LAST_LSN_OFFSET = Pattern.compile("\"lastLsnOffset\"\\s*:\\s*(-?\\d+)");
+    private static final Pattern INDEX_STATUS = Pattern.compile("\"status\"\\s*:\\s*\"([^\"]*)\"");
+
+    private final Config config;
+    private final String tableSpace;
+
+    ServerStatusSampler(Config config) {
+        this.config = config;
+        this.tableSpace = "herd";
+    }
+
+    /**
+     * Runs one sample round-trip and returns a nested field map suitable for
+     * {@link BenchOutput#status(String, double, LinkedHashMap)}. Never throws — errors are
+     * surfaced as an {@code error=<message>} field so the status thread keeps trying on the
+     * next tick.
+     */
+    LinkedHashMap<String, Object> sample() {
+        LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+        try (Connection conn = java.sql.DriverManager.getConnection(
+                config.effectiveJdbcUrl(), config.username, config.password)) {
+            conn.setAutoCommit(true);
+            fillLogStatus(conn, fields);
+            fillTableStats(conn, fields);
+            fillIndexStatus(conn, fields);
+        } catch (SQLException e) {
+            fields.put("error", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+        }
+        return fields;
+    }
+
+    private void fillLogStatus(Connection conn, LinkedHashMap<String, Object> fields) {
+        // SELECT * tolerates older servers that don't yet have the checkpoint_* columns.
+        String sql = "SELECT * FROM " + tableSpace + ".syslogstatus";
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            if (!rs.next()) {
+                return;
+            }
+            LinkedHashMap<String, Object> commitlog = new LinkedHashMap<>();
+            putLongIfPresent(rs, "ledger", commitlog, "ledger");
+            putLongIfPresent(rs, "offset", commitlog, "offset");
+            if (!commitlog.isEmpty()) {
+                fields.put("commitlog", commitlog);
+            }
+
+            LinkedHashMap<String, Object> checkpoint = new LinkedHashMap<>();
+            Long cpLedger = getLongOrNull(rs, "checkpoint_ledger");
+            Long cpOffset = getLongOrNull(rs, "checkpoint_offset");
+            Long cpDuration = getLongOrNull(rs, "checkpoint_duration_ms");
+            Timestamp cpTs = getTimestampOrNull(rs, "checkpoint_timestamp");
+            Integer dirtyLedgers = getIntOrNull(rs, "dirty_ledgers_count");
+            if (cpLedger != null) {
+                checkpoint.put("ledger", cpLedger);
+            }
+            if (cpOffset != null) {
+                checkpoint.put("offset", cpOffset);
+            }
+            if (dirtyLedgers != null) {
+                checkpoint.put("lag_ledgers", dirtyLedgers);
+            }
+            if (cpDuration != null) {
+                checkpoint.put("duration_ms", cpDuration);
+            }
+            if (cpTs != null) {
+                checkpoint.put("ts", TS_FORMAT.format(Instant.ofEpochMilli(cpTs.getTime())));
+            }
+            if (!checkpoint.isEmpty()) {
+                fields.put("checkpoint", checkpoint);
+            }
+        } catch (SQLException e) {
+            fields.put("syslogstatus_error", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+        }
+    }
+
+    private void fillTableStats(Connection conn, LinkedHashMap<String, Object> fields) {
+        String sql = "SELECT tablesize, dirtypages, dirtyrecords, buffersmemory, keysmemory "
+                + "FROM " + tableSpace + ".systablestats WHERE table_name=?";
+        try (java.sql.PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, config.tableName);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return;
+                }
+                LinkedHashMap<String, Object> table = new LinkedHashMap<>();
+                table.put("rows", rs.getLong("tablesize"));
+                table.put("dirty_pages", rs.getLong("dirtypages"));
+                table.put("dirty_records", rs.getLong("dirtyrecords"));
+                table.put("buffers_mb", rs.getLong("buffersmemory") / (1024L * 1024L));
+                table.put("keys_mb", rs.getLong("keysmemory") / (1024L * 1024L));
+                fields.put("table", table);
+            }
+        } catch (SQLException e) {
+            fields.put("systablestats_error", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+        }
+    }
+
+    private void fillIndexStatus(Connection conn, LinkedHashMap<String, Object> fields) {
+        String sql = "SELECT properties, index_type FROM " + tableSpace
+                + ".sysindexstatus WHERE table_name=? AND index_type='vector'";
+        try (java.sql.PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, config.tableName);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return;
+                }
+                String props = rs.getString("properties");
+                LinkedHashMap<String, Object> index = new LinkedHashMap<>();
+                extractLong(VECTOR_COUNT, props, v -> index.put("vectors", v));
+                extractLong(SEGMENT_COUNT, props, v -> index.put("segments", v));
+                extractLong(LAST_LSN_LEDGER, props, v -> index.put("lsn_ledger", v));
+                extractLong(LAST_LSN_OFFSET, props, v -> index.put("lsn_offset", v));
+                Matcher m = INDEX_STATUS.matcher(props == null ? "" : props);
+                if (m.find()) {
+                    index.put("status", m.group(1));
+                }
+                if (!index.isEmpty()) {
+                    fields.put("index", index);
+                }
+            }
+        } catch (SQLException e) {
+            fields.put("sysindexstatus_error", e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+        }
+    }
+
+    private static void extractLong(Pattern p, String haystack, java.util.function.LongConsumer sink) {
+        if (haystack == null) {
+            return;
+        }
+        Matcher m = p.matcher(haystack);
+        if (m.find()) {
+            try {
+                sink.accept(Long.parseLong(m.group(1)));
+            } catch (NumberFormatException ignore) {
+                // Malformed properties payload — skip this field rather than abort the whole sample.
+            }
+        }
+    }
+
+    private static void putLongIfPresent(ResultSet rs, String column,
+                                         LinkedHashMap<String, Object> target, String key) throws SQLException {
+        Long v = getLongOrNull(rs, column);
+        if (v != null) {
+            target.put(key, v);
+        }
+    }
+
+    private static Long getLongOrNull(ResultSet rs, String column) {
+        try {
+            long v = rs.getLong(column);
+            return rs.wasNull() ? null : v;
+        } catch (SQLException e) {
+            // Column doesn't exist on an older server — treat as null.
+            return null;
+        }
+    }
+
+    private static Integer getIntOrNull(ResultSet rs, String column) {
+        try {
+            int v = rs.getInt(column);
+            return rs.wasNull() ? null : v;
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+
+    private static Timestamp getTimestampOrNull(ResultSet rs, String column) {
+        try {
+            Timestamp v = rs.getTimestamp(column);
+            return rs.wasNull() ? null : v;
+        } catch (SQLException e) {
+            return null;
+        }
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -249,6 +249,50 @@ public class VectorBench {
             progressThread.setDaemon(true);
             progressThread.start();
 
+            // Optional status thread: every statusIntervalSeconds, query the server's
+            // syslogstatus/systablestats/sysindexstatus tables and emit a [status] line.
+            // Independent of the progress thread so slow server queries don't stall progress.
+            Thread statusThread = null;
+            if (config.statusIntervalSeconds > 0) {
+                final long statusIntervalMs = (long) config.statusIntervalSeconds * 1000L;
+                final MetricsCollector ingestMetricsForStatus = ingestMetrics;
+                final long ingestStartForStatus = ingestStart;
+                final AtomicLong commitsTotalForStatus = commitsTotal;
+                final AtomicLong commitsRecoveredForStatus = commitsRecovered;
+                statusThread = new Thread(() -> {
+                    ServerStatusSampler sampler = new ServerStatusSampler(config);
+                    long nextSample = System.currentTimeMillis() + statusIntervalMs;
+                    while (!ingestDone.get()) {
+                        try {
+                            long now = System.currentTimeMillis();
+                            if (now < nextSample) {
+                                Thread.sleep(Math.min(500L, nextSample - now));
+                                continue;
+                            }
+                            nextSample = now + statusIntervalMs;
+                            LinkedHashMap<String, Object> fields = sampler.sample();
+                            LinkedHashMap<String, Object> commits = new LinkedHashMap<>();
+                            commits.put("total", commitsTotalForStatus.get());
+                            commits.put("recovered", commitsRecoveredForStatus.get());
+                            MetricsCollector.Stats s = ingestMetricsForStatus.computeStats();
+                            commits.put("last_ms", round2(ingestMetricsForStatus.getLastNanos() / 1e6));
+                            commits.put("avg_ms", round2(s.meanNanos() / 1e6));
+                            commits.put("p50_ms", round2(s.p50Nanos() / 1e6));
+                            commits.put("p99_ms", round2(s.p99Nanos() / 1e6));
+                            commits.put("max_ms", round2(s.maxNanos() / 1e6));
+                            fields.put("commits", commits);
+                            double elapsed = (System.nanoTime() - ingestStartForStatus) / 1e9;
+                            out.status("ingest", elapsed, fields);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                    }
+                }, "vector-bench-status");
+                statusThread.setDaemon(true);
+                statusThread.start();
+            }
+
             try (DatasetLoader.VectorStream stream = loader.streamBaseVectors(config.resumeFrom, toIngest)) {
                 for (float[] vec : stream) {
                     ingestQueue.put(vec);
@@ -263,6 +307,9 @@ public class VectorBench {
 
             ingestDone.set(true);
             progressThread.join();
+            if (statusThread != null) {
+                statusThread.join();
+            }
             double ingestSecs = (System.nanoTime() - ingestStart) / 1e9;
             out.phaseDone("ingest", ingestSecs);
 

--- a/vector-testings/src/test/java/herddb/vectortesting/BenchOutputTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/BenchOutputTest.java
@@ -239,6 +239,57 @@ class BenchOutputTest {
     }
 
     @Test
+    void plainStatusEmitsFlattenedKeyValueLine() {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        BenchOutput.PlainBenchOutput out = new BenchOutput.PlainBenchOutput(printStream(sink));
+
+        LinkedHashMap<String, Object> commitlog = new LinkedHashMap<>();
+        commitlog.put("ledger", 145L);
+        commitlog.put("offset", 12345L);
+        LinkedHashMap<String, Object> checkpoint = new LinkedHashMap<>();
+        checkpoint.put("ledger", 130L);
+        checkpoint.put("lag_ledgers", 15);
+        LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+        fields.put("commitlog", commitlog);
+        fields.put("checkpoint", checkpoint);
+
+        out.status("ingest", 1200.0, fields);
+
+        String captured = captureUtf8(sink).trim();
+        assertTrue(captured.startsWith("[status] phase=ingest"),
+                "status line must start with [status] tag; got: " + captured);
+        assertTrue(captured.contains("elapsed_s=1200"));
+        assertTrue(captured.contains("commitlog_ledger=145"));
+        assertTrue(captured.contains("commitlog_offset=12345"));
+        assertTrue(captured.contains("checkpoint_ledger=130"));
+        assertTrue(captured.contains("checkpoint_lag_ledgers=15"));
+    }
+
+    @Test
+    void jsonStatusEventHasNestedStructure() throws Exception {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        BenchOutput.JsonBenchOutput out = new BenchOutput.JsonBenchOutput(printStream(sink));
+
+        LinkedHashMap<String, Object> commitlog = new LinkedHashMap<>();
+        commitlog.put("ledger", 145L);
+        commitlog.put("offset", 12345L);
+        LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+        fields.put("commitlog", commitlog);
+
+        out.status("ingest", 1200.0, fields);
+
+        String captured = captureUtf8(sink).trim();
+        JsonNode node = MAPPER.readTree(captured);
+        assertEquals("status", node.get("event").asText());
+        assertEquals("ingest", node.get("phase").asText());
+        assertEquals(1200.0, node.get("elapsed_s").asDouble(), 0.001);
+        JsonNode cl = node.get("commitlog");
+        assertNotNull(cl, "commitlog object must survive JSON serialization: " + captured);
+        assertEquals(145L, cl.get("ledger").asLong());
+        assertEquals(12345L, cl.get("offset").asLong());
+    }
+
+    @Test
     void jsonSuppressesTextHeadersAndInfo() throws Exception {
         ByteArrayOutputStream sink = new ByteArrayOutputStream();
         BenchOutput.JsonBenchOutput out = new BenchOutput.JsonBenchOutput(printStream(sink));


### PR DESCRIPTION
Closes #159.

## Summary

Two related observability improvements that make it easier to see what the HerdDB server is doing during long-running vector benchmarks.

### Feature 1 — Last-checkpoint columns on `syslogstatus`

`TableSpaceManager` now records the LSN, wall-clock timestamp, and duration of the last completed checkpoint. `syslogstatus` exposes them next to the existing commit-log write-head columns so the "how far behind is the checkpoint" gap is readable with a single `SELECT` — no external checkpoint-analyser script required.

New columns on `syslogstatus`:
- `checkpoint_ledger` — BookKeeper ledger of the last completed checkpoint's durable LSN
- `checkpoint_offset` — offset within that ledger
- `checkpoint_timestamp` — wall-clock time the checkpoint finished
- `checkpoint_duration_ms` — how long it took
- `dirty_ledgers_count` — ledgers written since the last checkpoint (recovery-work proxy)

Columns are `null` until the first checkpoint completes, so `virtual` tablespaces and freshly booted replicas remain queryable.

### Feature 2 — Periodic `[status]` dump in `VectorBench`

New flag `--status-interval-seconds N` (default 60, `0` disables). During ingestion a dedicated daemon thread opens a short-lived JDBC connection every N seconds, queries `syslogstatus` / `systablestats` / `sysindexstatus`, and emits one line like:

```
[status] phase=ingest elapsed_s=1200 commitlog_ledger=145 commitlog_offset=12345 \
  checkpoint_ledger=130 checkpoint_offset=99000 checkpoint_lag_ledgers=15 \
  checkpoint_duration_ms=309517 checkpoint_ts=2026-04-18T09:21:07 \
  table_rows=25000000 dirty_pages=0 dirty_records=15371011 buffers_mb=10240 keys_mb=2149 \
  index_vectors=8000000 index_segments=190 index_lsn_ledger=42 index_lsn_offset=74169 index_status=tailing \
  commits_total=25000 commits_recovered=0 commits_last_ms=47 commits_avg_ms=52 \
  commits_p50_ms=49 commits_p99_ms=310 commits_max_ms=15200
```

In `--output-format json` mode the same snapshot is emitted as a `status` event with nested objects (`commitlog`, `checkpoint`, `table`, `index`, `commits`).

`MetricsCollector` gained `getLastNanos()` so `commits_last_ms` reflects the most recent batch commit. The sampler tolerates older servers missing the new checkpoint columns — absent columns simply produce null fields.

## Files

- `herddb-core` — `TableSpaceManager` (tracking fields + getters), `SyslogstatusManager` (new columns), new `SyslogstatusTest`
- `vector-testings` — `Config` (`--status-interval-seconds`), `MetricsCollector` (`lastNanos`), `BenchOutput` (`status(...)` + nested-map flatten for text), `VectorBench` (status thread in ingest phase), new `ServerStatusSampler`, new `BenchOutputTest` cases

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean
- [x] `mvn -pl herddb-core -Dtest=SyslogstatusTest,SysindexstatusTest,SystemTablesTest,CleanupOnCheckPointTest test` — green
- [x] `mvn -pl vector-testings test` — 40 tests green (includes new `BenchOutputTest` cases for `status(...)`)
- [x] Re-ran `DirectMultipleConcurrentUpdatesSuite*` — the `testWithTransactionsWithCheckpoints*` methods are flaky on `master` (3/3 failures on base branch without these changes), so I isolated them and verified the rest of the suite still passes. None of my changes touch checkpoint correctness — the new TableSpaceManager fields are only written in the existing `finally` block and only read by `syslogstatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)