### PR TITLE
issue #191: make S3 GCS compatibility mode opt-in

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -84,6 +84,10 @@ fileServer:
     # when the limit is reached. Set it slightly below the PVC size to leave
     # headroom for temporary write buffers.  150 Gi = 161061273600 bytes.
     cacheMaxBytes: 161061273600
+    # GCS's S3-compatible endpoint requires path-style addressing and rejects
+    # the AWS SDK v2 default request checksums (CRC32/CRC64NVME). Enable the
+    # compatibility mode so the S3 client is configured to match GCS.
+    gcsCompatibility: true
   storage:
     size: 200Gi
   resources:

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -126,6 +126,11 @@ fileServer:
     # NOTE: this key must be under fileServer.s3 — the template reads
     # .Values.fileServer.s3.cacheMaxBytes (not .Values.fileServer.cacheMaxBytes).
     cacheMaxBytes: 214748364800
+    # MinIO requires path-style S3 addressing. The chart auto-enables this
+    # whenever minio.enabled=true, so setting it here is redundant — kept
+    # explicit for parity with examples/gke/values.yaml and so the rendered
+    # fileserver.properties clearly shows s3.gcs.compatibility=true.
+    gcsCompatibility: true
   storage:
     # 200 GiB: sized to hold the full bigann 10M segment data in the local
     # disk cache without any MinIO fallback on warm queries.

--- a/herddb-kubernetes/src/main/helm/herddb/templates/file-server-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/file-server-configmap.yaml
@@ -39,6 +39,9 @@ data:
     s3.prefix={{ .Values.fileServer.s3.prefix }}
     {{- end }}
     cache.max.bytes={{ .Values.fileServer.s3.cacheMaxBytes | int64 }}
+    {{- if or .Values.fileServer.s3.gcsCompatibility .Values.minio.enabled }}
+    s3.gcs.compatibility=true
+    {{- end }}
     {{- end }}
     http.enable=true
     http.port={{ .Values.fileServer.httpPort }}

--- a/herddb-kubernetes/src/main/helm/herddb/tests/file-server-configmap_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/file-server-configmap_test.yaml
@@ -223,3 +223,35 @@ tests:
       - notMatchRegex:
           path: data["fileserver.properties"]
           pattern: "s3\\.access\\.key=minioadmin"
+
+  - it: should not emit s3.gcs.compatibility by default in s3 mode
+    set:
+      fileServer.storageMode: s3
+      fileServer.s3.bucket: my-bucket
+      fileServer.s3.accessKey: mykey
+      fileServer.s3.secretKey: mysecret
+    asserts:
+      - notMatchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.gcs\\.compatibility"
+
+  - it: should emit s3.gcs.compatibility=true when gcsCompatibility flag is on
+    set:
+      fileServer.storageMode: s3
+      fileServer.s3.bucket: my-bucket
+      fileServer.s3.accessKey: mykey
+      fileServer.s3.secretKey: mysecret
+      fileServer.s3.gcsCompatibility: true
+    asserts:
+      - matchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.gcs\\.compatibility=true"
+
+  - it: should auto-enable s3.gcs.compatibility when minio is enabled
+    set:
+      fileServer.storageMode: s3
+      minio.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["fileserver.properties"]
+          pattern: "s3\\.gcs\\.compatibility=true"

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -81,6 +81,12 @@ fileServer:
     prefix: ""
     # Local disk cache size in bytes (default 1 GB). The PVC is always used as cache dir.
     cacheMaxBytes: 1073741824
+    # Enable GCS-compatibility tweaks on the S3 client:
+    #  - path-style addressing (required by GCS and MinIO)
+    #  - disable SDK v2 default request/response checksums (GCS rejects them)
+    # Default false = behave as a standard AWS S3 client. Auto-enabled when
+    # minio.enabled=true (the in-cluster MinIO also needs path-style addressing).
+    gcsCompatibility: false
   storage:
     size: 10Gi
     storageClass: ""

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -58,6 +58,8 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -314,14 +316,31 @@ public class RemoteFileServer implements AutoCloseable {
         // the OS page cache serves hot data under kernel-managed memory pressure.
         long cacheMaxBytes = Long.parseLong(
                 config.getProperty("cache.max.bytes", String.valueOf(DEFAULT_CACHE_MAX_BYTES)));
+        // GCS's S3-compatible endpoint (and MinIO) requires path-style addressing and
+        // rejects the AWS SDK v2 default request/response checksums (CRC32/CRC64NVME).
+        // Enabling this flag bundles both workarounds. Off by default so the client
+        // behaves like a standard AWS S3 client (virtual-hosted-style, SDK-managed
+        // checksum validation).
+        boolean gcsCompatibility = Boolean.parseBoolean(
+                config.getProperty("s3.gcs.compatibility", "false"));
 
         S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(accessKey, secretKey)))
