### PR TITLE
Eliminate ReadResult.content copies on the file-service hot path

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -43,7 +43,9 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -423,8 +425,12 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                     public void onNext(ReadFileResponse response) {
                         if (response.getFound()) {
                             ByteString content = response.getContent();
-                            ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(content.size());
-                            buf.writeBytes(content.asReadOnlyByteBuffer());
+                            int size = content.size();
+                            ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(size);
+                            // Single copy from the protobuf LiteralByteString into the
+                            // pooled direct buffer; matches doReadFileRangeAsByteBufAsync.
+                            content.copyTo(buf.nioBuffer(0, size));
+                            buf.writerIndex(size);
                             result = buf;
                         }
                     }
@@ -654,6 +660,106 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     /**
+     * ByteBuf variant of {@link #readFileRangeAsync(String, long, int, int)} —
+     * the response bytes land directly in a pooled direct {@link ByteBuf} via
+     * {@code ByteString.copyTo(ByteBuffer)}, skipping the throw-away
+     * {@code byte[]} that {@code response.getContent().toByteArray()} would
+     * allocate. The protobuf parser still materialises the response payload
+     * once inside its {@code LiteralByteString} (gRPC marshaller-mandated copy);
+     * eliminating that requires bypassing protobuf entirely.
+     * <p>
+     * Cross-block ranges are returned as a {@link CompositeByteBuf} view of the
+     * two slices — no extra arraycopy. Caller MUST {@code release()} the result
+     * when done. Returns {@code null} if the file is not found.
+     */
+    public CompletableFuture<ByteBuf> readFileRangeAsByteBufAsync(String path, long offset,
+                                                                  int length, int blockSize) {
+        long startBlock = offset / blockSize;
+        long endBlock = (offset + length - 1) / blockSize;
+        if (startBlock == endBlock) {
+            return doReadFileRangeAsByteBufAsync(path, offset, length, blockSize);
+        }
+        int firstBlockEnd = (int) ((startBlock + 1) * (long) blockSize - offset);
+        int secondLength = length - firstBlockEnd;
+        return doReadFileRangeAsByteBufAsync(path, offset, firstBlockEnd, blockSize)
+                .thenCompose(first -> {
+                    if (first == null) {
+                        return CompletableFuture.completedFuture((ByteBuf) null);
+                    }
+                    long secondOffset = (startBlock + 1) * (long) blockSize;
+                    return doReadFileRangeAsByteBufAsync(path, secondOffset, secondLength, blockSize)
+                            .thenApply(second -> {
+                                if (second == null) {
+                                    return first;
+                                }
+                                // CompositeByteBuf gives a contiguous view over the two
+                                // pooled slices without copying their bytes. addComponent
+                                // takes ownership of the component's refcount.
+                                CompositeByteBuf composite = PooledByteBufAllocator.DEFAULT
+                                        .compositeDirectBuffer(2);
+                                composite.addComponent(true, first);
+                                composite.addComponent(true, second);
+                                return composite;
+                            })
+                            .exceptionally(t -> {
+                                ReferenceCountUtil.safeRelease(first);
+                                if (t instanceof RuntimeException) {
+                                    throw (RuntimeException) t;
+                                }
+                                throw new RuntimeException(t);
+                            });
+                });
+    }
+
+    private CompletableFuture<ByteBuf> doReadFileRangeAsByteBufAsync(String path, long offset,
+                                                                    int length, int blockSize) {
+        return retryAsync(() -> {
+            long blockIndex = offset / blockSize;
+            CompletableFuture<ByteBuf> future = new CompletableFuture<>();
+            readStubForBlock(path, blockIndex).readFileRange(
+                    ReadFileRangeRequest.newBuilder()
+                            .setPath(path)
+                            .setOffset(offset)
+                            .setLength(length)
+                            .setBlockSize(blockSize)
+                            .build(),
+                    new StreamObserver<ReadFileRangeResponse>() {
+                        private ByteBuf result;
+
+                        @Override
+                        public void onNext(ReadFileRangeResponse response) {
+                            if (response.getFound()) {
+                                ByteString content = response.getContent();
+                                int size = content.size();
+                                ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(size);
+                                // copyTo writes into the ByteBuffer view of the pooled buf
+                                // and the protobuf parser already holds the bytes in heap;
+                                // this is the single copy from heap into direct memory.
+                                content.copyTo(buf.nioBuffer(0, size));
+                                buf.writerIndex(size);
+                                result = buf;
+                            }
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            if (result != null) {
+                                result.release();
+                                result = null;
+                            }
+                            future.completeExceptionally(t);
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            future.complete(result);
+                        }
+                    });
+            return future;
+        }, "readFileRange", path, 0);
+    }
+
+    /**
      * Writes an {@link InputStream} as a multipart file, splitting into blocks of {@code blockSize}.
      * Uses a pooled heap ByteBuf internally to avoid per-block allocations.
      * Blocks are written sequentially. Returns the total number of bytes written.
@@ -783,6 +889,14 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     public byte[] readFileRange(String path, long offset, int length, int blockSize) {
         return getUnchecked(readFileRangeAsync(path, offset, length, blockSize));
+    }
+
+    /**
+     * Synchronous variant of {@link #readFileRangeAsByteBufAsync}.
+     * Caller MUST {@code release()} the returned buffer when done.
+     */
+    public ByteBuf readFileRangeAsByteBuf(String path, long offset, int length, int blockSize) {
+        return getUnchecked(readFileRangeAsByteBufAsync(path, offset, length, blockSize));
     }
 
     public int getBlockSize() {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -22,9 +22,10 @@ package herddb.remote;
 
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.bookkeeper.stats.Counter;
@@ -67,7 +68,15 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     private final Counter clientReadRequests;
 
     private long position;
-    private byte[] blockBuffer;
+    /**
+     * Pooled direct ByteBuf holding the currently-cached block. Owned by this reader
+     * and released in {@link #close()} (and on every reload). All accessors
+     * ({@link #readInt}, {@link #readLong}, {@link #readFloat}, {@link #readFully},
+     * {@link #read}) operate at absolute offsets via Netty's getX(int) primitives,
+     * which compile to Unsafe memcpy/load — no per-call temporary allocations.
+     */
+    @Nullable
+    private ByteBuf blockBuffer;
     private long bufferedBlockIndex = -1;
 
     /**
@@ -151,12 +160,23 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
 
     @Override
     public int readInt() throws IOException {
-        byte[] buf = new byte[4];
-        readFully(buf);
-        return ((buf[0] & 0xFF) << 24)
-                | ((buf[1] & 0xFF) << 16)
-                | ((buf[2] & 0xFF) << 8)
-                | (buf[3] & 0xFF);
+        ensureBlockLoaded();
+        int offsetInBlock = (int) (position % bufferSize);
+        // Block boundary check: an int never spans two blocks because writeBlockSize
+        // is constrained to be a multiple of bufferSize (see constructor); but the
+        // logical end-of-file may sit mid-block. Fall back to readFully(byte[4]) only
+        // if the int crosses a block boundary inside this buffered window.
+        if (offsetInBlock + Integer.BYTES <= blockBuffer.readableBytes()) {
+            int v = blockBuffer.getInt(offsetInBlock); // big-endian, matches the previous bit-shift code
+            position += Integer.BYTES;
+            return v;
+        }
+        byte[] tmp = new byte[Integer.BYTES];
+        readFully(tmp);
+        return ((tmp[0] & 0xFF) << 24)
+                | ((tmp[1] & 0xFF) << 16)
+                | ((tmp[2] & 0xFF) << 8)
+                | (tmp[3] & 0xFF);
     }
 
     @Override
@@ -166,11 +186,18 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
 
     @Override
     public long readLong() throws IOException {
-        byte[] buf = new byte[8];
-        readFully(buf);
+        ensureBlockLoaded();
+        int offsetInBlock = (int) (position % bufferSize);
+        if (offsetInBlock + Long.BYTES <= blockBuffer.readableBytes()) {
+            long v = blockBuffer.getLong(offsetInBlock); // big-endian
+            position += Long.BYTES;
+            return v;
+        }
+        byte[] tmp = new byte[Long.BYTES];
+        readFully(tmp);
         long v = 0;
-        for (int i = 0; i < 8; i++) {
-            v = (v << 8) | (buf[i] & 0xFF);
+        for (int i = 0; i < Long.BYTES; i++) {
+            v = (v << 8) | (tmp[i] & 0xFF);
         }
         return v;
     }
@@ -182,9 +209,11 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         while (remaining > 0) {
             ensureBlockLoaded();
             int offsetInBlock = (int) (position % bufferSize);
-            int available = blockBuffer.length - offsetInBlock;
+            int available = blockBuffer.readableBytes() - offsetInBlock;
             int toCopy = Math.min(available, remaining);
-            System.arraycopy(blockBuffer, offsetInBlock, dest, destOffset, toCopy);
+            // getBytes(int srcIndex, byte[] dst, int dstIndex, int length) is a single
+            // Unsafe memcpy from the pooled direct buffer into the heap array.
+            blockBuffer.getBytes(offsetInBlock, dest, destOffset, toCopy);
             position += toCopy;
             destOffset += toCopy;
             remaining -= toCopy;
@@ -193,9 +222,19 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
 
     @Override
     public void readFully(ByteBuffer buffer) throws IOException {
-        byte[] tmp = new byte[buffer.remaining()];
-        readFully(tmp);
-        buffer.put(tmp);
+        while (buffer.hasRemaining()) {
+            ensureBlockLoaded();
+            int offsetInBlock = (int) (position % bufferSize);
+            int available = blockBuffer.readableBytes() - offsetInBlock;
+            int toCopy = Math.min(available, buffer.remaining());
+            // Bounded view of the destination so getBytes copies exactly toCopy bytes
+            // without overshooting; no temporary heap array.
+            ByteBuffer view = buffer.duplicate();
+            view.limit(view.position() + toCopy);
+            blockBuffer.getBytes(offsetInBlock, view);
+            buffer.position(buffer.position() + toCopy);
+            position += toCopy;
+        }
     }
 
     @Override
@@ -214,17 +253,18 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
 
     @Override
     public void read(float[] floats, int offset, int count) throws IOException {
-        byte[] buf = new byte[count * 4];
-        readFully(buf);
-        ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.BIG_ENDIAN);
         for (int i = 0; i < count; i++) {
-            floats[offset + i] = bb.getFloat();
+            floats[offset + i] = readFloat();
         }
     }
 
     @Override
     public void close() throws IOException {
-        // stateless; nothing to close
+        if (blockBuffer != null) {
+            ReferenceCountUtil.safeRelease(blockBuffer);
+            blockBuffer = null;
+            bufferedBlockIndex = -1;
+        }
     }
 
     private void ensureBlockLoaded() throws IOException {
@@ -242,7 +282,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
             clientReadRequests.inc();
         }
         long startNanos = System.nanoTime();
-        byte[] data = client.readFileRange(path, bufferOffset, requestLength, writeBlockSize);
+        ByteBuf data = client.readFileRangeAsByteBuf(path, bufferOffset, requestLength, writeBlockSize);
         long elapsedNanos = System.nanoTime() - startNanos;
         if (data == null) {
             if (clientReadLatency != null) {
@@ -258,6 +298,10 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         }
         if (clientReadBytes != null) {
             clientReadBytes.inc();
+        }
+        // Release the previously cached block (if any) before reassigning.
+        if (blockBuffer != null) {
+            ReferenceCountUtil.safeRelease(blockBuffer);
         }
         blockBuffer = data;
         bufferedBlockIndex = bufferIndex;

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
@@ -73,7 +73,7 @@ public class CachingObjectStorage implements ObjectStorage {
     private final ExecutorService executor;
     private final Cache<String, Long> diskLru;
     private final Striped<ReadWriteLock> locks = Striped.lazyWeakReadWriteLock(STRIPES);
-    private final ConcurrentHashMap<String, CompletableFuture<ReadResult>> inFlightReads = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CompletableFuture<ByteBuf>> inFlightReads = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlightWrites = new ConcurrentHashMap<>();
 
     public CachingObjectStorage(ObjectStorage inner, Path cacheDir, ExecutorService executor,
@@ -169,6 +169,58 @@ public class CachingObjectStorage implements ObjectStorage {
         return result;
     }
 
+    /**
+     * Asynchronously writes {@code buf}'s readable bytes to a cache file using
+     * {@link AsynchronousFileChannel}. The caller must hold a refcount on
+     * {@code buf}; this method releases that refcount when the write completes
+     * (success or failure). The buffer's reader/writer indices are not modified.
+     */
+    private CompletableFuture<Void> writeCacheFileAsync(String path, ByteBuf buf) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        Path target = cacheFilePath(path);
+        Path tmp = cacheDir.resolve(target.getFileName() + ".tmp");
+        int len = buf.readableBytes();
+
+        try {
+            AsynchronousFileChannel channel = AsynchronousFileChannel.open(
+                    tmp, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            // nioBuffer on a direct pooled ByteBuf returns a view, no copy.
+            ByteBuffer nio = buf.nioBuffer(buf.readerIndex(), len);
+            channel.write(nio, 0, null, new CompletionHandler<Integer, Void>() {
+                @Override
+                public void completed(Integer bytesWritten, Void attachment) {
+                    try {
+                        channel.close();
+                        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                        result.complete(null);
+                    } catch (Throwable t) {
+                        deleteCacheFile(path);
+                        result.completeExceptionally(t);
+                    } finally {
+                        buf.release();
+                    }
+                }
+
+                @Override
+                public void failed(Throwable exc, Void attachment) {
+                    try {
+                        channel.close();
+                    } catch (IOException ignored) {
+                    }
+                    deleteCacheFile(path);
+                    buf.release();
+                    result.completeExceptionally(exc);
+                }
+            });
+        } catch (Throwable t) {
+            deleteCacheFile(path);
+            buf.release();
+            result.completeExceptionally(t);
+        }
+
+        return result;
+    }
+
     private void deleteCacheFile(String path) {
         try {
             Files.deleteIfExists(cacheFilePath(path));
@@ -197,6 +249,38 @@ public class CachingObjectStorage implements ObjectStorage {
                     return;
                 }
                 diskLru.put(path, (long) content.length);
+                pending.complete(null);
+            } finally {
+                inFlightWrites.remove(path, pending);
+            }
+        });
+
+        return pending;
+    }
+
+    /**
+     * ByteBuf overload of {@link #admitToDisk(String, byte[])}. The caller must hold
+     * a refcount on {@code buf}; this method releases that refcount when the disk
+     * write completes (success or failure). The buffer's reader/writer indices are
+     * not modified.
+     */
+    private CompletableFuture<Void> admitToDisk(String path, ByteBuf buf) {
+        CompletableFuture<Void> pending = new CompletableFuture<>();
+        CompletableFuture<Void> existing = inFlightWrites.putIfAbsent(path, pending);
+        if (existing != null) {
+            // Another thread is already writing this path; release our retain and attach.
+            buf.release();
+            return existing;
+        }
+
+        int size = buf.readableBytes();
+        writeCacheFileAsync(path, buf).whenComplete((v, err) -> {
+            try {
+                if (err != null) {
+                    pending.completeExceptionally(err);
+                    return;
+                }
+                diskLru.put(path, (long) size);
                 pending.complete(null);
             } finally {
                 inFlightWrites.remove(path, pending);
@@ -291,38 +375,87 @@ public class CachingObjectStorage implements ObjectStorage {
      * Loads {@code path} from the inner storage, deduplicating concurrent loads of the
      * same key. On a successful load the bytes are written to disk and registered in
      * the LRU before being returned.
+     * <p>
+     * The pooled {@link ByteBuf} from the inner storage is kept end-to-end: it is
+     * shared by the disk-write path and by every concurrent caller (each gets a
+     * {@code retainedDuplicate} via {@code pending.thenApply}). No heap copy.
      */
     private CompletableFuture<ReadResult> loadAndCache(String path) {
-        CompletableFuture<ReadResult> pending = new CompletableFuture<>();
-        CompletableFuture<ReadResult> existing = inFlightReads.putIfAbsent(path, pending);
+        CompletableFuture<ByteBuf> pending = new CompletableFuture<>();
+        // Register the wrapDuplicate dependent BEFORE issuing inner.read. inner.read
+        // may complete synchronously (e.g. test fakes returning a completed future),
+        // and the disk-write completion runs on an I/O thread that races with this
+        // method's return. Keeping the dependent attached up front guarantees it
+        // fires inside pending.complete — while the alive-for-followers retain is
+        // still held — instead of after the alive retain has already been released.
+        CompletableFuture<ReadResult> resultFuture = pending.thenApply(CachingObjectStorage::wrapDuplicate);
+
+        CompletableFuture<ByteBuf> existing = inFlightReads.putIfAbsent(path, pending);
         if (existing != null) {
-            return existing;
+            return existing.thenApply(CachingObjectStorage::wrapDuplicate);
         }
-        inner.read(path).thenCompose(result -> {
-            if (result.status() == ReadResult.Status.FOUND) {
-                // Write to cache asynchronously before returning the result
-                byte[] content = result.content();  // Make copy before releasing
-                result.release();  // Release the pooled ByteBuf
-                return admitToDisk(path, content).thenApply(v -> {
-                    // Need to return a new ReadResult with the content
-                    ByteBuf newBuf = PooledByteBufAllocator.DEFAULT.directBuffer(content.length);
-                    newBuf.writeBytes(content);
-                    return ReadResult.found(newBuf);
-                });
-            }
-            return CompletableFuture.completedFuture(result);
-        }).whenComplete((result, err) -> {
-            try {
-                if (err != null) {
+        inner.read(path).whenComplete((result, err) -> {
+            if (err != null) {
+                try {
                     pending.completeExceptionally(err);
-                } else {
-                    pending.complete(result);
+                } finally {
+                    inFlightReads.remove(path, pending);
                 }
+                return;
+            }
+            if (result.status() != ReadResult.Status.FOUND) {
+                try {
+                    pending.complete(null);
+                } finally {
+                    inFlightReads.remove(path, pending);
+                }
+                return;
+            }
+            ByteBuf buf = result.byteBuf();
+            // Two extra retains:
+            //   +1 for admitToDisk (released inside writeCacheFileAsync when the disk write finishes).
+            //   +1 to keep buf alive across pending.complete so all dependents
+            //      (original caller + any in-flight followers) can retainedDuplicate.
+            // The original `result`'s refcount is dropped right after.
+            buf.retain(2);
+            CompletableFuture<Void> diskWrite = admitToDisk(path, buf);
+            try {
+                diskWrite.whenComplete((v, e) -> {
+                    try {
+                        if (e != null) {
+                            try {
+                                pending.completeExceptionally(e);
+                            } finally {
+                                inFlightReads.remove(path, pending);
+                            }
+                            return;
+                        }
+                        try {
+                            // pending.complete fires all dependents synchronously here:
+                            // each does retainedDuplicate(buf), bumping refcount per caller.
+                            pending.complete(buf);
+                        } finally {
+                            inFlightReads.remove(path, pending);
+                        }
+                    } finally {
+                        // Drop the alive-for-followers retain. Each successful follower
+                        // already holds its own retainedDuplicate; failed completion has
+                        // no followers to keep alive.
+                        buf.release();
+                    }
+                });
             } finally {
-                inFlightReads.remove(path, pending);
+                result.release();
             }
         });
-        return pending;
+        return resultFuture;
+    }
+
+    private static ReadResult wrapDuplicate(ByteBuf buf) {
+        if (buf == null) {
+            return ReadResult.notFound();
+        }
+        return ReadResult.found(buf.retainedDuplicate());
     }
 
     @Override
@@ -418,9 +551,8 @@ public class CachingObjectStorage implements ObjectStorage {
             }
             int to = Math.min(offsetInBlock + length, blockLength);
             int sliceLength = to - offsetInBlock;
-            ByteBuf sliceBuf = PooledByteBufAllocator.DEFAULT.directBuffer(sliceLength);
-            sliceBuf.writeBytes(blockBuf, blockBuf.readerIndex() + offsetInBlock, sliceLength);
-            return ReadResult.found(sliceBuf);
+            // retainedSlice shares the underlying memory; no copy.
+            return ReadResult.found(blockBuf.retainedSlice(blockBuf.readerIndex() + offsetInBlock, sliceLength));
         } finally {
             full.release();
         }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
@@ -22,10 +22,9 @@ package herddb.remote.storage;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -53,8 +52,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
 
     private final ObjectStorage inner;
-    private final Cache<BlockKey, byte[]> cache;
-    private final ConcurrentHashMap<BlockKey, CompletableFuture<ReadResult>> inFlight = new ConcurrentHashMap<>();
+    private final Cache<BlockKey, ByteBuf> cache;
+    private final ConcurrentHashMap<BlockKey, CompletableFuture<ByteBuf>> inFlight = new ConcurrentHashMap<>();
     private final long maxBytes;
 
     public InMemoryBlockCacheObjectStorage(ObjectStorage inner, long maxBytes) {
@@ -65,7 +64,15 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
         this.maxBytes = maxBytes;
         this.cache = Caffeine.newBuilder()
                 .maximumWeight(maxBytes)
-                .weigher((BlockKey k, byte[] v) -> v == null ? 0 : v.length)
+                .weigher((BlockKey k, ByteBuf v) -> v == null ? 0 : v.readableBytes())
+                // Release the cache's retain on eviction (and on explicit invalidate*).
+                // Caffeine fires the removal listener for both size-based eviction and
+                // explicit invalidate(...)/invalidateAll(...) calls — covers all paths.
+                .removalListener((RemovalListener<BlockKey, ByteBuf>) (key, value, cause) -> {
+                    if (value != null) {
+                        value.release();
+                    }
+                })
                 .recordStats()
                 .build();
     }
@@ -90,9 +97,9 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
      */
     public long estimatedBytes() {
         long total = 0;
-        for (byte[] v : cache.asMap().values()) {
+        for (ByteBuf v : cache.asMap().values()) {
             if (v != null) {
-                total += v.length;
+                total += v.readableBytes();
             }
         }
         return total;
@@ -122,46 +129,57 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
         int offsetInBlock = (int) (offset % blockSize);
         BlockKey key = new BlockKey(path, blockIndex);
 
-        byte[] cached = cache.getIfPresent(key);
+        ByteBuf cached = cache.getIfPresent(key);
         if (cached != null) {
             return CompletableFuture.completedFuture(slice(cached, offsetInBlock, length));
         }
 
-        CompletableFuture<ReadResult> pending = new CompletableFuture<>();
-        CompletableFuture<ReadResult> existing = inFlight.putIfAbsent(key, pending);
+        CompletableFuture<ByteBuf> pending = new CompletableFuture<>();
+        // Register the slice dependent BEFORE issuing the inner read, so that if
+        // inner.readRange completes synchronously the wrapping happens inside
+        // pending.complete — see CachingObjectStorage.loadAndCache for the same race.
+        CompletableFuture<ReadResult> resultFuture = pending.thenApply(buf -> slice(buf, offsetInBlock, length));
+
+        CompletableFuture<ByteBuf> existing = inFlight.putIfAbsent(key, pending);
         if (existing != null) {
-            return existing.thenApply(full -> slice(fullBytes(full), offsetInBlock, length));
+            return existing.thenApply(buf -> slice(buf, offsetInBlock, length));
         }
 
         long blockStartOffset = blockIndex * (long) blockSize;
         inner.readRange(path, blockStartOffset, blockSize, blockSize).whenComplete((result, err) -> {
-            try {
-                if (err != null) {
-                    pending.completeExceptionally(err);
-                    return;
-                }
+            if (err != null) {
                 try {
-                    byte[] content = result.content();  // Extract bytes from pooled ByteBuf
-                    if (result.status() == ReadResult.Status.FOUND && content != null) {
-                        cache.put(key, content);
-                    }
-                    // Create a new ReadResult wrapping extracted bytes
-                    ReadResult toReturn;
-                    if (result.status() == ReadResult.Status.FOUND) {
-                        toReturn = ReadResult.found(Unpooled.wrappedBuffer(content));
-                    } else {
-                        toReturn = ReadResult.notFound();
-                    }
-                    pending.complete(toReturn);
+                    pending.completeExceptionally(err);
                 } finally {
-                    result.release();  // Release the original pooled ByteBuf
+                    inFlight.remove(key, pending);
                 }
+                return;
+            }
+            if (result.status() != ReadResult.Status.FOUND) {
+                try {
+                    pending.complete(null);
+                } finally {
+                    inFlight.remove(key, pending);
+                }
+                return;
+            }
+            ByteBuf buf = result.byteBuf();
+            // +1 for the cache's ownership; +1 to keep buf alive across pending.complete
+            // so all dependents (the original caller + any in-flight followers) can
+            // retainedSlice while the buf is still referenced. The original `result`'s
+            // refcount is dropped right after.
+            buf.retain(2);
+            cache.put(key, buf);
+            try {
+                pending.complete(buf);
             } finally {
                 inFlight.remove(key, pending);
+                buf.release();   // alive-for-followers retain
+                result.release(); // original ReadResult's refcount
             }
         });
 
-        return pending.thenApply(full -> slice(fullBytes(full), offsetInBlock, length));
+        return resultFuture;
     }
 
     @Override
@@ -216,25 +234,22 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
         cache.invalidateAll(toDrop);
     }
 
-    private static byte[] fullBytes(ReadResult full) {
-        if (full == null || full.status() != ReadResult.Status.FOUND) {
-            return null;
-        }
-        return full.content();
-    }
-
-    private static ReadResult slice(byte[] block, int offsetInBlock, int length) {
+    /**
+     * Returns a {@link ReadResult} whose buffer is a {@code retainedSlice} view of
+     * {@code block} — no copy. The caller releases the result; {@code block} keeps
+     * its existing refcounts (typically held by the cache and/or callers).
+     */
+    private static ReadResult slice(ByteBuf block, int offsetInBlock, int length) {
         if (block == null) {
             return ReadResult.notFound();
         }
-        if (offsetInBlock >= block.length) {
+        int blockLen = block.readableBytes();
+        if (offsetInBlock >= blockLen) {
             return ReadResult.notFound();
         }
-        int to = Math.min(offsetInBlock + length, block.length);
+        int to = Math.min(offsetInBlock + length, blockLen);
         int sliceLen = to - offsetInBlock;
-        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(sliceLen);
-        buf.writeBytes(block, offsetInBlock, sliceLen);
-        return ReadResult.found(buf);
+        return ReadResult.found(block.retainedSlice(block.readerIndex() + offsetInBlock, sliceLen));
     }
 
     /** Package-private: force Caffeine maintenance. Used by tests. */

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/ReadResult.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/ReadResult.java
@@ -94,8 +94,12 @@ public final class ReadResult {
     /**
      * Get content as byte array copy (convenience method).
      * <p>
-     * This makes a heap copy from the pooled direct ByteBuf.
-     * Prefer using {@link #byteBuf()} directly for better performance.
+     * This makes a heap copy from the pooled direct ByteBuf — used by tests only.
+     * Production code paths must use {@link #byteBuf()} (and call {@link #release()}
+     * when done) so the bytes flow zero-copy through the cache layers and onto the
+     * gRPC wire. Adding a new production caller reintroduces the
+     * {@code ReadResult.content} allocation hot-path that the cache-layer
+     * refactor removed.
      *
      * @return copy of content bytes, or null if NOT_FOUND
      */

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -344,5 +345,109 @@ public class RemoteRandomAccessReaderTest {
                         (byte) (BLOCK_SIZE + 7), (byte) (BLOCK_SIZE + 8)}, b2);
             }
         }
+    }
+
+    /**
+     * Exercises every accessor on a single file to lock in the ByteBuf-backed
+     * decode paths: {@code readFully(ByteBuffer)}, {@code readFully(long[])},
+     * {@code read(int[], ...)}, {@code read(float[], ...)}. Reads cross both
+     * a write-block boundary (every {@value READFULLY_WRITE_BLOCK} bytes) and
+     * a buffer-window boundary (every {@value READFULLY_BUFFER} bytes) so the
+     * reload path is hit for each accessor flavour. Endianness must match the
+     * pre-rewrite big-endian decoding.
+     */
+    @Test
+    public void testEveryAccessor() throws Exception {
+        // Layout of the file (200 bytes):
+        //   bytes [0..16)   — 4 ints used by read(int[])
+        //   bytes [16..32)  — 4 floats used by read(float[])
+        //   bytes [32..48)  — 2 longs used by readFully(long[])
+        //   bytes [48..58)  — 10 bytes copied via readFully(ByteBuffer)
+        //   bytes [58..62)  — 1 int used by readInt() at a non-aligned offset
+        //   bytes [62..70)  — 1 long used by readLong() across a buffer boundary (62..70 spans 64)
+        //   bytes [70..200) — sequential payload, used by readFully(byte[])
+        byte[] data = new byte[200];
+        ByteBuffer src = ByteBuffer.wrap(data);
+        int[] expectedInts = new int[]{0x01020304, 0x05060708, 0x090a0b0c, 0x0d0e0f10};
+        for (int v : expectedInts) {
+            src.putInt(v);
+        }
+        float[] expectedFloats = new float[]{1.5f, -2.25f, 1e-3f, 42.0f};
+        for (float v : expectedFloats) {
+            src.putInt(Float.floatToIntBits(v));
+        }
+        long[] expectedLongs = new long[]{0x0102030405060708L, 0x1011121314151617L};
+        for (long v : expectedLongs) {
+            src.putLong(v);
+        }
+        byte[] expectedBytes = "abcdefghij".getBytes();
+        src.put(expectedBytes);
+        int crossBufferInt = 0xCAFEBABE;
+        src.putInt(crossBufferInt);
+        long crossBufferLong = 0x0123456789ABCDEFL;
+        src.putLong(crossBufferLong);
+        // remaining bytes [70..200): sequence (byte) i
+        for (int i = src.position(); i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+
+        client.writeMultipartFile("ts/idx/accessors", new ByteArrayInputStream(data),
+                READFULLY_WRITE_BLOCK);
+        try (RemoteRandomAccessReader reader = openReadFullyReader("ts/idx/accessors", data.length)) {
+            int[] actualInts = new int[expectedInts.length];
+            reader.seek(0);
+            reader.read(actualInts, 0, actualInts.length);
+            assertArrayEquals(expectedInts, actualInts);
+            assertEquals(16, reader.getPosition());
+
+            float[] actualFloats = new float[expectedFloats.length];
+            reader.read(actualFloats, 0, actualFloats.length);
+            assertArrayEquals(expectedFloats, actualFloats, 0.0f);
+            assertEquals(32, reader.getPosition());
+
+            long[] actualLongs = new long[expectedLongs.length];
+            reader.readFully(actualLongs);
+            assertArrayEquals(expectedLongs, actualLongs);
+            assertEquals(48, reader.getPosition());
+
+            ByteBuffer dst = ByteBuffer.allocate(expectedBytes.length);
+            reader.readFully(dst);
+            assertEquals(expectedBytes.length, dst.position());
+            byte[] actualBytes = new byte[expectedBytes.length];
+            dst.flip();
+            dst.get(actualBytes);
+            assertArrayEquals(expectedBytes, actualBytes);
+            assertEquals(58, reader.getPosition());
+
+            // readInt() at byte 58 — within one buffer window (window 3 = bytes [48..64)).
+            assertEquals(crossBufferInt, reader.readInt());
+            assertEquals(62, reader.getPosition());
+
+            // readLong() at byte 62 — crosses the buffer boundary at byte 64.
+            assertEquals(crossBufferLong, reader.readLong());
+            assertEquals(70, reader.getPosition());
+
+            // Tail bytes via readFully(byte[]) cross a write-block boundary at byte 64
+            // and a second one at byte 128.
+            byte[] tail = new byte[data.length - (int) reader.getPosition()];
+            reader.readFully(tail);
+            assertArrayEquals(Arrays.copyOfRange(data, 70, data.length), tail);
+            assertEquals(data.length, reader.getPosition());
+        }
+    }
+
+    /** Calling close() twice must be safe and not over-release the cached buffer. */
+    @Test
+    public void testCloseIsIdempotent() throws Exception {
+        byte[] data = seqBytes(BLOCK_SIZE);
+        client.writeMultipartFile("ts/idx/close", new ByteArrayInputStream(data), BLOCK_SIZE);
+
+        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+                client, "ts/idx/close", data.length, BLOCK_SIZE);
+        reader.seek(0);
+        byte[] tmp = new byte[4];
+        reader.readFully(tmp); // forces a block load
+        reader.close();
+        reader.close(); // must not throw or over-release
     }
 }


### PR DESCRIPTION
## Summary

Profiles taken from the file-server (`profiles-herddb-file-server-0-20260419-081828/profile_mem.html`, `profile_cpu.html`) and the indexing-service (`profiles-herddb-indexing-service-0-20260419-082035/`) both showed the remote-file-service `readFileRange` path as a top allocator. The hot frames were `ReadResult.content` on the server and `ByteString.toByteArray` + per-call temporary `byte[]`s in `RemoteRandomAccessReader` on the client.

This PR makes the bytes flow zero-copy through the cache layers and through the JVector reader, dropping every avoidable heap copy except the one the gRPC protobuf marshaller mandates (the `LiteralByteString` materialisation on the client).

### Server side
- `CachingObjectStorage.loadAndCache` retains the inner storage's pooled `ByteBuf` instead of materialising a heap `byte[]` and reallocating a second pooled buffer; concurrent in-flight followers each get a `retainedDuplicate` of the same buffer.
- `sliceFromFull` returns a `retainedSlice` view (no copy).
- New `admitToDisk(String, ByteBuf)` overload writes the pooled buffer's `nioBuffer()` straight to the cache file via `AsynchronousFileChannel.write`.
- `InMemoryBlockCacheObjectStorage` now caches `ByteBuf` rather than `byte[]` and serves slices via `retainedSlice`. A Caffeine removal listener releases the cache's ref on eviction. Cache hits become true zero-copy from cache to gRPC wire (the server already wraps via `UnsafeByteOperations.unsafeWrap(byteBuf.nioBuffer())`).
- `ReadResult.content()` is kept for tests but documented as not-for-production.

### Client side
- New `RemoteFileServiceClient.readFileRangeAsByteBufAsync` writes the protobuf `ByteString` directly into a pooled direct `ByteBuf` via `copyTo(ByteBuffer)`, skipping the throw-away `byte[]` from `toByteArray`. Cross-block ranges return a `CompositeByteBuf` view instead of a third concatenated `byte[]`.
- `RemoteRandomAccessReader` keeps the cached block as a pooled direct `ByteBuf`. `readInt`, `readLong`, `readFloat`, `readFully(ByteBuffer)`, `read(int[])` and `read(float[])` use Netty's `getX(int)` / `getBytes(int, ByteBuffer)` primitives — single Unsafe memcpy each, no per-call temp arrays. `close()` releases the pooled buffer.
- `readFileAsByteBufAsync` switched to `copyTo(ByteBuffer)` for symmetry.

### Out of scope
The single protobuf-mandated heap copy on the client (inside the `LiteralByteString` produced by the gRPC marshaller) is not eliminated — that would require bypassing protobuf for the payload (e.g. a custom Netty PDU protocol like `herddb-net`). The user explicitly chose to stay on gRPC for this PR.

## Test plan
- [x] `mvn -pl herddb-remote-file-service test` — 159 tests pass (10 of them under `ResourceLeakDetector.PARANOID`).
- [x] `mvn -pl herddb-indexing-service test` — 213 tests pass.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green.
- [x] `RemoteRandomAccessReaderTest.testEveryAccessor` — new test exercising every accessor (`read(int[])`, `read(float[])`, `readFully(ByteBuffer)`, `readFully(long[])`, `readInt`/`readLong` across both block and buffer boundaries) so the rewrite cannot regress endianness or boundary handling.
- [x] `RemoteRandomAccessReaderTest.testCloseIsIdempotent` — pins the safe double-release behaviour.
- [ ] Re-profile a vector benchmark and confirm `ReadResult.content`, `ByteString.toByteArray`, and the per-call `byte[]` allocations in `RemoteRandomAccessReader` no longer appear in the top of `profile_mem.html` / `profile_cpu.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)