### PR TITLE
issue #202: parallel remote page uploads during checkpoint (block + BLink)

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -45,6 +45,7 @@ import herddb.storage.IndexStatus;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.SystemProperties;
 import herddb.utils.VisibleByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -57,6 +58,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -71,6 +75,20 @@ import java.util.stream.Stream;
 public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
     private static final Logger LOGGER = Logger.getLogger(BLinkKeyToPageIndex.class.getName());
+
+    /**
+     * Maximum number of dirty BLink nodes that a single
+     * {@link #checkpoint(LogSequenceNumber, boolean)} invocation will keep in
+     * flight when dispatching their page writes through
+     * {@link DataStorageManager#writeIndexPageAsync}. Tuned via the
+     * {@code herddb.checkpoint.flush.parallelism} system property (matches the
+     * user-facing {@code server.checkpoint.flush.parallelism} server config).
+     * Defaults to 16 to match
+     * {@code ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_PARALLELISM_DEFAULT}.
+     */
+    private static final int CHECKPOINT_FLUSH_PARALLELISM =
+            Math.max(1, SystemProperties.getIntSystemProperty(
+                    "herddb.checkpoint.flush.parallelism", 16));
 
     public static final byte METADATA_PAGE = 0;
     public static final byte INNER_NODE_PAGE = 1;
@@ -94,6 +112,19 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     private final BLinkIndexDataStorage<Bytes, Long> indexDataStorage;
 
     private volatile BLink<Bytes, Long> tree;
+
+    /**
+     * When non-null, {@link BLinkIndexDataStorageImpl#createPage} dispatches
+     * node writes through
+     * {@link DataStorageManager#writeIndexPageAsync(String, String, long, DataStorageManager.DataWriter)}
+     * and accumulates the returned futures on this batch. Set only for the
+     * duration of {@link #checkpoint(LogSequenceNumber, boolean)} so DML-driven
+     * page writes (splits, deletes) continue to go through the synchronous
+     * {@link DataStorageManager#writeIndexPage} path. Access is protected by
+     * the fact that checkpoint is serialized at the caller (the TableManager
+     * Phase-C write lock).
+     */
+    private volatile AsyncIndexWriteBatch currentBatch;
 
     private final AtomicBoolean closed;
 
@@ -341,7 +372,24 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                 return Collections.emptyList();
             }
 
-            BLinkMetadata<Bytes> metadata = getTree().checkpoint();
+            /*
+             * Install a per-checkpoint batch so node-page writes go through
+             * writeIndexPageAsync and run concurrently (issue #202). The BLink
+             * tree traversal itself remains sequential, but the remote I/O is
+             * fanned out up to CHECKPOINT_FLUSH_PARALLELISM in flight. All
+             * futures are awaited below before we persist the IndexStatus, so
+             * the checkpoint marker never references a page whose bytes are
+             * not yet durable.
+             */
+            AsyncIndexWriteBatch batch = new AsyncIndexWriteBatch(CHECKPOINT_FLUSH_PARALLELISM);
+            BLinkMetadata<Bytes> metadata;
+            currentBatch = batch;
+            try {
+                metadata = getTree().checkpoint();
+            } finally {
+                currentBatch = null;
+            }
+            awaitBatch(batch);
 
             byte[] metaPage = MetadataSerializer.INSTANCE.write(metadata);
 
