### PR TITLE
issue #181: stop leaking TableSpaceManager read lock on UPDATE value-read failure

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPage.java
@@ -21,6 +21,7 @@
 package herddb.remote;
 
 import herddb.core.DataPage;
+import herddb.core.HerdDBInternalException;
 import herddb.core.TableManager;
 import herddb.model.Record;
 import herddb.remote.LazyDataPageFormat.FixedHeader;
@@ -195,8 +196,12 @@ public final class LazyDataPage extends DataPage {
      * {@link herddb.core.TableManager}) sees a runtime exception instead of a
      * checked {@code DataStorageManagerException}. Callers can unwrap via
      * {@link Throwable#getCause()}.
+     *
+     * <p>Extends {@link HerdDBInternalException} so TableManager's existing
+     * defensive catches unwind locks instead of letting it escape synchronously
+     * and leak the TableSpaceManager read stamp (issue #181).
      */
-    public static final class LazyValueFetchException extends RuntimeException {
+    public static final class LazyValueFetchException extends HerdDBInternalException {
         private static final long serialVersionUID = 1L;
 
         LazyValueFetchException(String message, Throwable cause) {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -598,7 +598,12 @@ public class RemoteFileDataStorageManager extends DataStorageManager
                 }
                 return bytes;
             });
-        } catch (IllegalStateException e) {
+        } catch (RuntimeException e) {
+            // Broad catch: the loader delegates to the remote client, which can raise
+            // any unchecked exception on a wire failure. Wrapping as
+            // DataStorageManagerException keeps the method contract and lets
+            // LazyDataPage.get() route the error into a HerdDBInternalException
+            // that TableManager's defensive catches unwind (issue #181).
             throw new DataStorageManagerException(e.getMessage(), e);
         }
     }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/LazyDataPageFailureAndComplexTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/LazyDataPageFailureAndComplexTest.java
@@ -245,13 +245,45 @@ public class LazyDataPageFailureAndComplexTest {
         }
     }
 
-    // NOTE: a symmetrical "UPDATE fails cleanly when value read fails" test
-    // is intentionally omitted — see issue #181. A remote value-fetch
-    // failure raised from inside TableManager during an UPDATE leaves a
-    // StampedLock held in TableSpaceManager, so DBManager.close() blocks
-    // indefinitely on Activator join. The same lock leak exists with the
-    // legacy eager readPage() path, so it is not a lazy-page regression;
-    // once #181 is fixed, add the symmetrical test here.
+    // Regression test for issue #181: a RuntimeException from a value
+    // fetch during an UPDATE used to leak the TableSpaceManager read stamp
+    // and hang DBManager.close(). The @Test timeout guards against that
+    // regression: without the LazyValueFetchException reclassification,
+    // the try-with-resources close of `Embedded` would block forever on
+    // TableSpaceManager.acquireWriteLock("closeTablespace").
+    @Test(timeout = 60_000)
+    public void updateFailsCleanlyWhenValueReadFails() throws Exception {
+        try (RemoteEnv env = new RemoteEnv(folder)) {
+        // Phase 1: populate + checkpoint with a normal client.
+        try (Embedded e = new Embedded(env)) {
+            createTablespace(e.manager, TS);
+            createIntStringTable(e.manager, TS, "t1");
+            for (int i = 0; i < 20; i++) {
+                RemoteTestUtils.executeUpdate(e.manager,
+                        "INSERT INTO " + TS + ".t1(id, n) VALUES(?, ?)",
+                        Arrays.asList(i, "name-" + i));
+            }
+            e.manager.checkpoint();
+        }
+        // Phase 2: reopen, inject value-read failures, attempt UPDATE.
+        try (Embedded e = new Embedded(env)) {
+            assertTrue(e.manager.waitForBootOfLocalTablespaces(10000));
+            e.client.failValueReads.set(true);
+            try {
+                RemoteTestUtils.executeUpdate(e.manager,
+                        "UPDATE " + TS + ".t1 SET n = ? WHERE id = ?",
+                        Arrays.asList("updated", 7));
+                fail("expected UPDATE to fail when the remote value read fails");
+            } catch (Exception expected) {
+                // Surface contains our simulated failure somewhere in the cause chain.
+                assertTrue("exception chain must contain simulated failure; got " + expected,
+                        containsCauseMessage(expected, "simulated remote read failure"));
+            }
+            // The try-with-resources close of `e` must complete within the
+            // @Test timeout; that is the actual regression check for #181.
+        }
+        }
+    }
 
     @Test
     public void retryAfterFailureSucceeds() throws Exception {


### PR DESCRIPTION
## Summary

Closes #181.

When a value fetch from `DataStorageManager` failed during an UPDATE, the
`TableSpaceManager` read stamp leaked and `DBManager.close()` hung
forever on `acquireWriteLock("closeTablespace")`. Root cause:
`RemoteFileDataStorageManager.readPageValue` wrapped its loader in a
`try { ... } catch (IllegalStateException)` only, so a bare
`RuntimeException` from `readFileRange` (wire failure, short read, etc.)
escaped as an unchecked throwable that was not a
`HerdDBInternalException`. TableManager's defensive catches in
`executeUpdateAsync` / `accessTableData` are scoped to
`HerdDBInternalException`, so the exception propagated synchronously past
them — skipping the `whenComplete` that releases the tablespace read
stamp in `TableSpaceManager.executeTableAwareStatement`.

Fix:
- Widen the `readPageValue` catch to any `RuntimeException` and wrap as
  `DataStorageManagerException`, honouring the declared method contract
  for every transport-layer failure.
- Reclassify `LazyDataPage.LazyValueFetchException` as a
  `HerdDBInternalException` so — once the wrapping in
  `LazyDataPage.get()` happens — TableManager's existing defensive
  catches unwind their locks cleanly and turn the error into a failed
  `CompletableFuture`.
- Add the symmetrical `updateFailsCleanlyWhenValueReadFails` regression
  test anticipated by the NOTE comment in PR #179. The test uses
  `@Test(timeout = 60_000)` so a future regression fails fast instead of
  hanging CI.

## Test plan

- [x] `mvn -pl herddb-remote-file-service -Dtest=LazyDataPageFailureAndComplexTest#updateFailsCleanlyWhenValueReadFails test` — passes in ~2s, twice in a row (used to hang 60s before fix).
- [x] `mvn -pl herddb-remote-file-service -Dtest=LazyDataPageFailureAndComplexTest test` — 9/9 pass.
- [x] `mvn -pl herddb-remote-file-service test` — 241/241 pass.
- [x] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test` — 12/12 pass, run twice.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)