### PR TITLE
Fix Phase-C LSN race leaking unapplied commits into TableStatus (#157)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -221,15 +221,21 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private final StampedLock checkpointLock = new StampedLock();
 
     /**
-     * LSN of the last transactional commit whose apply to this table's pages has fully
-     * completed. Phase C reads this — rather than {@code log.getLastSequenceNumber()} —
-     * as {@code TableStatus.sequenceNumber}. See issue #157: log.getLastSequenceNumber
+     * LSN of the last log entry whose apply to this table's pages has fully completed.
+     * Phase C reads this — rather than {@code log.getLastSequenceNumber()} — as
+     * {@code TableStatus.sequenceNumber}. See issue #157: log.getLastSequenceNumber
      * can return the LSN of a commit whose apply is still waiting on the checkpoint
      * read lock; persisting that LSN would cause recovery to silently skip the commit
-     * after a restart (its change is not yet in any flushed page). Updated at the end
-     * of {@link #onTransactionCommit}, under the checkpoint read lock and after every
-     * applyInsert/applyUpdate/applyDelete for the transaction is done. Monotonic via
-     * {@link AtomicReference#updateAndGet}.
+     * after a restart (its change is not yet in any flushed page). Updated:
+     * <ul>
+     *   <li>At the end of {@link #onTransactionCommit} (under the checkpoint read
+     *       lock), with the transaction's COMMIT LSN, after every applyInsert/
+     *       applyUpdate/applyDelete for the transaction is done.</li>
+     *   <li>At the end of {@link #apply} for entries with {@code transactionId == 0}
+     *       (non-transactional DML and TRUNCATE), with the entry's LSN, after the
+     *       apply has touched pages.</li>
+     * </ul>
+     * Monotonic via {@link AtomicReference#updateAndGet}.
      */
     private final AtomicReference<LogSequenceNumber> lastAppliedSequenceNumber =
             new AtomicReference<>(LogSequenceNumber.START_OF_TIME);
@@ -2379,6 +2385,28 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             break;
             default:
                 throw new IllegalArgumentException("unhandled entry type " + entry.type);
+        }
+
+        /*
+         * Publish this entry's LSN into lastAppliedSequenceNumber for the same reason as
+         * {@link #onTransactionCommit}: Phase C uses this field as postFlushSequenceNumber, and
+         * it must cover every entry whose effect is in memory before Phase C reads it. We reach
+         * here for non-transactional DML (INSERT/UPDATE/DELETE with transactionId == 0, which
+         * runs applyInsert/applyUpdate/applyDelete inline) and for TRUNCATE (always logged with
+         * transactionId == 0 by {@link herddb.log.LogEntryFactory#truncate}). Transactional DML
+         * takes the "register-with-transaction" path earlier in the switch and does NOT touch
+         * pages, so the counter is bumped from {@code onTransactionCommit} instead.
+         *
+         * Entries filtered out by the recovery filter at lines ~2216/~2245 took an early
+         * {@code return} above and never reach this point, so we don't advance the counter for
+         * them — correct, since their effect is already in flushed pages from a prior run.
+         * See issue #157.
+         */
+        if (entry.transactionId == 0) {
+            final LogSequenceNumber entryLsn = writeResult.getLogSequenceNumber();
+            if (entryLsn != null) {
+                lastAppliedSequenceNumber.updateAndGet(cur -> entryLsn.after(cur) ? entryLsn : cur);
+            }
         }
 
     }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -109,6 +109,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -218,6 +219,20 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      * Allow checkpoint
      */
     private final StampedLock checkpointLock = new StampedLock();
