### PR TITLE
issue #173: surface bench ingest worker failures and track committed rows

### DIFF
--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -55,6 +55,7 @@ public class IngestionWorker implements Runnable {
     private final long ingestStartNanos;
     private final AtomicLong commitsTotal;
     private final AtomicLong commitsRecovered;
+    private final AtomicLong rowsCommitted;
 
     /**
      * Base of the exponential back-off between commit retries, in milliseconds.
@@ -65,7 +66,7 @@ public class IngestionWorker implements Runnable {
 
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
-                           AtomicLong commitsTotal, AtomicLong commitsRecovered) {
+                           AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted) {
         this.config = config;
         this.queue = queue;
         this.done = done;
@@ -75,6 +76,7 @@ public class IngestionWorker implements Runnable {
         this.ingestStartNanos = ingestStartNanos;
         this.commitsTotal = commitsTotal;
         this.commitsRecovered = commitsRecovered;
+        this.rowsCommitted = rowsCommitted;
     }
 
     private static String formatEta(double seconds) {
@@ -140,6 +142,7 @@ public class IngestionWorker implements Runnable {
             try {
                 long latencyNanos = flushBatch(ps, conn, batchStartNanos);
                 commitsTotal.incrementAndGet();
+                rowsCommitted.addAndGet(batch.size());
                 if (attempt > 0) {
                     commitsRecovered.incrementAndGet();
                 }
@@ -273,14 +276,14 @@ public class IngestionWorker implements Runnable {
                     rowsIngested += pendingBatch.size();
                     pendingBatch.clear();
                 }
-            } catch (SQLException | ExecutionException | InterruptedException e) {
-                System.err.println("Ingestion error: " + e.getMessage());
-                e.printStackTrace();
-                safelyRollback(conn);
             }
-        } catch (SQLException e) {
-            System.err.println("Connection error: " + e.getMessage());
-            e.printStackTrace();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Ingestion worker interrupted", e);
+        } catch (SQLException | ExecutionException e) {
+            // Propagate: awaitTermination ignores task exceptions, so swallowing here
+            // would silently drop the uncommitted pendingBatch.
+            throw new RuntimeException("Ingestion worker failed", e);
         }
     }
 }

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -30,8 +30,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -204,13 +206,15 @@ public class VectorBench {
             AtomicLong rowId = new AtomicLong(config.resumeFrom);
             AtomicLong commitsTotal = new AtomicLong(0);
             AtomicLong commitsRecovered = new AtomicLong(0);
+            AtomicLong rowsCommitted = new AtomicLong(0);
 
             long ingestStart = System.nanoTime();
 
             ExecutorService ingestPool = Executors.newFixedThreadPool(config.ingestThreads);
+            List<Future<?>> ingestFutures = new ArrayList<>(config.ingestThreads);
             for (int t = 0; t < config.ingestThreads; t++) {
-                ingestPool.submit(new IngestionWorker(config, ingestQueue, producerDone, rowId, ingestMetrics,
-                        ingestStatus, ingestStart, commitsTotal, commitsRecovered));
+                ingestFutures.add(ingestPool.submit(new IngestionWorker(config, ingestQueue, producerDone, rowId,
+                        ingestMetrics, ingestStatus, ingestStart, commitsTotal, commitsRecovered, rowsCommitted)));
             }
 
             // Progress display thread runs during the entire ingestion
@@ -306,6 +310,27 @@ public class VectorBench {
             ingestPool.shutdown();
             ingestPool.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
+            // awaitTermination ignores task-level exceptions, so a worker that died
+            // mid-flush leaves its partial batch silently uncommitted unless we
+            // explicitly drain each Future.
+            for (Future<?> f : ingestFutures) {
+                try {
+                    f.get();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause() != null ? e.getCause() : e;
+                    throw new IllegalStateException("Ingest worker failed: " + cause.getMessage(), cause);
+                }
+            }
+
+            long rowsAssigned = rowId.get() - config.resumeFrom;
+            long committed = rowsCommitted.get();
+            if (committed != rowsAssigned) {
+                throw new IllegalStateException(String.format(
+                        "Ingest lost %d rows: assigned=%d committed=%d "
+                                + "(no worker exception surfaced — investigate logs)",
+                        rowsAssigned - committed, rowsAssigned, committed));
+            }
+
             ingestDone.set(true);
             progressThread.join();
             if (statusThread != null) {
@@ -330,7 +355,7 @@ public class VectorBench {
 
             // Verify row count matches ingested records
             if (!config.skipVerify) {
-                long expectedRows = rowId.get();
+                long expectedRows = config.resumeFrom + rowsCommitted.get();
                 long[] actualCount = {0};
                 runWithProgress(out, "verification", "=== VERIFICATION (COUNT) ===", () -> {
                     try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
@@ -130,10 +130,15 @@ class IngestionWorkerTest {
     }
 
     private IngestionWorker createTestWorker() {
-        return createTestWorker(new Config(), new AtomicLong(0), new AtomicLong(0));
+        return createTestWorker(new Config(), new AtomicLong(0), new AtomicLong(0), new AtomicLong(0));
     }
 
     private IngestionWorker createTestWorker(Config config, AtomicLong commitsTotal, AtomicLong commitsRecovered) {
+        return createTestWorker(config, commitsTotal, commitsRecovered, new AtomicLong(0));
+    }
+
+    private IngestionWorker createTestWorker(Config config, AtomicLong commitsTotal, AtomicLong commitsRecovered,
+                                             AtomicLong rowsCommitted) {
         IngestionWorker worker = new IngestionWorker(
                 config,
                 new java.util.concurrent.LinkedBlockingQueue<>(),
@@ -143,7 +148,8 @@ class IngestionWorkerTest {
                 new java.util.concurrent.atomic.AtomicReference<>(""),
                 System.nanoTime(),
                 commitsTotal,
-                commitsRecovered
+                commitsRecovered,
+                rowsCommitted
         );
         worker.backoffBaseMillis = 0L; // keep tests fast
         return worker;
@@ -209,6 +215,80 @@ class IngestionWorkerTest {
         assertEquals(3, conn.commitAttempts, "initial + 2 retries = 3 attempts");
         assertEquals(0L, commitsTotal.get());
         assertEquals(0L, commitsRecovered.get());
+    }
+
+    /**
+     * A successful {@code commitWithRetry} bumps {@code rowsCommitted} by exactly
+     * the batch size — this counter is how {@code VectorBench} detects silent
+     * data loss (issue #173) before the 270 s COUNT(*) verification.
+     */
+    @Test
+    void testCommitWithRetryIncrementsRowsCommitted() throws Exception {
+        FakePreparedStatement ps = new FakePreparedStatement();
+        FakeConnection conn = new FakeConnection();
+
+        AtomicLong commitsTotal = new AtomicLong(0);
+        AtomicLong commitsRecovered = new AtomicLong(0);
+        AtomicLong rowsCommitted = new AtomicLong(0);
+        IngestionWorker worker = createTestWorker(new Config(), commitsTotal, commitsRecovered, rowsCommitted);
+
+        List<IngestionWorker.PendingRow> batch = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            batch.add(new IngestionWorker.PendingRow(i, new float[]{(float) i}));
+        }
+
+        worker.commitWithRetry(ps, conn, batch, System.nanoTime());
+
+        assertEquals(7L, rowsCommitted.get(), "rowsCommitted should equal batch size after one successful commit");
+        assertEquals(1L, commitsTotal.get());
+    }
+
+    /**
+     * When retries eventually succeed, {@code rowsCommitted} is bumped exactly once
+     * (not per-attempt) — the counter must reflect rows actually persisted, not
+     * attempted flushes.
+     */
+    @Test
+    void testRowsCommittedBumpedOnceDespiteRetries() throws Exception {
+        FakePreparedStatement ps = new FakePreparedStatement();
+        FakeConnection conn = new FakeConnection();
+        conn.commitFailsRemaining = 2;
+
+        Config config = new Config();
+        config.ingestCommitRetries = 3;
+        AtomicLong rowsCommitted = new AtomicLong(0);
+        IngestionWorker worker = createTestWorker(config, new AtomicLong(0), new AtomicLong(0), rowsCommitted);
+
+        List<IngestionWorker.PendingRow> batch = new ArrayList<>();
+        batch.add(new IngestionWorker.PendingRow(1L, new float[]{1f}));
+        batch.add(new IngestionWorker.PendingRow(2L, new float[]{2f}));
+
+        worker.commitWithRetry(ps, conn, batch, System.nanoTime());
+
+        assertEquals(2L, rowsCommitted.get(), "rowsCommitted should be bumped exactly once, not per-attempt");
+    }
+
+    /**
+     * When retries are exhausted, {@code rowsCommitted} stays at zero — no rows
+     * were persisted, so none should be counted as committed.
+     */
+    @Test
+    void testRowsCommittedNotBumpedOnExhaustedRetries() {
+        FakePreparedStatement ps = new FakePreparedStatement();
+        FakeConnection conn = new FakeConnection();
+        conn.failOnCommit = true;
+
+        Config config = new Config();
+        config.ingestCommitRetries = 2;
+        AtomicLong rowsCommitted = new AtomicLong(0);
+        IngestionWorker worker = createTestWorker(config, new AtomicLong(0), new AtomicLong(0), rowsCommitted);
+
+        List<IngestionWorker.PendingRow> batch = new ArrayList<>();
+        batch.add(new IngestionWorker.PendingRow(1L, new float[]{1f}));
+
+        assertThrows(SQLException.class,
+                () -> worker.commitWithRetry(ps, conn, batch, System.nanoTime()));
+        assertEquals(0L, rowsCommitted.get());
     }
 
     /**


### PR DESCRIPTION
Closes #173.

## Summary

The bigann 100M k3s bench failed with a `COUNT(*)` mismatch (99,997,000 vs 100,000,000) because 3 ingest batches (3,000 rows) were silently dropped. The cause: `IngestionWorker.run()` swallowed any `SQLException`/`ExecutionException`/`InterruptedException` from the final `pendingBatch` flush, and the main thread submitted workers as `Runnable` without ever draining a `Future<?>`. `ingestPool.awaitTermination()` ignores task-level exceptions, so partial batches of up to `batchSize` rows per worker could vanish without a trace.

Changes:
- `IngestionWorker.run()` now rethrows SQL/Execution/Interrupted failures as `RuntimeException` instead of logging and returning; the `Connection` try-with-resources already handles rollback on close.
- `commitWithRetry` bumps a new `rowsCommitted` `AtomicLong` by `batch.size()` after each successful flush (alongside `commitsTotal`).
- `VectorBench` now captures each worker `Future<?>`, joins them after `awaitTermination`, and asserts `rowsCommitted == rowId - resumeFrom` **before** the 270 s `COUNT(*)` verification — so any future silent-loss regression fails fast with a clear message (`"Ingest lost N rows: assigned=... committed=..."`).
- Verification `expectedRows` now uses `rowsCommitted` directly.

Unit tests cover the new counter: successful commit bumps `rowsCommitted` by batch size, retried commits bump it exactly once, exhausted retries leave it at zero.

## Test plan

- [x] `mvn -pl vector-testings -Dtest=IngestionWorkerTest test` — 11/11 passing (8 existing + 3 new)
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [ ] Re-run the original bigann 100M workload on k3s and confirm the bench succeeds (or, if any worker dies, fails loudly with an actionable message rather than a 270 s-delayed `COUNT(*)` mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)