### PR TITLE
issue #202: parallel Phase-B page flush for frozen newPages + drain

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -175,6 +175,15 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     private Gauge<Integer> activeTablespacesGauge;
     private final ExecutorService followersThreadPool;
 
+    /**
+     * Dedicated pool used by {@code TableManager} checkpoint flush loops to
+     * dispatch data-page writes to remote storage in parallel. Kept separate
+     * from {@link #callbacksExecutor} so saturating the checkpoint path cannot
+     * starve commit callbacks (the metric this pool exists to protect).
+     * Sized via {@link ServerConfiguration#PROPERTY_CHECKPOINT_FLUSH_THREADS}.
+     */
+    private final ExecutorService checkpointFlushExecutor;
+
     public DBManager(
             String nodeId, MetadataStorageManager metadataStorageManager, DataStorageManager dataStorageManager,
             CommitLogManager commitLogManager, Path tmpDirectory, herddb.network.ServerHostData hostData
@@ -212,6 +221,27 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         // todo: make it configurable, cached have some pitfalls under load
         this.followersThreadPool = Executors.newCachedThreadPool((Runnable r) -> new FastThreadLocalThread(
                 r, "herddb-worker-" + (hostData == null ? "local" : hostData.getHost() + ":" + hostData.getPort()) + "-" + r));
+        int checkpointFlushThreads = configuration.getInt(
+                ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_THREADS,
+                ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_THREADS_DEFAULT);
+        if (checkpointFlushThreads <= 0) {
+            // same escape hatch as callbacksExecutor: run flushes on the caller
+            // thread when tests/embedded users opt out of the pool.
+            this.checkpointFlushExecutor = MoreExecutors.newDirectExecutorService();
+        } else {
+            this.checkpointFlushExecutor = Executors.newFixedThreadPool(checkpointFlushThreads,
+                    new ThreadFactory() {
+                        private final AtomicLong count = new AtomicLong();
+
+                        @Override
+                        public Thread newThread(final Runnable r) {
+                            final String marker = hostData == null ? "local"
+                                    : hostData.getHost() + ":" + hostData.getPort();
+                            return new FastThreadLocalThread(r,
+                                    "db-checkpoint-flush-" + marker + "-" + count.incrementAndGet());
+                        }
+                    });
+        }
         this.recordSetFactory = dataStorageManager.createRecordSetFactory();
         this.metadataStorageManager = metadataStorageManager;
         this.dataStorageManager = dataStorageManager;
@@ -1003,11 +1033,13 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         }
         mainStatsLogger.unregisterGauge("active_tablespaces", activeTablespacesGauge);
         callbacksExecutor.shutdownNow();
