### PR TITLE
issue #165: add checkpoint progress logging

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -970,7 +970,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             case ALREADY_FLUSHED:
                 /* Already flushed (and possibly unloaded) by another thread */
-                LOGGER.log(Level.INFO, "New page {0} already flushed in a concurrent thread", page.pageId);
+                LOGGER.log(Level.FINE, "New page {0} already flushed in a concurrent thread", page.pageId);
                 return;
 
             case EMPTY_FLUSH:
@@ -1086,7 +1086,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         try {
 
             if (!page.writable) {
-                LOGGER.log(Level.INFO, "Mutable page {0} already flushed in a concurrent thread", page.pageId);
+                LOGGER.log(Level.FINE, "Mutable page {0} already flushed in a concurrent thread", page.pageId);
                 return FlushNewPageResult.ALREADY_FLUSHED;
             }
 
@@ -1102,7 +1102,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         lock.lock();
         try {
             if (!page.writable) {
-                LOGGER.log(Level.INFO, "Mutable page {0} already flushed in a concurrent thread", page.pageId);
+                LOGGER.log(Level.FINE, "Mutable page {0} already flushed in a concurrent thread", page.pageId);
                 return FlushNewPageResult.ALREADY_FLUSHED;
             }
 
@@ -3236,6 +3236,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
         long buildingPageSize = buildingPage.getUsedMemory();
 
+        /* Progress tracking for issue #165: emit periodic INFO during long Phase B runs. */
+        final long loopStart = System.currentTimeMillis();
+        long nextProgressLogAt = loopStart + 30_000L;
+        int processedPages = 0;
+        final int totalPages = workingPages.size();
+
         /* Building page lock (not needed on clean small pages) */
         Lock lock = null;
 
@@ -3459,6 +3465,16 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         }
                     }
 
+                }
+
+                processedPages++;
+                final long nowMs = System.currentTimeMillis();
+                if (processedPages % 1000 == 0 || nowMs >= nextProgressLogAt) {
+                    LOGGER.log(Level.INFO,
+                            "checkpoint {0}.{1} Phase B progress: {2}/{3} pages flushed, {4} records, elapsed {5} ms",
+                            new Object[]{table.tablespace, table.name, processedPages, totalPages,
+                                    flushedRecords, nowMs - loopStart});
+                    nextProgressLogAt = nowMs + 30_000L;
                 }
 
                 /* Do not continue if we have used up all given time */
@@ -3754,9 +3770,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
          * page. Phase C's final flush loop still runs under the write lock to preserve the
          * issue #46 invariant.
          */
+        final long drainStart = System.currentTimeMillis();
+        LOGGER.log(Level.INFO,
+                "checkpoint {0}.{1} draining pending new pages before Phase C (post-index elapsed {2} ms)",
+                new Object[]{table.tablespace, table.name, drainStart - indexcheckpoint});
         long[] drainedCounts = drainPendingNewPages();
         flushedNewPages += (int) drainedCounts[0];
         flushedRecords += drainedCounts[1];
+        LOGGER.log(Level.INFO,
+                "checkpoint {0}.{1} drain complete: {2} pages, {3} records in {4} ms",
+                new Object[]{table.tablespace, table.name, drainedCounts[0], drainedCounts[1],
+                        System.currentTimeMillis() - drainStart});
 
 
         /* ================================================================== */
@@ -3876,9 +3900,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
              * The write lock guarantees no threads are modifying the index concurrently,
              * which is required by BLink's checkpoint() contract.
              */
+            final long keyToPageStart = System.currentTimeMillis();
+            LOGGER.log(Level.INFO,
+                    "checkpoint {0}.{1} Phase C: checkpointing PK index at {2} ({3} active pages)",
+                    new Object[]{table.tablespace, table.name, postFlushSequenceNumber,
+                            pageSet.getActivePagesCount()});
             actions.addAll(keyToPage.checkpoint(postFlushSequenceNumber, pin));
             maybeWarnOnActionAccumulation(actions);
             keytopagecheckpoint = System.currentTimeMillis();
+            LOGGER.log(Level.INFO,
+                    "checkpoint {0}.{1} Phase C: PK index checkpoint done in {2} ms",
+                    new Object[]{table.tablespace, table.name, keytopagecheckpoint - keyToPageStart});
 
             pageSet.checkpointDone(flushedPages);
 
@@ -3892,9 +3924,16 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     Bytes.longToByteArray(nextPrimaryKeyValue.get()), nextPageId,
                     pageSet.getActivePagesView());
 
+            final long tableStatusStart = System.currentTimeMillis();
+            LOGGER.log(Level.INFO,
+                    "checkpoint {0}.{1} Phase C: writing table status to storage ({2} active pages)",
+                    new Object[]{table.tablespace, table.name, pageSet.getActivePagesCount()});
             actions.addAll(dataStorageManager.tableCheckpoint(tableSpaceUUID, table.uuid, tableStatus, pin));
             maybeWarnOnActionAccumulation(actions);
             tablecheckpoint = System.currentTimeMillis();
