### PR TITLE
Remove checkpoint blocking on vector tailers; add WAITFORINDEXES barrier

### DIFF
--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -170,7 +170,8 @@ invariants.
 
 ```
 ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
-    --ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000 --checkpoint
+    --ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000 \
+    --checkpoint --wait-for-indexes
 ```
 
 Rules that apply to every workload, including user-specified ones:
@@ -184,12 +185,18 @@ Rules that apply to every workload, including user-specified ones:
   If the user's command omits any of these flags, add them and tell
   the user you added them.
 - **Recall / query phases must only run AFTER a successful
-  checkpoint.** If the user's command includes a recall phase but no
+  checkpoint AND a `--wait-for-indexes` barrier.** The checkpoint no
+  longer blocks on external indexing-service catch-up, so without
+  `--wait-for-indexes` recall is measured against a partially populated
+  index. If the user's command includes a recall phase but no
   `--checkpoint`, insert `--checkpoint` before the recall flags and
-  tell the user. If the checkpoint phase fails, do NOT proceed to the
+  tell the user. Always pair it with `--wait-for-indexes` (insert if
+  missing). If the checkpoint phase fails, do NOT proceed to the
   recall phase — go to the failure path.
 - **Checkpoint timeout.** Always pass `--checkpoint-timeout-seconds 1800`.
   Never use a lower value.