@@ -361,6 +409,56 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
+        }
+    }
+
+    /**
+     * Joins every async index-page write submitted during checkpoint. If any
+     * future failed, surface the first root cause as a
+     * {@link DataStorageManagerException}; other failed futures are silently
+     * drained so that by the time we return all gRPC activity is quiesced and
+     * the checkpoint can fail cleanly without leaking work to the next phase.
+     */
+    private void awaitBatch(AsyncIndexWriteBatch batch) throws DataStorageManagerException {
+        List<CompletableFuture<Void>> futures = batch.snapshot();
+        if (futures.isEmpty()) {
+            return;
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).join();
+        } catch (CompletionException ex) {
+            Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+            if (cause instanceof DataStorageManagerException) {
+                throw (DataStorageManagerException) cause;
+            }
+            throw new DataStorageManagerException(
+                    "Error awaiting async BLink index page writes for index " + indexName, cause);
+        }
+    }
+
+    /**
+     * Per-checkpoint batch coordinating async BLink node page writes. Holds
+     * a semaphore bounding the number of in-flight writes and a list of the
+     * submitted futures. Not thread-safe for concurrent batch creation; only
+     * one batch is active at a time because checkpoint is serialized by the
+     * TableManager Phase-C write lock.
+     */
+    private static final class AsyncIndexWriteBatch {
+        final Semaphore permits;
+        // Guarded by `this` since futures are added by the (single) traversal
+        // thread but may be completed by arbitrary gRPC callback threads.
+        private final List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        AsyncIndexWriteBatch(int parallelism) {
+            this.permits = new Semaphore(parallelism);
+        }
+
+        synchronized void add(CompletableFuture<Void> future) {
+            futures.add(future);
+        }
+
+        synchronized List<CompletableFuture<Void>> snapshot() {
+            return new ArrayList<>(futures);
         }
     }
 
@@ -706,7 +804,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                 pageId = newPageId.getAndIncrement();
             }
 
-            dataStorageManager.writeIndexPage(tableSpace, indexName, pageId, out -> {
+            DataStorageManager.DataWriter writer = out -> {
 
                 /* Data version */
                 out.writeVLong(1);
@@ -734,7 +832,36 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
                 out.writeByte(NODE_PAGE_END_BLOCK);
 
-            });
+            };
+
+            /*
+             * When a checkpoint is in progress (currentBatch != null) dispatch
+             * the write asynchronously and record the future on the batch; the
+             * outer BLinkKeyToPageIndex.checkpoint joins every future before
+             * persisting the IndexStatus. Outside of checkpoint (e.g. DML
+             * splits or recovery rebuilds), keep the synchronous path so
+             * callers observe the write is durable before returning.
+             */
+            AsyncIndexWriteBatch batch = currentBatch;
+            if (batch != null) {
+                try {
+                    batch.permits.acquire();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while acquiring BLink async-write permit", ex);
+                }
+                CompletableFuture<Void> future;
+                try {
+                    future = dataStorageManager.writeIndexPageAsync(
+                            tableSpace, indexName, pageId, writer);
+                } catch (RuntimeException ex) {
+                    batch.permits.release();
+                    throw ex;
+                }
+                batch.add(future.whenComplete((v, t) -> batch.permits.release()));
+            } else {
+                dataStorageManager.writeIndexPage(tableSpace, indexName, pageId, writer);
+            }
 
             return pageId;
         }

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -469,6 +469,10 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                         configuration.getLong(
                                 ServerConfiguration.PROPERTY_REMOTE_LAZY_VALUE_CACHE_BYTES,
                                 ServerConfiguration.PROPERTY_REMOTE_LAZY_VALUE_CACHE_BYTES_DEFAULT));