+            LOGGER.log(Level.INFO,
+                    "checkpoint {0}.{1} Phase C: table status written in {2} ms",
+                    new Object[]{table.tablespace, table.name, tablecheckpoint - tableStatusStart});
 
             /*
              * Can happen when at checkpoint start all pages are set as dirty or immutable (immutable or

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -2571,13 +2571,35 @@ public class TableSpaceManager {
 
                     /* *** Phase C: write checkpoint marker — no tablespace lock needed *** */
                     // we are sure that all data has been flushed. upon recovery we will replay the log starting from this position
+                    final long writeCheckpointStart = System.currentTimeMillis();
+                    LOGGER.log(Level.INFO,
+                            "{0} checkpoint {1} Phase C: writing checkpoint sequence number {2} to storage",
+                            new Object[]{nodeId, tableSpaceName, logSequenceNumber});
                     actions.addAll(dataStorageManager.writeCheckpointSequenceNumber(tableSpaceUUID, logSequenceNumber));
+                    LOGGER.log(Level.INFO,
+                            "{0} checkpoint {1} Phase C: checkpoint sequence number written in {2} ms",
+                            new Object[]{nodeId, tableSpaceName,
+                                    System.currentTimeMillis() - writeCheckpointStart});
 
                     /* Indexes checkpoint is handled by TableManagers */
                     if (leader) {
+                        final long dropStart = System.currentTimeMillis();
+                        LOGGER.log(Level.INFO,
+                                "{0} checkpoint {1}: dropping old ledgers before {2}",
+                                new Object[]{nodeId, tableSpaceName, logSequenceNumber});
                         log.dropOldLedgers(logSequenceNumber);
+                        LOGGER.log(Level.INFO,
+                                "{0} checkpoint {1}: old ledger drop complete in {2} ms",
+                                new Object[]{nodeId, tableSpaceName, System.currentTimeMillis() - dropStart});
                         // Notify shared-storage read replicas of the new checkpoint
+                        final long publishStart = System.currentTimeMillis();
                         publishCheckpointLsnToMetadata(logSequenceNumber);
+                        final long publishElapsed = System.currentTimeMillis() - publishStart;
+                        if (publishElapsed > 1000) {
+                            LOGGER.log(Level.INFO,
+                                    "{0} checkpoint {1}: published checkpoint LSN to metadata in {2} ms",
+                                    new Object[]{nodeId, tableSpaceName, publishElapsed});
+                        }
                     }
 
                     _logSequenceNumber = log.getLastSequenceNumber();


### PR DESCRIPTION
## Summary

Closes #165.

During long periodic checkpoints on large workloads (bigann 100M vector bench) the server log goes silent for 3+ minutes while the checkpoint is in progress. The JVM is healthy and the checkpoint is making progress internally, but there is no visible evidence in the log — making it impossible to distinguish a healthy-but-slow checkpoint from a hung JVM.

This PR adds INFO-level progress logging to every sub-phase of the checkpoint pipeline so that at least one line is emitted every ≤ 60 s throughout a checkpoint:

- **Phase B (`cleanAndCompactPages`)**: aggregate progress line every 30 s or every 1000 pages flushed.
- **`drainPendingNewPages()`**: before/after bookends including how long the prior `indexManager.checkpoint()` took.
- **Phase C per-table**: before/after bookends around `keyToPage.checkpoint()` (BLink PK index) and `dataStorageManager.tableCheckpoint()` (TableStatus write).
- **Phase C tablespace marker**: before/after bookends around `dataStorageManager.writeCheckpointSequenceNumber()`.
- **Post-checkpoint housekeeping**: before/after bookends around `log.dropOldLedgers()`, plus a gated log around `publishCheckpointLsnToMetadata()` that fires only when the call exceeds 1 s.

Also downgrades the per-page `"already flushed in a concurrent thread"` message from INFO to FINE — the issue explicitly called this out as flooding the log, and keeping it at INFO would undermine the new aggregate progress line.

This is a pure logging change — no state mutation, no lock or ordering changes.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — PASS
- [ ] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test` — running locally, will follow up
- [ ] Manual smoke on k3s-local vector bench: verify an INFO line every ≤ 60 s throughout a full periodic checkpoint cycle

No new unit tests: the change is pure logging. The existing hammer suite above exercises the full checkpoint pipeline (concurrent DML + periodic checkpoints + recovery) and is the main regression gate for this area.

## Acceptance criteria (from the issue)

> After this change, the server log must emit at least one INFO-level checkpoint progress line every ≤ 60 seconds throughout the entire checkpoint duration, covering all phases (A, B, index catch-up, drain, C, ledger drop).

Met by the combination of Phase B's 30 s timer, the drain/Phase C/tablespace-marker bookends, and the existing Phase A and long-checkpoint-breakdown logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)