### PR TITLE
issue #174: zero-copy ByteBuffer vectors via jvector 4.0.0-rc.9-herddb-SNAPSHOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,10 @@ jobs:
           key: 'cache'
           restore-keys: 'cache'
       - name: 'Checkout jvector'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          repository: datastax/jvector
+          repository: eolivelli/jvector
+          ref: feature/bytebuffer-zero-copy-vectors
           path: jvector
       - name: 'Build jvector'
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector

--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -41,9 +41,10 @@ jobs:
           key: 'cache'
           restore-keys: 'cache'
       - name: 'Checkout jvector'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          repository: datastax/jvector
+          repository: eolivelli/jvector
+          ref: feature/bytebuffer-zero-copy-vectors
           path: jvector
       - name: 'Build jvector'
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector

--- a/VECTOR.md
+++ b/VECTOR.md
@@ -829,7 +829,7 @@ compaction thread wakes (timer or memory pressure)
 <dependency>
     <groupId>io.github.jbellis</groupId>
     <artifactId>jvector</artifactId>
-    <version>4.0.0-rc.9-SNAPSHOT</version>
+    <version>4.0.0-rc.9-herddb-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.github.jbellis</groupId>
             <artifactId>jvector</artifactId>
-            <version>4.0.0-rc.9-SNAPSHOT</version>
+            <version>4.0.0-rc.9-herddb-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper</groupId>

