### PR TITLE
issue #213: run tailer-driven IS checkpoint on dedicated thread

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -54,7 +54,10 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -131,6 +134,23 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     private ExecutorService[] applyWorkers;
     private int applyParallelism;
     private volatile Throwable asyncError;
+
+    /**
+     * Single-thread executor that runs {@link #checkpointAndSaveWatermark()}
+     * off the tailer thread (issue #213). The tailer must never block on a
+     * Phase B Future.get(); instead it hands the checkpoint work to this
+     * executor via {@link #triggerCheckpointAsync()} and keeps dispatching
+     * entries to the apply-worker pool.
+     */
+    private ExecutorService checkpointExecutor;
+
+    /**
+     * Tracks the most recently submitted tailer-driven checkpoint so that
+     * {@link #triggerCheckpointAsync()} can coalesce new triggers while one
+     * is still running, and {@link #forceCheckpointAndSaveWatermark()} and
+     * {@link #close()} can await it.
+     */
+    private volatile Future<?> inflightCheckpoint;
 
     /**
      * Wall-clock time at which {@link #start()} finished, used by the
@@ -232,8 +252,29 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     /**
      * Exposes the checkpoint+watermark save path for tests and the cluster
      * E2E test that needs to force a checkpoint at a specific point in time.
+     *
+     * <p>Issue #213: tailer-driven checkpoints now run on a background
+     * executor. To preserve the post-condition callers rely on — "after this
+     * returns, a fresh checkpoint has completed and, if successful, the
+     * watermark has been persisted" — we first await any in-flight async
+     * checkpoint, then run a synchronous one on the caller thread.
      */
     public void forceCheckpointAndSaveWatermark() {
+        Future<?> inflight = this.inflightCheckpoint;
+        if (inflight != null) {
+            try {
+                inflight.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOGGER.log(Level.WARNING, "Interrupted awaiting in-flight checkpoint in forceCheckpointAndSaveWatermark");
+                return;
+            } catch (ExecutionException e) {
+                // The async task already logged the failure; we still run a
+                // fresh sync checkpoint below so the caller's post-condition
+                // is satisfied.
+                LOGGER.log(Level.FINE, "In-flight async checkpoint ended with failure", e.getCause());
+            }
+        }
         checkpointAndSaveWatermark();
     }
 
@@ -429,6 +470,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
         LOGGER.log(Level.INFO, "DML apply workers started, parallelism={0}, queueCapacity={1}",
                 new Object[]{applyParallelism, queueCapacity});
+
+        // Single-thread executor that runs tailer-driven checkpoints off the
+        // tailer thread (issue #213). Must be started before the tailer so
+        // triggerCheckpointAsync() can submit tasks as soon as the tailer
+        // starts processing entries.
+        checkpointExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "indexing-checkpoint");
+            t.setDaemon(true);
+            return t;
+        });
 
         // Validate instance identity
         if (numInstances < 1) {
@@ -657,11 +708,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             entriesSinceLastCheckpoint++;
 
             // Periodically force a checkpoint and then persist the watermark.
+            // The checkpoint runs on a dedicated thread (issue #213) so the
+            // tailer never blocks on Phase B Future.get() and the apply-worker
+            // pool keeps receiving entries throughout the checkpoint window.
             // The watermark is saved ONLY after all stores successfully
             // checkpoint — never at any other time. See
             // {@link WatermarkStore} for the save contract.
             if (entriesSinceLastCheckpoint >= watermarkCheckpointIntervalEntries) {
-                checkpointAndSaveWatermark();
+                triggerCheckpointAsync();
             }
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Error processing entry at LSN " + lsn + ": " + entry, e);
@@ -716,6 +770,41 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         checkAsyncError();
     }
 
