### PR TITLE
Fix follower post-dump checkpoint persisting START_OF_TIME LSN

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -330,6 +330,15 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         LOGGER.log(Level.INFO, "Table " + table.name + ", receiving dump,"
                 + "done at external logPosition " + dumpLogSequenceNumber);
         this.dumpLogSequenceNumber = dumpLogSequenceNumber;
+        // The dump reflects all writes up to dumpLogSequenceNumber, so advance
+        // lastAppliedSequenceNumber accordingly. Otherwise the first checkpoint
+        // after the dump (e.g. the post-download checkpoint on a freshly
+        // bootstrapped follower, which applies no log entries) would persist
+        // TableStatus.sequenceNumber = START_OF_TIME, and on restart recovery
+        // would be unable to locate the records that live in the already-on-disk
+        // pages.
+        lastAppliedSequenceNumber.updateAndGet(cur ->
+                dumpLogSequenceNumber.after(cur) ? dumpLogSequenceNumber : cur);
     }
 
     void restoreFinished() {
@@ -692,7 +701,16 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             nextPrimaryKeyValue.set(Bytes.toLong(tableStatus.nextPrimaryKeyValue, 0));
             nextPageId = tableStatus.nextPageId;
             bootSequenceNumber = tableStatus.sequenceNumber;
-            lastAppliedSequenceNumber.set(bootSequenceNumber);
+            // Monotonic: prepareForRestore() may have already published a
+            // higher LSN (the dump's target position) when bootstrapping a
+            // follower from a snapshot. On a fresh table the persisted
+            // TableStatus is synthesised with START_OF_TIME, and a plain set()
+            // here would silently roll that pre-set dump LSN back to -1/-1,
+            // which made post-download checkpoints persist an unusable
+            // TableStatus.sequenceNumber on the follower.
+            final LogSequenceNumber bootLsn = bootSequenceNumber;
+            lastAppliedSequenceNumber.updateAndGet(cur ->
+                    bootLsn.after(cur) ? bootLsn : cur);
             activePagesAtBoot.putAll(tableStatus.activePages);
         }
         keyToPage.start(bootSequenceNumber, created);

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -459,15 +459,23 @@ public class BootFollowerTest extends MultiServerBase {
                 server_2.start();
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
-                for (int i = 0; i < size; i++) {
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                            TransactionContext.NO_TRANSACTION);
-                    if (found.found()) {
-                        break;
+                // Verify that the recovered rows are visible after reboot.
+                // Bounded wait keeps the test from hanging for ~33 min if the
+                // follower fails to recover — the original loop could sleep
+                // up to 20_000 × 100 ms before giving up.
+                TestUtils.waitForCondition(() -> {
+                    for (int i = 0; i < size; i++) {
+                        GetResult found = server_2.getManager().get(
+                                new GetStatement(TableSpace.DEFAULT, "t1",
+                                        Bytes.from_int(i), null, false),
+                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                TransactionContext.NO_TRANSACTION);
+                        if (found.found()) {
+                            return true;
+                        }
                     }
-                    Thread.sleep(100);
-                }
-
+                    return false;
+                }, TestUtils.NOOP, 30, "recovered data visible on rebooted follower");
             }
 
             assertEquals(3, callCount.get());


### PR DESCRIPTION
## Triage

The user asked whether `MultiNodeConsistencyCheckTest` hangs on CI. It does not — it consistently completes in ~10 s on CI and passes 10/10 locally. The CI symptom that made it _look_ like the culprit was Surefire reporting \"There was a timeout in the fork\" immediately after `MultiNodeConsistencyCheckTest` (the alphabetically last test in the cluster suite) finished on one fork. The surefire dumps in the failing runs (`jvmRun1.dump`, `jvmRun2.dump`) show the actual hung forks were running, in parallel, `SimpleFollowerTest#testCheckpointFollower` (already addressed by #188) and **`BootFollowerTest#testFollowerBootError`** — which this PR fixes.

## Root cause

Commit 858cbebd (#157) changed `TableManager.checkpoint()` Phase C to persist `lastAppliedSequenceNumber.get()` into `TableStatus.sequenceNumber` instead of the Phase-A snapshot, to fix an unrelated race. On a leader (or replica applying log entries) `lastAppliedSequenceNumber` is advanced from inside `apply(...)` / `onTransactionCommit(...)`. **On a follower that bootstraps from a dump there are no `apply()` calls at all** — `ReplicaFullTableDataDumpReceiver` / `TableManager.writeFromDump` writes pages directly — so the field stays at its construction default (`START_OF_TIME`) and the first post-download checkpoint persists `TableStatus.sequenceNumber = (-1,-1)` (visible in the surefire log as `checkpointing PK index at (-1,-1) (17 active pages)`).

On the subsequent reboot, recovery loads `activePages` correctly but the PK-index/table bootstrap LSN is `START_OF_TIME`, so queries behave as if the table were empty. The existing test loop `for (int i = 0; i < 20_000; i++)` with a 100 ms sleep between misses then stalls for up to ~33 minutes, blowing past the Surefire fork exit window and producing the `timeout in the fork` that killed sibling forks and reddened CI.

## Fix

- `TableManager.prepareForRestore(dumpLogSequenceNumber)` now publishes the dump's LSN into `lastAppliedSequenceNumber` (monotonic `updateAndGet` with `after()`).
- `TableManager.start()` no longer unconditionally `set()`s `lastAppliedSequenceNumber = bootSequenceNumber`; it uses the same monotonic `updateAndGet` so a pre-set dump LSN is not rolled back to `START_OF_TIME` when a freshly bootstrapped follower loads its synthetic empty `TableStatus`.
- `BootFollowerTest#testFollowerBootError`'s reboot data-visibility check is replaced with a bounded `TestUtils.waitForCondition(..., 30)` so a real regression fails fast instead of stalling the fork.

## Test plan

- [x] `mvn -pl herddb-core -Dtest=BootFollowerTest#testFollowerBootError -Dtest.groups=herddb.core.ClusterTest test` — 3/3 passes in ~11 s
- [x] `mvn -pl herddb-core -Dtest='BootFollowerTest,SimpleFollowerTest,CheckpointStaleLsnRecoveryTest,CheckpointStaleLsnRecoveryBookKeeperTest,TablespaceReplicasStateTest' -Dtest.groups=herddb.core.ClusterTest test` — 14/14 green
- [x] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test' test` — 12/12 green (CLAUDE.md mandate for checkpoint-adjacent changes)
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [ ] Watch CI pr-validation, core non-cluster, core cluster workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)