### PR TITLE
issue #196: per-query readFileRange metrics + multipart block cache

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -692,9 +692,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.maxVectorMemoryBytes = maxVectorMemoryBytes;
         this.memoryBudget = memoryBudget;
         this.maxLiveBytesPerCheckpoint = maxLiveBytesPerCheckpoint > 0 ? maxLiveBytesPerCheckpoint : 10L * 1024 * 1024 * 1024;
-        // segmentPageCacheMaxBytes is accepted for API compatibility but unused
-        // after removal of the page-based graph cache. A multipart-aware cache
-        // will be re-introduced in a follow-up change.
+        // segmentPageCacheMaxBytes is now honoured by the multipart-aware
+        // SegmentBlockCache, which lives on the RemoteFileDataStorageManager
+        // rather than inside this store — it sits under the jvector reader
+        // (RemoteRandomAccessReader) on the vector-search hot path. The
+        // constructor still validates the value for backward compatibility.
         if (segmentPageCacheMaxBytes < 0) {
             throw new IllegalArgumentException("segmentPageCacheMaxBytes must be >= 0");
         }

--- a/herddb-indexing-service/pom.xml
+++ b/herddb-indexing-service/pom.xml
@@ -65,6 +65,19 @@
             <artifactId>herddb-utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--
+          Depend on the remote-file-service module so that IndexingServiceEngine
+          can wire the shared SegmentBlockCache and VectorSearchRequestContext
+          directly into RemoteFileDataStorageManager (both live in
+          herddb-remote-file-service). IndexingServer already constructs a
+          RemoteFileDataStorageManager via RemoteFileServiceFactory, so this
+          merely makes the existing transitive relationship explicit.
+        -->
+        <dependency>
+            <groupId>org.herddb</groupId>
+            <artifactId>herddb-remote-file-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.herddb</groupId>
             <artifactId>herddb-auth-oidc</artifactId>

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -38,6 +38,8 @@ import herddb.model.Index;
 import herddb.model.Record;
 import herddb.model.Table;
 import herddb.model.TableSpace;
+import herddb.remote.RemoteFileDataStorageManager;
+import herddb.remote.SegmentBlockCache;
 import herddb.server.ServerConfiguration;
 import herddb.storage.DataStorageManager;
 import herddb.utils.Bytes;
@@ -115,6 +117,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     private DataStorageManager dataStorageManager;
     private long maxVectorMemoryBytes = Long.MAX_VALUE;
     private volatile String tableSpaceUUID;
+
+    /**
+     * Shared multipart-block cache used by {@link RemoteRandomAccessReader} on
+     * the vector-search hot path. Created in {@link #start()} from
+     * {@link IndexingServerConfiguration#PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES}
+     * and installed on the {@link RemoteFileDataStorageManager} when the DSM
+     * is a remote one. Replaces the page-keyed {@code SharedSegmentPageCache}
+     * that was removed when page-based persistence was dropped.
+     */
+    private volatile SegmentBlockCache segmentBlockCache;
 
     private ExecutorService[] applyWorkers;
     private int applyParallelism;
@@ -325,14 +337,26 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     IndexingServerConfiguration.PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT_DEFAULT);
             LOGGER.log(Level.INFO, "vector index maxLiveBytesPerCheckpoint: {0} bytes",
                     maxLiveBytesPerCheckpoint);
-            final long segmentPageCacheMaxBytes = config.getLong(
+            long segmentPageCacheMaxBytes = config.getLong(
                     IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES,
                     IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES_DEFAULT);
-            // segmentPageCacheMaxBytes is accepted for config compatibility but
-            // has no effect after the page-based cache was removed. A follow-up
-            // change will reintroduce a multipart-aware cache and log its size.
-            LOGGER.log(Level.INFO, "vector index segmentPageCacheMaxBytes: {0} (unused pending multipart cache)",
-                    segmentPageCacheMaxBytes);
+            // A value of 0 (default) means "auto-size": budget the cache at 1/4 of
+            // the JVM max heap. This matches the documented behaviour of the config
+            // property and the historical SharedSegmentPageCache default.
+            if (segmentPageCacheMaxBytes == 0) {
+                segmentPageCacheMaxBytes = Runtime.getRuntime().maxMemory() / 4;
+            }
+            this.segmentBlockCache = new SegmentBlockCache(segmentPageCacheMaxBytes);
+            LOGGER.log(Level.INFO,
+                    "vector index segmentPageCacheMaxBytes: {0} (active={1})",
+                    new Object[]{segmentPageCacheMaxBytes, segmentBlockCache.isActive()});
+            // Install the cache + stats logger on the remote DSM so that every
+            // multipartIndexReaderSupplier it builds routes reads through it.
+            if (dataStorageManager instanceof RemoteFileDataStorageManager) {
+                ((RemoteFileDataStorageManager) dataStorageManager)
+                        .setSegmentBlockCache(segmentBlockCache, statsLogger);
+            }
+            registerSegmentBlockCacheMetrics(segmentBlockCache);
 
             final long vectorMemLimit = maxVectorMemoryBytes;
             final VectorMemoryBudget budget = this;
@@ -1659,12 +1683,102 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 }
             });
             pvs.setSegmentSizeStats(indexStats.getOpStatsLogger("segment_size_bytes"));
-
-            // Segment graph-page cache gauges were removed when the page-based
-            // persistence path was deleted. A multipart-aware cache will be
-            // re-introduced as a follow-up, at which point its gauges will be
-            // registered here.
         }
+    }
+
+    /**
+     * Registers Prometheus gauges + derived counters for the shared
+     * {@link SegmentBlockCache}. Called once from {@link #start()} after the
+     * cache is created. All metrics are read lazily via {@link Gauge#getSample}
+     * so they stay in sync without any bookkeeping on the hot path.
+     */
+    private void registerSegmentBlockCacheMetrics(SegmentBlockCache cache) {
+        StatsLogger local = this.statsLogger;
+        if (local == null) {
+            return;
+        }
+        StatsLogger scope = local.scope("indexing").scope("segment_block_cache");
+        scope.registerGauge("hits", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.hitCount();
+            }
+        });
+        scope.registerGauge("misses", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.missCount();
+            }
+        });
+        scope.registerGauge("evictions", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.evictionCount();
+            }
+        });
+        scope.registerGauge("load_success", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.loadSuccessCount();
+            }
+        });
+        scope.registerGauge("load_failure", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.loadFailureCount();
+            }
+        });
+        scope.registerGauge("load_time_nanos_total", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.totalLoadTimeNanos();
+            }
+        });
+        scope.registerGauge("size_entries", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.estimatedSize();
+            }
+        });
+        scope.registerGauge("size_bytes", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.weightedSize();
+            }
+        });
+        scope.registerGauge("max_bytes", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.maxBytes();
+            }
+        });
     }
 
     @Override

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -346,15 +346,23 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             if (segmentPageCacheMaxBytes == 0) {
                 segmentPageCacheMaxBytes = Runtime.getRuntime().maxMemory() / 4;
             }
-            this.segmentBlockCache = new SegmentBlockCache(segmentPageCacheMaxBytes);
+            this.segmentBlockCache = segmentPageCacheMaxBytes > 0
+                    ? new SegmentBlockCache(segmentPageCacheMaxBytes)
+                    : SegmentBlockCache.disabled();
             LOGGER.log(Level.INFO,
                     "vector index segmentPageCacheMaxBytes: {0} (active={1})",
                     new Object[]{segmentPageCacheMaxBytes, segmentBlockCache.isActive()});
             // Install the cache + stats logger on the remote DSM so that every
             // multipartIndexReaderSupplier it builds routes reads through it.
+            // Stats logger may still be null at this point (set later by
+            // IndexingServer.start()); fall back to NullStatsLogger so the DSM
+            // setter can enforce non-null.
             if (dataStorageManager instanceof RemoteFileDataStorageManager) {
+                StatsLogger readerStats = this.statsLogger != null
+                        ? this.statsLogger
+                        : org.apache.bookkeeper.stats.NullStatsLogger.INSTANCE;
                 ((RemoteFileDataStorageManager) dataStorageManager)
-                        .setSegmentBlockCache(segmentBlockCache, statsLogger);
+                        .setSegmentBlockCache(segmentBlockCache, readerStats);
             }
             registerSegmentBlockCacheMetrics(segmentBlockCache);
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -39,6 +39,7 @@ import herddb.indexing.proto.SearchRequest;
 import herddb.indexing.proto.SearchResponse;
 import herddb.indexing.proto.SearchResult;
 import herddb.log.LogSequenceNumber;
+import herddb.remote.VectorSearchRequestContext;
 import herddb.utils.Bytes;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -73,6 +74,18 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
     private final Counter statusRequests;
     private final Counter statusErrors;
 