+
+    /**
+     * LSN of the last transactional commit whose apply to this table's pages has fully
+     * completed. Phase C reads this — rather than {@code log.getLastSequenceNumber()} —
+     * as {@code TableStatus.sequenceNumber}. See issue #157: log.getLastSequenceNumber
+     * can return the LSN of a commit whose apply is still waiting on the checkpoint
+     * read lock; persisting that LSN would cause recovery to silently skip the commit
+     * after a restart (its change is not yet in any flushed page). Updated at the end
+     * of {@link #onTransactionCommit}, under the checkpoint read lock and after every
+     * applyInsert/applyUpdate/applyDelete for the transaction is done. Monotonic via
+     * {@link AtomicReference#updateAndGet}.
+     */
+    private final AtomicReference<LogSequenceNumber> lastAppliedSequenceNumber =
+            new AtomicReference<>(LogSequenceNumber.START_OF_TIME);
 
     /**
      * auto_increment support
@@ -671,6 +686,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             nextPrimaryKeyValue.set(Bytes.toLong(tableStatus.nextPrimaryKeyValue, 0));
             nextPageId = tableStatus.nextPageId;
             bootSequenceNumber = tableStatus.sequenceNumber;
+            lastAppliedSequenceNumber.set(bootSequenceNumber);
             activePagesAtBoot.putAll(tableStatus.activePages);
         }
         keyToPage.start(bootSequenceNumber, created);
@@ -2177,6 +2193,19 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     }
                 }
             }
+            /*
+             * Publish the commit's LSN as "last fully applied" BEFORE releasing the
+             * checkpoint read lock. Phase C acquires the write lock only after all
+             * readers have released; at that point every apply whose LSN is below
+             * this value has its change in memory and will be flushed. Applies still
+             * waiting for the read lock have NOT bumped this counter yet, so their
+             * LSNs stay above the Phase-C snapshot and get replayed from the WAL on
+             * restart. See issue #157.
+             */
+            LogSequenceNumber commitLsn = transaction.lastSequenceNumber;
+            if (commitLsn != null) {
+                lastAppliedSequenceNumber.updateAndGet(cur -> commitLsn.after(cur) ? commitLsn : cur);
+            }
         } finally {
             checkpointLock.asReadLock().unlock();
         }
@@ -3320,6 +3349,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                              * buildingPage
                              */
                             checkpointProcessedDirtyRecords.inc();
+                            if (LOGGER.isLoggable(Level.FINE)) {
+                                final Long currentPageId = keyToPage.get(unshared.key);
+                                LOGGER.log(Level.FINE,
+                                        "issue-157 dirty-page CAS-fail: table {0}.{1} key={2} oldPageId={3} buildingPage={4} currentKeyToPage={5}",
+                                        new Object[]{table.tablespace, table.name, unshared.key,
+                                            page.pageId, buildingPage.pageId, currentPageId});
+                            }
                         }
 
                     } else {
@@ -3341,10 +3377,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                          */
                         boolean handled = keyToPage.put(unshared.key, buildingPage.pageId, page.pageId);
                         if (!handled) {
+                            final Long currentPageId = keyToPage.get(unshared.key);
                             LOGGER.log(Level.INFO,
-                                    "Concurrent DML modified a record on clean page {0} during checkpoint compaction"
-                                            + " for table {1}.{2}. Aborting compaction of this page.",
-                                    new Object[]{page.pageId, table.tablespace, table.name});
+                                    "issue-157 clean-page CAS-fail: table {0}.{1} key={2} oldPageId={3} buildingPage={4} currentKeyToPage={5} — aborting compaction of this page.",
+                                    new Object[]{table.tablespace, table.name, unshared.key,
+                                        page.pageId, buildingPage.pageId, currentPageId});
                             abortPageCompaction = true;
                             break;
                         }
