### PR TITLE
Harden LazyValueCacheTest.weightBoundedEviction against Caffeine async buffer

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/LazyValueCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/LazyValueCache.java
@@ -124,6 +124,13 @@ public final class LazyValueCache {
         return cache == null ? 0L : cache.estimatedSize();
     }
 
+    /** Package-private: force Caffeine maintenance. Used by tests. */
+    void cleanUp() {
+        if (cache != null) {
+            cache.cleanUp();
+        }
+    }
+
     /** Caffeine stats snapshot, or {@code null} if the cache is disabled. */
     public CacheStats stats() {
         return cache == null ? null : cache.stats();

--- a/herddb-remote-file-service/src/test/java/herddb/remote/LazyValueCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/LazyValueCacheTest.java
@@ -94,6 +94,10 @@ public class LazyValueCacheTest {
             });
         }
         assertEquals(16, loaderCalls.get());
+        // Caffeine weight-based eviction flows through an async write buffer;
+        // drain it before refetching so the test does not race the maintenance
+        // thread on CI.
+        cache.cleanUp();
         // Now fetch the very first keys again; some must have been evicted
         // and re-loaded. We don't pin down exactly which ones are resident
         // (Caffeine's TinyLFU makes no such guarantee), only that the cache


### PR DESCRIPTION
## Summary

- CI sporadically fails `LazyValueCacheTest.weightBoundedEviction` with `some entries should have been evicted and reloaded; got 0 reloads`.
- Caffeine's weight-based eviction flows through an async write buffer drained by its maintenance task; under CI scheduling the buffer can still be pending when the refetch loop runs, so entries over the 256-byte budget have not yet been evicted.
- Add a package-private `cleanUp()` on `LazyValueCache` (same convention as `CachingObjectStorage#cleanUp` and `InMemoryBlockCacheObjectStorage#cleanUp`) and invoke it in the test between the insert and refetch loops.
- Same class of fix as commit `e52c1068` ("Harden cache-size assertions against Caffeine's async write buffer") for `SharedSegmentPageCacheTest` / `PageStoreReaderTest`.

Replaces #184 (rebased onto master so the PR contains only the test-hardening commit).

## Test plan

- [x] `mvn -pl herddb-remote-file-service -Dtest=LazyValueCacheTest test` — 9/9 green.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci -pl herddb-remote-file-service -am` — clean.
- [ ] CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)