+    // Per-request readFileRange metrics — populated from VectorSearchRequestContext
+    // at the end of every search(). Allow attributing network I/O to an
+    // individual VectorSearch RPC (see issue #196).
+    private final Counter searchReadFileRangeCalls;
+    private final Counter searchReadFileRangeBytes;
+    private final Counter searchReadFileRangeWaitNanos;
+    private final OpStatsLogger searchReadFileRangeCallsPerRequest;
+    private final OpStatsLogger searchReadFileRangeBytesPerRequest;
+    private final OpStatsLogger searchReadFileRangeWaitPerRequest;
+    private final OpStatsLogger searchCacheHitsPerRequest;
+    private final OpStatsLogger searchCacheMissesPerRequest;
+
     public IndexingServiceImpl(IndexingServiceEngine engine, StatsLogger statsLogger) {
         this.engine = engine;
         StatsLogger scope = statsLogger.scope("indexing");
@@ -82,12 +95,24 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
         this.searchBytes = scope.getCounter("search_bytes");
         this.statusRequests = scope.getCounter("status_requests");
         this.statusErrors = scope.getCounter("status_errors");
+        this.searchReadFileRangeCalls = scope.getCounter("search_readfilerange_calls");
+        this.searchReadFileRangeBytes = scope.getCounter("search_readfilerange_bytes");
+        this.searchReadFileRangeWaitNanos = scope.getCounter("search_readfilerange_wait_nanos");
+        this.searchReadFileRangeCallsPerRequest =
+                scope.getOpStatsLogger("search_readfilerange_calls_per_request");
+        this.searchReadFileRangeBytesPerRequest =
+                scope.getOpStatsLogger("search_readfilerange_bytes_per_request");
+        this.searchReadFileRangeWaitPerRequest =
+                scope.getOpStatsLogger("search_readfilerange_wait_per_request");
+        this.searchCacheHitsPerRequest = scope.getOpStatsLogger("search_cache_hits_per_request");
+        this.searchCacheMissesPerRequest = scope.getOpStatsLogger("search_cache_misses_per_request");
     }
 
     @Override
     public void search(SearchRequest request, StreamObserver<SearchResponse> responseObserver) {
         searchRequests.inc();
         long start = System.nanoTime();
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
         try {
             float[] vector = new float[request.getVectorCount()];
             for (int i = 0; i < vector.length; i++) {
@@ -116,17 +141,53 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
             searchLatency.registerSuccessfulEvent(elapsedMicros, TimeUnit.MICROSECONDS);
             searchBytes.inc();
+            recordRequestContext(ctx, true);
             responseObserver.onNext(response);
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
             searchErrors.inc();
             long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - start);
             searchLatency.registerFailedEvent(elapsedMicros, TimeUnit.MICROSECONDS);
+            recordRequestContext(ctx, false);
             LOGGER.log(Level.SEVERE, "Search failed for index " + request.getIndex(), e);
             responseObserver.onError(Status.INTERNAL
                     .withDescription(e.getMessage())
                     .withCause(e)
                     .asRuntimeException());
+        } finally {
+            VectorSearchRequestContext.end();
+        }
+    }
+
+    /**
+     * Drains the per-request accumulator into the aggregate counters and the
+     * per-request histograms. Keeps the drain logic in one place so that the
+     * success and failure paths in {@link #search} stay parallel.
+     */
+    private void recordRequestContext(VectorSearchRequestContext ctx, boolean success) {
+        if (ctx == null) {
+            return;
+        }
+        long calls = ctx.getReadFileRangeCalls();
+        long bytes = ctx.getReadFileRangeBytes();
+        long waitNanos = ctx.getReadFileRangeWaitNanos();
+        long hits = ctx.getCacheHits();
+        long misses = ctx.getCacheMisses();
+        searchReadFileRangeCalls.addCount(calls);
+        searchReadFileRangeBytes.addCount(bytes);
+        searchReadFileRangeWaitNanos.addCount(waitNanos);
+        if (success) {
+            searchReadFileRangeCallsPerRequest.registerSuccessfulEvent(calls, TimeUnit.NANOSECONDS);
+            searchReadFileRangeBytesPerRequest.registerSuccessfulEvent(bytes, TimeUnit.NANOSECONDS);
+            searchReadFileRangeWaitPerRequest.registerSuccessfulEvent(waitNanos, TimeUnit.NANOSECONDS);
+            searchCacheHitsPerRequest.registerSuccessfulEvent(hits, TimeUnit.NANOSECONDS);
+            searchCacheMissesPerRequest.registerSuccessfulEvent(misses, TimeUnit.NANOSECONDS);
+        } else {
+            searchReadFileRangeCallsPerRequest.registerFailedEvent(calls, TimeUnit.NANOSECONDS);
+            searchReadFileRangeBytesPerRequest.registerFailedEvent(bytes, TimeUnit.NANOSECONDS);
+            searchReadFileRangeWaitPerRequest.registerFailedEvent(waitNanos, TimeUnit.NANOSECONDS);
+            searchCacheHitsPerRequest.registerFailedEvent(hits, TimeUnit.NANOSECONDS);
+            searchCacheMissesPerRequest.registerFailedEvent(misses, TimeUnit.NANOSECONDS);
         }
     }
 

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -3857,6 +3857,186 @@
       "showTitle": true,
       "title": "File Server I/O Isolation (issue #100)",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 400,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "indexing_segment_block_cache_size_bytes{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "used [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "indexing_segment_block_cache_max_bytes{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "max [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "seriesOverrides": [
+            {
+              "alias": "/max/",
+              "fill": 0,
+              "dashes": true
+            }
+          ],
+          "title": "Shared Segment Block Cache — Size (bytes)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "bytes", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 401,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "indexing_segment_block_cache_size_entries{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "entries [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Shared Segment Block Cache — Entries",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "decimals": 0, "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 402,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_hits{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hits/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(indexing_segment_block_cache_misses{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "misses/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Shared Segment Block Cache — Hits / Misses (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 403,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 2,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_hits{job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate(indexing_segment_block_cache_hits{job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate(indexing_segment_block_cache_misses{job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hit ratio [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Shared Segment Block Cache — Hit Ratio (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "percentunit", "logBase": 1, "max": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 404,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_evictions{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "evictions/s [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Shared Segment Block Cache — Evictions (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 405,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_load_time_nanos_total{job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate(indexing_segment_block_cache_load_success{job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate(indexing_segment_block_cache_load_failure{job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg load ns [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Shared Segment Block Cache — Average Block Load Latency",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ns", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Shared Segment Block Cache (issue #196)",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,

--- a/herddb-remote-file-service/pom.xml
+++ b/herddb-remote-file-service/pom.xml
@@ -121,6 +121,18 @@
             <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+          Pulls in org.apache.bookkeeper.test.TestStatsProvider used by the
+          per-request metrics tests. It lives in bookkeeper-common:tests
+          in BK 4.16.x (it was moved from bookkeeper-server:tests in older
+          releases).
+        -->
+        <dependency>
+            <groupId>org.apache.bookkeeper</groupId>
+            <artifactId>bookkeeper-common</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -61,7 +61,6 @@ import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 
@@ -126,21 +125,21 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     private final LazyValueCache lazyValueCache;
 
     /**
-     * Optional shared multipart-block cache used by {@link RemoteRandomAccessReader}
-     * on the vector-index search path. Installed by the indexing-service engine
-     * at startup via {@link #setSegmentBlockCache}. May be {@code null} (no
-     * caching) for non-indexing callers.
+     * Shared multipart-block cache used by {@link RemoteRandomAccessReader}
+     * on the vector-index search path. Starts as
+     * {@link SegmentBlockCache#disabled()} (pass-through, no caching) and is
+     * replaced by the indexing-service engine at startup via
+     * {@link #setSegmentBlockCache}. Never {@code null}.
      */
-    @Nullable
-    private volatile SegmentBlockCache segmentBlockCache;
+    private volatile SegmentBlockCache segmentBlockCache = SegmentBlockCache.disabled();
 
     /**
-     * Optional stats logger forwarded to every {@link RemoteRandomAccessReader}
-     * created by {@link #multipartIndexReaderSupplier}, wired alongside the
-     * block cache. Drives the {@code rfs_client_read_*} counters.
+     * Stats logger forwarded to every {@link RemoteRandomAccessReader}
+     * created by {@link #multipartIndexReaderSupplier}. Starts as
+     * {@link NullStatsLogger#INSTANCE} and is replaced by the indexing-service
+     * engine alongside the block cache. Never {@code null}.
      */
-    @Nullable
-    private volatile StatsLogger readerStatsLogger;
+    private volatile StatsLogger readerStatsLogger = NullStatsLogger.INSTANCE;
 
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
@@ -172,25 +171,25 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     }
 
     /**
-     * Installs an optional shared {@link SegmentBlockCache} (and optional
-     * stats logger) to be used by every {@link RemoteRandomAccessReader}
-     * returned from {@link #multipartIndexReaderSupplier}. Intended to be
-     * called once at startup, before any vector-index segment is loaded.
-     * Passing {@code null} disables caching for subsequently-created readers.
+     * Installs the shared {@link SegmentBlockCache} and stats logger to be
+     * used by every {@link RemoteRandomAccessReader} returned from
+     * {@link #multipartIndexReaderSupplier}. Intended to be called once at
+     * startup, before any vector-index segment is loaded. Pass
+     * {@link SegmentBlockCache#disabled()} and/or
+     * {@link NullStatsLogger#INSTANCE} to disable either feature without
+     * reintroducing null checks on the hot path.
      */
-    public void setSegmentBlockCache(@Nullable SegmentBlockCache cache,
-                                     @Nullable StatsLogger statsLogger) {
-        this.segmentBlockCache = cache;
-        this.readerStatsLogger = statsLogger;
-        if (cache != null) {
-            LOGGER.log(Level.INFO,
-                    "SegmentBlockCache installed: active={0}, maxBytes={1}",
-                    new Object[]{cache.isActive(), cache.maxBytes()});
-        }
+    public void setSegmentBlockCache(SegmentBlockCache cache, StatsLogger statsLogger) {
+        this.segmentBlockCache = java.util.Objects.requireNonNull(cache,
+                "cache (use SegmentBlockCache.disabled() to disable)");
+        this.readerStatsLogger = java.util.Objects.requireNonNull(statsLogger,
+                "statsLogger (use NullStatsLogger.INSTANCE to disable)");
+        LOGGER.log(Level.INFO,
+                "SegmentBlockCache installed: active={0}, maxBytes={1}",
+                new Object[]{cache.isActive(), cache.maxBytes()});
     }
 
-    /** Visible for indexing-service gauges. */
-    @Nullable
+    /** Visible for indexing-service gauges. Never {@code null}. */
     public SegmentBlockCache getSegmentBlockCache() {
         return segmentBlockCache;
     }
@@ -764,10 +763,7 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         }
         // Drop any cached blocks for this path so a future segment rewritten
         // under the same logical path does not serve stale bytes.
-        SegmentBlockCache cache = this.segmentBlockCache;
-        if (cache != null) {
-            cache.invalidatePath(logicalPath);
-        }
+        segmentBlockCache.invalidatePath(logicalPath);
     }
 
     // -------------------------------------------------------------------------
@@ -1023,10 +1019,7 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         pendingDataDeletions.keySet().removeIf(k -> k.startsWith(prefix));
         pendingIndexDeletions.keySet().removeIf(k -> k.startsWith(prefix));
         lazyValueCache.invalidateForTablespace(tableSpace);
-        SegmentBlockCache cache = this.segmentBlockCache;
-        if (cache != null) {
-            cache.invalidatePrefix(prefix);
-        }
+        segmentBlockCache.invalidatePrefix(prefix);
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -61,7 +61,9 @@ import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
 
 /**
  * DataStorageManager that stores page data on remote RemoteFileService instances
@@ -123,6 +125,23 @@ public class RemoteFileDataStorageManager extends DataStorageManager
 
     private final LazyValueCache lazyValueCache;
 
+    /**
+     * Optional shared multipart-block cache used by {@link RemoteRandomAccessReader}
+     * on the vector-index search path. Installed by the indexing-service engine
+     * at startup via {@link #setSegmentBlockCache}. May be {@code null} (no
+     * caching) for non-indexing callers.
+     */
+    @Nullable
+    private volatile SegmentBlockCache segmentBlockCache;
+
+    /**
+     * Optional stats logger forwarded to every {@link RemoteRandomAccessReader}
+     * created by {@link #multipartIndexReaderSupplier}, wired alongside the
+     * block cache. Drives the {@code rfs_client_read_*} counters.
+     */
+    @Nullable
+    private volatile StatsLogger readerStatsLogger;
+
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client) {
@@ -150,6 +169,30 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     /** Client used for all remote I/O. Visible for lazy-page loading. */
     RemoteFileServiceClient getClient() {
         return client;
+    }
+
+    /**
+     * Installs an optional shared {@link SegmentBlockCache} (and optional
+     * stats logger) to be used by every {@link RemoteRandomAccessReader}
+     * returned from {@link #multipartIndexReaderSupplier}. Intended to be
+     * called once at startup, before any vector-index segment is loaded.
+     * Passing {@code null} disables caching for subsequently-created readers.
+     */
+    public void setSegmentBlockCache(@Nullable SegmentBlockCache cache,
+                                     @Nullable StatsLogger statsLogger) {
+        this.segmentBlockCache = cache;
+        this.readerStatsLogger = statsLogger;
+        if (cache != null) {
+            LOGGER.log(Level.INFO,
+                    "SegmentBlockCache installed: active={0}, maxBytes={1}",
+                    new Object[]{cache.isActive(), cache.maxBytes()});
+        }
+    }
+
+    /** Visible for indexing-service gauges. */
+    @Nullable
+    public SegmentBlockCache getSegmentBlockCache() {
+        return segmentBlockCache;
     }
 
     /**
@@ -704,7 +747,8 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         String logicalPath = remoteMultipartPath(tableSpace, uuid, fileType);
         int writeBlockSize = Math.max(client.getBlockSize(), MULTIPART_BLOCK_SIZE);
         return new RemoteRandomAccessReader.Supplier(
-                client, logicalPath, fileSize, writeBlockSize, READ_BUFFER_SIZE, null);
+                client, logicalPath, fileSize, writeBlockSize, READ_BUFFER_SIZE,
+                readerStatsLogger, segmentBlockCache);
     }
 
     @Override
@@ -717,6 +761,12 @@ public class RemoteFileDataStorageManager extends DataStorageManager
             LOGGER.log(Level.WARNING,
                     "deleteMultipartIndexFile: non-fatal error deleting {0}: {1}",
                     new Object[]{logicalPath, e.getMessage()});
+        }
+        // Drop any cached blocks for this path so a future segment rewritten
+        // under the same logical path does not serve stale bytes.
+        SegmentBlockCache cache = this.segmentBlockCache;
+        if (cache != null) {
+            cache.invalidatePath(logicalPath);
         }
     }
 
@@ -973,6 +1023,10 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         pendingDataDeletions.keySet().removeIf(k -> k.startsWith(prefix));
         pendingIndexDeletions.keySet().removeIf(k -> k.startsWith(prefix));
         lazyValueCache.invalidateForTablespace(tableSpace);
+        SegmentBlockCache cache = this.segmentBlockCache;
+        if (cache != null) {
+            cache.invalidatePrefix(prefix);
+        }
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -23,13 +23,14 @@ package herddb.remote;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 
@@ -61,13 +62,9 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     private final long totalSize;
     private final int writeBlockSize;
     private final int bufferSize;
-    @Nullable
     private final OpStatsLogger clientReadLatency;
-    @Nullable
     private final Counter clientReadBytes;
-    @Nullable
     private final Counter clientReadRequests;
-    @Nullable
     private final SegmentBlockCache blockCache;
 
     private long position;
@@ -84,24 +81,30 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
 
     /**
      * Full constructor with separate write block size (routing / chunk lookup),
-     * read buffer size (internal window for sequential reads), optional stats
-     * logger, and optional shared {@link SegmentBlockCache}.
+     * read buffer size (internal window for sequential reads), stats logger,
+     * and shared {@link SegmentBlockCache}.
+     *
+     * <p>Both {@code statsLogger} and {@code blockCache} are mandatory and
+     * non-null. Pass {@link NullStatsLogger#INSTANCE} to disable metrics and
+     * {@link SegmentBlockCache#disabled()} to disable caching — this keeps
+     * the hot path free of null checks.
      *
      * @param writeBlockSize the multipart chunk size used by the writer; must
      *                       be a multiple of the effective buffer size so that
      *                       a buffer window never crosses a chunk boundary
      * @param bufferSize     the read-side buffer window; capped to
      *                       {@code writeBlockSize} if larger
-     * @param statsLogger    optional stats logger for client-side metrics (nullable)
-     * @param blockCache     optional shared block cache; when non-null reads
-     *                       go through the cache and per-request counters
-     *                       (hits/misses) are recorded into the current
-     *                       {@link VectorSearchRequestContext}
+     * @param statsLogger    stats logger for client-side metrics; use
+     *                       {@link NullStatsLogger#INSTANCE} to disable
+     * @param blockCache     shared block cache; use
+     *                       {@link SegmentBlockCache#disabled()} to disable
      */
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int writeBlockSize, int bufferSize,
-                                    @Nullable StatsLogger statsLogger,
-                                    @Nullable SegmentBlockCache blockCache) {
+                                    StatsLogger statsLogger,
+                                    SegmentBlockCache blockCache) {
+        Objects.requireNonNull(statsLogger, "statsLogger (use NullStatsLogger.INSTANCE to disable)");
+        Objects.requireNonNull(blockCache, "blockCache (use SegmentBlockCache.disabled() to disable)");
         if (writeBlockSize <= 0) {
             throw new IllegalArgumentException("writeBlockSize must be > 0, got " + writeBlockSize);
         }
@@ -121,25 +124,23 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         this.bufferSize = effective;
         this.blockCache = blockCache;
 
-        if (statsLogger != null) {
-            StatsLogger clientScope = statsLogger.scope("rfs").scope("client");
-            this.clientReadLatency = clientScope.getOpStatsLogger("read_latency");
-            this.clientReadBytes = clientScope.getCounter("read_bytes");
-            this.clientReadRequests = clientScope.getCounter("read_requests");
-        } else {
-            this.clientReadLatency = null;
-            this.clientReadBytes = null;
-            this.clientReadRequests = null;
-        }
+        StatsLogger clientScope = statsLogger.scope("rfs").scope("client");
+        this.clientReadLatency = clientScope.getOpStatsLogger("read_latency");
+        this.clientReadBytes = clientScope.getCounter("read_bytes");
+        this.clientReadRequests = clientScope.getCounter("read_requests");
     }
 
     /**
-     * Convenience constructor without a block cache.
+     * Convenience constructor without a block cache (uses
+     * {@link SegmentBlockCache#disabled()}). A {@code null} stats logger is
+     * normalised to {@link NullStatsLogger#INSTANCE}.
      */
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int writeBlockSize, int bufferSize,
                                     @Nullable StatsLogger statsLogger) {
-        this(client, path, totalSize, writeBlockSize, bufferSize, statsLogger, null);
+        this(client, path, totalSize, writeBlockSize, bufferSize,
+                statsLogger != null ? statsLogger : NullStatsLogger.INSTANCE,
+                SegmentBlockCache.disabled());
     }
 
     /**
@@ -150,16 +151,19 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int blockSize,
                                     @Nullable StatsLogger statsLogger) {
-        this(client, path, totalSize, blockSize, blockSize, statsLogger, null);
+        this(client, path, totalSize, blockSize, blockSize,
+                statsLogger != null ? statsLogger : NullStatsLogger.INSTANCE,
+                SegmentBlockCache.disabled());
     }
 
     /**
-     * Convenience constructor without stats logging (backward compatibility).
-     * Equivalent to {@code RemoteRandomAccessReader(client, path, totalSize, blockSize, blockSize, null)}.
+     * Convenience constructor without stats logging or caching — suitable for
+     * tests and simple callers.
      */
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int blockSize) {
-        this(client, path, totalSize, blockSize, blockSize, null, null);
+        this(client, path, totalSize, blockSize, blockSize,
+                NullStatsLogger.INSTANCE, SegmentBlockCache.disabled());
     }
 
     @Override
@@ -297,73 +301,35 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
             throw new IOException("Read past end of file: position=" + position
                     + " totalSize=" + totalSize);
         }
-        final ByteBuf data;
-        final long elapsedNanos;
-        if (blockCache != null && blockCache.isActive()) {
-            // Decide hit vs miss *before* calling getBlock so the counter
-            // reflects whether the bytes came from memory or from a gRPC call.
-            VectorSearchRequestContext ctx = VectorSearchRequestContext.current();
-            boolean wasCached = blockCache.containsBlock(path, bufferOffset, bufferSize);
-            long startNanos = System.nanoTime();
-            byte[] bytes;
-            try {
-                bytes = blockCache.getBlock(path, bufferOffset, bufferSize,
-                        (p, off, len) -> fetchBytesFromRemote(p, off, len, bufferIndex));
-            } catch (IOException e) {
-                if (ctx != null && !wasCached) {
-                    ctx.recordCacheMiss();
-                }
-                throw e;
-            }
-            elapsedNanos = System.nanoTime() - startNanos;
-            if (ctx != null) {
-                if (wasCached) {
-                    ctx.recordCacheHit();
-                } else {
-                    ctx.recordCacheMiss();
-                }
-                // Even a cache hit represents one "logical read for a search",
-                // so count it in the per-request readFileRange accumulator.
-                ctx.recordReadFileRange(requestLength, elapsedNanos);
-            }
-            data = Unpooled.wrappedBuffer(bytes, 0, requestLength);
-        } else {
-            long startNanos = System.nanoTime();
-            ByteBuf fetched;
-            try {
-                fetched = client.readFileRangeAsByteBuf(path, bufferOffset, requestLength, writeBlockSize);
-            } catch (RuntimeException e) {
-                elapsedNanos = System.nanoTime() - startNanos;
-                if (clientReadLatency != null) {
-                    clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-                }
-                throw e;
-            }
-            elapsedNanos = System.nanoTime() - startNanos;
-            if (fetched == null) {
-                if (clientReadLatency != null) {
-                    clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-                }
-                throw new IOException("Block not found: path=" + path + " bufferIndex=" + bufferIndex);
-            }
-            if (clientReadRequests != null) {
-                clientReadRequests.inc();
-            }
-            if (clientReadBytes != null) {
-                clientReadBytes.addCount(requestLength);
-            }
-            if (clientReadLatency != null) {
-                clientReadLatency.registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-            }
-            VectorSearchRequestContext ctx = VectorSearchRequestContext.current();
-            if (ctx != null) {
-                // No cache configured: every read is a miss from the request's POV.
+        // Decide hit vs miss *before* calling getBlock so the per-request
+        // counter reflects whether the bytes came from memory or from gRPC.
+        // With SegmentBlockCache.disabled() containsBlock always returns
+        // false, which correctly attributes every read as a miss.
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.current();
+        boolean wasCached = blockCache.containsBlock(path, bufferOffset, bufferSize);
+        long startNanos = System.nanoTime();
+        ByteBuf data;
+        try {
+            data = blockCache.getBlock(path, bufferOffset, bufferSize,
+                    (p, off, len) -> fetchBlockFromRemote(p, off, len, bufferIndex));
+        } catch (IOException e) {
+            if (ctx != null && !wasCached) {
                 ctx.recordCacheMiss();
-                ctx.recordReadFileRange(requestLength, elapsedNanos);
             }
-            data = fetched;
+            throw e;
         }
-        // Release the previously cached block (if any) before reassigning.
+        long elapsedNanos = System.nanoTime() - startNanos;
+        if (ctx != null) {
+            if (wasCached) {
+                ctx.recordCacheHit();
+            } else {
+                ctx.recordCacheMiss();
+            }
+            // Even a cache hit represents one "logical read for a search",
+            // so count it in the per-request readFileRange accumulator.
+            ctx.recordReadFileRange(requestLength, elapsedNanos);
+        }
+        // Release the previously cached slice (if any) before reassigning.
         if (blockBuffer != null) {
             ReferenceCountUtil.safeRelease(blockBuffer);
         }
@@ -374,15 +340,15 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     /**
      * Loader callback invoked by {@link SegmentBlockCache} on a miss. Performs
      * the actual {@code readFileRange} gRPC call, updates the client-side
-     * counters ({@code rfs_client_read_*}), and returns a fresh heap-owned
-     * copy of the bytes so that the cache can own them independently of Netty
-     * pooling.
+     * counters ({@code rfs_client_read_*}), and returns a fresh pooled direct
+     * {@link ByteBuf} that the cache (or, in pass-through mode, the caller)
+     * takes ownership of.
      *
      * <p>The {@code len} argument is the nominal block size used for cache
      * keying; at end-of-file the actual fetch is clamped to the remaining
      * bytes so we don't request past {@link #totalSize}.
      */
-    private byte[] fetchBytesFromRemote(String p, long off, int len, long bufferIndex)
+    private ByteBuf fetchBlockFromRemote(String p, long off, int len, long bufferIndex)
             throws IOException {
         int actualLength = (int) Math.min((long) len, totalSize - off);
         if (actualLength <= 0) {
@@ -394,37 +360,19 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
             fetched = client.readFileRangeAsByteBuf(p, off, actualLength, writeBlockSize);
         } catch (RuntimeException e) {
             long elapsedNanos = System.nanoTime() - startNanos;
-            if (clientReadLatency != null) {
-                clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-            }
+            clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
             throw new IOException("readFileRange failed: path=" + p + " offset=" + off
                     + " length=" + actualLength, e);
         }
         long elapsedNanos = System.nanoTime() - startNanos;
         if (fetched == null) {
-            if (clientReadLatency != null) {
-                clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-            }
+            clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
             throw new IOException("Block not found: path=" + p + " bufferIndex=" + bufferIndex);
         }
-        try {
-            if (clientReadRequests != null) {
-                clientReadRequests.inc();
-            }
-            if (clientReadBytes != null) {
-                clientReadBytes.addCount(fetched.readableBytes());
-            }
-            if (clientReadLatency != null) {
-                clientReadLatency.registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-            }
-            // Copy out into a byte[] so the cache owns the bytes; release the
-            // pooled netty buffer immediately.
-            byte[] copy = new byte[fetched.readableBytes()];
-            fetched.getBytes(fetched.readerIndex(), copy);
-            return copy;
-        } finally {
-            ReferenceCountUtil.safeRelease(fetched);
-        }
+        clientReadRequests.inc();
+        clientReadBytes.addCount(fetched.readableBytes());
+        clientReadLatency.registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+        return fetched;
     }
 
     /**
@@ -438,31 +386,35 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         private final long totalSize;
         private final int writeBlockSize;
         private final int bufferSize;
-        @Nullable
         private final StatsLogger statsLogger;
-        @Nullable
         private final SegmentBlockCache blockCache;
 
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int writeBlockSize, int bufferSize,
-                        @Nullable StatsLogger statsLogger,
-                        @Nullable SegmentBlockCache blockCache) {
+                        StatsLogger statsLogger,
+                        SegmentBlockCache blockCache) {
             this.client = client;
             this.path = path;
             this.totalSize = totalSize;
             this.writeBlockSize = writeBlockSize;
             this.bufferSize = bufferSize;
-            this.statsLogger = statsLogger;
-            this.blockCache = blockCache;
+            this.statsLogger = Objects.requireNonNull(statsLogger,
+                    "statsLogger (use NullStatsLogger.INSTANCE to disable)");
+            this.blockCache = Objects.requireNonNull(blockCache,
+                    "blockCache (use SegmentBlockCache.disabled() to disable)");
         }
 
         /**
-         * Convenience constructor without a block cache.
+         * Convenience constructor without a block cache (uses
+         * {@link SegmentBlockCache#disabled()}). {@code null} stats logger is
+         * normalised to {@link NullStatsLogger#INSTANCE}.
          */
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int writeBlockSize, int bufferSize,
                         @Nullable StatsLogger statsLogger) {
-            this(client, path, totalSize, writeBlockSize, bufferSize, statsLogger, null);
+            this(client, path, totalSize, writeBlockSize, bufferSize,
+                    statsLogger != null ? statsLogger : NullStatsLogger.INSTANCE,
+                    SegmentBlockCache.disabled());
         }
 
         /**
@@ -472,15 +424,18 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int blockSize,
                         @Nullable StatsLogger statsLogger) {
-            this(client, path, totalSize, blockSize, blockSize, statsLogger, null);
+            this(client, path, totalSize, blockSize, blockSize,
+                    statsLogger != null ? statsLogger : NullStatsLogger.INSTANCE,
+                    SegmentBlockCache.disabled());
         }
 
         /**
-         * Convenience constructor without stats logging (backward compatibility).
+         * Convenience constructor without stats logging or caching.
          */
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int blockSize) {
-            this(client, path, totalSize, blockSize, blockSize, null, null);
+            this(client, path, totalSize, blockSize, blockSize,
+                    NullStatsLogger.INSTANCE, SegmentBlockCache.disabled());
         }
 
         @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -23,6 +23,7 @@ package herddb.remote;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -66,6 +67,8 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     private final Counter clientReadBytes;
     @Nullable
     private final Counter clientReadRequests;
+    @Nullable
+    private final SegmentBlockCache blockCache;
 
     private long position;
     /**
@@ -80,8 +83,9 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     private long bufferedBlockIndex = -1;
 
     /**
-     * Full constructor with separate write block size (routing / chunk lookup)
-     * and read buffer size (internal window for sequential reads).
+     * Full constructor with separate write block size (routing / chunk lookup),
+     * read buffer size (internal window for sequential reads), optional stats
+     * logger, and optional shared {@link SegmentBlockCache}.
      *
      * @param writeBlockSize the multipart chunk size used by the writer; must
      *                       be a multiple of the effective buffer size so that
@@ -89,10 +93,15 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
      * @param bufferSize     the read-side buffer window; capped to
      *                       {@code writeBlockSize} if larger
      * @param statsLogger    optional stats logger for client-side metrics (nullable)
+     * @param blockCache     optional shared block cache; when non-null reads
+     *                       go through the cache and per-request counters
+     *                       (hits/misses) are recorded into the current
+     *                       {@link VectorSearchRequestContext}
      */
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int writeBlockSize, int bufferSize,
-                                    @Nullable StatsLogger statsLogger) {
+                                    @Nullable StatsLogger statsLogger,
+                                    @Nullable SegmentBlockCache blockCache) {
         if (writeBlockSize <= 0) {
             throw new IllegalArgumentException("writeBlockSize must be > 0, got " + writeBlockSize);
         }
@@ -110,6 +119,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         this.totalSize = totalSize;
         this.writeBlockSize = writeBlockSize;
         this.bufferSize = effective;
+        this.blockCache = blockCache;
 
         if (statsLogger != null) {
             StatsLogger clientScope = statsLogger.scope("rfs").scope("client");
@@ -124,6 +134,15 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     }
 
     /**
+     * Convenience constructor without a block cache.
+     */
+    public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
+                                    long totalSize, int writeBlockSize, int bufferSize,
+                                    @Nullable StatsLogger statsLogger) {
+        this(client, path, totalSize, writeBlockSize, bufferSize, statsLogger, null);
+    }
+
+    /**
      * Convenience constructor for the case where the caller has no distinct
      * read-buffer size. Equivalent to
      * {@code RemoteRandomAccessReader(client, path, totalSize, blockSize, blockSize, statsLogger)}.
@@ -131,7 +150,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int blockSize,
                                     @Nullable StatsLogger statsLogger) {
-        this(client, path, totalSize, blockSize, blockSize, statsLogger);
+        this(client, path, totalSize, blockSize, blockSize, statsLogger, null);
     }
 
     /**
@@ -140,7 +159,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
      */
     public RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
                                     long totalSize, int blockSize) {
-        this(client, path, totalSize, blockSize, blockSize, null);
+        this(client, path, totalSize, blockSize, blockSize, null, null);
     }
 
     @Override
@@ -278,26 +297,71 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
             throw new IOException("Read past end of file: position=" + position
                     + " totalSize=" + totalSize);
         }
-        if (clientReadRequests != null) {
-            clientReadRequests.inc();
-        }
-        long startNanos = System.nanoTime();
-        ByteBuf data = client.readFileRangeAsByteBuf(path, bufferOffset, requestLength, writeBlockSize);
-        long elapsedNanos = System.nanoTime() - startNanos;
-        if (data == null) {
-            if (clientReadLatency != null) {
-                clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+        final ByteBuf data;
+        final long elapsedNanos;
+        if (blockCache != null && blockCache.isActive()) {
+            // Decide hit vs miss *before* calling getBlock so the counter
+            // reflects whether the bytes came from memory or from a gRPC call.
+            VectorSearchRequestContext ctx = VectorSearchRequestContext.current();
+            boolean wasCached = blockCache.containsBlock(path, bufferOffset, bufferSize);
+            long startNanos = System.nanoTime();
+            byte[] bytes;
+            try {
+                bytes = blockCache.getBlock(path, bufferOffset, bufferSize,
+                        (p, off, len) -> fetchBytesFromRemote(p, off, len, bufferIndex));
+            } catch (IOException e) {
+                if (ctx != null && !wasCached) {
+                    ctx.recordCacheMiss();
+                }
+                throw e;
             }
-            throw new IOException("Block not found: path=" + path + " bufferIndex=" + bufferIndex);
-        }
-        if (clientReadLatency != null) {
-            clientReadLatency.registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
-        }
-        if (clientReadRequests != null) {
-            clientReadRequests.inc();
-        }
-        if (clientReadBytes != null) {
-            clientReadBytes.inc();
+            elapsedNanos = System.nanoTime() - startNanos;
+            if (ctx != null) {
+                if (wasCached) {
+                    ctx.recordCacheHit();
+                } else {
+                    ctx.recordCacheMiss();
+                }
+                // Even a cache hit represents one "logical read for a search",
+                // so count it in the per-request readFileRange accumulator.
+                ctx.recordReadFileRange(requestLength, elapsedNanos);
+            }
+            data = Unpooled.wrappedBuffer(bytes, 0, requestLength);
+        } else {
+            long startNanos = System.nanoTime();
+            ByteBuf fetched;
+            try {
+                fetched = client.readFileRangeAsByteBuf(path, bufferOffset, requestLength, writeBlockSize);
+            } catch (RuntimeException e) {
+                elapsedNanos = System.nanoTime() - startNanos;
+                if (clientReadLatency != null) {
+                    clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+                }
+                throw e;
+            }
+            elapsedNanos = System.nanoTime() - startNanos;
+            if (fetched == null) {
+                if (clientReadLatency != null) {
+                    clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+                }
+                throw new IOException("Block not found: path=" + path + " bufferIndex=" + bufferIndex);
+            }
+            if (clientReadRequests != null) {
+                clientReadRequests.inc();
+            }
+            if (clientReadBytes != null) {
+                clientReadBytes.addCount(requestLength);
+            }
+            if (clientReadLatency != null) {
+                clientReadLatency.registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+            }
+            VectorSearchRequestContext ctx = VectorSearchRequestContext.current();
+            if (ctx != null) {
+                // No cache configured: every read is a miss from the request's POV.
+                ctx.recordCacheMiss();
+                ctx.recordReadFileRange(requestLength, elapsedNanos);
+            }
+            data = fetched;
         }
         // Release the previously cached block (if any) before reassigning.
         if (blockBuffer != null) {
@@ -305,6 +369,62 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         }
         blockBuffer = data;
         bufferedBlockIndex = bufferIndex;
+    }
+
+    /**
+     * Loader callback invoked by {@link SegmentBlockCache} on a miss. Performs
+     * the actual {@code readFileRange} gRPC call, updates the client-side
+     * counters ({@code rfs_client_read_*}), and returns a fresh heap-owned
+     * copy of the bytes so that the cache can own them independently of Netty
+     * pooling.
+     *
+     * <p>The {@code len} argument is the nominal block size used for cache
+     * keying; at end-of-file the actual fetch is clamped to the remaining
+     * bytes so we don't request past {@link #totalSize}.
+     */
+    private byte[] fetchBytesFromRemote(String p, long off, int len, long bufferIndex)
+            throws IOException {
+        int actualLength = (int) Math.min((long) len, totalSize - off);
+        if (actualLength <= 0) {
+            throw new IOException("Read past end of file: offset=" + off + " totalSize=" + totalSize);
+        }
+        long startNanos = System.nanoTime();
+        ByteBuf fetched;
+        try {
+            fetched = client.readFileRangeAsByteBuf(p, off, actualLength, writeBlockSize);
+        } catch (RuntimeException e) {
+            long elapsedNanos = System.nanoTime() - startNanos;
+            if (clientReadLatency != null) {
+                clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+            }
+            throw new IOException("readFileRange failed: path=" + p + " offset=" + off
+                    + " length=" + actualLength, e);
+        }
+        long elapsedNanos = System.nanoTime() - startNanos;
+        if (fetched == null) {
+            if (clientReadLatency != null) {
+                clientReadLatency.registerFailedEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+            }
+            throw new IOException("Block not found: path=" + p + " bufferIndex=" + bufferIndex);
+        }
+        try {
+            if (clientReadRequests != null) {
+                clientReadRequests.inc();
+            }
+            if (clientReadBytes != null) {
+                clientReadBytes.addCount(fetched.readableBytes());
+            }
+            if (clientReadLatency != null) {
+                clientReadLatency.registerSuccessfulEvent(elapsedNanos, TimeUnit.NANOSECONDS);
+            }
+            // Copy out into a byte[] so the cache owns the bytes; release the
+            // pooled netty buffer immediately.
+            byte[] copy = new byte[fetched.readableBytes()];
+            fetched.getBytes(fetched.readerIndex(), copy);
+            return copy;
+        } finally {
+            ReferenceCountUtil.safeRelease(fetched);
+        }
     }
 
     /**
@@ -320,16 +440,29 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         private final int bufferSize;
         @Nullable
         private final StatsLogger statsLogger;
+        @Nullable
+        private final SegmentBlockCache blockCache;
 
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int writeBlockSize, int bufferSize,
-                        @Nullable StatsLogger statsLogger) {
+                        @Nullable StatsLogger statsLogger,
+                        @Nullable SegmentBlockCache blockCache) {
             this.client = client;
             this.path = path;
             this.totalSize = totalSize;
             this.writeBlockSize = writeBlockSize;
             this.bufferSize = bufferSize;
             this.statsLogger = statsLogger;
+            this.blockCache = blockCache;
+        }
+
+        /**
+         * Convenience constructor without a block cache.
+         */
+        public Supplier(RemoteFileServiceClient client, String path,
+                        long totalSize, int writeBlockSize, int bufferSize,
+                        @Nullable StatsLogger statsLogger) {
+            this(client, path, totalSize, writeBlockSize, bufferSize, statsLogger, null);
         }
 
         /**
@@ -339,7 +472,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int blockSize,
                         @Nullable StatsLogger statsLogger) {
-            this(client, path, totalSize, blockSize, blockSize, statsLogger);
+            this(client, path, totalSize, blockSize, blockSize, statsLogger, null);
         }
 
         /**
@@ -347,12 +480,13 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
          */
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int blockSize) {
-            this(client, path, totalSize, blockSize, blockSize, null);
+            this(client, path, totalSize, blockSize, blockSize, null, null);
         }
 
         @Override
         public RandomAccessReader get() throws IOException {
-            return new RemoteRandomAccessReader(client, path, totalSize, writeBlockSize, bufferSize, statsLogger);
+            return new RemoteRandomAccessReader(client, path, totalSize,
+                    writeBlockSize, bufferSize, statsLogger, blockCache);
         }
 
         @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -23,7 +23,6 @@ package herddb.remote;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
@@ -81,8 +80,17 @@ public final class SegmentBlockCache {
 
     private final long maxBytes;
     private final Cache<BlockKey, ByteBuf> cache;
-    private final AtomicLong passthroughLoads = new AtomicLong();
-    private final AtomicLong passthroughLoadFailures = new AtomicLong();
+    // We track hit/miss/load stats ourselves because the only way to do an
+    // atomic retain-under-lock is via asMap().compute(), and Caffeine's
+    // recordStats() does not count compute() invocations as gets. Keeping our
+    // own counters is also what makes the stats meaningful for the Grafana
+    // panels and the per-request cache_hits_per_request histogram.
+    private final AtomicLong hits = new AtomicLong();
+    private final AtomicLong misses = new AtomicLong();
+    private final AtomicLong evictions = new AtomicLong();
+    private final AtomicLong loadSuccess = new AtomicLong();
+    private final AtomicLong loadFailure = new AtomicLong();
+    private final AtomicLong loadTimeNanos = new AtomicLong();
 
     public SegmentBlockCache(long maxBytes) {
         this.maxBytes = maxBytes;
@@ -97,9 +105,11 @@ public final class SegmentBlockCache {
                         // the cache. Callers receive retained slices, so an
                         // eviction while a slice is in flight does not cause
                         // use-after-free.
+                        if (cause != null && cause.wasEvicted()) {
+                            evictions.incrementAndGet();
+                        }
                         ReferenceCountUtil.safeRelease(v);
                     })
-                    .recordStats()
                     .build();
         }
     }
@@ -124,6 +134,14 @@ public final class SegmentBlockCache {
      * retained slice; the caller MUST release it exactly once. The underlying
      * shared entry is released automatically when evicted.
      *
+     * <p><b>Concurrency</b>: retain happens under the map's per-entry lock
+     * via {@link java.util.concurrent.ConcurrentMap#compute compute}, so it
+     * can never race with the removal listener's release. This avoids a
+     * nasty {@link io.netty.util.IllegalReferenceCountException} that would
+     * otherwise fire when an entry is evicted between
+     * {@code cache.get()} returning a reference and the caller bumping its
+     * refcount.
+     *
      * @param path       logical multipart path
      * @param offset     block start, must be a multiple of {@code length}
      * @param length     block length in bytes (> 0)
@@ -145,44 +163,86 @@ public final class SegmentBlockCache {
         }
         long blockIndex = offset / length;
         BlockKey key = new BlockKey(path, blockIndex);
+
+        // Everything happens inside a single asMap().compute() call so that
+        // the retain is atomic with the entry-present check — no window for
+        // the removal listener to release underneath us. Caffeine serialises
+        // concurrent callers on the same key, giving single-flight semantics
+        // for the loader. Hit/miss/load stats are recorded manually inside
+        // the function because Caffeine's recordStats() does not instrument
+        // asMap().compute().
+        ByteBuf retained;
         try {
-            ByteBuf shared = cache.get(key, k -> {
-                try {
-                    ByteBuf loaded = loader.load(path, offset, length);
-                    if (loaded == null) {
-                        throw new CacheLoadException(new IOException(
-                                "loader returned null for " + path + "@" + offset));
-                    }
-                    return loaded;
-                } catch (IOException e) {
-                    throw new CacheLoadException(e);
+            retained = cache.asMap().compute(key, (k, existing) -> {
+                if (existing != null) {
+                    // Hit: bump refcount by one so the caller has a handle
+                    // independent of the cache's ownership.
+                    hits.incrementAndGet();
+                    existing.retain();
+                    return existing;
                 }
+                // Miss: run the loader. Loader returns a buf with refCnt=1
+                // (its own fresh allocation). We retain once more so the
+                // final refCnt=2 means "one ref owned by the cache (released
+                // on eviction), one ref owned by the caller".
+                misses.incrementAndGet();
+                long startNanos = System.nanoTime();
+                ByteBuf loaded;
+                try {
+                    loaded = loader.load(path, offset, length);
+                } catch (IOException ioe) {
+                    loadFailure.incrementAndGet();
+                    loadTimeNanos.addAndGet(System.nanoTime() - startNanos);
+                    throw new CacheLoadException(ioe);
+                }
+                loadTimeNanos.addAndGet(System.nanoTime() - startNanos);
+                if (loaded == null) {
+                    loadFailure.incrementAndGet();
+                    throw new CacheLoadException(new IOException(
+                            "loader returned null for " + path + "@" + offset));
+                }
+                loadSuccess.incrementAndGet();
+                loaded.retain();
+                return loaded;
             });
-            if (shared == null) {
-                throw new IOException("cache load returned null for " + path + "@" + offset);
-            }
-            // retainedSlice bumps the refcount on the shared entry and returns
-            // a duplicate view with its own reader/writer indices. The caller
-            // releases the slice; the cache releases the shared entry on
-            // eviction.
-            return shared.retainedSlice(0, shared.readableBytes());
         } catch (CacheLoadException e) {
             throw (IOException) e.getCause();
+        }
+        if (retained == null) {
+            // Should not happen: compute returns non-null either via the hit
+            // branch or via the loader branch (loader null/throw becomes
+            // CacheLoadException). Defensive fallback.
+            return invokeLoader(loader, path, offset, length);
+        }
+        try {
+            // retainedSlice bumps the shared refcount again and returns a
+            // caller-owned view with independent reader/writer indices.
+            return retained.retainedSlice(0, retained.readableBytes());
+        } finally {
+            // Drop the "caller retain" we added inside compute; the slice
+            // we returned carries its own ref, so the shared entry stays
+            // alive as long as either the cache holds it or a slice is
+            // outstanding.
+            retained.release();
         }
     }
 
     private ByteBuf invokeLoader(BlockLoader loader, String path, long offset, int length)
             throws IOException {
+        long startNanos = System.nanoTime();
         try {
             ByteBuf buf = loader.load(path, offset, length);
             if (buf == null) {
-                passthroughLoadFailures.incrementAndGet();
+                loadFailure.incrementAndGet();
+                loadTimeNanos.addAndGet(System.nanoTime() - startNanos);
                 throw new IOException("loader returned null for " + path + "@" + offset);
             }
-            passthroughLoads.incrementAndGet();
+            loadSuccess.incrementAndGet();
+            loadTimeNanos.addAndGet(System.nanoTime() - startNanos);
             return buf;
         } catch (IOException e) {
-            passthroughLoadFailures.incrementAndGet();
+            loadFailure.incrementAndGet();
+            loadTimeNanos.addAndGet(System.nanoTime() - startNanos);
             throw e;
         }
     }
@@ -291,31 +351,33 @@ public final class SegmentBlockCache {
     }
 
     // ---------------------------------------------------------------------
-    // Stats accessors — all return 0 when the cache is disabled.
+    // Stats accessors. Hits/misses are 0 when the cache is disabled (pass-
+    // through mode) because no lookups happen; load_success / load_failure /
+    // load_time still track the pass-through loader calls.
     // ---------------------------------------------------------------------
 
     public long hitCount() {
-        return cache == null ? 0 : stats().hitCount();
+        return hits.get();
     }
 
     public long missCount() {
-        return cache == null ? 0 : stats().missCount();
+        return misses.get();
     }
 
     public long evictionCount() {
-        return cache == null ? 0 : stats().evictionCount();
+        return evictions.get();
     }
 
     public long loadSuccessCount() {
-        return cache == null ? passthroughLoads.get() : stats().loadSuccessCount();
+        return loadSuccess.get();
     }
 
     public long loadFailureCount() {
-        return cache == null ? passthroughLoadFailures.get() : stats().loadFailureCount();
+        return loadFailure.get();
     }
 
     public long totalLoadTimeNanos() {
-        return cache == null ? 0 : stats().totalLoadTime();
+        return loadTimeNanos.get();
     }
 
     public long estimatedSize() {
@@ -329,10 +391,6 @@ public final class SegmentBlockCache {
         return cache.policy().eviction()
                 .map(e -> e.weightedSize().orElse(0L))
                 .orElse(0L);
-    }
-
-    private CacheStats stats() {
-        return cache.stats();
     }
 
     // ---------------------------------------------------------------------

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -1,0 +1,315 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+
+/**
+ * Shared, byte-weighted, multipart-aware block cache for remote vector-index
+ * segment files. Replaces the page-keyed {@code SharedSegmentPageCache} that
+ * was removed when page-based persistence was dropped in favour of multipart
+ * objects.
+ *
+ * <p>Keys are {@code (path, blockIndex)} pairs where {@code path} is the
+ * logical multipart path used by {@link RemoteRandomAccessReader} and
+ * {@code blockIndex = offset / blockSize}. Values are {@code byte[]} payloads
+ * owned by the cache. On a miss the provided {@link BlockLoader} is invoked
+ * exactly once per key (Caffeine {@code get} de-duplicates concurrent misses);
+ * the same {@code byte[]} instance is then handed to all waiters. The array
+ * is immutable once returned: callers must not mutate it.
+ *
+ * <p>Eviction is byte-weighted LRU bounded by {@code maxBytes}. A value of
+ * {@code 0} (or negative) turns the cache off — {@link #getBlock} then invokes
+ * the loader on every call and caches nothing.
+ *
+ * <p>Why {@code byte[]} instead of a direct {@code ByteBuf}: the cache is
+ * long-lived and shared across readers, so owning Netty-pooled buffers would
+ * require an explicit {@code RemovalListener} to release them on eviction and
+ * careful ref-counting on every hit. Storing {@code byte[]} keeps lifecycle
+ * trivial; readers wrap the array with {@code Unpooled.wrappedBuffer(byte[])}
+ * for a zero-copy {@code ByteBuf} view.
+ *
+ * @author enrico.olivelli
+ */
+public final class SegmentBlockCache {
+
+    /** Loads a single block when the cache misses. */
+    @FunctionalInterface
+    public interface BlockLoader {
+        byte[] load(String path, long offset, int length) throws IOException;
+    }
+
+    private final long maxBytes;
+    @Nullable
+    private final Cache<BlockKey, byte[]> cache;
+    private final AtomicLong passthroughLoads = new AtomicLong();
+    private final AtomicLong passthroughLoadFailures = new AtomicLong();
+
+    public SegmentBlockCache(long maxBytes) {
+        this.maxBytes = maxBytes;
+        if (maxBytes <= 0) {
+            this.cache = null;
+        } else {
+            this.cache = Caffeine.newBuilder()
+                    .maximumWeight(maxBytes)
+                    .weigher((BlockKey k, byte[] v) -> v == null ? 0 : v.length)
+                    .recordStats()
+                    .build();
+        }
+    }
+
+    /** Returns {@code true} when caching is enabled (configured budget > 0). */
+    public boolean isActive() {
+        return cache != null;
+    }
+
+    public long maxBytes() {
+        return maxBytes;
+    }
+
+    /**
+     * Fetches the block at {@code (path, offset, length)}, consulting the
+     * cache first and invoking {@code loader} on miss. {@code offset} must be
+     * a multiple of {@code length} — this is the natural alignment used by
+     * {@link RemoteRandomAccessReader}, where the read window is a fixed-size
+     * sliding buffer. The value is returned as a caller-read-only {@code byte[]};
+     * do not mutate.
+     *
+     * @param path       logical multipart path
+     * @param offset     block start, must be a multiple of {@code length}
+     * @param length     block length in bytes (>= 0); when cache is inactive
+     *                   the loader receives exactly these arguments
+     * @param loader     invoked at most once per key on miss
+     */
+    public byte[] getBlock(String path, long offset, int length, BlockLoader loader)
+            throws IOException {
+        Objects.requireNonNull(path, "path");
+        Objects.requireNonNull(loader, "loader");
+        if (length <= 0) {
+            throw new IllegalArgumentException("length must be > 0, got " + length);
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be >= 0, got " + offset);
+        }
+        if (cache == null) {
+            return invokeLoader(loader, path, offset, length);
+        }
+        long blockIndex = offset / length;
+        BlockKey key = new BlockKey(path, blockIndex);
+        try {
+            return cache.get(key, k -> {
+                try {
+                    byte[] bytes = loader.load(path, offset, length);
+                    if (bytes == null) {
+                        throw new CacheLoadException(new IOException(
+                                "loader returned null for " + path + "@" + offset));
+                    }
+                    return bytes;
+                } catch (IOException e) {
+                    throw new CacheLoadException(e);
+                }
+            });
+        } catch (CacheLoadException e) {
+            throw (IOException) e.getCause();
+        }
+    }
+
+    private byte[] invokeLoader(BlockLoader loader, String path, long offset, int length)
+            throws IOException {
+        try {
+            byte[] bytes = loader.load(path, offset, length);
+            if (bytes == null) {
+                passthroughLoadFailures.incrementAndGet();
+                throw new IOException("loader returned null for " + path + "@" + offset);
+            }
+            passthroughLoads.incrementAndGet();
+            return bytes;
+        } catch (IOException e) {
+            passthroughLoadFailures.incrementAndGet();
+            throw e;
+        }
+    }
+
+    /**
+     * Checks whether the cache currently holds the block at
+     * {@code (path, offset, length)} without triggering a load or affecting
+     * LRU ordering. Used by {@link RemoteRandomAccessReader} to distinguish
+     * per-request cache hits from cache misses.
+     */
+    public boolean containsBlock(String path, long offset, int length) {
+        if (cache == null) {
+            return false;
+        }
+        long blockIndex = offset / length;
+        return cache.asMap().containsKey(new BlockKey(path, blockIndex));
+    }
+
+    /**
+     * Removes every cached block whose key path equals {@code path}. Called
+     * when a multipart segment file is deleted or rewritten so that stale
+     * bytes cannot be served to a subsequent reader that happens to hit the
+     * same logical path.
+     */
+    public void invalidatePath(String path) {
+        if (cache == null || path == null) {
+            return;
+        }
+        Iterator<BlockKey> it = cache.asMap().keySet().iterator();
+        while (it.hasNext()) {
+            BlockKey k = it.next();
+            if (path.equals(k.path)) {
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Removes every cached block whose key path starts with {@code prefix}.
+     * Used by bulk deletions (e.g. {@code eraseTablespaceData}) so that
+     * multipart segments sharing a logical prefix are invalidated together.
+     */
+    public void invalidatePrefix(String prefix) {
+        if (cache == null || prefix == null) {
+            return;
+        }
+        Iterator<BlockKey> it = cache.asMap().keySet().iterator();
+        while (it.hasNext()) {
+            BlockKey k = it.next();
+            if (k.path.startsWith(prefix)) {
+                it.remove();
+            }
+        }
+    }
+
+    public void clear() {
+        if (cache != null) {
+            cache.invalidateAll();
+        }
+    }
+
+    /**
+     * Forces Caffeine to drain its async maintenance queue. Tests use this
+     * before asserting on eviction counts; not needed in production.
+     */
+    public void cleanUp() {
+        if (cache != null) {
+            cache.cleanUp();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Stats accessors — all return 0 when the cache is disabled.
+    // ---------------------------------------------------------------------
+
+    public long hitCount() {
+        return cache == null ? 0 : stats().hitCount();
+    }
+
+    public long missCount() {
+        return cache == null ? 0 : stats().missCount();
+    }
+
+    public long evictionCount() {
+        return cache == null ? 0 : stats().evictionCount();
+    }
+
+    public long loadSuccessCount() {
+        return cache == null ? passthroughLoads.get() : stats().loadSuccessCount();
+    }
+
+    public long loadFailureCount() {
+        return cache == null ? passthroughLoadFailures.get() : stats().loadFailureCount();
+    }
+
+    public long totalLoadTimeNanos() {
+        return cache == null ? 0 : stats().totalLoadTime();
+    }
+
+    public long estimatedSize() {
+        return cache == null ? 0 : cache.estimatedSize();
+    }
+
+    public long weightedSize() {
+        if (cache == null) {
+            return 0;
+        }
+        return cache.policy().eviction()
+                .map(e -> e.weightedSize().orElse(0L))
+                .orElse(0L);
+    }
+
+    private CacheStats stats() {
+        return cache.stats();
+    }
+
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /** Immutable composite cache key. Hash is precomputed to avoid repeated path hashing. */
+    static final class BlockKey {
+        final String path;
+        final long blockIndex;
+        private final int hash;
+
+        BlockKey(String path, long blockIndex) {
+            this.path = Objects.requireNonNull(path, "path");
+            this.blockIndex = blockIndex;
+            this.hash = 31 * path.hashCode() + Long.hashCode(blockIndex);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BlockKey)) {
+                return false;
+            }
+            BlockKey k = (BlockKey) o;
+            return hash == k.hash && blockIndex == k.blockIndex && path.equals(k.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "BlockKey{" + path + "@" + blockIndex + '}';
+        }
+    }
+
+    /** Unchecked wrapper used inside the Caffeine loader to propagate IOException. */
+    private static final class CacheLoadException extends RuntimeException {
+        CacheLoadException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -22,12 +22,15 @@ package herddb.remote;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nullable;
 
 /**
  * Shared, byte-weighted, multipart-aware block cache for remote vector-index
@@ -37,36 +40,47 @@ import javax.annotation.Nullable;
  *
  * <p>Keys are {@code (path, blockIndex)} pairs where {@code path} is the
  * logical multipart path used by {@link RemoteRandomAccessReader} and
- * {@code blockIndex = offset / blockSize}. Values are {@code byte[]} payloads
- * owned by the cache. On a miss the provided {@link BlockLoader} is invoked
- * exactly once per key (Caffeine {@code get} de-duplicates concurrent misses);
- * the same {@code byte[]} instance is then handed to all waiters. The array
- * is immutable once returned: callers must not mutate it.
+ * {@code blockIndex = offset / blockSize}. Values are pooled direct
+ * {@link ByteBuf}s owned by the cache; on a hit {@link #getBlock} returns a
+ * fresh {@link ByteBuf#retainedSlice() retained slice} which the caller is
+ * responsible for releasing. On eviction the cache releases its own reference
+ * via a Caffeine removal listener.
  *
- * <p>Eviction is byte-weighted LRU bounded by {@code maxBytes}. A value of
- * {@code 0} (or negative) turns the cache off — {@link #getBlock} then invokes
- * the loader on every call and caches nothing.
- *
- * <p>Why {@code byte[]} instead of a direct {@code ByteBuf}: the cache is
- * long-lived and shared across readers, so owning Netty-pooled buffers would
- * require an explicit {@code RemovalListener} to release them on eviction and
- * careful ref-counting on every hit. Storing {@code byte[]} keeps lifecycle
- * trivial; readers wrap the array with {@code Unpooled.wrappedBuffer(byte[])}
- * for a zero-copy {@code ByteBuf} view.
+ * <p>Eviction is byte-weighted LRU bounded by {@code maxBytes}. A budget of
+ * {@code 0} (or negative) disables caching: use {@link #disabled()} to get a
+ * pass-through singleton that always invokes the loader and caches nothing.
+ * Callers always hold a non-null {@code SegmentBlockCache} — the disabled
+ * instance is interchangeable with a real one and eliminates null checks.
  *
  * @author enrico.olivelli
  */
 public final class SegmentBlockCache {
 
-    /** Loads a single block when the cache misses. */
+    /**
+     * Loads a single block when the cache misses. The returned {@link ByteBuf}
+     * must be caller-owned: the cache takes ownership and is responsible for
+     * releasing it on eviction. Implementations are free to return a pooled
+     * direct buffer (the typical case for network reads).
+     */
     @FunctionalInterface
     public interface BlockLoader {
-        byte[] load(String path, long offset, int length) throws IOException;
+        ByteBuf load(String path, long offset, int length) throws IOException;
+    }
+
+    private static final SegmentBlockCache DISABLED = new SegmentBlockCache(0L);
+
+    /**
+     * @return a singleton pass-through cache. Calls to {@link #getBlock}
+     *     always invoke the loader; no entries are stored. Intended for
+     *     configurations where the block cache is explicitly off, or for
+     *     tests / tooling that does not care about caching.
+     */
+    public static SegmentBlockCache disabled() {
+        return DISABLED;
     }
 
     private final long maxBytes;
-    @Nullable
-    private final Cache<BlockKey, byte[]> cache;
+    private final Cache<BlockKey, ByteBuf> cache;
     private final AtomicLong passthroughLoads = new AtomicLong();
     private final AtomicLong passthroughLoadFailures = new AtomicLong();
 
@@ -77,7 +91,14 @@ public final class SegmentBlockCache {
         } else {
             this.cache = Caffeine.newBuilder()
                     .maximumWeight(maxBytes)
-                    .weigher((BlockKey k, byte[] v) -> v == null ? 0 : v.length)
+                    .weigher((BlockKey k, ByteBuf v) -> v == null ? 0 : v.capacity())
+                    .removalListener((BlockKey k, ByteBuf v, RemovalCause cause) -> {
+                        // Release the cache's reference when the entry leaves
+                        // the cache. Callers receive retained slices, so an
+                        // eviction while a slice is in flight does not cause
+                        // use-after-free.
+                        ReferenceCountUtil.safeRelease(v);
+                    })
                     .recordStats()
                     .build();
         }
@@ -97,16 +118,18 @@ public final class SegmentBlockCache {
      * cache first and invoking {@code loader} on miss. {@code offset} must be
      * a multiple of {@code length} — this is the natural alignment used by
      * {@link RemoteRandomAccessReader}, where the read window is a fixed-size
-     * sliding buffer. The value is returned as a caller-read-only {@code byte[]};
-     * do not mutate.
+     * sliding buffer.
+     *
+     * <p><b>Ownership</b>: the returned {@link ByteBuf} is a caller-owned
+     * retained slice; the caller MUST release it exactly once. The underlying
+     * shared entry is released automatically when evicted.
      *
      * @param path       logical multipart path
      * @param offset     block start, must be a multiple of {@code length}
-     * @param length     block length in bytes (>= 0); when cache is inactive
-     *                   the loader receives exactly these arguments
+     * @param length     block length in bytes (> 0)
      * @param loader     invoked at most once per key on miss
      */
-    public byte[] getBlock(String path, long offset, int length, BlockLoader loader)
+    public ByteBuf getBlock(String path, long offset, int length, BlockLoader loader)
             throws IOException {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(loader, "loader");
@@ -117,38 +140,47 @@ public final class SegmentBlockCache {
             throw new IllegalArgumentException("offset must be >= 0, got " + offset);
         }
         if (cache == null) {
+            // Pass-through: loader owns the buffer, no retain/release dance.
             return invokeLoader(loader, path, offset, length);
         }
         long blockIndex = offset / length;
         BlockKey key = new BlockKey(path, blockIndex);
         try {
-            return cache.get(key, k -> {
+            ByteBuf shared = cache.get(key, k -> {
                 try {
-                    byte[] bytes = loader.load(path, offset, length);
-                    if (bytes == null) {
+                    ByteBuf loaded = loader.load(path, offset, length);
+                    if (loaded == null) {
                         throw new CacheLoadException(new IOException(
                                 "loader returned null for " + path + "@" + offset));
                     }
-                    return bytes;
+                    return loaded;
                 } catch (IOException e) {
                     throw new CacheLoadException(e);
                 }
             });
+            if (shared == null) {
+                throw new IOException("cache load returned null for " + path + "@" + offset);
+            }
+            // retainedSlice bumps the refcount on the shared entry and returns
+            // a duplicate view with its own reader/writer indices. The caller
+            // releases the slice; the cache releases the shared entry on
+            // eviction.
+            return shared.retainedSlice(0, shared.readableBytes());
         } catch (CacheLoadException e) {
             throw (IOException) e.getCause();
         }
     }
 
-    private byte[] invokeLoader(BlockLoader loader, String path, long offset, int length)
+    private ByteBuf invokeLoader(BlockLoader loader, String path, long offset, int length)
             throws IOException {
         try {
-            byte[] bytes = loader.load(path, offset, length);
-            if (bytes == null) {
+            ByteBuf buf = loader.load(path, offset, length);
+            if (buf == null) {
                 passthroughLoadFailures.incrementAndGet();
                 throw new IOException("loader returned null for " + path + "@" + offset);
             }
             passthroughLoads.incrementAndGet();
-            return bytes;
+            return buf;
         } catch (IOException e) {
             passthroughLoadFailures.incrementAndGet();
             throw e;
@@ -220,6 +252,42 @@ public final class SegmentBlockCache {
         if (cache != null) {
             cache.cleanUp();
         }
+    }
+
+    /**
+     * Convenience used by tests: copy a cached entry's bytes into a heap
+     * array without affecting LRU ordering. Returns {@code null} when the
+     * entry is not cached.
+     */
+    byte[] peekBytes(String path, long offset, int length) {
+        if (cache == null) {
+            return null;
+        }
+        long blockIndex = offset / length;
+        ByteBuf shared = cache.asMap().get(new BlockKey(path, blockIndex));
+        if (shared == null) {
+            return null;
+        }
+        byte[] copy = new byte[shared.readableBytes()];
+        shared.getBytes(shared.readerIndex(), copy);
+        return copy;
+    }
+
+    /**
+     * Convenience for the common pattern of wrapping a heap byte[] from a
+     * legacy loader into an unpooled {@link ByteBuf} that the cache can own.
+     */
+    public static ByteBuf wrapForCache(byte[] bytes) {
+        return io.netty.buffer.Unpooled.wrappedBuffer(bytes);
+    }
+
+    /**
+     * Allocates a pooled direct buffer of {@code length} bytes. Exposed for
+     * loaders that build their own payload rather than copying from another
+     * {@link ByteBuf}.
+     */
+    public static ByteBuf allocateDirect(int length) {
+        return PooledByteBufAllocator.DEFAULT.directBuffer(length);
     }
 
     // ---------------------------------------------------------------------

--- a/herddb-remote-file-service/src/main/java/herddb/remote/VectorSearchRequestContext.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/VectorSearchRequestContext.java
@@ -1,0 +1,138 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+/**
+ * Thread-scoped accumulator for per-request metrics on the vector-search hot
+ * path. A single {@code VectorSearch} gRPC handler thread executes the whole
+ * search synchronously (see {@code IndexingServiceImpl.search} →
+ * {@code PersistentVectorStore.searchInternal} → {@code GraphSearcher.search}),
+ * so a plain {@link ThreadLocal} is sufficient to correlate
+ * {@code readFileRange} calls back to the originating request.
+ *
+ * <p>Usage pattern from the gRPC handler:
+ * <pre>{@code
+ * VectorSearchRequestContext.begin();
+ * try {
+ *     // ... perform the search; ensureBlockLoaded in the file client
+ *     //     updates the current context via VectorSearchRequestContext.current()
+ *     VectorSearchRequestContext ctx = VectorSearchRequestContext.current();
+ *     // read ctx.getReadFileRangeCalls() etc. and feed them to histograms
+ * } finally {
+ *     VectorSearchRequestContext.end();
+ * }
+ * }</pre>
+ *
+ * <p>This class lives in {@code herddb-remote-file-service} (instead of the
+ * indexing-service module) because {@code RemoteRandomAccessReader} needs to
+ * update the context from the read hot path, and the indexing-service module
+ * already depends on this module. Keeping the class here avoids a dependency
+ * inversion.
+ *
+ * <p>Fields are plain {@code long}s (no atomics) because access is
+ * single-threaded per request. {@link #current()} returns {@code null} outside
+ * an active request — callers MUST null-check so that non-search read paths
+ * (e.g. data-page lazy loads) don't trip an NPE.
+ *
+ * @author enrico.olivelli
+ */
+public final class VectorSearchRequestContext {
+
+    private static final ThreadLocal<VectorSearchRequestContext> CURRENT = new ThreadLocal<>();
+
+    private long readFileRangeCalls;
+    private long readFileRangeBytes;
+    private long readFileRangeWaitNanos;
+    private long cacheHits;
+    private long cacheMisses;
+
+    private VectorSearchRequestContext() {
+        // created via begin()
+    }
+
+    /**
+     * Installs a fresh context in the current thread's {@link ThreadLocal} and
+     * returns it. Overwrites any previously-active context (caller is expected
+     * to have ended it first).
+     */
+    public static VectorSearchRequestContext begin() {
+        VectorSearchRequestContext ctx = new VectorSearchRequestContext();
+        CURRENT.set(ctx);
+        return ctx;
+    }
+
+    /**
+     * Removes the current-thread context so that unrelated subsequent work on
+     * this thread does not accidentally accumulate into it. Safe to call even
+     * if no context is active.
+     */
+    public static void end() {
+        CURRENT.remove();
+    }
+
+    /**
+     * @return the active context for the current thread, or {@code null} when
+     *         no search request is in progress.
+     */
+    public static VectorSearchRequestContext current() {
+        return CURRENT.get();
+    }
+
+    /**
+     * Records a single successful {@code readFileRange} round-trip. Called
+     * from {@code RemoteRandomAccessReader.ensureBlockLoaded} regardless of
+     * whether the bytes ultimately came from the network or from a local
+     * cache — cache hits use {@link #recordCacheHit()} in addition to this.
+     */
+    public void recordReadFileRange(int bytes, long elapsedNanos) {
+        readFileRangeCalls++;
+        readFileRangeBytes += bytes;
+        readFileRangeWaitNanos += elapsedNanos;
+    }
+
+    public void recordCacheHit() {
+        cacheHits++;
+    }
+
+    public void recordCacheMiss() {
+        cacheMisses++;
+    }
+
+    public long getReadFileRangeCalls() {
+        return readFileRangeCalls;
+    }
+
+    public long getReadFileRangeBytes() {
+        return readFileRangeBytes;
+    }
+
+    public long getReadFileRangeWaitNanos() {
+        return readFileRangeWaitNanos;
+    }
+
+    public long getCacheHits() {
+        return cacheHits;
+    }
+
+    public long getCacheMisses() {
+        return cacheMisses;
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderCacheAndMetricsTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderCacheAndMetricsTest.java
@@ -1,0 +1,212 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies the client-side read metrics
+ * ({@code rfs_client_read_requests}/{@code rfs_client_read_bytes}), the shared
+ * {@link SegmentBlockCache} integration, and the per-request counters driven
+ * by {@link VectorSearchRequestContext}.
+ *
+ * <p>This covers the issue #196 scope (per-request readFileRange observability)
+ * plus the two pre-existing counter bugs fixed in {@code ensureBlockLoaded}:
+ * the double-incremented {@code clientReadRequests} and the
+ * {@code clientReadBytes.inc()} that counted requests instead of bytes.
+ */
+public class RemoteRandomAccessReaderCacheAndMetricsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final int BLOCK_SIZE = 64;
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+    private TestStatsProvider statsProvider;
+    private TestStatsProvider.TestStatsLogger statsLogger;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new RemoteFileServer(0, folder.newFolder("data").toPath());
+        server.start();
+        client = new RemoteFileServiceClient(List.of("localhost:" + server.getPort()));
+        statsProvider = new TestStatsProvider();
+        statsLogger = statsProvider.getStatsLogger("");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        server.stop();
+        VectorSearchRequestContext.end();
+    }
+
+    private static byte[] seqBytes(int length) {
+        byte[] b = new byte[length];
+        for (int i = 0; i < length; i++) {
+            b[i] = (byte) (i & 0xFF);
+        }
+        return b;
+    }
+
+    private long counter(String scope, String name) {
+        return statsLogger.scope(scope).getCounter(name).get().longValue();
+    }
+
+    @Test
+    public void clientReadCountersReflectActualRpcCallsAndBytes() throws Exception {
+        byte[] data = seqBytes(BLOCK_SIZE * 3);
+        client.writeMultipartFile("ts/idx/one", new ByteArrayInputStream(data), BLOCK_SIZE);
+
+        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+                client, "ts/idx/one", data.length, BLOCK_SIZE, BLOCK_SIZE,
+                statsLogger, null);
+        // Sequential read over 3 blocks — should trigger exactly 3 RPCs.
+        byte[] buf = new byte[BLOCK_SIZE * 3];
+        reader.readFully(buf);
+        reader.close();
+
+        long requests = counter("rfs.client", "read_requests");
+        long bytes = counter("rfs.client", "read_bytes");
+        assertEquals("one RPC per block (no double-counting)", 3L, requests);
+        assertEquals("read_bytes reflects actual bytes, not request count",
+                (long) BLOCK_SIZE * 3, bytes);
+    }
+
+    @Test
+    public void perRequestContextIsPopulatedByReadsInsideBeginEnd() throws Exception {
+        byte[] data = seqBytes(BLOCK_SIZE * 2);
+        client.writeMultipartFile("ts/idx/ctx", new ByteArrayInputStream(data), BLOCK_SIZE);
+
+        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+                client, "ts/idx/ctx", data.length, BLOCK_SIZE, BLOCK_SIZE,
+                statsLogger, null);
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        try {
+            byte[] buf = new byte[BLOCK_SIZE * 2];
+            reader.readFully(buf);
+        } finally {
+            reader.close();
+        }
+        assertEquals(2L, ctx.getReadFileRangeCalls());
+        assertEquals((long) BLOCK_SIZE * 2, ctx.getReadFileRangeBytes());
+        assertTrue("wait time should be positive", ctx.getReadFileRangeWaitNanos() > 0L);
+        // With no cache configured every read counts as a miss.
+        assertEquals(0L, ctx.getCacheHits());
+        assertEquals(2L, ctx.getCacheMisses());
+        VectorSearchRequestContext.end();
+    }
+
+    @Test
+    public void perRequestContextIsNotTouchedOutsideBeginEnd() throws Exception {
+        byte[] data = seqBytes(BLOCK_SIZE);
+        client.writeMultipartFile("ts/idx/no-ctx", new ByteArrayInputStream(data), BLOCK_SIZE);
+
+        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+                client, "ts/idx/no-ctx", data.length, BLOCK_SIZE, BLOCK_SIZE,
+                statsLogger, null);
+        byte[] buf = new byte[BLOCK_SIZE];
+        reader.readFully(buf);
+        reader.close();
+        // No exception means ensureBlockLoaded safely handles a null context.
+    }
+
+    @Test
+    public void secondReaderShareCacheAndSeesHits() throws Exception {
+        byte[] data = seqBytes(BLOCK_SIZE * 3);
+        client.writeMultipartFile("ts/idx/shared", new ByteArrayInputStream(data), BLOCK_SIZE);
+
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+
+        ReaderSupplier supplier = new RemoteRandomAccessReader.Supplier(
+                client, "ts/idx/shared", data.length, BLOCK_SIZE, BLOCK_SIZE,
+                statsLogger, cache);
+
+        // Warm the cache on reader #1 — 3 misses → 3 RPCs.
+        RemoteRandomAccessReader r1 = (RemoteRandomAccessReader) supplier.get();
+        byte[] buf = new byte[BLOCK_SIZE * 3];
+        r1.readFully(buf);
+        r1.close();
+        long requestsAfterFirstReader = counter("rfs.client", "read_requests");
+        assertEquals(3L, requestsAfterFirstReader);
+
+        // Reader #2: same segment, same byte ranges. All reads should be hits.
+        RemoteRandomAccessReader r2 = (RemoteRandomAccessReader) supplier.get();
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        byte[] buf2 = new byte[BLOCK_SIZE * 3];
+        r2.readFully(buf2);
+        r2.close();
+        long requestsAfterSecondReader = counter("rfs.client", "read_requests");
+        assertEquals("no additional RPCs — all served from cache",
+                requestsAfterFirstReader, requestsAfterSecondReader);
+        assertEquals("3 cache hits for the 3 re-read blocks", 3L, ctx.getCacheHits());
+        assertEquals(0L, ctx.getCacheMisses());
+        // The per-request accumulator still tracks the logical reads.
+        assertEquals(3L, ctx.getReadFileRangeCalls());
+        assertEquals((long) BLOCK_SIZE * 3, ctx.getReadFileRangeBytes());
+        VectorSearchRequestContext.end();
+
+        assertNotNull("reader returned non-null bytes", buf2);
+        assertTrue("final block payload correct", buf2[BLOCK_SIZE * 3 - 1] == buf[BLOCK_SIZE * 3 - 1]);
+    }
+
+    @Test
+    public void cacheInvalidatePathForcesReloadFromRemote() throws Exception {
+        byte[] data = seqBytes(BLOCK_SIZE * 2);
+        client.writeMultipartFile("ts/idx/inv", new ByteArrayInputStream(data), BLOCK_SIZE);
+
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ReaderSupplier supplier = new RemoteRandomAccessReader.Supplier(
+                client, "ts/idx/inv", data.length, BLOCK_SIZE, BLOCK_SIZE,
+                statsLogger, cache);
+
+        RemoteRandomAccessReader r1 = (RemoteRandomAccessReader) supplier.get();
+        byte[] buf = new byte[BLOCK_SIZE * 2];
+        r1.readFully(buf);
+        r1.close();
+        long requestsAfterWarm = counter("rfs.client", "read_requests");
+        assertEquals(2L, requestsAfterWarm);
+
+        cache.invalidatePath("ts/idx/inv");
+
+        // After invalidation, next read must refetch from remote.
+        RemoteRandomAccessReader r2 = (RemoteRandomAccessReader) supplier.get();
+        byte[] buf2 = new byte[BLOCK_SIZE * 2];
+        r2.readFully(buf2);
+        r2.close();
+        long requestsAfterInvalidate = counter("rfs.client", "read_requests");
+        assertEquals("invalidation forced 2 more RPCs",
+                requestsAfterWarm + 2, requestsAfterInvalidate);
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderCacheAndMetricsTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderCacheAndMetricsTest.java
@@ -91,7 +91,7 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
 
         RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
                 client, "ts/idx/one", data.length, BLOCK_SIZE, BLOCK_SIZE,
-                statsLogger, null);
+                statsLogger, SegmentBlockCache.disabled());
         // Sequential read over 3 blocks — should trigger exactly 3 RPCs.
         byte[] buf = new byte[BLOCK_SIZE * 3];
         reader.readFully(buf);
@@ -111,7 +111,7 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
 
         RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
                 client, "ts/idx/ctx", data.length, BLOCK_SIZE, BLOCK_SIZE,
-                statsLogger, null);
+                statsLogger, SegmentBlockCache.disabled());
         VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
         try {
             byte[] buf = new byte[BLOCK_SIZE * 2];
@@ -135,7 +135,7 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
 
         RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
                 client, "ts/idx/no-ctx", data.length, BLOCK_SIZE, BLOCK_SIZE,
-                statsLogger, null);
+                statsLogger, SegmentBlockCache.disabled());
         byte[] buf = new byte[BLOCK_SIZE];
         reader.readFully(buf);
         reader.close();

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheHammerTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheHammerTest.java
@@ -1,0 +1,299 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetector.Level;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Multi-threaded hammer test for {@link SegmentBlockCache} that exercises the
+ * retained-slice + shared-entry refcount discipline under concurrent get /
+ * release / invalidate / eviction pressure.
+ *
+ * <p>Invariants verified:
+ * <ul>
+ *   <li>Every slice handed to a reader is fully readable (refcount > 0) until
+ *       the reader releases it.</li>
+ *   <li>Releasing a slice never throws or fails (no double release).</li>
+ *   <li>No leaked loader-allocated {@link ByteBuf} — Netty's
+ *       {@link ResourceLeakDetector} set to PARANOID flags any lost
+ *       reference; the test fails if the detector reports any leaks.</li>
+ *   <li>After the run, the cache's own remaining entries are releasable via
+ *       {@link SegmentBlockCache#clear()} without error, and the loader's
+ *       allocated-vs-released counters reconcile.</li>
+ * </ul>
+ *
+ * <p>The loader deliberately allocates <em>pooled direct</em> buffers because
+ * that is the real production path (bytes come from
+ * {@link RemoteFileServiceClient#readFileRangeAsByteBuf}, which hands out
+ * pooled direct buffers); mis-handling ref-counts on pooled buffers is what
+ * would actually blow up in production.
+ */
+public class SegmentBlockCacheHammerTest {
+
+    private static final int BLOCK_SIZE = 1024;
+    private static final int DISTINCT_BLOCKS = 64;        // enough keys to force LRU churn
+    private static final int CACHE_BUDGET = 16 * BLOCK_SIZE;  // 16 slots, 48 misses otherwise
+    private static final int THREADS = 16;
+    private static final int ITERATIONS_PER_THREAD = 4_000;
+    private static final int PATHS = 4;                   // exercise invalidatePath / invalidatePrefix
+
+    private Level previousLeakLevel;
+
+    @Before
+    public void enableParanoidLeakDetection() {
+        // Promote leak detection so any lost ByteBuf reference flips the test
+        // to failure. The previous level is restored in @After so we don't
+        // poison sibling tests.
+        this.previousLeakLevel = ResourceLeakDetector.getLevel();
+        ResourceLeakDetector.setLevel(Level.PARANOID);
+    }
+
+    @After
+    public void restoreLeakDetection() {
+        if (previousLeakLevel != null) {
+            ResourceLeakDetector.setLevel(previousLeakLevel);
+        }
+    }
+
+    @Test(timeout = 120_000)
+    public void concurrentGetReleaseInvalidateStaysLeakFreeAndBalanced() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(CACHE_BUDGET);
+        AtomicLong allocated = new AtomicLong();
+        AtomicLong loaderCalls = new AtomicLong();
+        AtomicLong loaderFailures = new AtomicLong();
+
+        // Track every allocated (loader-created) ByteBuf so we can assert at
+        // the end that the cache has released all of them. "allocated -
+        // evicted-from-cache - still-in-cache" must be zero.
+        ConcurrentLinkedQueue<ByteBuf> allAllocated = new ConcurrentLinkedQueue<>();
+
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(BLOCK_SIZE);
+            // Fill with a reproducible pattern so readers can validate.
+            byte tag = (byte) ((p.hashCode() ^ (int) off) & 0xFF);
+            for (int i = 0; i < BLOCK_SIZE; i++) {
+                buf.writeByte(tag);
+            }
+            allocated.incrementAndGet();
+            loaderCalls.incrementAndGet();
+            allAllocated.add(buf);
+            return buf;
+        };
+
+        AtomicBoolean failure = new AtomicBoolean();
+        List<Throwable> errors = new ArrayList<>();
+        CountDownLatch ready = new CountDownLatch(THREADS);
+        CountDownLatch go = new CountDownLatch(1);
+
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS + 1);
+        try {
+            // Invalidation thread: periodically drops entries to force more
+            // evictions from a direction other than the LRU budget alone, so
+            // refcount handling under invalidation gets exercised.
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                Random rnd = new Random(1);
+                while (!Thread.currentThread().isInterrupted()
+                        && loaderCalls.get() < (long) THREADS * 100) {
+                    // wait for the workers to warm up a bit
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+                for (int i = 0; i < 32; i++) {
+                    int pathIdx = rnd.nextInt(PATHS);
+                    if ((i & 1) == 0) {
+                        cache.invalidatePath("seg" + pathIdx);
+                    } else {
+                        cache.invalidatePrefix("seg");
+                    }
+                    try {
+                        Thread.sleep(2);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            });
+
+            for (int t = 0; t < THREADS; t++) {
+                final int seed = t;
+                pool.submit(() -> {
+                    Random rnd = new Random(seed);
+                    ready.countDown();
+                    try {
+                        go.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    try {
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            int pathIdx = rnd.nextInt(PATHS);
+                            int blockIdx = rnd.nextInt(DISTINCT_BLOCKS);
+                            String path = "seg" + pathIdx;
+                            long offset = (long) blockIdx * BLOCK_SIZE;
+                            byte expectedTag =
+                                    (byte) ((path.hashCode() ^ (int) offset) & 0xFF);
+
+                            ByteBuf slice = cache.getBlock(path, offset, BLOCK_SIZE, loader);
+                            try {
+                                // Basic sanity: refcount must be > 0 and the
+                                // payload must match what the loader wrote.
+                                // Sampling a few bytes is enough — we're
+                                // stressing refcount handling, not content.
+                                if (slice.refCnt() <= 0) {
+                                    throw new AssertionError(
+                                            "slice had refCnt=" + slice.refCnt());
+                                }
+                                byte actual = slice.getByte(0);
+                                if (actual != expectedTag) {
+                                    throw new AssertionError(
+                                            "corrupted bytes for " + path + "@" + offset);
+                                }
+                                byte mid = slice.getByte(BLOCK_SIZE / 2);
+                                if (mid != expectedTag) {
+                                    throw new AssertionError("mid byte wrong");
+                                }
+                            } finally {
+                                // The release discipline for callers: release
+                                // the slice exactly once. Doing this inside a
+                                // finally also guarantees no leaked references
+                                // if the assertions above throw.
+                                boolean fullyReleased = slice.release();
+                                // A slice release() returning true means THIS
+                                // ref hit zero. It doesn't say anything about
+                                // the underlying shared entry — which is fine.
+                                // What we must NOT see is an IllegalReferenceCountException
+                                // (that would mean a double release).
+                                if (slice.refCnt() != 0 && !fullyReleased) {
+                                    // A retained slice should always hit 0
+                                    // after a single release.
+                                    throw new AssertionError(
+                                            "slice refcount after release = " + slice.refCnt());
+                                }
+                            }
+                        }
+                    } catch (IOException | RuntimeException | AssertionError e) {
+                        synchronized (errors) {
+                            errors.add(e);
+                        }
+                        failure.set(true);
+                    }
+                });
+            }
+
+            assertTrue("workers ready", ready.await(10, TimeUnit.SECONDS));
+            go.countDown();
+            pool.shutdown();
+            assertTrue("pool finished in time",
+                    pool.awaitTermination(90, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+
+        // Surface any in-worker failure with its stack trace.
+        synchronized (errors) {
+            if (!errors.isEmpty()) {
+                AssertionError ae = new AssertionError(
+                        "worker(s) failed: " + errors.size() + " error(s); first=" + errors.get(0));
+                ae.initCause(errors.get(0));
+                throw ae;
+            }
+        }
+        assertEquals("no worker flagged failure", false, failure.get());
+
+        // All remaining cached entries must be releasable cleanly.
+        cache.clear();
+        cache.cleanUp();
+        assertEquals("cache fully drained", 0L, cache.estimatedSize());
+
+        // Final invariant: every buffer the loader allocated must now be
+        // fully released (refCnt == 0). Anything still alive is a leak —
+        // either the cache lost track of an entry on eviction, or a slice
+        // was retained beyond the caller's release.
+        int stillAlive = 0;
+        for (ByteBuf buf : allAllocated) {
+            if (buf.refCnt() != 0) {
+                stillAlive++;
+            }
+        }
+        if (stillAlive != 0) {
+            fail("leak: " + stillAlive + " / " + allAllocated.size()
+                    + " loader-allocated buffers still have refCnt > 0 after cache.clear()");
+        }
+
+        // Loader failures should be zero in the normal path (the loader here
+        // never throws). If this starts firing in the future it means the
+        // cache is invoking the loader in an error mode we need to inspect.
+        assertEquals(0L, loaderFailures.get());
+
+        // The shared cache counters should be internally consistent: the
+        // number of load_success we see should match the number of loader
+        // calls (Caffeine only calls the loader on miss; concurrent misses
+        // dedupe via getBlock).
+        assertTrue("loader invoked at least once", loaderCalls.get() > 0);
+        assertTrue("hits > 0 once the cache warms up", cache.hitCount() > 0);
+        assertNotNull(allAllocated.peek());  // silence unused-warning for iteration path
+        assertNull("sanity: no lingering null entries enqueued",
+                findNull(allAllocated));
+    }
+
+    private static <T> T findNull(Iterable<T> it) {
+        for (T t : it) {
+            if (t == null) {
+                return null;  // finding null -> return null sentinel anyway
+            }
+        }
+        return null;
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
@@ -1,0 +1,286 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Covers the {@link SegmentBlockCache} behavioural contract inherited from
+ * the deleted {@code SharedSegmentPageCache}: hits vs misses, concurrent
+ * single-flight loading, byte-weighted eviction, path invalidation, stats
+ * accessors, and pass-through mode when the cache is disabled.
+ */
+public class SegmentBlockCacheTest {
+
+    private static final int BLOCK = 1024;
+
+    private static byte[] fill(int len, byte value) {
+        byte[] b = new byte[len];
+        for (int i = 0; i < len; i++) {
+            b[i] = value;
+        }
+        return b;
+    }
+
+    @Test
+    public void firstLoadInvokesLoaderAndCachesResult() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        AtomicInteger loads = new AtomicInteger();
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            loads.incrementAndGet();
+            return fill(BLOCK, (byte) 0x42);
+        };
+
+        byte[] first = cache.getBlock("seg", 0L, BLOCK, loader);
+        byte[] second = cache.getBlock("seg", 0L, BLOCK, loader);
+
+        assertEquals("loader invoked exactly once", 1, loads.get());
+        assertSame("cache hit returns same array", first, second);
+        assertEquals(1L, cache.hitCount());
+        assertEquals(1L, cache.missCount());
+        assertEquals(1L, cache.loadSuccessCount());
+    }
+
+    @Test
+    public void differentOffsetsProduceDifferentEntries() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) off);
+
+        byte[] b0 = cache.getBlock("seg", 0L, BLOCK, loader);
+        byte[] b1 = cache.getBlock("seg", BLOCK, BLOCK, loader);
+
+        assertEquals((byte) 0, b0[0]);
+        assertEquals((byte) BLOCK, b1[0]);
+        assertEquals(2L, cache.estimatedSize());
+    }
+
+    @Test
+    public void concurrentMissesOnSameKeyInvokeLoaderOnce() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        AtomicInteger loaderCalls = new AtomicInteger();
+        CountDownLatch inLoader = new CountDownLatch(1);
+        CountDownLatch releaseLoader = new CountDownLatch(1);
+
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            loaderCalls.incrementAndGet();
+            inLoader.countDown();
+            try {
+                releaseLoader.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("interrupted", e);
+            }
+            return fill(BLOCK, (byte) 0xA5);
+        };
+
+        ExecutorService pool = Executors.newFixedThreadPool(32);
+        try {
+            Set<byte[]> observed = Collections.newSetFromMap(new ConcurrentHashMap<>());
+            CountDownLatch started = new CountDownLatch(32);
+            for (int i = 0; i < 32; i++) {
+                pool.submit(() -> {
+                    started.countDown();
+                    try {
+                        observed.add(cache.getBlock("seg", 0L, BLOCK, loader));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+            assertTrue("at least one thread should enter the loader",
+                    inLoader.await(5, TimeUnit.SECONDS));
+            releaseLoader.countDown();
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+            assertEquals("loader invoked once despite 32 concurrent misses",
+                    1, loaderCalls.get());
+            assertEquals("all waiters see the identical cached byte[]", 1, observed.size());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void byteWeightedEvictionRespectsBudget() throws Exception {
+        // Budget = 4 KB, entries = 1 KB each. Loading 20 entries forces eviction.
+        SegmentBlockCache cache = new SegmentBlockCache(4L * BLOCK);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 1);
+
+        for (int i = 0; i < 20; i++) {
+            cache.getBlock("seg", (long) i * BLOCK, BLOCK, loader);
+        }
+        cache.cleanUp();
+
+        assertTrue("some entries must have been evicted to respect the byte budget",
+                cache.evictionCount() > 0);
+        assertTrue("weightedSize within budget after drain, got " + cache.weightedSize(),
+                cache.weightedSize() <= 4L * BLOCK);
+    }
+
+    @Test
+    public void invalidatePathDropsOnlyMatchingEntries() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 0);
+        cache.getBlock("segA", 0L, BLOCK, loader);
+        cache.getBlock("segA", BLOCK, BLOCK, loader);
+        cache.getBlock("segB", 0L, BLOCK, loader);
+
+        cache.invalidatePath("segA");
+
+        assertFalse(cache.containsBlock("segA", 0L, BLOCK));
+        assertFalse(cache.containsBlock("segA", BLOCK, BLOCK));
+        assertTrue(cache.containsBlock("segB", 0L, BLOCK));
+    }
+
+    @Test
+    public void invalidatePrefixDropsAllEntriesUnderPrefix() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 0);
+        cache.getBlock("ts1/idx/a", 0L, BLOCK, loader);
+        cache.getBlock("ts1/idx/b", 0L, BLOCK, loader);
+        cache.getBlock("ts2/idx/a", 0L, BLOCK, loader);
+
+        cache.invalidatePrefix("ts1/");
+
+        assertFalse(cache.containsBlock("ts1/idx/a", 0L, BLOCK));
+        assertFalse(cache.containsBlock("ts1/idx/b", 0L, BLOCK));
+        assertTrue(cache.containsBlock("ts2/idx/a", 0L, BLOCK));
+    }
+
+    @Test
+    public void loaderIoExceptionIsSurfacedAndNotCached() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        AtomicInteger calls = new AtomicInteger();
+        SegmentBlockCache.BlockLoader failingThenOk = (p, off, len) -> {
+            int call = calls.incrementAndGet();
+            if (call == 1) {
+                throw new IOException("transient");
+            }
+            return fill(BLOCK, (byte) 1);
+        };
+
+        IOException thrown = assertThrows(IOException.class,
+                () -> cache.getBlock("seg", 0L, BLOCK, failingThenOk));
+        assertEquals("transient", thrown.getMessage());
+
+        // Subsequent call must not surface the previous failure: Caffeine does
+        // not memoize negative results, so the loader runs a second time and
+        // succeeds.
+        byte[] value = cache.getBlock("seg", 0L, BLOCK, failingThenOk);
+        assertEquals((byte) 1, value[0]);
+        assertEquals("loader invoked twice: one failure + one success", 2, calls.get());
+    }
+
+    @Test
+    public void loaderReturningNullSurfacesIoException() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> null;
+        IOException thrown = assertThrows(IOException.class,
+                () -> cache.getBlock("seg", 0L, BLOCK, loader));
+        assertTrue("message mentions null loader result, was: " + thrown.getMessage(),
+                thrown.getMessage().contains("null"));
+    }
+
+    @Test
+    public void zeroMaxBytesBypassesCache() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(0);
+        assertFalse("cache disabled", cache.isActive());
+
+        AtomicInteger calls = new AtomicInteger();
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            calls.incrementAndGet();
+            return fill(BLOCK, (byte) 7);
+        };
+
+        byte[] a = cache.getBlock("seg", 0L, BLOCK, loader);
+        byte[] b = cache.getBlock("seg", 0L, BLOCK, loader);
+        assertNotNull(a);
+        assertNotNull(b);
+        assertArrayEquals(a, b);
+        assertEquals("loader invoked on every call in pass-through mode",
+                2, calls.get());
+        assertEquals(0L, cache.hitCount());
+        assertEquals(0L, cache.missCount());
+        assertEquals("passthrough loads tracked via fallback counter",
+                2L, cache.loadSuccessCount());
+        assertEquals(0L, cache.weightedSize());
+    }
+
+    @Test
+    public void containsBlockDoesNotTriggerLoad() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        AtomicInteger calls = new AtomicInteger();
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            calls.incrementAndGet();
+            return fill(BLOCK, (byte) 0);
+        };
+
+        assertFalse(cache.containsBlock("seg", 0L, BLOCK));
+        assertEquals("containsBlock must not call the loader", 0, calls.get());
+
+        cache.getBlock("seg", 0L, BLOCK, loader);
+        assertTrue(cache.containsBlock("seg", 0L, BLOCK));
+    }
+
+    @Test
+    public void blockKeysWithSameHashButDifferentFieldsAreNotEqual() {
+        SegmentBlockCache.BlockKey a = new SegmentBlockCache.BlockKey("segA", 1L);
+        SegmentBlockCache.BlockKey b = new SegmentBlockCache.BlockKey("segB", 1L);
+        SegmentBlockCache.BlockKey c = new SegmentBlockCache.BlockKey("segA", 2L);
+        if (a.equals(b) || a.equals(c)) {
+            fail("distinct keys equal each other");
+        }
+        Set<SegmentBlockCache.BlockKey> set = new HashSet<>();
+        set.add(a);
+        assertTrue(set.contains(new SegmentBlockCache.BlockKey("segA", 1L)));
+    }
+
+    @Test
+    public void clearRemovesAllEntries() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 0);
+        cache.getBlock("segA", 0L, BLOCK, loader);
+        cache.getBlock("segB", 0L, BLOCK, loader);
+        assertEquals(2L, cache.estimatedSize());
+        cache.clear();
+        cache.cleanUp();
+        assertEquals(0L, cache.estimatedSize());
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
@@ -24,10 +24,11 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,18 +45,29 @@ import org.junit.Test;
  * Covers the {@link SegmentBlockCache} behavioural contract inherited from
  * the deleted {@code SharedSegmentPageCache}: hits vs misses, concurrent
  * single-flight loading, byte-weighted eviction, path invalidation, stats
- * accessors, and pass-through mode when the cache is disabled.
+ * accessors, and pass-through mode via {@link SegmentBlockCache#disabled()}.
  */
 public class SegmentBlockCacheTest {
 
     private static final int BLOCK = 1024;
 
-    private static byte[] fill(int len, byte value) {
-        byte[] b = new byte[len];
+    /** Allocates a pooled direct buffer with the given byte pattern. */
+    private static ByteBuf direct(int len, byte value) {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(len);
         for (int i = 0; i < len; i++) {
-            b[i] = value;
+            buf.writeByte(value);
         }
-        return b;
+        return buf;
+    }
+
+    private static byte[] readAllAndRelease(ByteBuf buf) {
+        try {
+            byte[] out = new byte[buf.readableBytes()];
+            buf.getBytes(buf.readerIndex(), out);
+            return out;
+        } finally {
+            buf.release();
+        }
     }
 
     @Test
@@ -64,14 +76,20 @@ public class SegmentBlockCacheTest {
         AtomicInteger loads = new AtomicInteger();
         SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
             loads.incrementAndGet();
-            return fill(BLOCK, (byte) 0x42);
+            return direct(BLOCK, (byte) 0x42);
         };
 
-        byte[] first = cache.getBlock("seg", 0L, BLOCK, loader);
-        byte[] second = cache.getBlock("seg", 0L, BLOCK, loader);
+        ByteBuf first = cache.getBlock("seg", 0L, BLOCK, loader);
+        ByteBuf second = cache.getBlock("seg", 0L, BLOCK, loader);
 
-        assertEquals("loader invoked exactly once", 1, loads.get());
-        assertSame("cache hit returns same array", first, second);
+        try {
+            assertEquals("loader invoked exactly once", 1, loads.get());
+            assertEquals("two retained slices have identical content",
+                    first.getByte(0), second.getByte(0));
+        } finally {
+            first.release();
+            second.release();
+        }
         assertEquals(1L, cache.hitCount());
         assertEquals(1L, cache.missCount());
         assertEquals(1L, cache.loadSuccessCount());
@@ -80,10 +98,10 @@ public class SegmentBlockCacheTest {
     @Test
     public void differentOffsetsProduceDifferentEntries() throws Exception {
         SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
-        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) off);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) off);
 
-        byte[] b0 = cache.getBlock("seg", 0L, BLOCK, loader);
-        byte[] b1 = cache.getBlock("seg", BLOCK, BLOCK, loader);
+        byte[] b0 = readAllAndRelease(cache.getBlock("seg", 0L, BLOCK, loader));
+        byte[] b1 = readAllAndRelease(cache.getBlock("seg", BLOCK, BLOCK, loader));
 
         assertEquals((byte) 0, b0[0]);
         assertEquals((byte) BLOCK, b1[0]);
@@ -106,18 +124,23 @@ public class SegmentBlockCacheTest {
                 Thread.currentThread().interrupt();
                 throw new IOException("interrupted", e);
             }
-            return fill(BLOCK, (byte) 0xA5);
+            return direct(BLOCK, (byte) 0xA5);
         };
 
         ExecutorService pool = Executors.newFixedThreadPool(32);
         try {
-            Set<byte[]> observed = Collections.newSetFromMap(new ConcurrentHashMap<>());
+            Set<Byte> observedFirstByte = Collections.newSetFromMap(new ConcurrentHashMap<>());
             CountDownLatch started = new CountDownLatch(32);
             for (int i = 0; i < 32; i++) {
                 pool.submit(() -> {
                     started.countDown();
                     try {
-                        observed.add(cache.getBlock("seg", 0L, BLOCK, loader));
+                        ByteBuf slice = cache.getBlock("seg", 0L, BLOCK, loader);
+                        try {
+                            observedFirstByte.add(slice.getByte(0));
+                        } finally {
+                            slice.release();
+                        }
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -131,7 +154,7 @@ public class SegmentBlockCacheTest {
             assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
             assertEquals("loader invoked once despite 32 concurrent misses",
                     1, loaderCalls.get());
-            assertEquals("all waiters see the identical cached byte[]", 1, observed.size());
+            assertEquals("all waiters see identical bytes", 1, observedFirstByte.size());
         } finally {
             pool.shutdownNow();
         }
@@ -141,10 +164,10 @@ public class SegmentBlockCacheTest {
     public void byteWeightedEvictionRespectsBudget() throws Exception {
         // Budget = 4 KB, entries = 1 KB each. Loading 20 entries forces eviction.
         SegmentBlockCache cache = new SegmentBlockCache(4L * BLOCK);
-        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 1);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 1);
 
         for (int i = 0; i < 20; i++) {
-            cache.getBlock("seg", (long) i * BLOCK, BLOCK, loader);
+            cache.getBlock("seg", (long) i * BLOCK, BLOCK, loader).release();
         }
         cache.cleanUp();
 
@@ -157,10 +180,10 @@ public class SegmentBlockCacheTest {
     @Test
     public void invalidatePathDropsOnlyMatchingEntries() throws Exception {
         SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
-        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 0);
-        cache.getBlock("segA", 0L, BLOCK, loader);
-        cache.getBlock("segA", BLOCK, BLOCK, loader);
-        cache.getBlock("segB", 0L, BLOCK, loader);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0);
+        cache.getBlock("segA", 0L, BLOCK, loader).release();
+        cache.getBlock("segA", BLOCK, BLOCK, loader).release();
+        cache.getBlock("segB", 0L, BLOCK, loader).release();
 
         cache.invalidatePath("segA");
 
@@ -172,10 +195,10 @@ public class SegmentBlockCacheTest {
     @Test
     public void invalidatePrefixDropsAllEntriesUnderPrefix() throws Exception {
         SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
-        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 0);
-        cache.getBlock("ts1/idx/a", 0L, BLOCK, loader);
-        cache.getBlock("ts1/idx/b", 0L, BLOCK, loader);
-        cache.getBlock("ts2/idx/a", 0L, BLOCK, loader);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0);
+        cache.getBlock("ts1/idx/a", 0L, BLOCK, loader).release();
+        cache.getBlock("ts1/idx/b", 0L, BLOCK, loader).release();
+        cache.getBlock("ts2/idx/a", 0L, BLOCK, loader).release();
 
         cache.invalidatePrefix("ts1/");
 
@@ -193,7 +216,7 @@ public class SegmentBlockCacheTest {
             if (call == 1) {
                 throw new IOException("transient");
             }
-            return fill(BLOCK, (byte) 1);
+            return direct(BLOCK, (byte) 1);
         };
 
         IOException thrown = assertThrows(IOException.class,
@@ -203,8 +226,12 @@ public class SegmentBlockCacheTest {
         // Subsequent call must not surface the previous failure: Caffeine does
         // not memoize negative results, so the loader runs a second time and
         // succeeds.
-        byte[] value = cache.getBlock("seg", 0L, BLOCK, failingThenOk);
-        assertEquals((byte) 1, value[0]);
+        ByteBuf value = cache.getBlock("seg", 0L, BLOCK, failingThenOk);
+        try {
+            assertEquals((byte) 1, value.getByte(0));
+        } finally {
+            value.release();
+        }
         assertEquals("loader invoked twice: one failure + one success", 2, calls.get());
     }
 
@@ -219,18 +246,18 @@ public class SegmentBlockCacheTest {
     }
 
     @Test
-    public void zeroMaxBytesBypassesCache() throws Exception {
-        SegmentBlockCache cache = new SegmentBlockCache(0);
-        assertFalse("cache disabled", cache.isActive());
+    public void disabledSingletonBypassesCache() throws Exception {
+        SegmentBlockCache cache = SegmentBlockCache.disabled();
+        assertFalse("disabled singleton is inactive", cache.isActive());
 
         AtomicInteger calls = new AtomicInteger();
         SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
             calls.incrementAndGet();
-            return fill(BLOCK, (byte) 7);
+            return direct(BLOCK, (byte) 7);
         };
 
-        byte[] a = cache.getBlock("seg", 0L, BLOCK, loader);
-        byte[] b = cache.getBlock("seg", 0L, BLOCK, loader);
+        byte[] a = readAllAndRelease(cache.getBlock("seg", 0L, BLOCK, loader));
+        byte[] b = readAllAndRelease(cache.getBlock("seg", 0L, BLOCK, loader));
         assertNotNull(a);
         assertNotNull(b);
         assertArrayEquals(a, b);
@@ -238,9 +265,13 @@ public class SegmentBlockCacheTest {
                 2, calls.get());
         assertEquals(0L, cache.hitCount());
         assertEquals(0L, cache.missCount());
-        assertEquals("passthrough loads tracked via fallback counter",
-                2L, cache.loadSuccessCount());
         assertEquals(0L, cache.weightedSize());
+    }
+
+    @Test
+    public void disabledSingletonIsShared() {
+        assertTrue("disabled() is a singleton",
+                SegmentBlockCache.disabled() == SegmentBlockCache.disabled());
     }
 
     @Test
@@ -249,13 +280,13 @@ public class SegmentBlockCacheTest {
         AtomicInteger calls = new AtomicInteger();
         SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
             calls.incrementAndGet();
-            return fill(BLOCK, (byte) 0);
+            return direct(BLOCK, (byte) 0);
         };
 
         assertFalse(cache.containsBlock("seg", 0L, BLOCK));
         assertEquals("containsBlock must not call the loader", 0, calls.get());
 
-        cache.getBlock("seg", 0L, BLOCK, loader);
+        cache.getBlock("seg", 0L, BLOCK, loader).release();
         assertTrue(cache.containsBlock("seg", 0L, BLOCK));
     }
 
@@ -275,9 +306,9 @@ public class SegmentBlockCacheTest {
     @Test
     public void clearRemovesAllEntries() throws Exception {
         SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
-        SegmentBlockCache.BlockLoader loader = (p, off, len) -> fill(BLOCK, (byte) 0);
-        cache.getBlock("segA", 0L, BLOCK, loader);
-        cache.getBlock("segB", 0L, BLOCK, loader);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0);
+        cache.getBlock("segA", 0L, BLOCK, loader).release();
+        cache.getBlock("segB", 0L, BLOCK, loader).release();
         assertEquals(2L, cache.estimatedSize());
         cache.clear();
         cache.cleanUp();

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
@@ -246,9 +246,11 @@ public class SegmentBlockCacheTest {
     }
 
     @Test
-    public void disabledSingletonBypassesCache() throws Exception {
-        SegmentBlockCache cache = SegmentBlockCache.disabled();
-        assertFalse("disabled singleton is inactive", cache.isActive());
+    public void zeroMaxBytesBypassesCache() throws Exception {
+        // A fresh disabled cache (rather than the shared disabled() singleton)
+        // gives deterministic counter values for this assertion.
+        SegmentBlockCache cache = new SegmentBlockCache(0);
+        assertFalse("cache disabled", cache.isActive());
 
         AtomicInteger calls = new AtomicInteger();
         SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
@@ -266,6 +268,8 @@ public class SegmentBlockCacheTest {
         assertEquals(0L, cache.hitCount());
         assertEquals(0L, cache.missCount());
         assertEquals(0L, cache.weightedSize());
+        assertEquals("passthrough loads tracked via load_success counter",
+                2L, cache.loadSuccessCount());
     }
 
     @Test

--- a/herddb-remote-file-service/src/test/java/herddb/remote/VectorSearchRequestContextTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/VectorSearchRequestContextTest.java
@@ -1,0 +1,113 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Verifies the lifecycle and accumulator semantics of
+ * {@link VectorSearchRequestContext}.
+ */
+public class VectorSearchRequestContextTest {
+
+    @After
+    public void ensureContextCleared() {
+        VectorSearchRequestContext.end();
+    }
+
+    @Test
+    public void currentIsNullOutsideRequest() {
+        assertNull("no active context at thread start", VectorSearchRequestContext.current());
+    }
+
+    @Test
+    public void beginInstallsFreshContext() {
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        assertNotNull(ctx);
+        assertSame(ctx, VectorSearchRequestContext.current());
+        assertEquals(0L, ctx.getReadFileRangeCalls());
+        assertEquals(0L, ctx.getReadFileRangeBytes());
+        assertEquals(0L, ctx.getReadFileRangeWaitNanos());
+        assertEquals(0L, ctx.getCacheHits());
+        assertEquals(0L, ctx.getCacheMisses());
+    }
+
+    @Test
+    public void endClearsThreadLocal() {
+        VectorSearchRequestContext.begin();
+        VectorSearchRequestContext.end();
+        assertNull(VectorSearchRequestContext.current());
+    }
+
+    @Test
+    public void recordReadFileRangeAccumulates() {
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        ctx.recordReadFileRange(1024, 1_000_000L);
+        ctx.recordReadFileRange(2048, 500_000L);
+        assertEquals(2L, ctx.getReadFileRangeCalls());
+        assertEquals(3072L, ctx.getReadFileRangeBytes());
+        assertEquals(1_500_000L, ctx.getReadFileRangeWaitNanos());
+    }
+
+    @Test
+    public void recordCacheHitsAndMissesTrackSeparately() {
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        ctx.recordCacheHit();
+        ctx.recordCacheHit();
+        ctx.recordCacheHit();
+        ctx.recordCacheMiss();
+        assertEquals(3L, ctx.getCacheHits());
+        assertEquals(1L, ctx.getCacheMisses());
+    }
+
+    @Test
+    public void beginReturnsNewInstanceOnEachCall() {
+        VectorSearchRequestContext first = VectorSearchRequestContext.begin();
+        first.recordReadFileRange(16, 1L);
+        VectorSearchRequestContext.end();
+        VectorSearchRequestContext second = VectorSearchRequestContext.begin();
+        assertNotSame(first, second);
+        // The second request must start from a clean slate — counters from
+        // the previous request must not leak across begin() boundaries.
+        assertEquals(0L, second.getReadFileRangeCalls());
+        assertEquals(0L, second.getReadFileRangeBytes());
+    }
+
+    @Test
+    public void threadLocalIsolatesBetweenThreads() throws Exception {
+        VectorSearchRequestContext.begin().recordReadFileRange(100, 1L);
+
+        final VectorSearchRequestContext[] observedOnOtherThread = new VectorSearchRequestContext[1];
+        Thread t = new Thread(() -> observedOnOtherThread[0] = VectorSearchRequestContext.current());
+        t.start();
+        t.join();
+
+        // A second thread must not inherit this thread's context — otherwise a
+        // stray reader running on a different thread would pollute our counters.
+        assertNull(observedOnOtherThread[0]);
+    }
+}


### PR DESCRIPTION
## Summary

- **Per-query observability (issue #196 literal ask)**: eight new metrics on the `VectorSearch` path so I/O can be attributed to an individual gRPC request — counters for total `readFileRange` calls / bytes / wait-nanos, plus per-request histograms (including cache hits/misses). Scope-based naming under `indexing_search_*` matches existing HerdDB convention.
- **Multipart-aware byte-range cache**: re-introduces `SegmentBlockCache`, the replacement for the `SharedSegmentPageCache` removed in `4bf6b440`. Caffeine-backed byte-weighted LRU with single-flight de-duplication; keyed by `(path, blockIndex)`; budgeted from the already-defined `indexing.vector.segmentPageCacheMaxBytes` (default: 1/4 of heap). Invalidated on segment delete + tablespace erase.
- **Correctness side-fix**: `RemoteRandomAccessReader.ensureBlockLoaded` used to increment `clientReadRequests` twice per RPC and call `clientReadBytes.inc()` (counting requests instead of bytes). Both are fixed in the same method we're editing.

## Why the cache is the real fix for the 113k-RPCs-per-query observed on GKE

jvector already keeps HNSW layers 1..N resident in RAM via `OnDiskGraphIndex.loadInMemoryLayers`, so only Layer 0 is read from disk during a search. On gist1m with 21 segments a k=100 query still produces ~113k `readFileRange` RPCs because there was no cache underneath `RemoteRandomAccessReader` — the reader's 16 KiB sliding window gets invalidated on almost every HNSW hop. A shared byte-range LRU captures the re-visited L0 neighbourhoods across readers and across repeated queries.

## Out of scope (noted and deferred)

- Explicit "top-levels preload": unnecessary — jvector already keeps L1+ in RAM.
- Prefetching / read-ahead beyond the current buffer window.
- Per-index Prometheus labels.

## Test plan

- [x] `mvn -pl herddb-remote-file-service test` — 235/235 green (includes 24 new tests: `VectorSearchRequestContextTest`, `SegmentBlockCacheTest`, `RemoteRandomAccessReaderCacheAndMetricsTest`).
- [x] `mvn -pl herddb-indexing-service test` — 225/225 green.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — BUILD SUCCESS across all modules.
- [x] Hammer suite `DirectMultipleConcurrentUpdatesSuite*Test` (per CLAUDE.md) — 12/12 green.
- [ ] End-to-end k3s/GKE vector-bench run to validate the expected order-of-magnitude drop in `indexing_search_readfilerange_calls_per_request` and a non-trivial `cache_hits / (cache_hits + cache_misses)` ratio after warm-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)