### PR TITLE
issue #199: treat S3 NoSuchKeyException as no-op on delete

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/S3ObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/S3ObjectStorage.java
@@ -241,8 +241,21 @@ public class S3ObjectStorage implements ObjectStorage {
                 .bucket(bucket)
                 .key(toKey(path))
                 .build();
-        // S3 DELETE is idempotent; always returns true
-        return client.deleteObject(request).thenApply(resp -> Boolean.TRUE);
+        // S3 DELETE is idempotent: native S3 silently succeeds for a missing key, but
+        // S3-compatible stores (notably GCS) surface it as NoSuchKeyException. The end
+        // state — object absent — is what the caller wanted, so treat 404 as success.
+        return client.deleteObject(request)
+                .<Boolean>thenApply(resp -> Boolean.TRUE)
+                .exceptionally(t -> {
+                    Throwable cause = (t instanceof CompletionException) ? t.getCause() : t;
+                    if (cause instanceof NoSuchKeyException) {
+                        return Boolean.TRUE;
+                    }
+                    if (cause instanceof RuntimeException) {
+                        throw (RuntimeException) cause;
+                    }
+                    throw new RuntimeException(cause);
+                });
     }
 
     @Override

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/S3ObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/S3ObjectStorageTest.java
@@ -1,0 +1,147 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Unit tests for {@link S3ObjectStorage} that cover the GCS S3-compatibility quirk where
+ * DELETE on a missing key returns {@code 404 NoSuchKey} instead of succeeding silently.
+ */
+public class S3ObjectStorageTest {
+
+    /**
+     * Regression test for issue #199. GCS reports 404 when deleting an object that is not
+     * present (native S3 is silent). The storage layer must treat this as the desired
+     * end-state and return successfully, otherwise the higher-level retry wrapper in
+     * {@code RemoteFileServiceClient} will retry up to 10× with exponential back-off and
+     * stall post-checkpoint cleanup for ~11 minutes per file.
+     */
+    @Test
+    public void deleteReturnsTrueWhenS3ReturnsNoSuchKey() throws Exception {
+        S3AsyncClient client = fakeClient(req -> CompletableFuture.failedFuture(
+                NoSuchKeyException.builder().message("The specified key does not exist.").build()));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        Boolean result = storage.delete("missing.page").get();
+
+        assertTrue(result);
+    }
+
+    /**
+     * Non-404 errors must still propagate so the generic retry wrapper can handle
+     * transient failures. This guards against accidentally widening the catch.
+     */
+    @Test
+    public void deletePropagatesNonNoSuchKeyFailure() throws Exception {
+        S3Exception failure = (S3Exception) S3Exception.builder()
+                .statusCode(503).message("slow down").build();
+        S3AsyncClient client = fakeClient(req -> CompletableFuture.failedFuture(failure));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        try {
+            storage.delete("transient.page").get();
+            fail("expected S3Exception to propagate");
+        } catch (ExecutionException e) {
+            assertSame(failure, e.getCause());
+        }
+    }
+
+    /**
+     * deleteLogical() combines a single-object delete and a multipart-prefix delete.
+     * The single-object delete can hit the NoSuchKey path on GCS even while no multipart
+     * blocks exist; the composed future must still complete successfully.
+     */
+    @Test
+    public void deleteLogicalSwallowsNoSuchKeyFromSingleObjectDelete() throws Exception {
+        S3AsyncClient client = (S3AsyncClient) Proxy.newProxyInstance(
+                S3AsyncClient.class.getClassLoader(),
+                new Class<?>[] {S3AsyncClient.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "deleteObject":
+                            return CompletableFuture.failedFuture(
+                                    NoSuchKeyException.builder().message("missing").build());
+                        case "listObjectsV2":
+                            return CompletableFuture.completedFuture(
+                                    ListObjectsV2Response.builder()
+                                            .contents(Collections.emptyList())
+                                            .isTruncated(false)
+                                            .build());
+                        case "close":
+                            return null;
+                        default:
+                            throw new UnsupportedOperationException(
+                                    "fake client does not implement " + method.getName());
+                    }
+                });
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        Boolean deleted = storage.deleteLogical("ghost.page").get();
+
+        // deleteLogical = (blocks > 0) || single-delete; delete() now returns TRUE on 404 to
+        // stay consistent with native S3 (idempotent), so the composed future resolves to TRUE.
+        assertEquals(Boolean.TRUE, deleted);
+    }
+
+    private static S3AsyncClient fakeClient(Function<DeleteObjectRequest, CompletableFuture<DeleteObjectResponse>> deleteHandler) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            if ("deleteObject".equals(method.getName()) && args != null && args.length == 1
+                    && args[0] instanceof DeleteObjectRequest) {
+                return deleteHandler.apply((DeleteObjectRequest) args[0]);
+            }
+            if ("listObjectsV2".equals(method.getName()) && args != null && args.length == 1
+                    && args[0] instanceof ListObjectsV2Request) {
+                return CompletableFuture.completedFuture(
+                        ListObjectsV2Response.builder()
+                                .contents(Collections.emptyList())
+                                .isTruncated(false)
+                                .build());
+            }
+            if ("close".equals(method.getName())) {
+                return null;
+            }
+            throw new UnsupportedOperationException(
+                    "fake client does not implement " + method.getName());
+        };
+        return (S3AsyncClient) Proxy.newProxyInstance(
+                S3AsyncClient.class.getClassLoader(),
+                new Class<?>[] {S3AsyncClient.class},
+                handler);
+    }
+}


### PR DESCRIPTION
## Summary

- GCS in S3-compatibility mode returns `404 NoSuchKey` when deleting a missing object. Native S3 silently succeeds, so `S3ObjectStorage.delete()` never handled the exception — it propagated through `deleteLogical` → gRPC (`Status.INTERNAL`) → `RemoteFileServiceClient.retryAsync`, which retried 10× with exponential back-off (1 s → 512 s, ≈ 1023 s cumulative per file). Post-checkpoint cleanup runs synchronously inside `TableManager.flush()`, so every missing page stalled ingest `COMMIT`s for up to ~11 min (observed: p99 192 s, max 688 s, ~150× throughput drop).
- Align `S3ObjectStorage.delete()` with the existing `read()`/`readRange()` pattern: unwrap `CompletionException`, swallow `NoSuchKeyException` as "object already absent = desired end state" (matches native S3 idempotent-delete semantics), and propagate any other failure so the generic retry wrapper can still handle real transient errors.
- New unit test `S3ObjectStorageTest` fakes `S3AsyncClient` via `java.lang.reflect.Proxy` (no Mockito in the module) to assert: 404 on `delete()` returns `TRUE` without throwing, non-404 failures still propagate, and `deleteLogical()` completes cleanly when the single-object delete hits 404 and there are no multipart blocks.

Fixes #199.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [x] `mvn -B -pl herddb-remote-file-service -Dtest='S3ObjectStorageTest,RemoteFileDataStorageManagerBasicTest,RemoteFileDataStorageManagerRetentionTest' test` — 28/28 pass
- [ ] CI: full `herddb-remote-file-service` suite including `S3ObjectStorageIT` (MinIO TestContainer) on GitHub runners
- [ ] Re-run bigann 100M GKE + GCS bench and confirm post-checkpoint `deleteFile` no longer retries

## Out of scope

- Retry classification in `RemoteFileServiceClient.retryAsync` — generic back-off is still correct for real transient failures; the bug was the lower layer mislabelling a permanent condition.
- `deleteByPrefix` hardening — the batch `DeleteObjects` API reports per-key failures in the response rather than throwing, so it wasn't involved in the stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)