@@ -3776,23 +3813,35 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
 
             /*
-             * Re-read the log position AFTER all page flushes (Phase B + Phase C remaining newPages)
-             * completed, under the Phase C write lock. This LSN is an upper bound on the LSN of any
-             * entry whose effect is in a flushed page for THIS table — Phase C just flushed every
-             * remaining dirty page, so at this moment every entry with LSN ≤ postFlushSequenceNumber
-             * that affects this table is persisted.
+             * Use the LSN of the last log entry whose apply to THIS table has fully completed
+             * (tracked by {@link #lastAppliedSequenceNumber}, updated at the end of
+             * {@link #onTransactionCommit} under the checkpoint read lock). Phase C holds the
+             * write lock; the StampedLock contract guarantees that every reader has released
+             * before the write lock is granted, so every commit whose apply completed has
+             * already published its LSN to this field, and its change is sitting in a page
+             * that Phase C has flushed (currentDirtyRecordsPage or an earlier newPage).
+             *
+             * We cannot use {@code log.getLastSequenceNumber()} here: it returns the last LSN
+             * ASSIGNED to the log, which includes commits whose apply callbacks are still
+             * queued on callbacksExecutor and blocked on the checkpoint read lock. Persisting
+             * such an LSN as {@code TableStatus.sequenceNumber} loses those commits on restart —
+             * their applies run after Phase C releases the lock, writing to the fresh
+             * currentDirtyRecordsPage which is not flushed until the next checkpoint, while
+             * the per-table recovery filter at line 2114 skips their WAL entries because
+             * the persisted LSN already advertised them as applied. See issue #157.
              *
              * Persisting this LSN (rather than the Phase-A snapshot) as TableStatus.sequenceNumber
-             * makes the per-table recovery filter in {@code apply(...)} and
-             * {@code onTransactionCommit(...)} correctly skip entries/commits that were applied to
-             * flushed pages during Phase B — previously those entries could be replayed and
-             * re-applied, tripping duplicate-key {@code IllegalStateException} during recovery of
-             * the tablespace (issue #145).
-             *
-             * Phase C holds checkpointLock.asWriteLock(), so no concurrent DML on this table can
-             * advance the log between this read and the tableStatus write.
+             * still gets us the issue #145 guarantee — entries applied to flushed pages during
+             * Phase B are correctly skipped on recovery — because those applies updated
+             * lastAppliedSequenceNumber before Phase C read it.
              */