+        checkpointFlushExecutor.shutdownNow();
 
         // lastly give a chance to not "leak" even if not critical (ie not keep used instances after close())
         try {
             followersThreadPool.awaitTermination(1, SECONDS);
             callbacksExecutor.awaitTermination(1, SECONDS); // give a chance to not "leak" even if not critical
+            checkpointFlushExecutor.awaitTermination(1, SECONDS);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -1597,6 +1629,14 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     public ExecutorService getCallbacksExecutor() {
         return callbacksExecutor;
+    }
+
+    /**
+     * Dedicated executor used by {@code TableManager} checkpoint flush loops
+     * to fan out page writes to remote storage in parallel.
+     */
+    public ExecutorService getCheckpointFlushExecutor() {
+        return checkpointFlushExecutor;
     }
 
     public ServerSidePreparedStatementCache getPreparedStatementsCache() {

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -102,8 +102,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -300,6 +302,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      * Compaction (small pages) target max milliseconds
      */
     private final long compactionTargetTime;
+
+    /**
+     * Max concurrent page writes dispatched to the checkpoint-flush executor
+     * during Phase B. Read once at construction from
+     * {@link ServerConfiguration#PROPERTY_CHECKPOINT_FLUSH_PARALLELISM}.
+     */
+    private final int checkpointFlushParallelism;
 
     /**
      * Soft upper bound on the number of {@link PostCheckpointAction} entries a
@@ -540,6 +549,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 ServerConfiguration.PROPERTY_COMPACTION_DURATION_DEFAULT);
 
         this.compactionTargetTime = compactionTargetTime < 0 ? Long.MAX_VALUE : compactionTargetTime;
+
+        this.checkpointFlushParallelism = Math.max(1,
+                tableSpaceManager.getDbmanager().getServerConfiguration().getInt(
+                        ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_PARALLELISM,
+                        ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_PARALLELISM_DEFAULT));
 
         int maxActionsPerCheckpointCycle = tableSpaceManager.getDbmanager().getServerConfiguration().getInt(
                 ServerConfiguration.PROPERTY_CHECKPOINT_MAX_ACTIONS_PER_CYCLE,
@@ -939,6 +953,74 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     /**
+     * Bounded-parallel collector of {@code dataStorageManager.writePage} calls
+     * submitted to the DBManager checkpoint-flush executor during Phase B
+     * (issue #202). Lives for a single Phase-B invocation on one table.
+     *
+     * <p>The {@link #submit(Runnable)} call blocks (on a semaphore) when the
+     * configured parallelism limit is reached, so the caller cannot run ahead
+     * of the executor indefinitely and hold unbounded in-memory pages while
+     * their writes queue up. The corresponding permit is released inside the
+     * executor task's {@code finally} block so a throwing flush does not leak
+     * a permit.
+     *
+     * <p>{@link #awaitAll()} joins every submitted future and re-throws the
+     * first failure as a {@link DataStorageManagerException}. All other
+     * failures are drained silently to keep subsequent checkpoint teardown
+     * consistent — the first one already tells the operator what broke.
+     */
+    private static final class CheckpointFlushBatch {
+        private final ExecutorService executor;
+        private final Semaphore permits;
+        private final List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        CheckpointFlushBatch(ExecutorService executor, int parallelism) {
+            this.executor = executor;
+            this.permits = new Semaphore(Math.max(1, parallelism));
+        }
+
+        void submit(Runnable flushAction) throws DataStorageManagerException {
+            try {
+                permits.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new DataStorageManagerException(
+                        "Interrupted acquiring checkpoint flush permit", e);
+            }
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                try {
+                    flushAction.run();
+                } finally {
+                    permits.release();
+                }
+            }, executor);
+            synchronized (futures) {
+                futures.add(future);
+            }
+        }
+
+        void awaitAll() throws DataStorageManagerException {
+            CompletableFuture<?>[] arr;
+            synchronized (futures) {
+                arr = futures.toArray(new CompletableFuture<?>[0]);
+            }
+            if (arr.length == 0) {
+                return;
+            }
+            try {
+                CompletableFuture.allOf(arr).join();
+            } catch (CompletionException ex) {
+                Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+                if (cause instanceof DataStorageManagerException) {
+                    throw (DataStorageManagerException) cause;
+                }
+                throw new DataStorageManagerException(
+                        "Parallel checkpoint page flush failed", cause);
+            }
+        }
+    }
+
+    /**
      * Remove the page from {@link #newPages}, set it as "not writable" and write it
      * to disk
      * <p>
@@ -1059,17 +1141,28 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         } finally {
             checkpointLock.asWriteLock().unlock();
         }
-        long pagesFlushed = 0;
-        long recordsFlushed = 0;
-        for (DataPage page : snapshot) {
-            flushNewPageForCheckpoint(page, null);
-            if (!page.isEmpty()) {
-                ++pagesFlushed;
-                recordsFlushed += page.size();
-            }
+        // Parallel drain (issue #202): pages in the snapshot are independent new pages,
+        // each taking its own page.pageLock. Fan out through the DBManager checkpoint-flush
+        // executor so remote storage I/O overlaps instead of serializing.
+        final CheckpointFlushBatch batch = new CheckpointFlushBatch(
+                tableSpaceManager.getCheckpointFlushExecutor(), checkpointFlushParallelism);
+        final AtomicLong pagesFlushed = new AtomicLong();
+        final AtomicLong recordsFlushed = new AtomicLong();
+        for (DataPage dataPage : snapshot) {
+            final DataPage page = dataPage;
+            final boolean wasNonEmpty = !page.isEmpty();
+            final int recordCount = page.size();
+            batch.submit(() -> {
+                flushNewPageForCheckpoint(page, null);
+                if (wasNonEmpty) {
+                    pagesFlushed.incrementAndGet();
+                    recordsFlushed.addAndGet(recordCount);
+                }
+            });
         }
+        batch.awaitAll();
         drainedNewPagesOutsideLock.addAndGet(snapshot.size());
-        return new long[]{pagesFlushed, recordsFlushed};
+        return new long[]{pagesFlushed.get(), recordsFlushed.get()};
     }
 
     /**
@@ -3747,17 +3840,33 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
          * We pass null as spareDataPage to avoid spare-data stealing which could race with
          * concurrent DML modifying the keyToPage mappings of compacted records in buildingPage.
          * buildingPage will be flushed in Phase C.
+         *
+         * Frozen pages are independent of each other (no shared state, each takes its own
+         * page.pageLock), so their flushes can run concurrently on the DBManager
+         * checkpoint-flush executor (issue #202). Empty pages still go through flush so the
+         * EMPTY_FLUSH path removes them from `pages`/pageReplacementPolicy. The AtomicLongs
+         * avoid any happens-before concern between the executor threads and the main thread
+         * reading the counters after awaitAll returns.
          */