--- a/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
@@ -21,6 +21,8 @@
 package herddb.index.vector;
 
 import herddb.utils.Bytes;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -45,11 +47,46 @@ public abstract class AbstractVectorStore implements AutoCloseable {
 
     public abstract void addVector(Bytes pk, float[] vector);
 
+    /**
+     * Zero-copy counterpart of {@link #addVector(Bytes, float[])}. Stores from the
+     * caller-owned buffer's current position up to its limit as a vector of
+     * {@code remaining() / Float.BYTES} floats; the buffer is not retained past
+     * this call.
+     *
+     * <p>Implementations that can consume the buffer directly (e.g. jvector-backed
+     * stores wrapping it as a {@code BufferVectorFloat}) should override this method
+     * to avoid the {@code float[]} materialization that the default implementation
+     * performs as a compatibility fallback.
+     *
+     * <p>Use {@link ByteOrder#LITTLE_ENDIAN} for the native-SIMD fast path; big-endian
+     * buffers still work correctly but only under the Panama fallback.
+     */
+    public void addVector(Bytes pk, ByteBuffer vector) {
+        if (vector == null) {
+            return;
+        }
+        float[] floats = new float[vector.remaining() / Float.BYTES];
+        vector.asFloatBuffer().get(floats);
+        addVector(pk, floats);
+    }
+
     public abstract void removeVector(Bytes pk);
 
     public abstract int size();
 
     public abstract List<Map.Entry<Bytes, Float>> search(float[] queryVector, int topK);
+
+    /**
+     * Zero-copy counterpart of {@link #search(float[], int)}. Interprets the
+     * caller-owned buffer's remaining bytes as the query vector; the buffer is not
+     * retained past this call. See {@link #addVector(Bytes, ByteBuffer)} for the
+     * copy / byte-order contract.
+     */
+    public List<Map.Entry<Bytes, Float>> search(ByteBuffer queryVector, int topK) {
+        float[] floats = new float[queryVector.remaining() / Float.BYTES];
+        queryVector.asFloatBuffer().get(floats);
+        return search(floats, topK);
+    }
 
     public abstract long estimatedMemoryUsageBytes();
 

--- a/herddb-core/src/main/java/herddb/index/vector/ChannelFileBackedVectorValues.java
+++ b/herddb-core/src/main/java/herddb/index/vector/ChannelFileBackedVectorValues.java
@@ -95,9 +95,8 @@ class ChannelFileBackedVectorValues extends FileBackedVectorValues {
     // Guarded by synchronized(this) for growing
     private volatile long fileSize;
 
-    // Per-copy reusable buffer to avoid allocations in getVector (null for original instances)
-    private final float[] sharedBuffer;
-    private final VectorFloat<?> sharedVector;
+    // Copy instances share file/channels with the original and must NOT close them
+    private final boolean isCopy;
 
     ChannelFileBackedVectorValues(int dimension, long expectedSize, Path tempDir) throws IOException {
         this.dimension = dimension;
@@ -112,8 +111,7 @@ class ChannelFileBackedVectorValues extends FileBackedVectorValues {
 
         // No large pre-allocation; file starts empty and grows on demand
         this.fileSize = 0;
-        this.sharedBuffer = null;
-        this.sharedVector = null;
+        this.isCopy = false;
 
         if (expectedSize <= ARRAY_INDEX_THRESHOLD) {
             this.offsetIndex = new ArrayOffsetIndex((int) Math.max(expectedSize, 16));
@@ -127,7 +125,7 @@ class ChannelFileBackedVectorValues extends FileBackedVectorValues {
                                            FileChannel channel, AtomicInteger count,
                                            AtomicLong appendPosition, OffsetIndex offsetIndex,
                                            ConcurrentLinkedQueue<FileChannel> openReadChannels,
-                                           long fileSize, boolean shared) {
+                                           long fileSize) {
         this.dimension = dimension;
         this.vectorByteSize = (long) dimension * Float.BYTES;
         this.filePath = filePath;
@@ -139,13 +137,7 @@ class ChannelFileBackedVectorValues extends FileBackedVectorValues {
         this.openReadChannels = openReadChannels;
         this.readChannel = ThreadLocal.withInitial(this::openReadChannel);
         this.fileSize = fileSize;
-        if (shared) {
-            this.sharedBuffer = new float[dimension];
-            this.sharedVector = VTS.createFloatVector(sharedBuffer);
-        } else {
-            this.sharedBuffer = null;
-            this.sharedVector = null;
-        }
+        this.isCopy = true;
     }
 
     private ByteBuffer getOrAllocateBuffer() {
@@ -264,10 +256,10 @@ class ChannelFileBackedVectorValues extends FileBackedVectorValues {
         ByteBuffer buf = getOrAllocateBuffer();
         readFullyAt(buf, offset);
         buf.flip();
-
-        float[] floats = sharedBuffer != null ? sharedBuffer : new float[dimension];
-        buf.asFloatBuffer().get(floats);
-        return sharedVector != null ? sharedVector : VTS.createFloatVector(floats);
+        // Zero-copy: wrap the thread-local direct buffer as a VectorFloat view. The
+        // returned VectorFloat aliases the buffer, so callers must treat it per the
+        // isValueShared()=true contract (no retention across calls on this thread).
+        return VTS.wrapFloatVector(buf);
     }
 
     @Override
@@ -278,12 +270,12 @@ class ChannelFileBackedVectorValues extends FileBackedVectorValues {
     @Override
     public RandomAccessVectorValues copy() {
         return new ChannelFileBackedVectorValues(dimension, filePath, raf, channel, count,
-                appendPosition, offsetIndex, openReadChannels, fileSize, true);
+                appendPosition, offsetIndex, openReadChannels, fileSize);
     }
 
     @Override
     public void close() throws IOException {
-        if (sharedBuffer != null) {
+        if (isCopy) {
             return; // copy — shared resources owned by the original
         }
         try {

--- a/herddb-core/src/main/java/herddb/index/vector/MmapFileBackedVectorValues.java
+++ b/herddb-core/src/main/java/herddb/index/vector/MmapFileBackedVectorValues.java
@@ -26,6 +26,8 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -48,6 +50,11 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
 
     private final int dimension;
     private final long vectorByteSize;
+    /**
+     * Maximum segment size, rounded DOWN to a whole multiple of {@link #vectorByteSize}
+     * so that a vector never straddles a segment boundary — a straddle would defeat
+     * the zero-copy slice-and-wrap path in {@link #getVector(int)}.
+     */
     private final int maxSegmentSize;
     private final Path filePath;
     private final RandomAccessFile raf;
@@ -58,14 +65,19 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
     private volatile MappedByteBuffer[] segments;
     private volatile long mappedSize;
 
-    // Per-copy reusable buffer to avoid allocations in getVector (null for original instances)
-    private final float[] sharedBuffer;
-    private final VectorFloat<?> sharedVector;
+    // Copy instances share file/channels with the original and must NOT close them
+    private final boolean isCopy;
 
     MmapFileBackedVectorValues(int dimension, long expectedSize, Path tempDir, int maxSegmentSize) throws IOException {
         this.dimension = dimension;
         this.vectorByteSize = (long) dimension * Float.BYTES;
-        this.maxSegmentSize = maxSegmentSize;
+        if (vectorByteSize > maxSegmentSize) {
+            throw new IllegalArgumentException(
+                    "vectorByteSize " + vectorByteSize + " exceeds maxSegmentSize " + maxSegmentSize
+                    + "; a single vector does not fit in one mapped segment");
+        }
+        // Round down to a multiple of vectorByteSize so vectors never straddle segments.
+        this.maxSegmentSize = (int) ((maxSegmentSize / vectorByteSize) * vectorByteSize);
         this.filePath = Files.createTempFile(tempDir, "vec-rebuild-", ".tmp");
         this.raf = new RandomAccessFile(filePath.toFile(), "rw");
         this.channel = raf.getChannel();
@@ -74,15 +86,14 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
         raf.setLength(initialSize);
         this.mappedSize = initialSize;
         this.segments = mapSegments(initialSize);
-        this.sharedBuffer = null;
-        this.sharedVector = null;
+        this.isCopy = false;
     }
 
     // Constructor for copy() — shares the same file, optionally with a reusable read buffer
     private MmapFileBackedVectorValues(int dimension, Path filePath, RandomAccessFile raf,
                                         FileChannel channel, AtomicInteger count,
                                         MappedByteBuffer[] segments, long mappedSize,
-                                        int maxSegmentSize, boolean shared) {
+                                        int maxSegmentSize) {
         this.dimension = dimension;
         this.vectorByteSize = (long) dimension * Float.BYTES;
         this.maxSegmentSize = maxSegmentSize;
@@ -92,13 +103,7 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
         this.count = count;
         this.segments = segments;
         this.mappedSize = mappedSize;
-        if (shared) {
-            this.sharedBuffer = new float[dimension];
-            this.sharedVector = VTS.createFloatVector(sharedBuffer);
-        } else {
-            this.sharedBuffer = null;
-            this.sharedVector = null;
-        }
+        this.isCopy = true;
     }
 
     private MappedByteBuffer[] mapSegments(long totalSize) throws IOException {
@@ -107,7 +112,11 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
         while (offset < totalSize) {
             long remaining = totalSize - offset;
             int segSize = (int) Math.min(remaining, maxSegmentSize);
-            segs.add(channel.map(FileChannel.MapMode.READ_WRITE, offset, segSize));
+            MappedByteBuffer seg = channel.map(FileChannel.MapMode.READ_WRITE, offset, segSize);
+            // Native order is required for jvector's native-SIMD fast path when the
+            // segment is later wrapped as a VectorFloat in getVector.
+            seg.order(ByteOrder.nativeOrder());
+            segs.add(seg);
             offset += segSize;
         }
         return segs.toArray(new MappedByteBuffer[0]);
@@ -178,15 +187,16 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
     @Override
     public VectorFloat<?> getVector(int nodeId) {
         long offset = (long) nodeId * vectorByteSize;
-        float[] floats = sharedBuffer != null ? sharedBuffer : new float[dimension];
         MappedByteBuffer[] segs = segments;
-        for (int i = 0; i < dimension; i++) {
-            long pos = offset + (long) i * Float.BYTES;
-            int segIndex = (int) (pos / maxSegmentSize);
-            int segOffset = (int) (pos % maxSegmentSize);
-            floats[i] = segs[segIndex].getFloat(segOffset);
-        }
-        return sharedVector != null ? sharedVector : VTS.createFloatVector(floats);
+        int segIndex = (int) (offset / maxSegmentSize);
+        int segOffset = (int) (offset % maxSegmentSize);
+        // maxSegmentSize is aligned to vectorByteSize in the constructor, so a vector
+        // never straddles a segment boundary — a single slice covers it.
+        ByteBuffer view = segs[segIndex].duplicate();
+        view.position(segOffset).limit(segOffset + (int) vectorByteSize);
+        ByteBuffer slice = view.slice();
+        slice.order(ByteOrder.nativeOrder());
+        return VTS.wrapFloatVector(slice);
     }
 
     @Override
@@ -197,12 +207,12 @@ class MmapFileBackedVectorValues extends FileBackedVectorValues {
     @Override
     public RandomAccessVectorValues copy() {
         return new MmapFileBackedVectorValues(dimension, filePath, raf, channel, count,
-                segments, mappedSize, maxSegmentSize, true);
+                segments, mappedSize, maxSegmentSize);
     }
 
     @Override
     public void close() throws IOException {
-        if (sharedBuffer != null) {
+        if (isCopy) {
             return; // copy — shared resources owned by the original
         }
         // Force unmap is not strictly possible via public API, but the GC will handle it.

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -1038,7 +1038,24 @@ public class PersistentVectorStore extends AbstractVectorStore {
         if (vector == null || vector.length == 0) {
             return;
         }
+        addVectorInternal(pk, vector.length, VTS.createFloatVector(vector));
+    }
 
+    /**
+     * Zero-copy variant of {@link #addVector(Bytes, float[])}: wraps the caller-owned
+     * buffer as a {@code VectorFloat<?>} view via {@code wrapFloatVector} rather than
+     * materializing a {@code float[]}. The buffer is not retained past this call.
+     */
+    @Override
+    public void addVector(Bytes pk, ByteBuffer vector) {
+        if (vector == null || vector.remaining() == 0) {
+            return;
+        }
+        int dim = vector.remaining() / Float.BYTES;
+        addVectorInternal(pk, dim, VTS.wrapFloatVector(vector));
+    }
+
+    private void addVectorInternal(Bytes pk, int dim, VectorFloat<?> vec) {
         // Back-pressure: if checkpoint Phase B is active and live cap exceeded,
         // wait for Phase C to complete before proceeding.
         CountDownLatch latch = checkpointPhaseComplete;
@@ -1062,15 +1079,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
         stateLock.readLock().lock();
         try {
             if (dimension == 0) {
-                initBuilderForDimension(vector.length);
+                initBuilderForDimension(dim);
             }
-            if (vector.length != dimension) {
+            if (dim != dimension) {
                 LOGGER.log(Level.WARNING,
                         "vector dimension mismatch on insert: expected {0} but got {1}, skipping",
-                        new Object[]{dimension, vector.length});
+                        new Object[]{dimension, dim});
                 return;
             }
-            VectorFloat<?> vec = VTS.createFloatVector(vector);
 
             List<LiveGraphShard> shards = this.liveShards;
             LiveGraphShard active = shards.get(shards.size() - 1);
@@ -1146,8 +1162,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     @Override
     public List<Map.Entry<Bytes, Float>> search(float[] queryVector, int topK) {
+        return searchInternal(VTS.createFloatVector(queryVector), topK);
+    }
+
+    /**
+     * Zero-copy variant of {@link #search(float[], int)}: interprets the caller-owned
+     * buffer's remaining bytes as the query vector without materializing a {@code float[]}.
+     * The buffer is not retained past this call.
+     */
+    @Override
+    public List<Map.Entry<Bytes, Float>> search(ByteBuffer queryVector, int topK) {
+        return searchInternal(VTS.wrapFloatVector(queryVector), topK);
+    }
+
+    private List<Map.Entry<Bytes, Float>> searchInternal(VectorFloat<?> qv, int topK) {
         List<Map.Entry<Bytes, Float>> results = new ArrayList<>();
-        VectorFloat<?> qv = VTS.createFloatVector(queryVector);
 
         // Overquery each source to improve recall when merging across segments.
         // Each source returns more candidates; the final merge picks the true topK.

--- a/herddb-core/src/test/java/herddb/index/vector/FileBackedVectorValuesTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/FileBackedVectorValuesTest.java
@@ -22,9 +22,9 @@ package herddb.index.vector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.BufferVectorFloat;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
@@ -233,24 +233,18 @@ public class FileBackedVectorValuesTest {
     }
 
     @Test
-    public void testCopyUsesSharedBuffer() throws Exception {
+    public void testGetVectorIsZeroCopy() throws Exception {
+        // getVector must return a BufferVectorFloat view over the underlying storage —
+        // not an ArrayVectorFloat that would imply a per-call float[] materialization.
         int dimension = 3;
         Path tempDir = tempFolder.getRoot().toPath();
 
         try (FileBackedVectorValues fbv = createFBV(dimension, 5, tempDir)) {
             fbv.putVector(0, new float[]{1, 2, 3});
-            fbv.putVector(1, new float[]{4, 5, 6});
-
-            RandomAccessVectorValues copy = fbv.copy();
-            assertTrue(copy.isValueShared());
-
-            // Two calls to getVector on the copy should return the same VectorFloat reference
-            VectorFloat<?> v1 = copy.getVector(0);
-            VectorFloat<?> v2 = copy.getVector(1);
-            assertSame(v1, v2); // same shared object, overwritten each time
-
-            // The value should reflect the last call
-            assertArrayEquals(new float[]{4, 5, 6}, toFloatArray(v2), 0.0001f);
+            VectorFloat<?> v = fbv.getVector(0);
+            assertTrue("Expected BufferVectorFloat (zero-copy), got " + v.getClass().getName(),
+                    v instanceof BufferVectorFloat);
+            assertArrayEquals(new float[]{1, 2, 3}, toFloatArray(v), 0.0001f);
         }
     }
 
@@ -339,10 +333,12 @@ public class FileBackedVectorValuesTest {
 
     @Test
     public void testVectorStraddlingSegmentBoundary() throws Exception {
-        // Ensure a vector whose bytes cross a segment boundary is handled correctly.
-        // dimension=4 => 16 bytes per vector. Segment size = 24 bytes.
-        // Vector 0: bytes [0..15] -> segment 0
-        // Vector 1: bytes [16..31] -> straddles segment 0 (bytes 16-23) and segment 1 (bytes 24-31)
+        // MmapFileBackedVectorValues rounds maxSegmentSize DOWN to a multiple of
+        // vectorByteSize so vectors never straddle — a prerequisite for the zero-copy
+        // slice-and-wrap path. This test verifies that round-trip correctness still
+        // holds when the caller requests a non-aligned segment size.
+        // dimension=4 => 16 bytes per vector. Requested segment size = 24 bytes =>
+        // aligned to 16 bytes, i.e. one vector per segment.
         int dimension = 4;
         int maxSegmentSize = 24;
         Path tempDir = tempFolder.getRoot().toPath();

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreByteBufferOverloadTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreByteBufferOverloadTest.java
@@ -1,0 +1,157 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that the zero-copy {@link PersistentVectorStore#addVector(Bytes, ByteBuffer)}
+ * and {@link PersistentVectorStore#search(ByteBuffer, int)} overloads produce the
+ * same results as their {@code float[]} counterparts, across both little- and
+ * big-endian buffers.
+ *
+ * <p>The little-endian buffer hits jvector's native-SIMD fast path on x86 / ARM;
+ * the big-endian buffer falls back to the Panama scalar path. Both are expected
+ * to produce identical top-K results for identical inputs.
+ */
+public class PersistentVectorStoreByteBufferOverloadTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+    }
+
+    private static float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private static ByteBuffer toBuffer(float[] v, ByteOrder order) {
+        ByteBuffer bb = ByteBuffer.allocate(v.length * Float.BYTES).order(order);
+        bb.asFloatBuffer().put(v);
+        return bb;
+    }
+
+    private static void assertResultsEqual(List<Map.Entry<Bytes, Float>> expected,
+                                           List<Map.Entry<Bytes, Float>> actual) {
+        assertEquals("result size mismatch", expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals("PK mismatch at rank " + i,
+                    expected.get(i).getKey(), actual.get(i).getKey());
+            // Scores should be numerically identical for identical vectors — allow
+            // a small tolerance in case the SIMD vs scalar paths round slightly
+            // differently for big-endian inputs.
+            assertEquals("score mismatch at rank " + i,
+                    expected.get(i).getValue(), actual.get(i).getValue(), 1e-5f);
+        }
+    }
+
+    @Test
+    public void testAddViaByteBufferMatchesFloatArray() throws Exception {
+        for (ByteOrder order : new ByteOrder[]{ByteOrder.LITTLE_ENDIAN, ByteOrder.BIG_ENDIAN}) {
+            Path dirA = tmpFolder.newFolder().toPath();
+            Path dirB = tmpFolder.newFolder().toPath();
+            try (PersistentVectorStore storeA = createStore(dirA);
+                 PersistentVectorStore storeB = createStore(dirB)) {
+                storeA.start();
+                storeB.start();
+
+                Random rng = new Random(42);
+                int dim = 32;
+                int n = 80;
+                float[] query = randomVector(rng, dim);
+
+                // Generate the same vectors in both stores but insert them via
+                // different overloads.
+                rng = new Random(1234);
+                for (int i = 0; i < n; i++) {
+                    float[] v = randomVector(rng, dim);
+                    storeA.addVector(Bytes.from_int(i), v);
+                    storeB.addVector(Bytes.from_int(i), toBuffer(v, order));
+                }
+
+                assertEquals(n, storeA.size());
+                assertEquals(n, storeB.size());
+
+                List<Map.Entry<Bytes, Float>> resultsA = storeA.search(query, 10);
+                List<Map.Entry<Bytes, Float>> resultsB = storeB.search(query, 10);
+                assertResultsEqual(resultsA, resultsB);
+            }
+        }
+    }
+
+    @Test
+    public void testSearchViaByteBufferMatchesFloatArray() throws Exception {
+        for (ByteOrder order : new ByteOrder[]{ByteOrder.LITTLE_ENDIAN, ByteOrder.BIG_ENDIAN}) {
+            Path dir = tmpFolder.newFolder().toPath();
+            try (PersistentVectorStore store = createStore(dir)) {
+                store.start();
+
+                Random rng = new Random(7);
+                int dim = 32;
+                int n = 80;
+                for (int i = 0; i < n; i++) {
+                    store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+                }
+
+                float[] query = randomVector(rng, dim);
+                List<Map.Entry<Bytes, Float>> fromArray = store.search(query, 10);
+                List<Map.Entry<Bytes, Float>> fromBuffer = store.search(toBuffer(query, order), 10);
+                assertResultsEqual(fromArray, fromBuffer);
+            }
+        }
+    }
+
+    @Test
+    public void testEmptyAndNullBuffersAreNoOps() throws Exception {
+        Path dir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(dir)) {
+            store.start();
+            // null and empty should be no-ops — same contract as the float[] overload
+            store.addVector(Bytes.from_int(1), (ByteBuffer) null);
+            store.addVector(Bytes.from_int(2), ByteBuffer.allocate(0));
+            assertEquals(0, store.size());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #174. Eliminates the per-vector `float[]` materialization on the jvector-facing hot paths by wrapping caller-owned `ByteBuffer`s directly as `VectorFloat<?>` views, using the new zero-copy primitives in [`eolivelli/jvector @ feature/bytebuffer-zero-copy-vectors`](https://github.com/eolivelli/jvector/tree/feature/bytebuffer-zero-copy-vectors) (published as `4.0.0-rc.9-herddb-SNAPSHOT`).

### What changes

- **jvector dependency** — `herddb-core/pom.xml` and `VECTOR.md` bumped to `4.0.0-rc.9-herddb-SNAPSHOT`. Both CI workflows (`ci.yml`, `kubernetes-tests.yml`) now clone `eolivelli/jvector` at the feature branch and build it before running the HerdDB tests.
- **`ChannelFileBackedVectorValues.getVector`** — returns `VTS.wrapFloatVector(buf)` directly over the `ThreadLocal` direct native-order buffer; the per-call `float[]` allocation and the `sharedBuffer`/`sharedVector` dead-weight fallback are gone.
- **`MmapFileBackedVectorValues.getVector`** — returns a sliced `MappedByteBuffer` view wrapped as a `VectorFloat`. Two prerequisites:
  - `maxSegmentSize` is rounded DOWN to a multiple of `vectorByteSize` so vectors never straddle a segment boundary (a straddle would defeat slicing).
  - Each mapped segment is flipped to `ByteOrder.nativeOrder()` so `wrapFloatVector` hits jvector's SIMD fast path on x86/ARM. Safe — the temp file is created fresh per instance.
- **`AbstractVectorStore`** — adds `ByteBuffer` overloads of `addVector` and `search` with safe materialize-to-`float[]` default impls so non-jvector stores stay source-compatible.
- **`PersistentVectorStore`** — overrides both `ByteBuffer` overloads with the zero-copy path (`VTS.wrapFloatVector`) and factors the back-pressure / stateLock body out of the two `addVector` (and two `search`) variants into a private helper.

### Out of scope (follow-ups)

- Pushing `ByteBuffer` upstream through `IndexingServiceEngine.extractVector` and `VectorANNScanOp.execute` — requires `DataAccessor` / `RecordSerializer` / protobuf changes that are orthogonal to the jvector-boundary work.
- Replacing `FileBackedVectorValues` with jvector's `ByteBufferRandomAccessVectorValues` in the checkpoint Phase-B rebuild path.
- Switching `Bytes.to_float_array` / `from_float_array` to little-endian.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [x] `mvn -pl herddb-core -Dtest='FileBackedVectorValuesTest,VectorStorageTest,SegmentedMappedReaderTest,VectorSegmentSearchErrorTest' test` — 64/64 green
- [x] `mvn -pl herddb-indexing-service -Dtest='PersistentVectorStoreSearchTest,PersistentVectorStoreRecallTest,PersistentVectorStoreConcurrentCheckpointTest,PersistentVectorStoreByteBufferOverloadTest,CheckpointAndSaveWatermarkTest' test` — 27/27 green
- [x] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test` (CLAUDE.md hammer gate) — 12/12 green
- [x] New `PersistentVectorStoreByteBufferOverloadTest` exercises the ByteBuffer overloads against the `float[]` overloads for both little- and big-endian buffers.
- [ ] CI (`Java CI`, `Java CI - Kubernetes tests`) must build jvector from the fork and go green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)