-            final LogSequenceNumber postFlushSequenceNumber = log.getLastSequenceNumber();
+            final LogSequenceNumber postFlushSequenceNumber = lastAppliedSequenceNumber.get();
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE,
+                        "issue-157 phase-C LSN: table {0}.{1} phaseA={2} postFlush={3} flushedDirty={4} flushedSmall={5} flushedNew={6} newPagesLeft={7}",
+                        new Object[]{table.tablespace, table.name, sequenceNumber, postFlushSequenceNumber,
+                            flushedDirtyPages, flushedSmallPages, flushedNewPages, newPages.size()});
+            }
 
             /*
              * Checkpoint the primary key index (BLink tree).

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuite.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuite.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -79,6 +80,10 @@ public abstract class DirectMultipleConcurrentUpdatesSuite {
         serverConfiguration.set(ServerConfiguration.PROPERTY_LOGDIR, folder.newFolder().getAbsolutePath());
 
         ConcurrentHashMap<String, Long> expectedValue = new ConcurrentHashMap<>();
+        // issue #157: per-key history of writes (thread, op, tx, oldValue -> newValue) — dumped
+        // when erroredKeys is non-empty so we can match stale reads against the actual sequence
+        // of committed writes. CopyOnWriteArrayList keeps appends from different threads safe.
+        ConcurrentHashMap<String, List<String>> writeHistory = new ConcurrentHashMap<>();
         try (Server server = new Server(serverConfiguration)) {
             server.start();
             server.waitForStandaloneBoot();
@@ -156,6 +161,13 @@ public abstract class DirectMultipleConcurrentUpdatesSuite {
                                                                   commitTransaction(manager, TableSpace.DEFAULT, transactionId);
                                                               }
                                                               expectedValue.put(key, value);
+                                                              writeHistory
+                                                                      .computeIfAbsent(key, unused -> new CopyOnWriteArrayList<>())
+                                                                      .add(String.format("t=%d tid=%d %s %d->%d",
+                                                                              Thread.currentThread().getId(),
+                                                                              transactionId,
+                                                                              update ? "UPD" : "GET",
+                                                                              actual, value));
 
                                                           } catch (Exception err) {
                                                               throw new RuntimeException(err);
@@ -187,6 +199,9 @@ public abstract class DirectMultipleConcurrentUpdatesSuite {
                         System.out.println("expected value " + data.get("n1") + ", but got " + Long.valueOf(entry.getValue()) + " for key " + entry.getKey());
                         erroredKeys.add(entry.getKey());
                     }
+                }
+                if (!erroredKeys.isEmpty()) {
+                    dumpHistory("PRE-RESTART", erroredKeys, expectedValue, writeHistory);
                 }
                 assertTrue(erroredKeys.isEmpty());
 
@@ -225,7 +240,33 @@ public abstract class DirectMultipleConcurrentUpdatesSuite {
                     erroredKeys.add(entry.getKey());
                 }
             }
+            if (!erroredKeys.isEmpty()) {
+                dumpHistory("POST-RESTART", erroredKeys, expectedValue, writeHistory);
+            }
             assertTrue(erroredKeys.isEmpty());
         }
+    }
+
+    /**
+     * Diagnostics for issue #157. Print the full writer-thread history for every key that the
+     * final scan returned a stale value for. "expected" is the last value any thread put into
+     * {@code expectedValue}; the dump lets us correlate it with the (threadId, txId, oldValue,
+     * newValue) sequence of committed writes on the same key.
+     */
+    private static void dumpHistory(
+            String stage,
+            List<String> erroredKeys,
+            Map<String, Long> expectedValue,
+            Map<String, List<String>> writeHistory) {
+        System.out.println("=== issue-157 diagnostics [" + stage + "] — " + erroredKeys.size() + " errored keys ===");
+        for (String key : erroredKeys) {
+            Long expected = expectedValue.get(key);
+            List<String> history = writeHistory.getOrDefault(key, Collections.emptyList());
+            System.out.println("  key=" + key + " expected=" + expected + " history(" + history.size() + "):");
+            for (String h : history) {
+                System.out.println("    " + h);
+            }
+        }
+        System.out.println("=== end issue-157 diagnostics [" + stage + "] ===");
     }
 }


### PR DESCRIPTION
## Summary
- TableManager Phase C captured `postFlushSequenceNumber` via `log.getLastSequenceNumber()`, which returns the last LSN *assigned* to the WAL — including commits whose apply callback is queued on `callbacksExecutor` and still blocked on the checkpoint read lock. Persisting that LSN as `TableStatus.sequenceNumber` caused recovery to silently skip those commits after restart (their change wasn't in any flushed page), producing the stale-read symptom from issue #157.
- Track the LSN of the last fully-applied transactional commit in a new per-table `AtomicReference` (`lastAppliedSequenceNumber`), updated at the end of `onTransactionCommit` under the checkpoint read lock. Phase C reads this instead. `StampedLock`'s contract guarantees every reader has released before the write lock is granted, so every applied commit's LSN is published before Phase C reads; callbacks still waiting for the read lock have NOT bumped the counter and their entries are replayed from the WAL on restart.
- Keeps the issue #145 guarantee: entries applied to flushed pages during Phase B are still correctly skipped on recovery.
- Targeted diagnostics: Phase-B CAS-fail FINE logs (key, pages, current keyToPage), Phase-C LSN FINE log, and failure-time writer-history dump in the hammer suite.

## Test plan
- [x] 20 iterations of `DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest` — 0/20 failures (baseline without fix: ~30%).
- [x] 15 iterations of `DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest` — 0/15 failures.
- [x] Full hammer trio: passes.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean.
- [ ] Investigation ongoing: one trio run saw a rare second-order stale read (single-update case, no CAS-fails involved). Will follow up in this PR if the remaining race is a distinct bug.

Fixes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)