-        long flushedNewPages = 0;
+        final CheckpointFlushBatch frozenFlushBatch = new CheckpointFlushBatch(
+                tableSpaceManager.getCheckpointFlushExecutor(), checkpointFlushParallelism);
+        final AtomicLong frozenFlushedPages = new AtomicLong();
+        final AtomicLong frozenFlushedRecords = new AtomicLong();
         for (DataPage dataPage : frozenNewPages) {
-            /* Always call flush even for empty pages: EMPTY_FLUSH removes the page from `pages` and
-             * pageReplacementPolicy, which is required for the rotated-out currentDirtyRecordsPage. */
-            flushNewPageForCheckpoint(dataPage, null);
-            if (!dataPage.isEmpty()) {
-                ++flushedNewPages;
-                flushedRecords += dataPage.size();
-            }
+            final DataPage page = dataPage;
+            final boolean wasNonEmpty = !page.isEmpty();
+            final int recordCount = page.size();
+            frozenFlushBatch.submit(() -> {
+                flushNewPageForCheckpoint(page, null);
+                if (wasNonEmpty) {
+                    frozenFlushedPages.incrementAndGet();
+                    frozenFlushedRecords.addAndGet(recordCount);
+                }
+            });
         }
+        frozenFlushBatch.awaitAll();
+        long flushedNewPages = frozenFlushedPages.get();
+        flushedRecords += frozenFlushedRecords.get();
 
 
         /* ********************************** */

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -3036,6 +3036,14 @@ public class TableSpaceManager {
         return callbacksExecutor;
     }
 