+    /**
+     * Called from the tailer thread when the watermark-checkpoint-interval
+     * threshold is reached. Hands the checkpoint off to
+     * {@link #checkpointExecutor} so the tailer returns immediately and keeps
+     * dispatching entries to the apply-worker pool while Phase B runs.
+     *
+     * <p>If a previous tailer-driven checkpoint is still running, the trigger
+     * is coalesced: {@code entriesSinceLastCheckpoint} is NOT reset, so the
+     * next call to {@code processEntry} will try again and fire as soon as
+     * the in-flight checkpoint completes. The {@code checkpointLock.tryLock}
+     * inside {@code PersistentVectorStore.doCheckpoint} already makes
+     * overlapping cycles a safe no-op, so at-most-one submission is purely a
+     * throughput optimisation.
+     */
+    private void triggerCheckpointAsync() {
+        Future<?> inflight = this.inflightCheckpoint;
+        if (inflight != null && !inflight.isDone()) {
+            LOGGER.log(Level.FINE,
+                    "Checkpoint trigger coalesced: previous tailer-driven checkpoint still running");
+            return;
+        }
+        if (checkpointExecutor == null || checkpointExecutor.isShutdown()) {
+            // Engine is closing or not fully started; skip silently.
+            return;
+        }
+        entriesSinceLastCheckpoint = 0;
+        try {
+            this.inflightCheckpoint = checkpointExecutor.submit(this::checkpointAndSaveWatermark);
+        } catch (java.util.concurrent.RejectedExecutionException e) {
+            // Submitted during shutdown race — acceptable; the next tailer
+            // trigger (if the engine survives) will retry.
+            LOGGER.log(Level.FINE, "Checkpoint trigger rejected (executor shutting down)");
+        }
+    }
+
     private void checkAsyncError() {
         Throwable err = asyncError;
         if (err != null) {
@@ -755,6 +844,26 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     // package-private for testing
     void awaitPendingWorkForTest() {
         awaitPendingWork();
+    }
+
+    /**
+     * Invokes {@link #triggerCheckpointAsync()} (used by tests that want to
+     * exercise the async checkpoint path without driving the full
+     * {@code processEntry} code path).
+     */
+    // package-private for testing
+    void triggerCheckpointAsyncForTest() {
+        triggerCheckpointAsync();
+    }
+
+    /**
+     * Returns the currently tracked in-flight tailer-driven checkpoint
+     * {@link Future}, or {@code null} if none is tracked (used by tests to
+     * verify coalescing and shutdown semantics).
+     */
+    // package-private for testing
+    Future<?> getInflightCheckpointFutureForTest() {
+        return inflightCheckpoint;
     }
 
     /**
@@ -1804,6 +1913,28 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
+        }
+
+        // Shut down the checkpoint executor BEFORE the apply workers so that
+        // any in-flight Phase B can complete and save the watermark. Doing
+        // this after the apply workers are shut down would cause the in-flight
+        // checkpoint's awaitPendingWork() barrier-submit to fail with
+        // RejectedExecutionException.
+        if (checkpointExecutor != null) {
+            checkpointExecutor.shutdown();
+            try {
+                if (!checkpointExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                    LOGGER.log(Level.WARNING,
+                            "In-flight checkpoint did not complete within 30s of shutdown; forcing shutdownNow");
+                    checkpointExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                checkpointExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+            checkpointExecutor = null;
+            inflightCheckpoint = null;
+            LOGGER.info("Checkpoint executor shut down");
         }
 
         // Drain and shut down apply workers

--- a/herddb-indexing-service/src/test/java/herddb/indexing/AsyncCheckpointTriggerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/AsyncCheckpointTriggerTest.java
@@ -1,0 +1,485 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import herddb.codec.RecordSerializer;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests the async tailer-driven checkpoint trigger introduced for issue #213.
+ *
+ * <p>Before issue #213 the tailer thread executed
+ * {@link IndexingServiceEngine#forceCheckpointAndSaveWatermark() checkpointAndSaveWatermark()}
+ * inline; while Phase B of the FusedPQ checkpoint was running the tailer
+ * could not dispatch new entries, and all striped apply-workers went idle.
+ * The fix hands the checkpoint off to a single-thread background executor so
+ * the tailer returns immediately and apply-workers keep receiving work.
+ *
+ * <p>These tests drive the engine directly (bypassing a real commit-log
+ * tailer) and use {@link PersistentVectorStore#setCheckpointPhaseBHook(Runnable)}
+ * to park the checkpoint inside Phase B, which is where the blocking
+ * {@code Future.get()} lived.
+ */
+public class AsyncCheckpointTriggerTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private int savedMinLive;
+    private long savedDeferral;
+
+    @Before
+    public void saveGateState() {
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        savedDeferral = PersistentVectorStore.maxCheckpointDeferralMs;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreGateState() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+        PersistentVectorStore.maxCheckpointDeferralMs = savedDeferral;
+    }
+
+    private static final class RecordingWatermarkStore implements WatermarkStore {
+        private final AtomicReference<LogSequenceNumber> saved = new AtomicReference<>();
+        private volatile int saveCount;
+
+        @Override
+        public synchronized LogSequenceNumber load() {
+            LogSequenceNumber v = saved.get();
+            return v != null ? v : LogSequenceNumber.START_OF_TIME;
+        }
+
+        @Override
+        public synchronized void save(LogSequenceNumber lsn) throws IOException {
+            saved.set(lsn);
+            saveCount++;
+        }
+
+        synchronized LogSequenceNumber current() {
+            return saved.get();
+        }
+
+        synchronized int getSaveCount() {
+            return saveCount;
+        }
+    }
+
+    private Table createTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private static MemoryMetadataStorageManager createTestMetadata() throws Exception {
+        MemoryMetadataStorageManager m = new MemoryMetadataStorageManager();
+        m.start();
+        m.ensureDefaultTableSpace("local", "local", 0, 1);
+        return m;
+    }
+
+    /**
+     * Context holding the engine, the live PersistentVectorStore, and the
+     * recording watermark so every test can share the boot path.
+     */
+    private static final class EngineCtx implements AutoCloseable {
+        final IndexingServiceEngine engine;
+        final PersistentVectorStore store;
+        final RecordingWatermarkStore watermark;
+        final Table table;
+        final LogSequenceNumber bootstrapLastLsn;
+
+        EngineCtx(IndexingServiceEngine engine, PersistentVectorStore store,
+                  RecordingWatermarkStore watermark, Table table,
+                  LogSequenceNumber bootstrapLastLsn) {
+            this.engine = engine;
+            this.store = store;
+            this.watermark = watermark;
+            this.table = table;
+            this.bootstrapLastLsn = bootstrapLastLsn;
+        }
+
+        @Override
+        public void close() throws Exception {
+            engine.close();
+        }
+    }
+
+    /**
+     * Boots an engine with a persistent vector-store factory, applies the
+     * DDL, ingests enough vectors to clear the FusedPQ threshold, takes one
+     * successful checkpoint to establish a baseline watermark, and returns
+     * the context with the live store exposed.
+     */
+    private EngineCtx bootAndBaseline() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, config);
+        engine.setMetadataStorageManager(createTestMetadata());
+
+        RecordingWatermarkStore watermark = new RecordingWatermarkStore();
+        engine.setWatermarkStore(watermark);
+
+        AtomicReference<PersistentVectorStore> storeRef = new AtomicReference<>();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(
+                128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName, dataDirectory, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, "tstblspace", vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE,
+                    VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            storeRef.set(pvs);
+            return pvs;
+        });
+
+        engine.start();
+
+        Table table = createTable();
+        engine.applyEntry(new LogSequenceNumber(1, 1), LogEntryFactory.createTable(table, null));
+        Index index = Index.builder()
+                .name("vidx")
+                .table("vectable")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+        engine.applyEntry(new LogSequenceNumber(1, 2), LogEntryFactory.createIndex(index, null));
+
+        PersistentVectorStore store = storeRef.get();
+        assertNotNull("store should have been created by DDL", store);
+
+        Random rng = new Random(29);
+        int numVectors = 300;
+        int dim = 32;
+        LogSequenceNumber lastLsn = null;
+        for (int i = 0; i < numVectors; i++) {
+            Record record = RecordSerializer.makeRecord(table,
+                    "pk", "k" + i,
+                    "vec", randomVector(rng, dim));
+            LogEntry insert = LogEntryFactory.insert(table, record.key, record.value, null);
+            lastLsn = new LogSequenceNumber(1, 100 + i);
+            engine.applySingleEntryForTest(lastLsn, insert);
+        }
+        engine.awaitPendingWorkForTest();
+        engine.setLastProcessedLsnForTest(lastLsn);
+
+        // Establish a baseline watermark so later deltas are easy to reason about.
+        engine.forceCheckpointAndSaveWatermark();
+        assertEquals("baseline checkpoint should have saved once",
+                1, watermark.getSaveCount());
+
+        return new EngineCtx(engine, store, watermark, table, lastLsn);
+    }
+
+    private LogSequenceNumber ingestMore(EngineCtx ctx, long startLsn, int count, Random rng, int dim) {
+        LogSequenceNumber lastLsn = null;
+        for (int i = 0; i < count; i++) {
+            Record record = RecordSerializer.makeRecord(ctx.table,
+                    "pk", "k-extra-" + startLsn + "-" + i,
+                    "vec", randomVector(rng, dim));
+            LogEntry insert = LogEntryFactory.insert(ctx.table, record.key, record.value, null);
+            lastLsn = new LogSequenceNumber(1, startLsn + i);
+            ctx.engine.applySingleEntryForTest(lastLsn, insert);
+        }
+        ctx.engine.awaitPendingWorkForTest();
+        ctx.engine.setLastProcessedLsnForTest(lastLsn);
+        return lastLsn;
+    }
+
+    /**
+     * When a Phase B hook parks the store's checkpoint, a tailer-driven
+     * trigger must return quickly (no Future.get() on the caller thread).
+     * After the hook releases, the in-flight Future must complete and the
+     * watermark must advance to the LSN captured at trigger time.
+     */
+    @Test(timeout = 60_000)
+    public void testTriggerIsNonBlockingAndWatermarkAdvancesAfterRelease() throws Exception {
+        try (EngineCtx ctx = bootAndBaseline()) {
+            Random rng = new Random(37);
+            LogSequenceNumber lastLsn = ingestMore(ctx, 2_000, 200, rng, 32);
+
+            CountDownLatch phaseBEntered = new CountDownLatch(1);
+            CountDownLatch releasePhaseB = new CountDownLatch(1);
+            ctx.store.setCheckpointPhaseBHook(() -> {
+                phaseBEntered.countDown();
+                try {
+                    releasePhaseB.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            int saveCountBefore = ctx.watermark.getSaveCount();
+
+            long t0 = System.nanoTime();
+            ctx.engine.triggerCheckpointAsyncForTest();
+            long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+            // Submitting to the executor should be effectively instant; allow
+            // generous slack for a loaded CI machine.
+            assertTrue("trigger must not block the caller; elapsed=" + elapsedMs + " ms",
+                    elapsedMs < 1_000);
+
+            Future<?> inflight = ctx.engine.getInflightCheckpointFutureForTest();
+            assertNotNull("inflight future should be tracked", inflight);
+
+            assertTrue("async checkpoint must have reached Phase B",
+                    phaseBEntered.await(30, TimeUnit.SECONDS));
+
+            // While the checkpoint is parked, the watermark must NOT have moved.
+            assertEquals("watermark must not advance while checkpoint is parked",
+                    saveCountBefore, ctx.watermark.getSaveCount());
+
+            releasePhaseB.countDown();
+            inflight.get(30, TimeUnit.SECONDS);
+
+            assertEquals("watermark should advance once async checkpoint completes",
+                    saveCountBefore + 1, ctx.watermark.getSaveCount());
+            assertEquals("watermark advanced to the LSN captured at trigger time",
+                    lastLsn, ctx.watermark.current());
+
+            ctx.store.setCheckpointPhaseBHook(null);
+        }
+    }
+
+    /**
+     * A second trigger fired while the first async checkpoint is still
+     * running must be coalesced (same Future) — the engine relies on the
+     * {@code tryLock} skip inside PersistentVectorStore as a safety net, but
+     * we want to avoid queueing redundant work in the first place.
+     */
+    @Test(timeout = 60_000)
+    public void testOverlappingTriggersAreCoalesced() throws Exception {
+        try (EngineCtx ctx = bootAndBaseline()) {
+            Random rng = new Random(41);
+            ingestMore(ctx, 3_000, 200, rng, 32);
+
+            CountDownLatch phaseBEntered = new CountDownLatch(1);
+            CountDownLatch releasePhaseB = new CountDownLatch(1);
+            ctx.store.setCheckpointPhaseBHook(() -> {
+                phaseBEntered.countDown();
+                try {
+                    releasePhaseB.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            ctx.engine.triggerCheckpointAsyncForTest();
+            Future<?> first = ctx.engine.getInflightCheckpointFutureForTest();
+            assertNotNull(first);
+            assertTrue(phaseBEntered.await(30, TimeUnit.SECONDS));
+
+            // Second trigger while first is parked — must be coalesced.
+            ctx.engine.triggerCheckpointAsyncForTest();
+            Future<?> second = ctx.engine.getInflightCheckpointFutureForTest();
+            assertSame("second trigger must reuse the in-flight future", first, second);
+
+            releasePhaseB.countDown();
+            first.get(30, TimeUnit.SECONDS);
+
+            // After completion a fresh trigger IS allowed (we use a no-op
+            // hook now so the new checkpoint completes quickly).
+            ctx.store.setCheckpointPhaseBHook(null);
+            ctx.engine.triggerCheckpointAsyncForTest();
+            Future<?> third = ctx.engine.getInflightCheckpointFutureForTest();
+            assertNotNull(third);
+            assertTrue("a new submission is expected after the previous one finished",
+                    third != first);
+            third.get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * {@code close()} must wait for any in-flight async checkpoint so the
+     * final watermark is persisted before the engine shuts down.
+     */
+    @Test(timeout = 60_000)
+    public void testCloseAwaitsInflightCheckpoint() throws Exception {
+        EngineCtx ctx = bootAndBaseline();
+        try {
+            Random rng = new Random(53);
+            LogSequenceNumber lastLsn = ingestMore(ctx, 4_000, 200, rng, 32);
+
+            // A long-but-bounded delay inside Phase B: close() must wait it
+            // out instead of racing the watermark save.
+            CountDownLatch phaseBEntered = new CountDownLatch(1);
+            ctx.store.setCheckpointPhaseBHook(() -> {
+                phaseBEntered.countDown();
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            int saveCountBefore = ctx.watermark.getSaveCount();
+            ctx.engine.triggerCheckpointAsyncForTest();
+            assertTrue("async checkpoint must have reached Phase B",
+                    phaseBEntered.await(30, TimeUnit.SECONDS));
+
+            // close() should block until the parked checkpoint above finishes,
+            // then observe the watermark save.
+            ctx.engine.close();
+
+            assertEquals("close must wait for in-flight checkpoint to persist watermark",
+                    saveCountBefore + 1, ctx.watermark.getSaveCount());
+            assertEquals("watermark matches last processed LSN at trigger time",
+                    lastLsn, ctx.watermark.current());
+        } finally {
+            // Safety: if the assertion before engine.close() failed, make
+            // sure we still clean up.
+            try {
+                ctx.engine.close();
+            } catch (Exception ignored) {
+                // already closed
+            }
+        }
+    }
+
+    /**
+     * {@code forceCheckpointAndSaveWatermark()} must first await any
+     * in-flight async checkpoint, then run a fresh synchronous checkpoint,
+     * so tests and admin callers observe a deterministic post-condition
+     * regardless of what the tailer has been doing.
+     */
+    @Test(timeout = 60_000)
+    public void testForceAwaitsInflightAndRunsFreshCheckpoint() throws Exception {
+        try (EngineCtx ctx = bootAndBaseline()) {
+            Random rng = new Random(61);
+            LogSequenceNumber lastLsn = ingestMore(ctx, 5_000, 200, rng, 32);
+
+            CountDownLatch phaseBEntered = new CountDownLatch(1);
+            CountDownLatch releasePhaseB = new CountDownLatch(1);
+            ctx.store.setCheckpointPhaseBHook(() -> {
+                phaseBEntered.countDown();
+                try {
+                    releasePhaseB.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            int saveCountBefore = ctx.watermark.getSaveCount();
+            ctx.engine.triggerCheckpointAsyncForTest();
+            assertTrue(phaseBEntered.await(30, TimeUnit.SECONDS));
+
+            // Run force() on a worker thread so we can unblock Phase B after
+            // verifying it has started to wait.
+            Thread forcer = new Thread(ctx.engine::forceCheckpointAndSaveWatermark, "test-forcer");
+            forcer.start();
+
+            // Give the forcer time to reach the inflight.get() wait. Then
+            // release Phase B: the async task finishes, force() runs a second
+            // checkpoint on the caller, which must save the watermark again.
+            // (There is no deterministic way to observe the forcer blocking
+            // without reflection; the timing here is generous.)
+            Thread.sleep(500);
+            assertEquals("async checkpoint must not have saved yet while Phase B is parked",
+                    saveCountBefore, ctx.watermark.getSaveCount());
+            releasePhaseB.countDown();
+
+            // Clear the hook so the force()'s own synchronous checkpoint
+            // does not park a second time.
+            ctx.store.setCheckpointPhaseBHook(null);
+
+            forcer.join(30_000);
+            assertTrue("forcer thread should have terminated", !forcer.isAlive());
+
+            // At least two saves: one from the async task, one from force().
+            // There may be extra transient saves if the store advances the
+            // LSN in between, but strictly more than the baseline.
+            assertTrue("watermark must have advanced at least twice; saveCount="
+                            + ctx.watermark.getSaveCount(),
+                    ctx.watermark.getSaveCount() >= saveCountBefore + 2);
+            assertEquals("watermark points at the last processed LSN",
+                    lastLsn, ctx.watermark.current());
+        }
+    }
+
+    /** Guard: if the engine is never started, close() must not NPE on checkpointExecutor. */
+    @Test
+    public void testCloseBeforeStartDoesNotFail() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, config);
+        engine.close();
+        assertNull("no in-flight checkpoint before start",
+                engine.getInflightCheckpointFutureForTest());
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #213 — the `indexing-service-tailer` no longer blocks during an IS checkpoint.
- Moves `checkpointAndSaveWatermark()` onto a single-thread `indexing-checkpoint` executor; the tailer fires and forgets so apply-workers keep receiving entries while `PersistentVectorStore.doCheckpointFusedPQPhaseB` runs.
- Overlapping tailer triggers are coalesced; `forceCheckpointAndSaveWatermark()` awaits any in-flight async checkpoint before running a fresh sync one, preserving the public post-condition.
- `close()` shuts the checkpoint executor down before the apply-workers so the final watermark still lands on disk.
- No changes to `PersistentVectorStore` — the existing stateLock/checkpointLock split already tolerates concurrent DML during Phase B.

## Evidence — before

Per the issue, during a 200 M-row bigann ingest the tailer was observed parked on `FutureTask.get()` inside `doCheckpointFusedPQPhaseB` while all 16 `indexing-apply-worker-*` threads sat on `LinkedBlockingQueue.take()`. With this change the tailer returns from `processEntry()` as soon as the checkpoint is submitted, and the apply-workers keep draining their queues throughout Phase B.

## Test plan

- [x] `mvn -pl herddb-indexing-service test` — 230/230 pass (includes new `AsyncCheckpointTriggerTest`).
- [x] Hammer gate from `CLAUDE.md`: `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` — 12/12 passing, run twice (as suggested in `CLAUDE.md`).
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean.
- [ ] Optional follow-up: end-to-end vector bench with a lowered `indexing.watermark.checkpoint.interval.entries` (e.g. 20 000) + jstack during a checkpoint window to confirm the apply-workers stay busy.

### New unit tests

`AsyncCheckpointTriggerTest` covers:
1. Trigger is non-blocking while Phase B is parked via `setCheckpointPhaseBHook`; watermark advances to the captured LSN once the hook releases.
2. A second trigger fired while a checkpoint is parked is coalesced (same `Future`); a fresh trigger is allowed once the previous one completes.
3. `close()` waits for the in-flight async checkpoint so the watermark is persisted.
4. `forceCheckpointAndSaveWatermark()` awaits the in-flight async checkpoint, then runs a fresh synchronous one (watermark advances at least twice).
5. `close()` before `start()` does not NPE on the new executor field.

## Out of scope

- Lowering the `indexing.watermark.checkpoint.interval.entries` default from 100 000 — its comment currently blames this bug for the large default. Once #213 lands, tightening the cadence can ship as its own PR with benchmarks.
- Restructuring `doCheckpointFusedPQPhaseB` to be fire-and-notify (Option 3 from the issue). Not needed once the checkpoint no longer runs on the tailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)