-                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 // Use AWS CRT async HTTP client for better stability and non-blocking shutdown
                 .httpClientBuilder(AwsCrtAsyncHttpClient.builder());
+        if (gcsCompatibility) {
+            LOGGER.log(Level.INFO, "S3 client: GCS compatibility mode enabled "
+                    + "(path-style addressing, SDK checksums WHEN_REQUIRED)");
+            clientBuilder
+                    .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                    .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                    .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+        } else {
+            LOGGER.log(Level.INFO, "S3 client: standard AWS mode "
+                    + "(virtual-hosted-style, SDK default checksums)");
+        }
 
         if (endpoint != null && !endpoint.isEmpty()) {
             clientBuilder.endpointOverride(URI.create(endpoint));

--- a/herddb-remote-file-service/src/test/java/herddb/remote/S3RemoteFileServerTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/S3RemoteFileServerTest.java
@@ -113,6 +113,9 @@ public class S3RemoteFileServerTest {
         config.setProperty("s3.prefix", testPrefix);
         config.setProperty("cache.dir", dataDir.resolve("s3-cache").toString());
         config.setProperty("cache.max.bytes", String.valueOf(512 * 1024 * 1024));
+        // MinIO requires path-style addressing; enable the GCS-compat bundle so
+        // the server-side client configures pathStyleAccessEnabled(true).
+        config.setProperty("s3.gcs.compatibility", "true");
         return config;
     }
 

--- a/herddb-services/src/test/java/herddb/server/IndexingServiceWithS3E2ETest.java
+++ b/herddb-services/src/test/java/herddb/server/IndexingServiceWithS3E2ETest.java
@@ -145,6 +145,9 @@ public class IndexingServiceWithS3E2ETest {
         config.setProperty("s3.prefix", testPrefix);
         config.setProperty("cache.dir", fileServerDataDir.resolve("s3-cache").toString());
         config.setProperty("cache.max.bytes", String.valueOf(64 * 1024 * 1024));
+        // MinIO requires path-style addressing; enable the GCS-compat bundle so
+        // the server-side client configures pathStyleAccessEnabled(true).
+        config.setProperty("s3.gcs.compatibility", "true");
         return config;
     }
 


### PR DESCRIPTION
## Summary
- `RemoteFileServer.buildS3ObjectStorage` now reads an `s3.gcs.compatibility` boolean (default `false`). When enabled it turns on path-style addressing **and** sets `RequestChecksumCalculation.WHEN_REQUIRED` / `ResponseChecksumValidation.WHEN_REQUIRED` on the `S3AsyncClientBuilder` — the AWS SDK v2 default request checksums (CRC32/CRC64NVME) are what GCS's S3 endpoint rejects. Off by default, so the client behaves like a stock AWS S3 client (virtual-hosted-style, SDK-managed checksums).
- Helm chart: new `fileServer.s3.gcsCompatibility` value (default `false`), auto-enabled when `minio.enabled=true` since the in-cluster MinIO also needs path-style addressing. Rendered as `s3.gcs.compatibility=true` in `fileserver.properties`.
- `examples/gke/values.yaml` sets `gcsCompatibility: true` so the GKE bench keeps working against GCS out of the box.
- MinIO-backed integration tests (`S3RemoteFileServerTest`, `IndexingServiceWithS3E2ETest`) set `s3.gcs.compatibility=true` in the `RemoteFileServer` config so the server-side client still uses path-style against MinIO.

## Test plan
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [x] `helm unittest herddb-kubernetes/src/main/helm/herddb` — 123/123 tests pass including the 3 new assertions (default-off, explicit-on, minio auto-on)
- [x] `helm template … -f examples/gke/values.yaml` renders `s3.gcs.compatibility=true` in `fileserver.properties`
- [ ] CI run on the PR
- [ ] Manual GKE smoke via `herddb-gke-bench` flow using the updated `examples/gke/values.yaml` (real regression gate: `PutObject` against GCS)

Closes nothing automatically — reference only. Issue #191 is the CRC32C thread; this PR addresses the client-side GCS compatibility fallout of the SDK's default CRC32 request checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)