+    /**
+     * Expose the DBManager-scoped checkpoint flush executor so TableManager can
+     * dispatch Phase-B page writes in parallel without reaching for DBManager directly.
+     */
+    public ExecutorService getCheckpointFlushExecutor() {
+        return dbmanager.getCheckpointFlushExecutor();
+    }
+
     @Override
     public String toString() {
         return "TableSpaceManager [nodeId=" + nodeId

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -119,6 +119,18 @@ public final class ServerConfiguration {
     public static final int PROPERTY_CHECKPOINT_FLUSH_PARALLELISM_DEFAULT = 16;
 
     /**
+     * Thread pool size for the dedicated checkpoint-flush executor used by
+     * {@code TableManager} to fan out Phase-B data page writes to remote
+     * storage in parallel. Kept separate from the shared
+     * {@link #PROPERTY_ASYNC_WORKER_THREADS} pool (which runs commit callbacks)
+     * so a slow checkpoint flush cannot starve commit latency — which is the
+     * metric this pool exists to protect.
+     */
+    public static final String PROPERTY_CHECKPOINT_FLUSH_THREADS =
+            "server.checkpoint.flush.threads";
+    public static final int PROPERTY_CHECKPOINT_FLUSH_THREADS_DEFAULT = 16;
+
+    /**
      * When true, the leader publishes checkpoint metadata to remote storage (S3)
      * so that shared-storage read replicas can consume it.
      */

--- a/herddb-core/src/test/java/herddb/core/CheckpointParallelFlushTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointParallelFlushTest.java
@@ -1,0 +1,207 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.Record;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.server.ServerConfiguration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Regression tests for issue #202's Phase-B parallel page flush. The frozen-pages loop
+ * and {@code drainPendingNewPages} now fan their per-page writes out through the
+ * DBManager checkpoint-flush executor; these tests prove it by:
+ *
+ * <ul>
+ *   <li>wrapping the {@link MemoryDataStorageManager} so every {@code writePage} call
+ *       bumps an in-flight counter and briefly sleeps — the MAX observed in-flight
+ *       must exceed 1 when many pages exist, proving the calls actually overlap;</li>
+ *   <li>injecting a failure on the N-th {@code writePage} and asserting the whole
+ *       checkpoint fails with a recognisable cause, not a silent partial-success.</li>
+ * </ul>
+ */
+public class CheckpointParallelFlushTest {
+
+    @Test
+    public void parallelFrozenPagesFlushRunsConcurrently() throws Exception {
+        // Small page size so INSERTs create many frozen newPages at Phase A snapshot.
+        ServerConfiguration config = new ServerConfiguration();
+        config.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, 256);
+        // Keep async worker pool threaded (default) so the checkpoint-flush executor
+        // gets its configured parallelism.
+        config.set(ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_THREADS, 8);
+        config.set(ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_PARALLELISM, 8);
+
+        InFlightTrackingStorage ds = new InFlightTrackingStorage();
+        ds.pageWriteDelayMillis = 40L;
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager(nodeId,
+                new MemoryMetadataStorageManager(), ds, new MemoryCommitLogManager(),
+                null, null, config, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, s1 string)",
+                    Collections.emptyList());
+            // 60 rows × ~60-byte values at 256-byte page size → many frozen newPages.
+            for (int i = 0; i < 60; i++) {
+                execute(manager,
+                        "INSERT INTO tblspace1.t1(k1,s1) values(?,?)",
+                        Arrays.asList("k" + i, "payload-" + i + "-padding-padding-padding"));
+            }
+
+            ds.resetCounters();
+            manager.checkpoint();
+
+            assertTrue("expected writePage to be invoked during checkpoint, got "
+                            + ds.writePageCount.get(),
+                    ds.writePageCount.get() > 0);
+            assertTrue("expected MAX in-flight writePage > 1 (actual " + ds.maxInFlight.get()
+                            + "), proving parallel Phase-B flush is engaged",
+                    ds.maxInFlight.get() > 1);
+
+            // Sanity: data survives round-trip.
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1",
+                    Collections.emptyList())) {
+                assertEquals(60, s.consume().size());
+            }
+        }
+    }
+
+    @Test
+    public void failedPageWriteFailsCheckpointCleanly() throws Exception {
+        ServerConfiguration config = new ServerConfiguration();
+        config.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, 256);
+        config.set(ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_THREADS, 4);
+        config.set(ServerConfiguration.PROPERTY_CHECKPOINT_FLUSH_PARALLELISM, 4);
+
+        InFlightTrackingStorage ds = new InFlightTrackingStorage();
+        ds.failOnWriteCount = 3; // third writePage call throws
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager(nodeId,
+                new MemoryMetadataStorageManager(), ds, new MemoryCommitLogManager(),
+                null, null, config, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, s1 string)",
+                    Collections.emptyList());
+            for (int i = 0; i < 40; i++) {
+                execute(manager,
+                        "INSERT INTO tblspace1.t1(k1,s1) values(?,?)",
+                        Arrays.asList("k" + i, "payload-" + i + "-padding-padding-padding"));
+            }
+
+            // Call TableManager.checkpoint directly so the failure propagates past the
+            // per-table try/catch that TableSpaceManager.checkpoint uses to keep going
+            // when a table drops mid-checkpoint.
+            AbstractTableManager tm = manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+            try {
+                tm.checkpoint(false);
+                fail("TableManager.checkpoint must fail when a writePage throws");
+            } catch (Exception expected) {
+                String message = expected.getMessage() == null ? "" : expected.getMessage();
+                Throwable cause = expected.getCause();
+                String causeMessage = cause == null || cause.getMessage() == null
+                        ? "" : cause.getMessage();
+                assertTrue("expected injected-failure cause; got: " + expected,
+                        message.contains("injected") || causeMessage.contains("injected"));
+            }
+
+            // Record data is still durable via the commit log — the checkpoint marker
+            // didn't advance, so a recovery would replay all 40 rows. We verify the
+            // in-memory state is still consistent (no orphaned rows, no panics).
+            try (DataScanner s = scan(manager, "SELECT * FROM tblspace1.t1",
+                    Collections.emptyList())) {
+                assertEquals(40, s.consume().size());
+            }
+        }
+    }
+
+    /**
+     * {@link MemoryDataStorageManager} wrapper that counts {@code writePage} invocations,
+     * tracks peak concurrency, optionally sleeps to widen the overlap window, and
+     * optionally fails on the N-th invocation.
+     */
+    private static final class InFlightTrackingStorage extends MemoryDataStorageManager {
+        final AtomicInteger writePageCount = new AtomicInteger();
+        final AtomicInteger inFlight = new AtomicInteger();
+        final AtomicInteger maxInFlight = new AtomicInteger();
+        volatile long pageWriteDelayMillis = 0L;
+        volatile int failOnWriteCount = -1;
+        private final CountDownLatch dummy = new CountDownLatch(0);
+
+        void resetCounters() {
+            writePageCount.set(0);
+            inFlight.set(0);
+            maxInFlight.set(0);
+        }
+
+        @Override
+        public void writePage(String tableSpace, String uuid, long pageId,
+                Collection<Record> newPage) throws herddb.storage.DataStorageManagerException {
+            int hits = writePageCount.incrementAndGet();
+            int current = inFlight.incrementAndGet();
+            maxInFlight.accumulateAndGet(current, Math::max);
+            try {
+                if (failOnWriteCount > 0 && hits == failOnWriteCount) {
+                    throw new RuntimeException("injected writePage failure (#" + hits + ")");
+                }
+                if (pageWriteDelayMillis > 0) {
+                    try {
+                        dummy.await(pageWriteDelayMillis, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                super.writePage(tableSpace, uuid, pageId, newPage);
+            } finally {
+                inFlight.decrementAndGet();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #206. Phase B's per-page `writePage` loop was still serial on the two hot paths that dominate checkpoint duration for insert-heavy workloads:

- **Frozen newPages flush** (`TableManager.java:3751-3760`) — every page that was accumulating DML writes before Phase A rotated the current page.
- **`drainPendingNewPages`** (`TableManager.java:1064`) — the pages that accumulate in `newPages` while Phase B and `indexManager.checkpoint` run.

Both loops now dispatch each `flushNewPageForCheckpoint` call through a new `CheckpointFlushBatch`, which submits onto a dedicated `checkpointFlushExecutor` on `DBManager` (thread count via the new `server.checkpoint.flush.threads`, default 16) and bounds concurrent in-flight writes via the existing `server.checkpoint.flush.parallelism` (default 16). A callbacksExecutor-free pool prevents checkpoint from starving commit callbacks.

Frozen pages and drain-snapshot pages are independent — each holds its own `page.pageLock` during `flushNewPage` — so the fan-out is safe without restructuring `flushMutablePage`. `cleanAndCompactPages` (buildingPage rotation) and Phase C stay serial; the issue #46 invariant is unchanged.

## Test plan
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean across all 22 modules
- [x] `mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test` — 12/12 green, run twice (24/24)
- [x] `mvn -pl herddb-core -Dtest='CheckpointTest,CheckpointDrainNewPagesTest,ConcurrentCheckpointTest,NewPageTest,CheckpointMemoryBoundsTest,DropOldPagesTest,UnloadDirtyPageTest' test` — 27/27 green
- [x] New targeted tests in `CheckpointParallelFlushTest`:
  - `parallelFrozenPagesFlushRunsConcurrently` — wraps `MemoryDataStorageManager` and asserts max in-flight `writePage` > 1, proving the fan-out is engaged
  - `failedPageWriteFailsCheckpointCleanly` — injects a failure on the third `writePage` and asserts `TableManager.checkpoint` surfaces it with the injected cause
- [ ] Measure on the GKE bigann bench — expect the combined effect of #206 + this PR to close most of the 28% ingest-throughput gap reported in issue #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)