+                dsmConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM,
+                        configuration.getInt(
+                                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM,
+                                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT));
                 DataStorageManager dsm = factory.createDataStorageManager(
                         dataDirectory, tmpDirectory, diskswapThreshold, client, dsmConfig);
 

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -94,6 +94,31 @@ public final class ServerConfiguration {
     public static final int PROPERTY_REMOTE_FILE_CLIENT_RETRIES_DEFAULT = 10;
 
     /**
+     * Maximum number of block uploads that a single {@code writePage} invocation
+     * may keep in flight when splitting a page into multipart blocks for
+     * {@link herddb.remote.RemoteFileDataStorageManager}. Larger values speed up
+     * checkpoint flush to remote storage at the cost of more concurrent HTTP/2
+     * streams and transient memory held in gRPC buffers. The parent ByteBuf stays
+     * pinned until all block futures complete.
+     */
+    public static final String PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM =
+            "remote.file.block.parallelism";
+    public static final int PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT = 8;
+
+    /**
+     * Maximum number of concurrent page/index-page writes to remote storage
+     * during a single checkpoint flush (e.g. parallel BLink node writes in
+     * {@code BLinkKeyToPageIndex.checkpoint}). Bounds the global fan-out so a
+     * small remote cluster is not saturated. Combined with
+     * {@link #PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM} the total in-flight
+     * gRPC streams from a checkpoint are at most
+     * {@code flush.parallelism * block.parallelism}.
+     */
+    public static final String PROPERTY_CHECKPOINT_FLUSH_PARALLELISM =
+            "server.checkpoint.flush.parallelism";
+    public static final int PROPERTY_CHECKPOINT_FLUSH_PARALLELISM_DEFAULT = 16;
+
+    /**
      * When true, the leader publishes checkpoint metadata to remote storage (S3)
      * so that shared-storage read replicas can consume it.
      */

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
@@ -154,6 +155,35 @@ public abstract class DataStorageManager implements AutoCloseable {
     }
 
     public abstract void writeIndexPage(String tableSpace, String uuid, long pageId, DataWriter writer);
+
+    /**
+     * Async variant of {@link #writeIndexPage}. Implementations that dispatch
+     * the write to remote storage should return a future that completes when
+     * the page is durable; callers (e.g. {@code BLinkKeyToPageIndex.checkpoint}
+     * that fires many writes in parallel) join all the returned futures before
+     * considering the checkpoint complete.
+     *
+     * <p>The default implementation runs {@link #writeIndexPage} synchronously
+     * on the calling thread and returns an already-completed future — adequate
+     * for in-memory and local-disk backends where there is no benefit from
+     * overlapping writes.
+     *
+     * <p>The {@code writer} may be invoked synchronously on the caller thread
+     * to serialize data into a buffer, even when the returned future is still
+     * pending; implementations must finish consuming the writer before
+     * returning, so the caller can safely reuse the {@code DataWriter} state.
+     */
+    public CompletableFuture<Void> writeIndexPageAsync(String tableSpace, String uuid, long pageId,
+            DataWriter writer) {
+        try {
+            writeIndexPage(tableSpace, uuid, pageId, writer);
+            return CompletableFuture.completedFuture(null);
+        } catch (RuntimeException ex) {
+            CompletableFuture<Void> failed = new CompletableFuture<>();
+            failed.completeExceptionally(ex);
+            return failed;
+        }
+    }
 
     /**
      * Deletes a single index page that was previously written with {@link #writeIndexPage}.

--- a/herddb-core/src/test/java/herddb/index/blink/BLinkParallelWriteCheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BLinkParallelWriteCheckpointTest.java
@@ -1,0 +1,166 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Exercises the parallel BLink node-write path added for issue #202. The BLink
+ * primary-key index checkpoint fires a {@code writeIndexPageAsync} per dirty
+ * node; this test wraps a {@link MemoryDataStorageManager} with a spy that
+ * dispatches each async write onto a real executor so the futures actually run
+ * off-thread, and checks both correctness (IndexStatus.activePages,
+ * successful checkpoint) and error propagation.
+ */
+public class BLinkParallelWriteCheckpointTest {
+
+    private static BLinkKeyToPageIndex newIndex(DataStorageManager ds) {
+        MemoryManager mem = new MemoryManager(
+                5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+        return idx;
+    }
+
+    @Test
+    public void checkpointDispatchesEachNodeViaWriteIndexPageAsync() throws Exception {
+        // Populate enough keys to produce many dirty BLink leaves and inner nodes. The
+        // async call counter was 0 before checkpoint (population doesn't install a
+        // batch — all writes go through the sync path). After checkpoint, async count
+        // must be strictly positive, proving the new path in BLinkKeyToPageIndex is
+        // actually reached.
+        CountingAsyncStorage ds = new CountingAsyncStorage();
+        try (BLinkKeyToPageIndex idx = newIndex(ds)) {
+            for (int i = 0; i < 2000; i++) {
+                idx.put(Bytes.from_int(i), (long) i);
+            }
+            assertEquals("Population should go through sync path only",
+                    0, ds.asyncCalls.get());
+            List<PostCheckpointAction> actions = idx.checkpoint(
+                    new LogSequenceNumber(1, 1), false);
+            for (PostCheckpointAction a : actions) {
+                a.run();
+            }
+            assertTrue("Expected writeIndexPageAsync calls during checkpoint, got "
+                            + ds.asyncCalls.get(),
+                    ds.asyncCalls.get() > 0);
+        } finally {
+            ds.shutdown();
+        }
+    }
+
+    @Test
+    public void failingAsyncWriteFailsCheckpointCleanly() throws Exception {
+        // Inject a failure in one writeIndexPageAsync call; the checkpoint must surface
+        // a DataStorageManagerException rather than silently complete with a
+        // half-published IndexStatus.
+        CountingAsyncStorage ds = new CountingAsyncStorage();
+        ds.failNthAsyncWrite(3);
+        try (BLinkKeyToPageIndex idx = newIndex(ds)) {
+            for (int i = 0; i < 2000; i++) {
+                idx.put(Bytes.from_int(i), (long) i);
+            }
+            try {
+                idx.checkpoint(new LogSequenceNumber(1, 1), false);
+                fail("checkpoint must fail when an async index write fails");
+            } catch (DataStorageManagerException expected) {
+                assertTrue("unexpected cause: " + expected,
+                        expected.getMessage() != null
+                                && (expected.getMessage().contains("injected")
+                                        || (expected.getCause() != null
+                                                && expected.getCause().getMessage().contains("injected"))));
+            }
+        } finally {
+            ds.shutdown();
+        }
+    }
+
+    /**
+     * {@link MemoryDataStorageManager} subclass that:
+     * <ul>
+     *   <li>Dispatches {@code writeIndexPageAsync} onto a real executor so the
+     *       futures actually complete off-thread (the default implementation
+     *       runs synchronously).</li>
+     *   <li>Counts async and sync writes so the test can assert the correct
+     *       path was taken.</li>
+     *   <li>Can inject a failure on the N-th async write for the error path.</li>
+     * </ul>
+     */
+    private static final class CountingAsyncStorage extends MemoryDataStorageManager {
+        final AtomicInteger asyncCalls = new AtomicInteger();
+        private final AtomicInteger asyncSeq = new AtomicInteger();
+        volatile int failAt = -1;
+        private final ExecutorService exec = Executors.newFixedThreadPool(4, r -> {
+            Thread t = new Thread(r, "blink-parallel-test-writer");
+            t.setDaemon(true);
+            return t;
+        });
+
+        void failNthAsyncWrite(int n) {
+            this.failAt = n;
+        }
+
+        void shutdown() throws InterruptedException {
+            exec.shutdown();
+            exec.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public CompletableFuture<Void> writeIndexPageAsync(String tableSpace, String indexName,
+                long pageId, DataWriter writer) {
+            asyncCalls.incrementAndGet();
+            int seq = asyncSeq.incrementAndGet();
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            exec.submit(() -> {
+                if (failAt > 0 && seq == failAt) {
+                    future.completeExceptionally(new RuntimeException(
+                            "injected failure on async write #" + seq));
+                    return;
+                }
+                try {
+                    // Delegate the actual byte storage to the synchronous base impl.
+                    super.writeIndexPage(tableSpace, indexName, pageId, writer);
+                    future.complete(null);
+                } catch (RuntimeException ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
@@ -146,6 +146,12 @@ public class PromotableRemoteFileDataStorageManager extends DataStorageManager {
     }
 
     @Override
+    public java.util.concurrent.CompletableFuture<Void> writeIndexPageAsync(String tableSpace,
+            String uuid, long pageId, DataWriter writer) {
+        return activeDelegate.writeIndexPageAsync(tableSpace, uuid, pageId, writer);
+    }
+
+    @Override
     public void fullTableScan(String tableSpace, String uuid, FullTableScanConsumer consumer) throws DataStorageManagerException {
         activeDelegate.fullTableScan(tableSpace, uuid, consumer);
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -32,6 +32,7 @@ import herddb.model.Index;
 import herddb.model.Record;
 import herddb.model.Table;
 import herddb.model.Transaction;
+import herddb.server.ServerConfiguration;
 import herddb.storage.DataPageDoesNotExistException;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
@@ -55,7 +56,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
@@ -79,6 +83,13 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     private final RemoteFileServiceClient client;
     private final Path tmpDir;
     private final int swapThreshold;
+
+    /**
+     * Maximum number of concurrent block uploads per {@link #writePage} call
+     * when splitting a page into multipart blocks. Configured via
+     * {@link ServerConfiguration#PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM}.
+     */
+    private final int blockUploadParallelism;
 
     /**
      * When set, checkpoint metadata (TableStatus, IndexStatus, table/index definitions,
@@ -144,16 +155,26 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client) {
-        this(localMetadataDir, tmpDir, swapThreshold, client, new LazyValueCache(0L));
+        this(localMetadataDir, tmpDir, swapThreshold, client, new LazyValueCache(0L),
+                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT);
     }
 
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client, LazyValueCache lazyValueCache) {
+        this(localMetadataDir, tmpDir, swapThreshold, client, lazyValueCache,
+                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT);
+    }
+
+    public RemoteFileDataStorageManager(
+            Path localMetadataDir, Path tmpDir, int swapThreshold,
+            RemoteFileServiceClient client, LazyValueCache lazyValueCache,
+            int blockUploadParallelism) {
         this.tmpDir = tmpDir;
         this.swapThreshold = swapThreshold;
         this.client = client;
         this.lazyValueCache = lazyValueCache == null ? new LazyValueCache(0L) : lazyValueCache;
+        this.blockUploadParallelism = Math.max(1, blockUploadParallelism);
         this.localMetadataManager = new FileDataStorageManager(
                 localMetadataDir, tmpDir, swapThreshold,
                 false, false, false, false, false,
@@ -489,6 +510,15 @@ public class RemoteFileDataStorageManager extends DataStorageManager
      * subsequent {@link RemoteFileServiceClient#readFileRange} calls can
      * satisfy byte-range reads. Blocks larger than a single server block
      * are split into consecutive blocks.
+     * <p>
+     * For multi-block payloads, block uploads are dispatched concurrently
+     * via {@link RemoteFileServiceClient#writeFileBlockAsync}, bounded to
+     * {@link #blockUploadParallelism} in-flight at any time. Each slice is
+     * a view over the caller-owned parent {@code buf}; the parent must stay
+     * live until this method returns, which is guaranteed because every
+     * submitted future is joined before we return (success or failure).
+     * Writes to the same {@code path} target different {@code blockIndex}
+     * keys and can legally complete out of order.
      */
     private void writeAsMultipart(String path, ByteBuf buf) {
         final int blockSize = client.getBlockSize();
@@ -498,16 +528,77 @@ public class RemoteFileDataStorageManager extends DataStorageManager
             client.writeFileBlock(path, 0L, io.netty.buffer.Unpooled.EMPTY_BUFFER);
             return;
         }
+        if (total <= blockSize) {
+            // single-block fast path — avoid CompletableFuture / semaphore overhead
+            client.writeFileBlock(path, 0L, buf.slice(buf.readerIndex(), total));
+            return;
+        }
+        final int maxInFlight = Math.max(1, blockUploadParallelism);
+        final Semaphore permits = new Semaphore(maxInFlight);
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
         long blockIndex = 0L;
         int pos = buf.readerIndex();
         int remaining = total;
-        while (remaining > 0) {
-            int chunk = Math.min(remaining, blockSize);
-            ByteBuf slice = buf.slice(pos, chunk);
-            client.writeFileBlock(path, blockIndex, slice);
-            pos += chunk;
-            remaining -= chunk;
-            blockIndex++;
+        RuntimeException submissionFailure = null;
+        try {
+            while (remaining > 0) {
+                permits.acquire();
+                int chunk = Math.min(remaining, blockSize);
+                ByteBuf slice = buf.slice(pos, chunk);
+                CompletableFuture<Void> future;
+                try {
+                    future = client.writeFileBlockAsync(path, blockIndex, slice);
+                } catch (RuntimeException ex) {
+                    // Synchronous failure while submitting the stub call; release the permit,
+                    // stop submitting, and fall through to drain the in-flight futures so
+                    // the parent ByteBuf is safe to release after we return.
+                    permits.release();
+                    submissionFailure = ex;
+                    break;
+                }
+                futures.add(future.whenComplete((r, t) -> permits.release()));
+                pos += chunk;
+                remaining -= chunk;
+                blockIndex++;
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            // Drain whatever futures we did submit; the parent ByteBuf belongs to the caller.
+            joinAllSilently(futures);
+            throw new RuntimeException("Interrupted during parallel block upload of " + path, ex);
+        }
+        CompletionException joinFailure = null;
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        } catch (CompletionException ex) {
+            joinFailure = ex;
+        }
+        if (submissionFailure != null) {
+            throw submissionFailure;
+        }
+        if (joinFailure != null) {
+            Throwable cause = joinFailure.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw joinFailure;
+        }
+    }
+
+    /**
+     * Join every future unconditionally so the caller can safely release the
+     * parent ByteBuf even when some blocks failed. Individual failures are
+     * swallowed here — the outer {@code allOf(...).join()} call in the
+     * happy-path surfaces the root cause.
+     */
+    private static void joinAllSilently(List<CompletableFuture<Void>> futures) {
+        for (CompletableFuture<Void> f : futures) {
+            try {
+                f.join();
+            } catch (CompletionException ignored) {
+                // another future already carries the original error; we just need the buf pinned
+                // until every in-flight gRPC call is done, success or failure.
+            }
         }
     }
 
@@ -660,6 +751,42 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         } catch (IOException e) {
             throw new RuntimeException("Error writing remote index page: " + path, e);
         }
+    }
+
+    @Override
+    public CompletableFuture<Void> writeIndexPageAsync(String tableSpace, String uuid, long pageId,
+            DataWriter writer) {
+        // Serialize synchronously on the caller thread (so the DataWriter state is fully
+        // consumed before we return), then dispatch the network write asynchronously.
+        String path = remoteIndexPagePath(tableSpace, uuid, pageId);
+        final ByteBuf buf;
+        try {
+            buf = serializeIndexPage(writer);
+        } catch (IOException e) {
+            CompletableFuture<Void> failed = new CompletableFuture<>();
+            failed.completeExceptionally(
+                    new RuntimeException("Error serializing remote index page: " + path, e));
+            return failed;
+        }
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+        try {
+            client.writeFileAsync(path, buf).whenComplete((bytesWritten, err) -> {
+                try {
+                    if (err != null) {
+                        result.completeExceptionally(err);
+                    } else {
+                        result.complete(null);
+                    }
+                } finally {
+                    buf.release();
+                }
+            });
+        } catch (RuntimeException ex) {
+            // Synchronous failure building the stub: release the buf now and fail the future.
+            buf.release();
+            result.completeExceptionally(ex);
+        }
+        return result;
     }
 
     @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceFactoryImpl.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceFactoryImpl.java
@@ -64,10 +64,13 @@ public class RemoteFileServiceFactoryImpl implements RemoteFileServiceFactory {
         long valueCacheBytes = readLong(config,
                 ServerConfiguration.PROPERTY_REMOTE_LAZY_VALUE_CACHE_BYTES,
                 ServerConfiguration.PROPERTY_REMOTE_LAZY_VALUE_CACHE_BYTES_DEFAULT);
+        int blockParallelism = readInt(config,
+                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM,
+                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT);
         LazyValueCache cache = new LazyValueCache(valueCacheBytes);
         return new RemoteFileDataStorageManager(
                 dataDirectory, tmpDirectory, swapThreshold,
-                (RemoteFileServiceClient) client, cache);
+                (RemoteFileServiceClient) client, cache, blockParallelism);
     }
 
     private static long readLong(Map<String, Object> config, String key, long defaultValue) {
@@ -80,6 +83,21 @@ public class RemoteFileServiceFactoryImpl implements RemoteFileServiceFactory {
         }
         try {
             return Long.parseLong(v.toString());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private static int readInt(Map<String, Object> config, String key, int defaultValue) {
+        Object v = config.get(key);
+        if (v == null) {
+            return defaultValue;
+        }
+        if (v instanceof Number) {
+            return ((Number) v).intValue();
+        }
+        try {
+            return Integer.parseInt(v.toString());
         } catch (NumberFormatException e) {
             return defaultValue;
         }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileBlockParallelismTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileBlockParallelismTest.java
@@ -1,0 +1,200 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import herddb.model.Record;
+import herddb.utils.Bytes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Validates the parallel-block-upload path added for issue #202. Uses a
+ * small client block size so a short record list already spans multiple
+ * blocks and exercises the fan-out code in
+ * {@code RemoteFileDataStorageManager.writeAsMultipart}.
+ */
+public class RemoteFileBlockParallelismTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new RemoteFileServer(0, folder.newFolder("remote").toPath());
+        server.start();
+        Map<String, Object> clientConfig = new HashMap<>();
+        // Small block size so ordinary test payloads cross the block boundary and
+        // actually exercise writeAsMultipart's parallel fan-out. Kept at 1 KiB so
+        // two blocks cover typical test page sizes — readFileRange (used by
+        // readPage) spans at most two blocks, so staying near that limit keeps
+        // the round-trip path working while still crossing the multi-block branch.
+        clientConfig.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, 1024);
+        client = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), clientConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    private RemoteFileDataStorageManager newStorage(int blockParallelism) throws Exception {
+        RemoteFileDataStorageManager storage = new RemoteFileDataStorageManager(
+                folder.newFolder().toPath(),
+                folder.newFolder().toPath(),
+                1000, client, new LazyValueCache(0L), blockParallelism);
+        storage.start();
+        return storage;
+    }
+
+    @Test
+    public void multiBlockPageRoundTripsWithParallelism8() throws Exception {
+        try (RemoteFileDataStorageManager storage = newStorage(8)) {
+            storage.initTablespace("ts1");
+            storage.initTable("ts1", "uuid1");
+
+            // Block size is 1 KiB — 4 records of ~400 bytes each should push total
+            // payload past one block and into the second, exercising the parallel
+            // fan-out. We stay under ~2 KiB so readFileRange's 2-block span covers
+            // the whole page on read-back.
+            List<Record> page = new ArrayList<>();
+            for (int i = 0; i < 4; i++) {
+                byte[] value = new byte[400];
+                Arrays.fill(value, (byte) ('a' + (i % 26)));
+                page.add(new Record(Bytes.from_string("key-" + i), Bytes.from_array(value)));
+            }
+            storage.writePage("ts1", "uuid1", 7L, page);
+
+            List<Record> read = storage.readPage("ts1", "uuid1", 7L);
+            assertEquals(page.size(), read.size());
+            // Records should round-trip byte-for-byte.
+            Map<Bytes, Bytes> expected = new HashMap<>();
+            for (Record r : page) {
+                expected.put(r.key, r.value);
+            }
+            for (Record r : read) {
+                Bytes exp = expected.get(r.key);
+                assertNotNull("missing key after round-trip: " + r.key, exp);
+                assertEquals(exp, r.value);
+            }
+        }
+    }
+
+    @Test
+    public void singleBlockPageStillWorksWithParallelismEnabled() throws Exception {
+        // Tiny payload that fits in one block — exercises the single-block fast path
+        // so we keep coverage on the non-parallel branch.
+        try (RemoteFileDataStorageManager storage = newStorage(8)) {
+            storage.initTablespace("ts1");
+            storage.initTable("ts1", "uuid1");
+            List<Record> page = Collections.singletonList(
+                    new Record(Bytes.from_string("k"), Bytes.from_string("v")));
+            storage.writePage("ts1", "uuid1", 1L, page);
+
+            List<Record> read = storage.readPage("ts1", "uuid1", 1L);
+            assertEquals(1, read.size());
+            assertEquals(page.get(0).key, read.get(0).key);
+            assertEquals(page.get(0).value, read.get(0).value);
+        }
+    }
+
+    @Test
+    public void emptyPageStillCreatesBlockZero() throws Exception {
+        // writeAsMultipart must always create at least one block for an empty payload so
+        // readers can see a valid file descriptor. The parallel path keeps that behavior.
+        try (RemoteFileDataStorageManager storage = newStorage(4)) {
+            storage.initTablespace("ts1");
+            storage.initTable("ts1", "uuid1");
+            storage.writePage("ts1", "uuid1", 1L, Collections.emptyList());
+            // readFileRange of block 0 succeeds (the file exists even if it has no records).
+            byte[] prefix = client.readFileRange(
+                    "ts1/uuid1/data/1.page", 0L, 4, client.getBlockSize());
+            assertNotNull(prefix);
+        }
+    }
+
+    @Test
+    public void parallelismOneStillWritesAllBlocks() throws Exception {
+        // Regression: a parallelism cap of 1 must still deliver every block; the semaphore
+        // acquire/release loop degenerates to serial but the code path is the parallel one.
+        try (RemoteFileDataStorageManager storage = newStorage(1)) {
+            storage.initTablespace("ts1");
+            storage.initTable("ts1", "uuid1");
+            List<Record> page = new ArrayList<>();
+            // ~1.2 KiB payload: forces a second block at the 1 KiB boundary.
+            for (int i = 0; i < 3; i++) {
+                byte[] value = new byte[400];
+                Arrays.fill(value, (byte) i);
+                page.add(new Record(Bytes.from_string("k-" + i), Bytes.from_array(value)));
+            }
+            storage.writePage("ts1", "uuid1", 3L, page);
+            assertEquals(page.size(), storage.readPage("ts1", "uuid1", 3L).size());
+        }
+    }
+
+    @Test
+    public void writeFailsCleanlyWhenClientClosedMidFlight() throws Exception {
+        // If the client is closed while a write is in flight the parallel path must
+        // surface the error (not silently succeed). This also protects against a buffer
+        // still being pinned after a partial submission failure.
+        RemoteFileDataStorageManager storage = newStorage(4);
+        storage.initTablespace("ts1");
+        storage.initTable("ts1", "uuid1");
+        server.stop();
+        AtomicInteger failures = new AtomicInteger();
+        List<Record> page = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            byte[] v = new byte[400];
+            Arrays.fill(v, (byte) i);
+            page.add(new Record(Bytes.from_string("k-" + i), Bytes.from_array(v)));
+        }
+        try {
+            storage.writePage("ts1", "uuid1", 42L, page);
+            fail("writePage should have failed with the server stopped");
+        } catch (RuntimeException expected) {
+            failures.incrementAndGet();
+        } finally {
+            storage.close();
+        }
+        assertEquals(1, failures.get());
+    }
+}


### PR DESCRIPTION
## Summary
Addresses the 28% ingest-throughput loss caused by full-flush checkpoints that serialize every page upload to the remote file service (issue #202). This PR bundles two independent axes of remote-I/O parallelism; neither changes the checkpoint locking model.

- **Block fan-out** inside `RemoteFileDataStorageManager.writeAsMultipart` — the multipart blocks of a single page are uploaded concurrently via the existing `writeFileBlockAsync` API, bounded by `remote.file.block.parallelism` (default 8). Single-block and empty payloads keep the sync fast path.
- **BLink node fan-out** inside `BLinkKeyToPageIndex.checkpoint` (the primary-key index, which runs under the Phase C write lock and today serializes every dirty BLink node write). A per-checkpoint batch dispatches each node via a new `DataStorageManager.writeIndexPageAsync` (overridden by the remote DSM to call `client.writeFileAsync`); all futures are joined before persisting `IndexStatus`. DML-driven splits keep the sync path. Bounded by `herddb.checkpoint.flush.parallelism` (default 16).

Next up (separate PR): parallel page flush in Phase B (`cleanAndCompactPages`, frozen-newPages loop, `drainPendingNewPages`) backed by a dedicated `checkpointFlushExecutor` on DBManager.

## Test plan
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean across all 22 modules
- [x] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test` — 12/12 green, run twice (24/24)
- [x] `mvn -pl herddb-remote-file-service -Dtest='RemoteFileDataStorageManagerBasicTest,RemoteFileServiceTest,RemoteFileServiceClientByteBufTest,RemoteFileServiceClientTest,RemoteFileDataStorageManagerRangeReadTest,LazyDataPageTest' test` — 58/58 green
- [x] New targeted tests:
  - `RemoteFileBlockParallelismTest` — multi-block round-trip, single-block fast path, empty page, parallelism=1 regression, failure injection
  - `BLinkParallelWriteCheckpointTest` — async dispatch during checkpoint, failure propagation
- [ ] Measure on the GKE bigann bench — expect `commits_p99` during full-flush checkpoints to drop from ~100-200 s toward the ~2.5 s p50 floor and total checkpoint duration to shrink roughly in proportion to effective parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)