### PR TITLE
Fix FollowerThread StampedLock starvation deadlocking follower-side checkpoint

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1324,19 +1324,21 @@ public class TableSpaceManager {
         public void run() {
             try (CommitLog.FollowerContext context = log.startFollowing(actualLogSequenceNumber)) {
                 while (!isLeader() && !closed) {
-                    long readLock = acquireReadLock("follow");
-                    try {
-                        log.followTheLeader(actualLogSequenceNumber, (LogSequenceNumber num, LogEntry u) -> {
-                            try {
-                                apply(new CommitLogResult(num, false, true), u, false);
-                            } catch (Throwable t) {
-                                throw new RuntimeException(t);
-                            }
-                            return !isLeader() && !closed;
-                        }, context);
-                    } finally {
-                        releaseReadLock(readLock, "follow");
-                    }
+                    // Acquire the read lock per applied entry rather than around the whole
+                    // followTheLeader call: the BK long-poll inside would otherwise hold
+                    // the lock for up to LONG_POLL_TIMEOUT every iteration and starve
+                    // writers (e.g. a follower-side checkpoint) on the StampedLock.
+                    log.followTheLeader(actualLogSequenceNumber, (LogSequenceNumber num, LogEntry u) -> {
+                        long readLock = acquireReadLock("follow");
+                        try {
+                            apply(new CommitLogResult(num, false, true), u, false);
+                        } catch (Throwable t) {
+                            throw new RuntimeException(t);
+                        } finally {
+                            releaseReadLock(readLock, "follow");
+                        }
+                        return !isLeader() && !closed;
+                    }, context);
                 }
             } catch (Throwable t) {
                 LOGGER.log(Level.SEVERE, "follower error " + tableSpaceName, t);


### PR DESCRIPTION
## Summary

Fixes a deadlock in `SimpleFollowerTest.testCheckpointFollower` (and several other CI runs observed hanging for 300s+ since at least 2026-04-18). The test consistently hangs locally on `master` with `timeout 300 mvn ... -Dtest=SimpleFollowerTest` — with this patch it passes 10/10 runs in ~25s each.

## Root cause

`TableSpaceManager.FollowerThread.run()` acquired the tablespace-wide read lock (a `StampedLock`) around the **entire** `log.followTheLeader(...)` call. `followTheLeader` internally performs a BookKeeper long-poll (`readLastAddConfirmedAndEntry` with `LONG_POLL_TIMEOUT=1000ms`), so the read lock was held continuously even while the follower was idle waiting for new entries.

When the test (or an application) invokes a follower-side checkpoint via `DBManager.checkpoint()`, `TableSpaceManager.checkpoint(...)` tries to acquire the **write** lock on the same StampedLock (see `TableSpaceManager.java:2506`). `StampedLock` does not provide fair hand-off: the follower immediately re-acquires the read lock on every loop iteration (gap between release and re-acquire is a few nanoseconds in a tight `while` loop), and the waiting writer starves indefinitely. Jstack captured at the hang showed:

- `main` thread parked in `StampedLock.acquireWrite` on behalf of `TableSpaceManager.checkpoint` (line 2506)
- `FollowerThread` parked inside `readLastAddConfirmedAndEntry`, holding the read lock for up to 1s per iteration

## Fix

Move the read-lock acquisition into the per-entry lambda so the lock is only held around `apply(...)`, which is the brief, CPU-bound portion that actually mutates in-memory state. The BK long-poll now runs without any tablespace lock, letting a waiting writer acquire the write lock immediately.

```java
log.followTheLeader(actualLogSequenceNumber, (num, u) -> {
    long readLock = acquireReadLock("follow");
    try {
        apply(new CommitLogResult(num, false, true), u, false);
    } ... finally {
        releaseReadLock(readLock, "follow");
    }
    return !isLeader() && !closed;
}, context);
```

This preserves the original invariant — an entry is never applied concurrently with a checkpoint — while eliminating the lock hold during the idle long-poll.

## Test plan

- [x] `mvn -pl herddb-core -Dtest=SimpleFollowerTest -Dtest.groups=herddb.core.ClusterTest test` — 10/10 passes (~25s each)
- [x] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test' test` — 12/12 green (CLAUDE.md mandate for checkpoint-adjacent changes)
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — passes
- [ ] Watch CI: `pr-validation.yml`, core non-cluster, and core cluster workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)