+- **Wait-for-indexes timeout.** Always pass
+  `--wait-for-indexes-timeout 1800`. Never use a lower value.
 - **Custom datasets** live in `gs://herddb-datasets`. The tools pod
   is pre-configured with `VECTORBENCH_DATASETS_BUCKET=gs://herddb-datasets`
   (via the Helm chart's `tools.gcs.datasetsBucket`). To run a custom
@@ -459,9 +466,12 @@ preserve existing `section` / `timestamp` helpers, and add `--help`
   traces and SEVERE log lines **verbatim**.
 - Never attempt to recover a faulty cluster. Collect, file, stop.
 - Never run recall / query phases before a successful checkpoint.
+- Always pair `--checkpoint` with `--wait-for-indexes` before recall queries;
+  the checkpoint no longer blocks on indexing-service catch-up.
 - Default ingest uses `--ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000`
   unless the user overrides them.
-- Always use `--checkpoint-timeout-seconds 1800`. Never use a lower value.
+- Always use `--checkpoint-timeout-seconds 1800` and
+  `--wait-for-indexes-timeout 1800`. Never use lower values.
 - Long waits (minutes/hours) are acceptable, but supervision MUST
   tick at least every 60 s while a bench is running.
 - Never create a GH issue on success. Issues are for failures or

--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -197,7 +197,8 @@ forbidden.
 
 ```
 ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
-    --ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000 --checkpoint
+    --ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000 \
+    --checkpoint --wait-for-indexes
 ```
 
 Rules that apply to every workload, including user-specified ones:
@@ -210,12 +211,18 @@ Rules that apply to every workload, including user-specified ones:
   If the user's command omits any of these flags, add them and tell the user
   you added them.
 - **Recall / query phases (`-k`, recall tests) must only run AFTER a
-  successful checkpoint.** If the user's command includes a recall phase but
+  successful checkpoint AND a `--wait-for-indexes` barrier.** The checkpoint
+  no longer blocks on external indexing-service catch-up, so without
+  `--wait-for-indexes` recall is measured against a partially populated
+  index. If the user's command includes a recall phase but
   no `--checkpoint`, insert `--checkpoint` before the recall flags and tell
-  the user you inserted it. If the checkpoint phase fails, do NOT proceed to
+  the user you inserted it. Always pair it with `--wait-for-indexes`
+  (insert if missing). If the checkpoint phase fails, do NOT proceed to
   the recall phase — go to the failure path.
 - **Checkpoint timeout.** Always pass `--checkpoint-timeout-seconds 1800`.
   Never use a lower value.
+- **Wait-for-indexes timeout.** Always pass
+  `--wait-for-indexes-timeout 1800`. Never use a lower value.
 
 ---
 
@@ -552,9 +559,12 @@ any new flag.
   stack traces and SEVERE log lines **verbatim** in the body.
 - Never attempt to recover a faulty cluster. Collect, file, stop.
 - Never run recall / query phases before a successful checkpoint.
+- Always pair `--checkpoint` with `--wait-for-indexes` before recall queries;
+  the checkpoint no longer blocks on indexing-service catch-up.
 - Default ingest uses `--ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000`
   unless the user overrides them.
-- Always use `--checkpoint-timeout-seconds 1800`. Never use a lower value.
+- Always use `--checkpoint-timeout-seconds 1800` and
+  `--wait-for-indexes-timeout 1800`. Never use lower values.
 - Long waits (minutes/hours) are acceptable, but supervision MUST tick at
   least every 60 s while a bench is running.
 - Never create a GH issue on success. Issues are for failures or explicit

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -781,7 +781,8 @@ public class BookkeeperCommitLog extends CommitLog {
     }
 
     @Override
-    public void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber) throws LogNotAvailableException {
+    public void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber,
+                                LogSequenceNumber tailersFloor) throws LogNotAvailableException {
         if (ledgersRetentionPeriod <= 0) {
             return;
         }
@@ -789,19 +790,31 @@ public class BookkeeperCommitLog extends CommitLog {
         // during recovery (see recovery() — it starts reading at lastCheckPoint.ledgerId).
         // Time-based retention must never delete them. When no checkpoint has happened yet
         // (START_OF_TIME, ledgerId = -1) the floor is -1 and every active ledger is kept.
-        final long ledgerLimit = Math.min(lastCheckPointSequenceNumber.ledgerId, currentLedgerId);
+        long ledgerLimit = Math.min(lastCheckPointSequenceNumber.ledgerId, currentLedgerId);
+        // Honor an external tailers floor (e.g. remote indexing services): we must not
+        // delete ledgers any tailer still needs to read. START_OF_TIME (ledgerId = -1)
+        // means "no tailer constraint" and collapses to the pre-tailer behavior; any
+        // real floor pins retention at min(ledgerLimit, tailersFloor.ledgerId).
+        if (tailersFloor != null && tailersFloor.ledgerId >= 0
+                && tailersFloor.ledgerId < ledgerLimit) {
+            LOGGER.log(Level.INFO,
+                    "dropOldLedgers pinning retention at tailersFloor {0} (was {1}), tablespace {2}",
+                    new Object[]{tailersFloor, ledgerLimit, tableSpaceDescription()});
+            ledgerLimit = tailersFloor.ledgerId;
+        }
         LOGGER.log(Level.INFO,
-                "dropOldLedgers lastCheckPointSequenceNumber: {0}, ledgersRetentionPeriod: {1}, ledgerLimit: {2}, lastLedgerId: {3}, currentLedgerId: {4}, tablespace {5}, actualLedgersList {6}",
-                new Object[]{lastCheckPointSequenceNumber, ledgersRetentionPeriod, ledgerLimit,
+                "dropOldLedgers lastCheckPointSequenceNumber: {0}, tailersFloor: {1}, ledgersRetentionPeriod: {2}, ledgerLimit: {3}, lastLedgerId: {4}, currentLedgerId: {5}, tablespace {6}, actualLedgersList {7}",
+                new Object[]{lastCheckPointSequenceNumber, tailersFloor, ledgersRetentionPeriod, ledgerLimit,
                         lastLedgerId, currentLedgerId, tableSpaceDescription(), actualLedgersList});
         long min_timestamp = System.currentTimeMillis() - ledgersRetentionPeriod;
         List<Long> oldLedgers = actualLedgersList.getOldLedgers(min_timestamp);
         LOGGER.log(Level.INFO,
                 "dropOldLedgers currentLedgerId: {0}, lastLedgerId: {1}, dropping ledgers before {2}: {3} tablespace {4}",
                 new Object[]{currentLedgerId, lastLedgerId, new java.sql.Timestamp(min_timestamp), oldLedgers, tableSpaceDescription()});
+        final long finalLedgerLimit = ledgerLimit;
         List<Long> keptForRecovery = new ArrayList<>();
         oldLedgers.removeIf(id -> {
-            if (id >= ledgerLimit) {
+            if (id >= finalLedgerLimit) {
                 keptForRecovery.add(id);
                 return true;
             }

--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -36,6 +36,7 @@ import herddb.utils.LocalLockManager;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -148,19 +149,34 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     public abstract List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin) throws DataStorageManagerException;
 
     /**
-     * Ensures that all data is persisted from disk, with a timeout for remote catch-up.
-     * The default implementation delegates to {@link #checkpoint(LogSequenceNumber, boolean)},
-     * ignoring the timeout. Subclasses that need remote synchronization (e.g. vector indexes)
-     * should override this method.
+     * Retention floor for the commit log, in support of external tailers that
+     * consume this index's log entries (e.g. remote indexing services).
+     * Implementations with no external tailer return {@link Optional#empty()}
+     * so the checkpoint LSN alone drives retention. Implementations whose state
+     * lives in external tailers return the minimum LSN currently processed
+     * across all known tailers, or {@link LogSequenceNumber#START_OF_TIME} if
+     * any known tailer is unreachable (forces maximum retention until the
+     * tailer comes back).
      *
-     * @param sequenceNumber the checkpoint LSN
-     * @param pin whether to pin the checkpoint
-     * @param catchUpTimeoutMs maximum time to wait for remote catch-up in milliseconds
-     * @return list of post-checkpoint actions
-     * @throws DataStorageManagerException on storage errors or catch-up timeout
+     * @return the retention floor LSN, or empty when no external tailer exists
      */
-    public List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin, long catchUpTimeoutMs) throws DataStorageManagerException {
-        return checkpoint(sequenceNumber, pin);
+    public Optional<LogSequenceNumber> getTailersMinLsn() {
+        return Optional.empty();
+    }
+
+    /**
+     * Blocks until external tailers for this index have processed the commit
+     * log up to at least {@code targetLsn}, or the timeout expires. The
+     * default implementation is a no-op (returns {@code true}) because most
+     * indexes have no external tailer.
+     *
+     * @param targetLsn the LSN all tailers must reach
+     * @param timeoutMs maximum time to wait in milliseconds
+     * @return {@code true} if all tailers caught up in time, {@code false} on timeout
+     * @throws InterruptedException if the waiting thread is interrupted
+     */
+    public boolean waitForTailersCatchUp(LogSequenceNumber targetLsn, long timeoutMs) throws InterruptedException {
+        return true;
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
@@ -90,14 +90,6 @@ public interface AbstractTableManager extends AutoCloseable {
     TableCheckpoint checkpoint(boolean pin) throws DataStorageManagerException;
 
     /**
-     * Perform a checkpoint with a timeout for remote index catch-up.
-     * The default implementation delegates to {@link #checkpoint(boolean)}.
-     */
-    default TableCheckpoint checkpoint(boolean pin, long catchUpTimeoutMs) throws DataStorageManagerException {
-        return checkpoint(pin);
-    }
-
-    /**
      * Performs a full deep checkpoint cleaning as much space as possible.
      * <p>
      * It's an hint for table manager for perform a more aggressive checkpoint.

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -66,6 +66,7 @@ import herddb.model.commands.GetStatement;
 import herddb.model.commands.ScanStatement;
 import herddb.model.commands.TableConsistencyCheckStatement;
 import herddb.model.commands.TableSpaceConsistencyCheckStatement;
+import herddb.model.commands.WaitForIndexesStatement;
 import herddb.network.Channel;
 import herddb.network.ServerHostData;
 import herddb.proto.Pdu;
@@ -770,11 +771,27 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             return CompletableFuture.completedFuture(dropTableSpace((DropTableSpaceStatement) statement));
         }
         if (statement instanceof CheckpointStatement) {
-            CheckpointStatement checkpointStatement = (CheckpointStatement) statement;
             try {
-                checkpoint(checkpointStatement.getCatchUpTimeoutMs());
-            } catch (Exception e) {
+                checkpoint();
+            } catch (DataStorageManagerException | LogNotAvailableException e) {
                 return Futures.exception(new StatementExecutionException("CHECKPOINT failed: " + e.getMessage(), e));
+            }
+            return CompletableFuture.completedFuture(new DDLStatementExecutionResult(TransactionContext.NOTRANSACTION_ID));
+        }
+        if (statement instanceof WaitForIndexesStatement) {
+            WaitForIndexesStatement waitStatement = (WaitForIndexesStatement) statement;
+            TableSpaceManager manager = tablesSpaces.get(waitStatement.getTableSpace());
+            if (manager == null) {
+                return Futures.exception(new NotLeaderException("No such tableSpace " + waitStatement.getTableSpace()
+                        + " here (at " + nodeId + ")"));
+            }
+            try {
+                manager.waitForIndexes(waitStatement.getTimeoutMs());
+            } catch (StatementExecutionException e) {
+                return Futures.exception(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return Futures.exception(new StatementExecutionException("WAITFORINDEXES interrupted", e));
             }
             return CompletableFuture.completedFuture(new DDLStatementExecutionResult(TransactionContext.NOTRANSACTION_ID));
         }
@@ -1004,12 +1021,8 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     }
 
     public void checkpoint() throws DataStorageManagerException, LogNotAvailableException {
-        checkpoint(Long.MAX_VALUE);
-    }
-
-    public void checkpoint(long catchUpTimeoutMs) throws DataStorageManagerException, LogNotAvailableException {
         for (TableSpaceManager man : tablesSpaces.values()) {
-            man.checkpoint(false, false, false, catchUpTimeoutMs);
+            man.checkpoint(false, false, false);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3111,17 +3111,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     @Override
     public TableCheckpoint fullCheckpoint(boolean pin) throws DataStorageManagerException {
-        return checkpoint(Double.NEGATIVE_INFINITY, fillThreshold, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE, pin, Long.MAX_VALUE);
+        return checkpoint(Double.NEGATIVE_INFINITY, fillThreshold, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE, pin);
     }
 
     @Override
     public TableCheckpoint checkpoint(boolean pin) throws DataStorageManagerException {
-        return checkpoint(dirtyThreshold, fillThreshold, checkpointTargetTime, cleanupTargetTime, compactionTargetTime, pin, Long.MAX_VALUE);
-    }
-
-    @Override
-    public TableCheckpoint checkpoint(boolean pin, long catchUpTimeoutMs) throws DataStorageManagerException {
-        return checkpoint(dirtyThreshold, fillThreshold, checkpointTargetTime, cleanupTargetTime, compactionTargetTime, pin, catchUpTimeoutMs);
+        return checkpoint(dirtyThreshold, fillThreshold, checkpointTargetTime, cleanupTargetTime, compactionTargetTime, pin);
     }
 
     @Override
@@ -3510,8 +3505,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      */
     private TableCheckpoint checkpoint(
             double dirtyThreshold, double fillThreshold,
-            long checkpointTargetTime, long cleanupTargetTime, long compactionTargetTime, boolean pin,
-            long catchUpTimeoutMs
+            long checkpointTargetTime, long cleanupTargetTime, long compactionTargetTime, boolean pin
     ) throws DataStorageManagerException {
         LOGGER.log(Level.FINE, "tableCheckpoint dirtyThreshold: " + dirtyThreshold + ", {0}.{1} (pin: {2})", new Object[]{tableSpaceUUID, table.name, pin});
         if (createdInTransaction > 0) {
@@ -3751,7 +3745,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (indexes != null) {
             for (AbstractIndexManager indexManager : indexes.values()) {
                 // Checkpoint at the same position as this TableManager's sequenceNumber
-                actions.addAll(indexManager.checkpoint(sequenceNumber, pin, catchUpTimeoutMs));
+                actions.addAll(indexManager.checkpoint(sequenceNumber, pin));
             }
         }
         maybeWarnOnActionAccumulation(actions);

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -2415,11 +2415,6 @@ public class TableSpaceManager {
 
     // visible for testing
     public TableSpaceCheckpoint checkpoint(boolean full, boolean pin, boolean alreadLocked) throws DataStorageManagerException, LogNotAvailableException {
-        return checkpoint(full, pin, alreadLocked, Long.MAX_VALUE);
-    }
-
-    // visible for testing
-    public TableSpaceCheckpoint checkpoint(boolean full, boolean pin, boolean alreadLocked, long catchUpTimeoutMs) throws DataStorageManagerException, LogNotAvailableException {
         if (virtual) {
             return null;
         }
@@ -2465,7 +2460,7 @@ public class TableSpaceManager {
 
                     for (AbstractTableManager tableManager : tables.values()) {
                         if (!tableManager.isSystemTable()) {
-                            TableCheckpoint checkpoint = full ? tableManager.fullCheckpoint(pin) : tableManager.checkpoint(pin, catchUpTimeoutMs);
+                            TableCheckpoint checkpoint = full ? tableManager.fullCheckpoint(pin) : tableManager.checkpoint(pin);
                             if (checkpoint != null) {
                                 LOGGER.log(Level.INFO, "checkpoint done for table {0}.{1} (pin: {2})", new Object[]{tableSpaceName, tableManager.getTable().name, pin});
                                 actions.addAll(checkpoint.actions);
@@ -2479,7 +2474,8 @@ public class TableSpaceManager {
 
                     actions.addAll(dataStorageManager.writeCheckpointSequenceNumber(tableSpaceUUID, logSequenceNumber));
                     if (leader) {
-                        log.dropOldLedgers(logSequenceNumber);
+                        LogSequenceNumber tailersFloor = computeTailersRetentionFloor();
+                        log.dropOldLedgers(logSequenceNumber, tailersFloor);
                         // Notify shared-storage read replicas of the new checkpoint
                         publishCheckpointLsnToMetadata(logSequenceNumber);
                     }
@@ -2547,7 +2543,7 @@ public class TableSpaceManager {
                         // recovery will replay only actions with log position after the actual table-local checkpoint
                         if (!tableManager.isSystemTable()) {
                             try {
-                                TableCheckpoint checkpoint = full ? tableManager.fullCheckpoint(pin) : tableManager.checkpoint(pin, catchUpTimeoutMs);
+                                TableCheckpoint checkpoint = full ? tableManager.fullCheckpoint(pin) : tableManager.checkpoint(pin);
                                 if (checkpoint != null) {
                                     LOGGER.log(Level.INFO, "checkpoint done for table {0}.{1} (pin: {2})", new Object[]{tableSpaceName, tableManager.getTable().name, pin});
                                     actions.addAll(checkpoint.actions);
@@ -2584,10 +2580,11 @@ public class TableSpaceManager {
                     /* Indexes checkpoint is handled by TableManagers */
                     if (leader) {
                         final long dropStart = System.currentTimeMillis();
+                        LogSequenceNumber tailersFloor = computeTailersRetentionFloor();
                         LOGGER.log(Level.INFO,
-                                "{0} checkpoint {1}: dropping old ledgers before {2}",
-                                new Object[]{nodeId, tableSpaceName, logSequenceNumber});
-                        log.dropOldLedgers(logSequenceNumber);
+                                "{0} checkpoint {1}: dropping old ledgers before {2}, tailersFloor={3}",
+                                new Object[]{nodeId, tableSpaceName, logSequenceNumber, tailersFloor});
+                        log.dropOldLedgers(logSequenceNumber, tailersFloor);
                         LOGGER.log(Level.INFO,
                                 "{0} checkpoint {1}: old ledger drop complete in {2} ms",
                                 new Object[]{nodeId, tableSpaceName, System.currentTimeMillis() - dropStart});
@@ -2637,6 +2634,75 @@ public class TableSpaceManager {
         } catch (Exception err) {
             LOGGER.log(Level.WARNING, "Failed to publish checkpoint LSN to metadata for " + tableSpaceName, err);
         }
+    }
+
+    /**
+     * Blocks until every external tailer attached to an index in this
+     * tablespace has processed the commit log up to the LSN observed when
+     * this method starts, or the timeout expires.
+     *
+     * @param timeoutMs maximum time to wait across all indexes
+     * @throws StatementExecutionException if at least one index did not catch up before the deadline
+     */
+    public void waitForIndexes(long timeoutMs) throws StatementExecutionException, InterruptedException {
+        if (timeoutMs <= 0) {
+            throw new StatementExecutionException(
+                    "WAITFORINDEXES timeoutMs must be strictly positive, got " + timeoutMs);
+        }
+        LogSequenceNumber target = log.getLastWrittenSequenceNumber();
+        if (target == null || target.isStartOfTime()) {
+            LOGGER.log(Level.INFO,
+                    "{0} waitForIndexes {1}: log has no written entries yet, nothing to wait for",
+                    new Object[]{nodeId, tableSpaceName});
+            return;
+        }
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        List<String> lagging = new ArrayList<>();
+        for (AbstractIndexManager index : indexes.values()) {
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0) {
+                lagging.add(index.getIndexName());
+                continue;
+            }
+            boolean caughtUp = index.waitForTailersCatchUp(target, remaining);
+            if (!caughtUp) {
+                lagging.add(index.getIndexName());
+            }
+        }
+        if (!lagging.isEmpty()) {
+            throw new StatementExecutionException(
+                    "WAITFORINDEXES timed out after " + timeoutMs + " ms waiting for tablespace "
+                    + tableSpaceName + " indexes " + lagging + " to reach " + target);
+        }
+        LOGGER.log(Level.INFO,
+                "{0} waitForIndexes {1}: all tailers reached {2}",
+                new Object[]{nodeId, tableSpaceName, target});
+    }
+
+    /**
+     * Computes the commit-log retention floor contributed by external tailers
+     * across every index in this tablespace. Returns {@link LogSequenceNumber#START_OF_TIME}
+     * when no index contributes a floor (meaning: no tailer constraint; the
+     * commit log falls back to its default retention behavior). Short-circuits
+     * to {@code START_OF_TIME} the moment any index reports it — a tailer we
+     * can't reach pins retention entirely.
+     */
+    private LogSequenceNumber computeTailersRetentionFloor() {
+        LogSequenceNumber floor = null;
+        for (AbstractIndexManager index : indexes.values()) {
+            Optional<LogSequenceNumber> contributed = index.getTailersMinLsn();
+            if (!contributed.isPresent()) {
+                continue;
+            }
+            LogSequenceNumber lsn = contributed.get();
+            if (LogSequenceNumber.START_OF_TIME.equals(lsn)) {
+                return LogSequenceNumber.START_OF_TIME;
+            }
+            if (floor == null || floor.after(lsn)) {
+                floor = lsn;
+            }
+        }
+        return floor != null ? floor : LogSequenceNumber.START_OF_TIME;
     }
 
     private CompletableFuture<StatementExecutionResult> beginTransactionAsync(StatementEvaluationContext context, boolean releaseLock) throws StatementExecutionException {

--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -724,9 +724,10 @@ public class FileCommitLog extends CommitLog {
     }
 
     @Override
-    public void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber) throws LogNotAvailableException {
-        LOGGER.log(Level.SEVERE, "dropOldLedgers {2} lastCheckPointSequenceNumber: {0}, currentLedgerId: {1}",
-                new Object[]{lastCheckPointSequenceNumber, currentLedgerId, tableSpaceName});
+    public void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber,
+                                LogSequenceNumber tailersFloor) throws LogNotAvailableException {
+        LOGGER.log(Level.SEVERE, "dropOldLedgers {3} lastCheckPointSequenceNumber: {0}, tailersFloor: {1}, currentLedgerId: {2}",
+                new Object[]{lastCheckPointSequenceNumber, tailersFloor, currentLedgerId, tableSpaceName});
 
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(logDirectory)) {
             List<Path> names = new ArrayList<>();
@@ -744,6 +745,15 @@ public class FileCommitLog extends CommitLog {
             int count = 0;
 
             long ledgerLimit = Math.min(lastCheckPointSequenceNumber.ledgerId, currentLedgerId);
+            // Tailer floor: don't delete files any external tailer still needs.
+            // START_OF_TIME (ledgerId = -1) means "no constraint".
+            if (tailersFloor != null && tailersFloor.ledgerId >= 0
+                    && tailersFloor.ledgerId < ledgerLimit) {
+                LOGGER.log(Level.INFO,
+                        "dropOldLedgers {0}: pinning retention at tailersFloor {1} (was {2})",
+                        new Object[]{tableSpaceName, tailersFloor, ledgerLimit});
+                ledgerLimit = tailersFloor.ledgerId;
+            }
 
             for (Path path : names) {
                 boolean lastFile = path.equals(last);

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
@@ -24,6 +24,7 @@ import herddb.log.LogSequenceNumber;
 import herddb.utils.Bytes;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * SPI interface for remote vector index search.
@@ -77,6 +78,22 @@ public interface RemoteVectorIndexService extends AutoCloseable {
      * @throws InterruptedException if the waiting thread is interrupted
      */
     boolean waitForCatchUp(String tablespace, LogSequenceNumber sequenceNumber, long timeoutMs) throws InterruptedException;
+
+    /**
+     * Returns the minimum LSN across all known IndexingService instances for
+     * the given tablespace — the floor below which commit-log segments must
+     * not be deleted while tailers are active.
+     * <p>
+     * Returns {@link Optional#empty()} when no instances are configured for
+     * this tablespace (no retention constraint). Returns
+     * {@link Optional#of(Object) Optional.of(LogSequenceNumber.START_OF_TIME)}
+     * if any instance is unreachable, which forces maximum retention until
+     * the instance comes back.
+     *
+     * @param tablespace the tablespace whose tailers should be queried
+     * @return the retention floor, or {@link Optional#empty()} when no tailers exist
+     */
+    Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace);
 
     /**
      * Status information for a remote vector index.

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
@@ -39,6 +39,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -132,36 +133,43 @@ public class VectorIndexManager extends AbstractIndexManager {
     @Override
     public List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin)
             throws DataStorageManagerException {
-        return checkpoint(sequenceNumber, pin, DEFAULT_CATCHUP_TIMEOUT_MS);
+        // Vector index state lives in the remote IndexingService, which persists its own
+        // watermarks via its tailer. Checkpoint is a no-op here; commit-log retention is
+        // enforced via getTailersMinLsn() and the client-triggered EXECUTE WAITFORINDEXES.
+        return Collections.emptyList();
     }
 
-    private static final long DEFAULT_CATCHUP_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+    @Override
+    public Optional<LogSequenceNumber> getTailersMinLsn() {
+        try {
+            return remoteService().getMinProcessedLsn(tableSpaceUUID);
+        } catch (RuntimeException e) {
+            // Broad catch: RemoteVectorIndexService is a plugin boundary (gRPC client);
+            // any failure must not crash the checkpoint and must pin retention.
+            LOGGER.log(Level.WARNING,
+                    "getTailersMinLsn: remote service error, pinning retention at START_OF_TIME", e);
+            return Optional.of(LogSequenceNumber.START_OF_TIME);
+        }
+    }
 
     @Override
-    public List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin, long catchUpTimeoutMs)
-            throws DataStorageManagerException {
-        LOGGER.log(Level.INFO, "checkpoint index {0} on table {1} tablespace {2}, targetLSN={3}, pin={4}, timeout={5}ms",
-                new Object[]{index.name, index.table, tableSpaceUUID, sequenceNumber, pin, catchUpTimeoutMs});
+    public boolean waitForTailersCatchUp(LogSequenceNumber targetLsn, long timeoutMs) throws InterruptedException {
+        LOGGER.log(Level.INFO,
+                "waitForTailersCatchUp index {0} on table {1} tablespace {2}, targetLSN={3}, timeout={4}ms",
+                new Object[]{index.name, index.table, tableSpaceUUID, targetLsn, timeoutMs});
         long start = System.nanoTime();
-        try {
-            boolean caughtUp = remoteService().waitForCatchUp(tableSpaceUUID, sequenceNumber, catchUpTimeoutMs);
-            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            if (!caughtUp) {
-                LOGGER.log(Level.WARNING, "checkpoint index {0} on table {1} waitForCatchUp timed out after {2} ms",
-                        new Object[]{index.name, index.table, elapsedMs});
-                throw new DataStorageManagerException(
-                        "IndexingService catch-up timed out after " + elapsedMs + " ms for index " + index.name);
-            }
-            LOGGER.log(Level.INFO, "checkpoint index {0} on table {1} waitForCatchUp completed in {2} ms",
+        boolean caughtUp = remoteService().waitForCatchUp(tableSpaceUUID, targetLsn, timeoutMs);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        if (!caughtUp) {
+            LOGGER.log(Level.WARNING,
+                    "waitForTailersCatchUp index {0} on table {1} timed out after {2} ms",
                     new Object[]{index.name, index.table, elapsedMs});
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            LOGGER.log(Level.SEVERE, "checkpoint index {0} on table {1} interrupted after {2} ms",
+        } else {
+            LOGGER.log(Level.INFO,
+                    "waitForTailersCatchUp index {0} on table {1} completed in {2} ms",
                     new Object[]{index.name, index.table, elapsedMs});
-            throw new DataStorageManagerException("interrupted while waiting for IndexingService catch-up", e);
         }
-        return Collections.emptyList();
+        return caughtUp;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/log/CommitLog.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLog.java
@@ -102,7 +102,25 @@ public abstract class CommitLog implements AutoCloseable {
 
     public abstract boolean isClosed();
 
-    public abstract void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber) throws LogNotAvailableException;
+    /**
+     * Drops old commit-log segments that are no longer needed for recovery.
+     * <p>
+     * Implementations must retain every segment whose ledger ID is {@code >=}
+     * {@code lastCheckPointSequenceNumber.ledgerId} (needed to replay
+     * post-checkpoint entries on recovery) and every segment whose ledger ID
+     * is {@code >= tailersFloor.ledgerId} when {@code tailersFloor.ledgerId >= 0}
+     * (needed by external tailers, e.g. remote indexing services). Passing
+     * {@link LogSequenceNumber#START_OF_TIME} (ledgerId = -1) for
+     * {@code tailersFloor} means "no additional tailer constraint" and
+     * collapses to the pre-tailer behavior.
+     *
+     * @param lastCheckPointSequenceNumber LSN of the last completed checkpoint
+     * @param tailersFloor                 minimum LSN that external tailers still need,
+     *                                     or {@link LogSequenceNumber#START_OF_TIME} if none
+     */
+    public abstract void dropOldLedgers(
+            LogSequenceNumber lastCheckPointSequenceNumber,
+            LogSequenceNumber tailersFloor) throws LogNotAvailableException;
 
     protected CommitLogListener[] listeners = null;
 

--- a/herddb-core/src/main/java/herddb/mem/MemoryCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryCommitLogManager.java
@@ -103,7 +103,8 @@ public class MemoryCommitLogManager extends CommitLogManager {
             }
 
             @Override
-            public void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber) throws LogNotAvailableException {
+            public void dropOldLedgers(LogSequenceNumber lastCheckPointSequenceNumber,
+                                        LogSequenceNumber tailersFloor) throws LogNotAvailableException {
             }
 
             @Override

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
@@ -24,23 +24,16 @@ import herddb.model.Statement;
 
 /**
  * Triggers a full checkpoint on all tablespaces.
+ * <p>
+ * The optional second SQL argument ({@code EXECUTE CHECKPOINT 'ts', timeoutSeconds})
+ * is parsed for backward compatibility but no longer has any effect: the checkpoint
+ * no longer blocks on external indexing-service catch-up. Use
+ * {@code EXECUTE WAITFORINDEXES 'ts', timeoutSeconds} as an explicit sync barrier
+ * when clients need to observe a tailer-consistent view.
  */
 public class CheckpointStatement extends Statement {
 
-    public static final long DEFAULT_CATCHUP_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-
-    private final long catchUpTimeoutMs;
-
     public CheckpointStatement(String tableSpace) {
-        this(tableSpace, DEFAULT_CATCHUP_TIMEOUT_MS);
-    }
-
-    public CheckpointStatement(String tableSpace, long catchUpTimeoutMs) {
         super(tableSpace);
-        this.catchUpTimeoutMs = catchUpTimeoutMs;
-    }
-
-    public long getCatchUpTimeoutMs() {
-        return catchUpTimeoutMs;
     }
 }

--- a/herddb-core/src/main/java/herddb/model/commands/WaitForIndexesStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/WaitForIndexesStatement.java
@@ -1,0 +1,52 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.model.commands;
+
+import herddb.model.Statement;
+
+/**
+ * Blocks until every index in a tablespace has had its external tailers
+ * (e.g. remote indexing services) process the commit log up to the LSN
+ * observed when this statement starts executing, or the timeout expires.
+ * <p>
+ * Since checkpoints no longer synchronize clients with external tailers,
+ * clients that need a tailer-consistent view (for example, before running
+ * ANN queries) must call this explicitly:
+ * {@code EXECUTE WAITFORINDEXES 'tablespace', timeoutSeconds}. The timeout
+ * is mandatory and must be strictly positive.
+ */
+public class WaitForIndexesStatement extends Statement {
+
+    private final long timeoutMs;
+
+    public WaitForIndexesStatement(String tableSpace, long timeoutMs) {
+        super(tableSpace);
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException(
+                    "WAITFORINDEXES timeoutMs must be strictly positive, got " + timeoutMs);
+        }
+        this.timeoutMs = timeoutMs;
+    }
+
+    public long getTimeoutMs() {
+        return timeoutMs;
+    }
+}

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -69,6 +69,7 @@ import herddb.model.commands.TableConsistencyCheckStatement;
 import herddb.model.commands.TableSpaceConsistencyCheckStatement;
 import herddb.model.commands.TruncateTableStatement;
 import herddb.model.commands.UpdateStatement;
+import herddb.model.commands.WaitForIndexesStatement;
 import herddb.model.planner.AggregateOp;
 import herddb.model.planner.BindableTableScanOp;
 import herddb.model.planner.FilterOp;
@@ -1072,15 +1073,38 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                             "CHECKPOINT requires a tableSpaceName parameter");
                 }
                 if (paramCount == 2) {
+                    // Second argument preserved for backward compatibility; its value is ignored.
+                    // External-tailer catch-up is now the job of EXECUTE WAITFORINDEXES.
                     Object timeoutObj = resolveValue(execute.getExprList().getExpressions().get(1), true);
-                    if (timeoutObj == null || !(timeoutObj instanceof Number)) {
+                    if (timeoutObj != null && !(timeoutObj instanceof Number)) {
                         throw new StatementExecutionException(
                                 "CHECKPOINT timeout must be a number (seconds)");
                     }
-                    long timeoutMs = ((Number) timeoutObj).longValue() * 1000;
-                    return new CheckpointStatement(tableSpaceName.toString(), timeoutMs);
                 }
                 return new CheckpointStatement(tableSpaceName.toString());
+            }
+            case "WAITFORINDEXES": {
+                int paramCount = execute.getExprList() == null ? 0 : execute.getExprList().getExpressions().size();
+                if (paramCount != 2) {
+                    throw new StatementExecutionException(
+                            "WAITFORINDEXES requires two parameters (EXECUTE WAITFORINDEXES tableSpaceName, timeoutSeconds)");
+                }
+                Object tableSpaceName = resolveValue(execute.getExprList().getExpressions().get(0), true);
+                if (tableSpaceName == null) {
+                    throw new StatementExecutionException(
+                            "WAITFORINDEXES requires a tableSpaceName parameter");
+                }
+                Object timeoutObj = resolveValue(execute.getExprList().getExpressions().get(1), true);
+                if (timeoutObj == null || !(timeoutObj instanceof Number)) {
+                    throw new StatementExecutionException(
+                            "WAITFORINDEXES timeout must be a number (seconds)");
+                }
+                long timeoutSeconds = ((Number) timeoutObj).longValue();
+                if (timeoutSeconds <= 0) {
+                    throw new StatementExecutionException(
+                            "WAITFORINDEXES timeout must be strictly positive, got " + timeoutSeconds);
+                }
+                return new WaitForIndexesStatement(tableSpaceName.toString(), timeoutSeconds * 1000L);
             }
             case "COMMITTRANSACTION": {
                 if (execute.getExprList() == null || execute.getExprList().getExpressions().size() != 2) {

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -629,7 +629,7 @@ public class BookKeeperCommitLogTest {
                 info.setLedgersTimestamps(backdated);
                 man.saveActualLedgersList(tableSpaceUUID, info);
 
-                writer.dropOldLedgers(checkpointLsn);
+                writer.dropOldLedgers(checkpointLsn, LogSequenceNumber.START_OF_TIME);
 
                 List<Long> remaining = writer.getActualLedgersList().getActiveLedgers();
                 for (Long id : below) {
@@ -694,11 +694,74 @@ public class BookKeeperCommitLogTest {
                 info.setLedgersTimestamps(backdated);
                 man.saveActualLedgersList(tableSpaceUUID, info);
 
-                writer.dropOldLedgers(LogSequenceNumber.START_OF_TIME);
+                writer.dropOldLedgers(LogSequenceNumber.START_OF_TIME, LogSequenceNumber.START_OF_TIME);
 
                 List<Long> after = writer.getActualLedgersList().getActiveLedgers();
                 assertEquals("no ledgers may be dropped before any checkpoint has happened",
                         before, after);
+            }
+        }
+    }
+
+    /**
+     * A tailers floor below the checkpoint LSN must pin retention at the floor:
+     * ledgers the tailer has not yet processed stay on disk even though the
+     * checkpoint LSN alone would allow dropping them.
+     */
+    @Test
+    public void testDropOldLedgersHonorsTailersFloor() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = newServerConfigurationWithAutoPort();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            logManager.setLedgersRetentionPeriod(1);
+            man.start();
+            logManager.start();
+
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting(1);
+                writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
+                writer.rollNewLedger();
+                writer.log(LogEntryFactory.beginTransaction(4), true).getLogSequenceNumber();
+
+                List<Long> ledgerIds = new ArrayList<>(writer.getActualLedgersList().getActiveLedgers());
+                assertTrue("need at least three ledgers, got " + ledgerIds, ledgerIds.size() >= 3);
+
+                // Checkpoint at the last ledger — without a tailer floor, everything
+                // before it would be eligible for deletion.
+                long checkpointLedger = ledgerIds.get(ledgerIds.size() - 1);
+                LogSequenceNumber checkpointLsn = new LogSequenceNumber(checkpointLedger, 0);
+                // Tailer is still reading the first ledger: pin retention there.
+                long tailerLedger = ledgerIds.get(0);
+                LogSequenceNumber tailerFloor = new LogSequenceNumber(tailerLedger, 0);
+
+                // Age every ledger so time-based retention is satisfied.
+                LedgersInfo info = writer.getActualLedgersList();
+                List<Long> backdated = new ArrayList<>();
+                for (int i = 0; i < ledgerIds.size(); i++) {
+                    backdated.add(0L);
+                }
+                info.setLedgersTimestamps(backdated);
+                man.saveActualLedgersList(tableSpaceUUID, info);
+
+                writer.dropOldLedgers(checkpointLsn, tailerFloor);
+
+                List<Long> remaining = writer.getActualLedgersList().getActiveLedgers();
+                assertTrue("ledger " + tailerLedger + " must be kept (tailer still needs it); remaining=" + remaining,
+                        remaining.contains(tailerLedger));
+                for (Long id : ledgerIds) {
+                    if (id >= checkpointLedger) {
+                        assertTrue("ledger " + id + " at/after checkpoint must be kept; remaining=" + remaining,
+                                remaining.contains(id));
+                    }
+                }
             }
         }
     }

--- a/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -126,6 +127,11 @@ public class MockRemoteVectorIndexService implements RemoteVectorIndexService {
     @Override
     public boolean waitForCatchUp(String tablespace, LogSequenceNumber sequenceNumber, long timeoutMs) {
         return true; // mock always succeeds immediately
+    }
+
+    @Override
+    public Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace) {
+        return Optional.empty();
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/file/FileCommitLogTailerFloorTest.java
+++ b/herddb-core/src/test/java/herddb/file/FileCommitLogTailerFloorTest.java
@@ -1,0 +1,178 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.file;
+
+import static org.junit.Assert.assertTrue;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.server.ServerConfiguration;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Exercises the tailers-floor contract of {@link FileCommitLog#dropOldLedgers}.
+ * Rollover is triggered by setting {@code maxLogFileSize} very small so every
+ * entry starts a new ledger file.
+ */
+public class FileCommitLogTailerFloorTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private FileCommitLogManager newManager(Path base) {
+        return new FileCommitLogManager(base,
+                /* maxLogFileSize */ 1L,
+                ServerConfiguration.PROPERTY_MAX_UNSYNCHED_BATCH_DEFAULT,
+                ServerConfiguration.PROPERTY_MAX_UNSYNCHED_BATCH_BYTES_DEFAULT,
+                ServerConfiguration.PROPERTY_MAX_SYNC_TIME_DEFAULT,
+                /* requireSync */ false,
+                /* enableO_DIRECT */ false,
+                ServerConfiguration.PROPERTY_DEFERRED_SYNC_PERIOD_DEFAULT,
+                NullStatsLogger.INSTANCE);
+    }
+
+    private Path tsFolder(Path base) {
+        return base.resolve("ts.txlog");
+    }
+
+    private List<Long> listLogLedgers(Path logDirectory) throws java.io.IOException {
+        List<Long> ids = new ArrayList<>();
+        try (java.util.stream.Stream<Path> stream = Files.list(logDirectory)) {
+            for (Path p : (Iterable<Path>) stream::iterator) {
+                String name = p.getFileName().toString();
+                if (name.endsWith(".txlog")) {
+                    ids.add(Long.parseLong(name.replace(".txlog", ""), 16));
+                }
+            }
+        }
+        ids.sort(Comparator.naturalOrder());
+        return ids;
+    }
+
+    private LogSequenceNumber writeEntry(FileCommitLog log) throws Exception {
+        return log.log(LogEntryFactory.beginTransaction(0L), true).getLogSequenceNumber();
+    }
+
+    /**
+     * Without a tailer floor ({@code START_OF_TIME}), deletion is governed solely by the
+     * checkpoint LSN — existing behavior. Ledgers below the checkpoint are deleted;
+     * the last file is always retained.
+     */
+    @Test
+    public void startOfTimeFloorBehavesLikeBefore() throws Exception {
+        Path base = folder.newFolder().toPath();
+        LogSequenceNumber checkpoint;
+        try (FileCommitLogManager manager = newManager(base)) {
+            manager.start();
+            try (FileCommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                writeEntry(log);
+                writeEntry(log);
+                checkpoint = writeEntry(log);
+                writeEntry(log);
+                writeEntry(log);
+                List<Long> before = listLogLedgers(tsFolder(base));
+                assertTrue("expected multiple ledgers to be created, got " + before,
+                        before.size() >= 3);
+                log.dropOldLedgers(checkpoint, LogSequenceNumber.START_OF_TIME);
+            }
+            List<Long> after = listLogLedgers(tsFolder(base));
+            for (long id : after) {
+                assertTrue("ledger " + id + " below checkpoint " + checkpoint.ledgerId
+                                + " should have been dropped",
+                        id >= checkpoint.ledgerId || id == after.get(after.size() - 1));
+            }
+        }
+    }
+
+    /**
+     * A tailers floor below the checkpoint must pin retention at the floor: ledgers
+     * the tailer has not yet processed stay on disk even though the checkpoint LSN
+     * alone would allow dropping them.
+     */
+    @Test
+    public void tailersFloorPinsRetentionBelowCheckpoint() throws Exception {
+        Path base = folder.newFolder().toPath();
+        LogSequenceNumber oldLsn;
+        LogSequenceNumber checkpoint;
+        try (FileCommitLogManager manager = newManager(base)) {
+            manager.start();
+            try (FileCommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                oldLsn = writeEntry(log);
+                writeEntry(log);
+                writeEntry(log);
+                checkpoint = writeEntry(log);
+                writeEntry(log);
+                writeEntry(log);
+                log.dropOldLedgers(checkpoint, oldLsn);
+            }
+            List<Long> after = listLogLedgers(tsFolder(base));
+            assertTrue("ledger " + oldLsn.ledgerId + " must be kept (tailer still needs it); got " + after,
+                    after.contains(oldLsn.ledgerId));
+        }
+    }
+
+    /**
+     * Recovery must tolerate older log files that were kept on disk because a
+     * tailer pinned them: the recovery loop reads forward from the checkpoint
+     * ledger, so the extra older files are silently ignored.
+     */
+    @Test
+    public void recoverySkipsPiledUpOldLedgers() throws Exception {
+        Path base = folder.newFolder().toPath();
+        LogSequenceNumber oldLsn;
+        LogSequenceNumber checkpoint;
+        try (FileCommitLogManager manager = newManager(base)) {
+            manager.start();
+            try (FileCommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                oldLsn = writeEntry(log);
+                writeEntry(log);
+                checkpoint = writeEntry(log);
+                writeEntry(log);
+                log.dropOldLedgers(checkpoint, oldLsn);
+            }
+        }
+        try (FileCommitLogManager manager = newManager(base)) {
+            manager.start();
+            try (FileCommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                AtomicInteger applied = new AtomicInteger();
+                log.recovery(checkpoint, (lsn, entry) -> {
+                    applied.incrementAndGet();
+                    assertTrue("recovery must not replay entries below checkpoint LSN (got " + lsn + ")",
+                            lsn.ledgerId >= checkpoint.ledgerId);
+                }, false);
+                // Recovery completed without throwing and without replaying any
+                // ledger below the checkpoint — the piled old ledgers are silently
+                // skipped.
+            }
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
@@ -111,6 +111,11 @@ public class VectorIndexManagerSearchStreamTest {
         }
 
         @Override
+        public java.util.Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace) {
+            return java.util.Optional.empty();
+        }
+
+        @Override
         public void close() {
             // no-op
         }

--- a/herddb-core/src/test/java/herddb/mem/MemoryCommitLogTailerFloorTest.java
+++ b/herddb-core/src/test/java/herddb/mem/MemoryCommitLogTailerFloorTest.java
@@ -1,0 +1,56 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.mem;
+
+import herddb.log.CommitLog;
+import herddb.log.LogSequenceNumber;
+import org.junit.Test;
+
+/**
+ * MemoryCommitLog has no persistent state to drop, so {@code dropOldLedgers}
+ * is a no-op. These tests simply verify the two-argument signature is
+ * callable and that both {@code START_OF_TIME} and a real floor are
+ * accepted without throwing.
+ */
+public class MemoryCommitLogTailerFloorTest {
+
+    @Test
+    public void dropOldLedgersWithStartOfTimeFloorIsANoOp() throws Exception {
+        try (MemoryCommitLogManager manager = new MemoryCommitLogManager()) {
+            manager.start();
+            try (CommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                log.dropOldLedgers(new LogSequenceNumber(1, 0), LogSequenceNumber.START_OF_TIME);
+            }
+        }
+    }
+
+    @Test
+    public void dropOldLedgersWithTailersFloorIsANoOp() throws Exception {
+        try (MemoryCommitLogManager manager = new MemoryCommitLogManager()) {
+            manager.start();
+            try (CommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                log.dropOldLedgers(new LogSequenceNumber(10, 5), new LogSequenceNumber(3, 7));
+            }
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/sql/WaitForIndexesExecuteTest.java
+++ b/herddb-core/src/test/java/herddb/sql/WaitForIndexesExecuteTest.java
@@ -1,0 +1,118 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql;
+
+import static herddb.core.TestUtils.execute;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.DBManager;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.StatementExecutionException;
+import herddb.model.commands.WaitForIndexesStatement;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Parse + execute tests for the new {@code EXECUTE WAITFORINDEXES} SQL procedure.
+ * With no external tailers configured, the default implementation of
+ * {@link herddb.core.AbstractIndexManager#waitForTailersCatchUp} returns true,
+ * so the procedure completes immediately.
+ */
+public class WaitForIndexesExecuteTest {
+
+    private DBManager buildManager() throws Exception {
+        DBManager manager = new DBManager("localhost",
+                new MemoryMetadataStorageManager(),
+                new MemoryDataStorageManager(),
+                new MemoryCommitLogManager(), null, null);
+        manager.start();
+        assertTrue(manager.waitForBootOfLocalTablespaces(10000));
+        return manager;
+    }
+
+    @Test
+    public void waitForIndexesOnDefaultTablespaceWithNoIndexes() throws Exception {
+        try (DBManager manager = buildManager()) {
+            execute(manager, "CREATE TABLE herd.t1 (id int primary key, v varchar)", Collections.emptyList());
+            execute(manager, "INSERT INTO herd.t1 VALUES (1, 'hello')", Collections.emptyList());
+            execute(manager, "EXECUTE WAITFORINDEXES 'herd', 60", Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void waitForIndexesOnEmptyTablespace() throws Exception {
+        // No writes yet: log has no written LSN, so the procedure returns immediately.
+        try (DBManager manager = buildManager()) {
+            execute(manager, "EXECUTE WAITFORINDEXES 'herd', 60", Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void requiresTimeoutArgument() throws Exception {
+        try (DBManager manager = buildManager()) {
+            try {
+                execute(manager, "EXECUTE WAITFORINDEXES 'herd'", Collections.emptyList());
+                fail("Expected StatementExecutionException");
+            } catch (StatementExecutionException e) {
+                assertTrue(e.getMessage(),
+                        e.getMessage().contains("WAITFORINDEXES requires two parameters"));
+            }
+        }
+    }
+
+    @Test
+    public void rejectsZeroTimeout() throws Exception {
+        try (DBManager manager = buildManager()) {
+            try {
+                execute(manager, "EXECUTE WAITFORINDEXES 'herd', 0", Collections.emptyList());
+                fail("Expected StatementExecutionException");
+            } catch (StatementExecutionException e) {
+                assertTrue(e.getMessage(),
+                        e.getMessage().contains("strictly positive"));
+            }
+        }
+    }
+
+    @Test
+    public void rejectsNegativeTimeout() throws Exception {
+        try (DBManager manager = buildManager()) {
+            try {
+                execute(manager, "EXECUTE WAITFORINDEXES 'herd', -5", Collections.emptyList());
+                fail("Expected StatementExecutionException");
+            } catch (StatementExecutionException e) {
+                assertTrue(e.getMessage(),
+                        e.getMessage().contains("strictly positive"));
+            }
+        }
+    }
+
+    @Test
+    public void statementConstructorRejectsNonPositiveTimeout() {
+        try {
+            new WaitForIndexesStatement("herd", 0L);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("strictly positive"));
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -420,6 +421,42 @@ public class IndexingServiceClient implements RemoteVectorIndexService, DynamicS
         LOGGER.log(Level.WARNING, "Instance {0} did not catch up for tablespace {1} to {2} within timeout ({3} ms)",
                 new Object[]{server, tablespace, target, timeoutMs});
         return false;
+    }
+
+    @Override
+    public Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace) {
+        ServerSnapshot s = this.snapshot;
+        if (s.servers.isEmpty()) {
+            return Optional.empty();
+        }
+        LogSequenceNumber min = null;
+        for (Map.Entry<String, ManagedChannel> serverEntry : s.channels.entrySet()) {
+            String server = serverEntry.getKey();
+            ManagedChannel channel = serverEntry.getValue();
+            try {
+                IndexingServiceGrpc.IndexingServiceBlockingStub stub =
+                        IndexingServiceGrpc.newBlockingStub(channel)
+                                .withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
+                GetIndexStatusResponse resp = stub.getIndexStatus(GetIndexStatusRequest.newBuilder()
+                        .setTablespace(tablespace)
+                        .setTable("")
+                        .setIndex("")
+                        .build());
+                LogSequenceNumber instanceLsn = new LogSequenceNumber(
+                        resp.getLastLsnLedger(), resp.getLastLsnOffset());
+                if (min == null || min.after(instanceLsn)) {
+                    min = instanceLsn;
+                }
+            } catch (RuntimeException e) {
+                // Plugin boundary: any gRPC failure means we can't be sure the tailer
+                // has made progress, so we force maximum retention.
+                LOGGER.log(Level.WARNING,
+                        "getMinProcessedLsn: instance {0} unreachable for tablespace {1}: {2}",
+                        new Object[]{server, tablespace, e.getMessage()});
+                return Optional.of(LogSequenceNumber.START_OF_TIME);
+            }
+        }
+        return Optional.ofNullable(min);
     }
 
     public List<String> getServers() {

--- a/herddb-services/src/test/java/herddb/server/StaticDiscoveryRemoteFileIndexingTest.java
+++ b/herddb-services/src/test/java/herddb/server/StaticDiscoveryRemoteFileIndexingTest.java
@@ -154,8 +154,12 @@ public class StaticDiscoveryRemoteFileIndexingTest {
                                             "INSERT INTO t1(id, vec) VALUES(?, ?)",
                                             0, false, true, Arrays.asList(3, vecZ));
 
-                                    // Checkpoint to flush data to remote storage
+                                    // Checkpoint to flush data to remote storage, then wait for
+                                    // the indexing service to catch up on the commit log.
                                     server.getManager().checkpoint();
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "EXECUTE WAITFORINDEXES 'herd', 60",
+                                            0, false, true, Collections.emptyList());
 
                                     // ANN search for vector closest to X axis
                                     float[] query = {1.0f, 0.0f, 0.0f, 0.0f};

--- a/herddb-services/src/test/java/herddb/server/VectorIndexEndToEndTest.java
+++ b/herddb-services/src/test/java/herddb/server/VectorIndexEndToEndTest.java
@@ -254,8 +254,12 @@ public class VectorIndexEndToEndTest {
                                 "INSERT INTO t1(id, vec) VALUES(?, ?)",
                                 0, false, true, Arrays.asList(3, vecZ));
 
-                        // Force a checkpoint to make sure the indexing service has caught up
+                        // Force a checkpoint, then wait for the indexing service to catch up
+                        // (checkpoint no longer implicitly syncs tailers — see WAITFORINDEXES).
                         server.getManager().checkpoint();
+                        con.executeUpdate(TableSpace.DEFAULT,
+                                "EXECUTE WAITFORINDEXES 'herd', 60",
+                                0, false, true, Collections.emptyList());
 
                         // Search for the vector closest to X axis
                         float[] query = {1.0f, 0.0f, 0.0f, 0.0f};

--- a/herddb-services/src/test/java/herddb/server/ZKDiscoveryRemoteFileIndexingTest.java
+++ b/herddb-services/src/test/java/herddb/server/ZKDiscoveryRemoteFileIndexingTest.java
@@ -214,8 +214,12 @@ public class ZKDiscoveryRemoteFileIndexingTest {
                                                     "INSERT INTO t1(id, vec) VALUES(?, ?)",
                                                     0, false, true, Arrays.asList(4, vecW));
 
-                                            // Checkpoint to flush data to remote storage
+                                            // Checkpoint to flush data to remote storage, then wait
+                                            // for the indexing service to catch up on the log.
                                             server.getManager().checkpoint();
+                                            con.executeUpdate(TableSpace.DEFAULT,
+                                                    "EXECUTE WAITFORINDEXES 'herd', 60",
+                                                    0, false, true, Collections.emptyList());
 
                                             // ANN search for vector closest to Y axis
                                             float[] query = {0.0f, 1.0f, 0.0f, 0.0f};
@@ -378,6 +382,9 @@ public class ZKDiscoveryRemoteFileIndexingTest {
                                                     0, false, true, Arrays.asList(2, vecY));
 
                                             server.getManager().checkpoint();
+                                            con.executeUpdate(TableSpace.DEFAULT,
+                                                    "EXECUTE WAITFORINDEXES 'herd', 60",
+                                                    0, false, true, Collections.emptyList());
 
                                             float[] query = {0.0f, 1.0f, 0.0f, 0.0f};
                                             try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT,

--- a/herddb-services/src/test/java/herddb/server/ZKDiscoveryVectorIndexTest.java
+++ b/herddb-services/src/test/java/herddb/server/ZKDiscoveryVectorIndexTest.java
@@ -195,8 +195,11 @@ public class ZKDiscoveryVectorIndexTest {
                                             "INSERT INTO t1(id, vec) VALUES(?, ?)",
                                             0, false, true, Arrays.asList(4, vecW));
 
-                                    // Force checkpoint so the indexing service catches up
+                                    // Force checkpoint then wait for the indexing service to catch up
                                     server.getManager().checkpoint();
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "EXECUTE WAITFORINDEXES 'herd', 60",
+                                            0, false, true, Collections.emptyList());
 
                                     // ANN search for vector closest to X axis
                                     float[] query = {1.0f, 0.0f, 0.0f, 0.0f};
@@ -356,8 +359,11 @@ public class ZKDiscoveryVectorIndexTest {
                                         "INSERT INTO t1(id, vec) VALUES(?, ?)",
                                         0, false, true, Arrays.asList(4, vecW));
 
-                                // Force checkpoint so both indexing services catch up
+                                // Force checkpoint then wait for both indexing services to catch up
                                 server.getManager().checkpoint();
+                                con.executeUpdate(TableSpace.DEFAULT,
+                                        "EXECUTE WAITFORINDEXES 'herd', 60",
+                                        0, false, true, Collections.emptyList());
 
                                 // ANN search for vector closest to Y axis
                                 float[] query = {0.0f, 1.0f, 0.0f, 0.0f};
@@ -502,6 +508,9 @@ public class ZKDiscoveryVectorIndexTest {
                                             0, false, true, Arrays.asList(2, vecY));
 
                                     server.getManager().checkpoint();
+                                    con.executeUpdate(TableSpace.DEFAULT,
+                                            "EXECUTE WAITFORINDEXES 'herd', 60",
+                                            0, false, true, Collections.emptyList());
 
                                     float[] query = {1.0f, 0.0f, 0.0f, 0.0f};
                                     try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT,
@@ -627,6 +636,9 @@ public class ZKDiscoveryVectorIndexTest {
                                         0, false, true, Arrays.asList(2, vecY));
 
                                 server.getManager().checkpoint();
+                                con.executeUpdate(TableSpace.DEFAULT,
+                                        "EXECUTE WAITFORINDEXES 'herd', 60",
+                                        0, false, true, Collections.emptyList());
 
                                 float[] query = {0.0f, 1.0f, 0.0f, 0.0f};
                                 try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT,

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -63,6 +63,8 @@ public class Config {
     int ingestMaxOpsPerSecond = 100_000; // 0 = unlimited
     int ingestCommitRetries = 3;
     int checkpointTimeoutSeconds = 300;
+    boolean waitForIndexes = false;
+    int waitForIndexesTimeoutSeconds = 600;
     boolean noProgress = false;
     OutputFormat outputFormat = OutputFormat.TEXT;
     /**
@@ -104,6 +106,11 @@ public class Config {
                 "Retries per failed batch commit before failing the run (default: 3, "
                         + "exponential back-off 10s/20s/40s...)");
         opts.addOption(null, "checkpoint-timeout-seconds", true, "Seconds to wait for the Indexing Service to catch up during --checkpoint (default: 300)");
+        opts.addOption(null, "wait-for-indexes", false,
+                "Before running queries, run EXECUTE WAITFORINDEXES to block until all external tailers (indexing services) have caught up. "
+                        + "Required for reliable recall numbers when tailers are in use.");
+        opts.addOption(null, "wait-for-indexes-timeout", true,
+                "Seconds to wait for external tailers to catch up during --wait-for-indexes (default: 600)");
         opts.addOption(null, "no-progress", false,
                 "Disable animated spinner; emit one plain \\n-terminated line per progress sample "
                         + "(implicitly enabled when VECTOR_BENCH_NO_PROGRESS=1 or --output-format=json)");
@@ -220,6 +227,12 @@ public class Config {
         }
         if (cmd.hasOption("checkpoint-timeout-seconds")) {
             cfg.checkpointTimeoutSeconds = Integer.parseInt(cmd.getOptionValue("checkpoint-timeout-seconds"));
+        }
+        if (cmd.hasOption("wait-for-indexes")) {
+            cfg.waitForIndexes = true;
+        }
+        if (cmd.hasOption("wait-for-indexes-timeout")) {
+            cfg.waitForIndexesTimeoutSeconds = Integer.parseInt(cmd.getOptionValue("wait-for-indexes-timeout"));
         }
         if (cmd.hasOption("no-progress")) {
             cfg.noProgress = true;
@@ -345,6 +358,12 @@ public class Config {
         if (props.containsKey("checkpoint-timeout-seconds")) {
             checkpointTimeoutSeconds = Integer.parseInt(props.getProperty("checkpoint-timeout-seconds"));
         }
+        if (props.containsKey("wait-for-indexes")) {
+            waitForIndexes = Boolean.parseBoolean(props.getProperty("wait-for-indexes"));
+        }
+        if (props.containsKey("wait-for-indexes-timeout")) {
+            waitForIndexesTimeoutSeconds = Integer.parseInt(props.getProperty("wait-for-indexes-timeout"));
+        }
         if (props.containsKey("no-progress")) {
             noProgress = Boolean.parseBoolean(props.getProperty("no-progress"));
         }
@@ -429,6 +448,8 @@ public class Config {
                 + ", dropTable=" + dropTable
                 + ", checkpoint=" + checkpoint
                 + ", checkpointTimeoutSeconds=" + checkpointTimeoutSeconds
+                + ", waitForIndexes=" + waitForIndexes
+                + ", waitForIndexesTimeoutSeconds=" + waitForIndexesTimeoutSeconds
                 + ", clientTimeoutSeconds=" + clientTimeoutSeconds
                 + ", noProgress=" + noProgress
                 + ", outputFormat=" + outputFormat

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -97,6 +97,7 @@ public class VectorBench {
         // Summary accumulators
         double ingestionWallSecs = -1, indexWallSecs = -1, queryWallSecs = -1;
         double checkpointPostIngestSecs = -1, checkpointPostIndexSecs = -1;
+        double waitForIndexesSecs = -1;
         long ingestionRows = 0;
         double ingestionThroughput = 0;
         MetricsCollector.Stats ingestionLatency = null;
@@ -389,6 +390,19 @@ public class VectorBench {
             });
         }
 
+        // Phase 5c: Wait for external tailers (indexing services) to catch up.
+        // Without this barrier, ANN queries can miss recently inserted vectors because the
+        // VectorIndexManager checkpoint no longer blocks on tailer catch-up.
+        if (config.waitForIndexes) {
+            out.info("Waiting for indexing services to catch up (timeout " + config.waitForIndexesTimeoutSeconds + "s)...");
+            waitForIndexesSecs = runWithProgress(out, "wait_for_indexes", "=== WAIT FOR INDEXES ===", () -> {
+                try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
+                     Statement stmt = conn.createStatement()) {
+                    stmt.execute("EXECUTE WAITFORINDEXES 'herd', " + config.waitForIndexesTimeoutSeconds);
+                }
+            });
+        }
+
         // Phase 6: Queries
         out.header("=== QUERY PHASE ===");
         out.phaseStart("query");
@@ -467,6 +481,7 @@ public class VectorBench {
         double totalWallSecs = (System.nanoTime() - benchmarkStartNs) / 1e9;
         emitSummary(out, config, ingestionWallSecs, ingestionRows, ingestionThroughput, ingestionLatency,
                 checkpointPostIngestSecs, indexWallSecs, checkpointPostIndexSecs,
+                waitForIndexesSecs,
                 queryWallSecs, queriesRun, queryThroughput, queryLatency,
                 recall, recallK, recallQueries, totalWallSecs);
 
@@ -487,6 +502,7 @@ public class VectorBench {
                                     double checkpointPostIngestSecs,
                                     double indexWallSecs,
                                     double checkpointPostIndexSecs,
+                                    double waitForIndexesSecs,
                                     double queryWallSecs, long queriesRun, double queryThroughput,
                                     MetricsCollector.Stats queryLatency,
                                     double recall, int recallK, int recallQueries,
@@ -534,6 +550,13 @@ public class VectorBench {
             LinkedHashMap<String, Object> f = new LinkedHashMap<>();
             f.put("wall_time_s", round1(checkpointPostIndexSecs));
             out.phaseEnd("checkpoint_post_index", f);
+        }
+
+        if (waitForIndexesSecs >= 0) {
+            LinkedHashMap<String, Object> f = new LinkedHashMap<>();
+            f.put("wall_time_s", round1(waitForIndexesSecs));
+            f.put("timeout_s", config.waitForIndexesTimeoutSeconds);
+            out.phaseEnd("wait_for_indexes", f);
         }
 
         if (queryLatency != null) {


### PR DESCRIPTION
## Summary

- **Stop blocking tablespace checkpoints on external vector-index tailers.** `VectorIndexManager.checkpoint()` used to call `RemoteVectorIndexService.waitForCatchUp(...)` with a 5-minute timeout, serializing tablespace progress with indexing-service tailer speed. The correct invariant is *not* "checkpoint waits for tailers" but "commit-log segments a tailer still needs are not deleted". This PR moves the constraint from checkpoint-time blocking to retention-time filtering.
- **Pull-based retention floor.** Each `AbstractIndexManager` can contribute a floor via `getTailersMinLsn()`. `VectorIndexManager` returns the minimum LSN across all configured indexing-service instances, or `START_OF_TIME` if any is unreachable (forces maximum retention until it comes back). `TableSpaceManager.computeTailersRetentionFloor()` aggregates across indexes and passes the floor to `CommitLog.dropOldLedgers(checkpointLsn, tailersFloor)`. BookkeeperCommitLog / FileCommitLog honor it; MemoryCommitLog is a no-op. Recovery already tolerates piled-up older ledgers.
- **New SQL procedure `EXECUTE WAITFORINDEXES 'tablespace', timeoutSeconds`.** Because the checkpoint is no longer a sync point between clients and tailers, clients that need a tailer-consistent view (e.g. before ANN queries) must call this explicitly. Mandatory timeout, strictly positive. Plumbed via `WaitForIndexesStatement` → `DBManager.waitForIndexes()` → `TableSpaceManager.waitForIndexes()` → `AbstractIndexManager.waitForTailersCatchUp()`.
- **3-arg `checkpoint(LSN, boolean, long)` removed** through `AbstractIndexManager`, `AbstractTableManager`, `TableManager`, `TableSpaceManager`, `DBManager`. `CheckpointStatement` still parses the optional second SQL argument for backward compatibility but ignores it — the catch-up semantics are now in `WAITFORINDEXES`.
- **VectorBench gets `--wait-for-indexes` / `--wait-for-indexes-timeout`** flags that run the new procedure between index creation and the query phase. Recall was race-dependent without it. `herddb-k3s-bench` and `herddb-gke-bench` agent defaults updated to always pair `--checkpoint` with `--wait-for-indexes` before recall queries.

## Drop-vector-index case

Falls out naturally: once the index is gone, no `AbstractIndexManager` contributes a floor, so the next checkpoint drops the piled-up ledgers without any special handling.

## Tests

New / updated:
- `FileCommitLogTailerFloorTest` — floor pins retention below checkpoint; `START_OF_TIME` behaves like pre-change; recovery skips piled-up older ledgers.
- `MemoryCommitLogTailerFloorTest` — new two-arg `dropOldLedgers` signature accepted.
- `BookKeeperCommitLogTest.testDropOldLedgersHonorsTailersFloor` — cluster-mode equivalent. Existing tests updated for the new signature.
- `WaitForIndexesExecuteTest` — parse + execute, empty tablespace, mandatory timeout, rejection of zero / negative timeouts, constructor validation.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` green locally
- [x] `mvn -pl herddb-core -Dtest='FileCommitLogTailerFloorTest,MemoryCommitLogTailerFloorTest,WaitForIndexesExecuteTest,CheckpointExecuteTest' test` green (15/15)
- [x] Hammer suites `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` green (12/12)
- [x] Checkpoint-related regression (`Checkpoint*`, `*Checkpoint*`, `VectorIndexManager*`) green (65/65)
- [ ] Cluster-mode `BookKeeperCommitLogTest` (ZK-backed) — verify in CI
- [ ] Manual k3s-local smoke: stop an indexing-service pod mid-load, verify tablespace checkpoints keep completing while the BookKeeper ledger count grows, then restore and verify the next checkpoint drops the accumulated ledgers

🤖 Generated with [Claude Code](https://claude.com/claude-code)