### PR TITLE
issue #221: emit numShards in VectorBench DDL so IS cluster actually shards

### DIFF
--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -195,6 +195,12 @@ Rules that apply to every workload, including user-specified ones:
   recall phase — go to the failure path.
 - **Checkpoint timeout.** Always pass `--checkpoint-timeout-seconds 1800`.
   Never use a lower value.
+- **Vector index sharding.** `VectorBench` now emits `numShards 4` by default
+  so a 2/4-replica indexing-service cluster actually shards the work across
+  instances (`shardId % numInstances == instanceId`). Do not pass
+  `--index-num-shards` unless the user explicitly asks for a different value
+  (e.g. `--index-num-shards 1` to disable sharding for a single-replica run,
+  or a larger value to match a non-standard `indexingService.replicaCount`).
 - **Wait-for-indexes timeout.** Always pass
   `--wait-for-indexes-timeout 1800`. Never use a lower value.
 - **Custom datasets** live in `gs://herddb-datasets`. To run a GCS-hosted

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -186,9 +186,6 @@ public final class IndexingServerConfiguration {
     public static final String PROPERTY_NUM_INSTANCES = "indexing.cluster.numInstances";
     public static final int PROPERTY_NUM_INSTANCES_DEFAULT = 1;
 
-    public static final String PROPERTY_DEFAULT_NUM_SHARDS = "indexing.vector.default.numShards";
-    public static final int PROPERTY_DEFAULT_NUM_SHARDS_DEFAULT = 1;
-
     // Log tailing mode
     public static final String PROPERTY_LOG_TYPE = "indexing.log.type";
     public static final String PROPERTY_LOG_TYPE_DEFAULT = "file";

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -51,6 +51,7 @@ public class Config {
     boolean topKExplicit = false;
     int indexM = 16;
     int indexBeamWidth = 100;
+    int indexNumShards = 4;
     boolean skipIngest = false;
     boolean skipIndex = false;
     boolean skipVerify = false;
@@ -92,6 +93,9 @@ public class Config {
         opts.addOption("k", null, true, "LIMIT K for ANN queries (default: 10)");
         opts.addOption(null, "m", true, "Vector index M parameter (default: 16)");
         opts.addOption(null, "beam-width", true, "Vector index beamWidth (default: 100)");
+        opts.addOption(null, "index-num-shards", true,
+                "Vector index numShards (default: 4). Set to 1 to disable sharding; "
+                        + "otherwise emitted as `numShards N` in the CREATE VECTOR INDEX DDL.");
         opts.addOption(null, "skip-ingest", false, "Skip ingestion phase");
         opts.addOption(null, "skip-index", false, "Skip index creation");
         opts.addOption(null, "skip-verify", false, "Skip row count verification after ingestion");
@@ -191,6 +195,9 @@ public class Config {
         }
         if (cmd.hasOption("beam-width")) {
             cfg.indexBeamWidth = Integer.parseInt(cmd.getOptionValue("beam-width"));
+        }
+        if (cmd.hasOption("index-num-shards")) {
+            cfg.indexNumShards = Integer.parseInt(cmd.getOptionValue("index-num-shards"));
         }
         if (cmd.hasOption("skip-ingest")) {
             cfg.skipIngest = true;
@@ -321,6 +328,9 @@ public class Config {
         }
         if (props.containsKey("beam-width")) {
             indexBeamWidth = Integer.parseInt(props.getProperty("beam-width"));
+        }
+        if (props.containsKey("index-num-shards")) {
+            indexNumShards = Integer.parseInt(props.getProperty("index-num-shards"));
         }
         if (props.containsKey("skip-ingest")) {
             skipIngest = Boolean.parseBoolean(props.getProperty("skip-ingest"));

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -46,6 +46,19 @@ public class VectorBench {
         void run() throws Exception;
     }
 
+    static String buildCreateVectorIndexSql(Config config) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE VECTOR INDEX vidx ON ").append(config.tableName).append("(vec)")
+                .append(" WITH m=").append(config.indexM)
+                .append(" beamWidth=").append(config.indexBeamWidth)
+                .append(" similarity=").append(config.effectiveSimilarity())
+                .append(" fusedPQ=true");
+        if (config.indexNumShards > 1) {
+            sb.append(" numShards ").append(config.indexNumShards);
+        }
+        return sb.toString();
+    }
+
     /** Runs a task with a progress spinner and returns elapsed wall-clock seconds. */
     private static double runWithProgress(BenchOutput out, String phase, String label, SqlTask task) throws Exception {
         if (!out.suppressesText()) {
@@ -174,10 +187,7 @@ public class VectorBench {
 
         // Phase 4a: Index creation before ingestion (if requested)
         if (config.indexBeforeIngest && !config.skipIndex) {
-            String indexSql = "CREATE VECTOR INDEX vidx ON " + config.tableName + "(vec)"
-                    + " WITH m=" + config.indexM
-                    + " beamWidth=" + config.indexBeamWidth
-                    + " similarity=" + config.effectiveSimilarity() + " fusedPQ=true";
+            String indexSql = buildCreateVectorIndexSql(config);
             out.info("Executing (pre-ingest): " + indexSql);
             indexWallSecs = runWithProgress(out, "index_creation", "=== INDEX CREATION (pre-ingest) ===", () -> {
                 try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
@@ -389,10 +399,7 @@ public class VectorBench {
 
         // Phase 5: Index creation (post-ingest, unless already created before ingestion)
         if (!config.skipIndex && !config.indexBeforeIngest) {
-            String indexSql = "CREATE VECTOR INDEX vidx ON " + config.tableName + "(vec)"
-                    + " WITH m=" + config.indexM
-                    + " beamWidth=" + config.indexBeamWidth
-                    + " similarity=" + config.effectiveSimilarity() + " fusedPQ=true";
+            String indexSql = buildCreateVectorIndexSql(config);
             out.info("Executing: " + indexSql);
             indexWallSecs = runWithProgress(out, "index_creation", "=== INDEX CREATION ===", () -> {
                 try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);

--- a/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
@@ -81,6 +81,76 @@ class VectorBenchTest {
     }
 
     @Test
+    void buildCreateVectorIndexSqlDefaultIncludesNumShardsFour() throws Exception {
+        Config cfg = Config.parse(new String[]{});
+
+        String sql = VectorBench.buildCreateVectorIndexSql(cfg);
+
+        assertEquals(
+                "CREATE VECTOR INDEX vidx ON vector_bench(vec)"
+                        + " WITH m=16 beamWidth=100 similarity=" + cfg.effectiveSimilarity()
+                        + " fusedPQ=true numShards 4",
+                sql);
+    }
+
+    @Test
+    void buildCreateVectorIndexSqlOmitsClauseWhenNumShardsIsOne() throws Exception {
+        Config cfg = Config.parse(new String[]{"--index-num-shards", "1"});
+
+        String sql = VectorBench.buildCreateVectorIndexSql(cfg);
+
+        org.junit.jupiter.api.Assertions.assertFalse(
+                sql.contains("numShards"),
+                "numShards clause must be omitted when indexNumShards <= 1, got: " + sql);
+        assertEquals(
+                "CREATE VECTOR INDEX vidx ON vector_bench(vec)"
+                        + " WITH m=16 beamWidth=100 similarity=" + cfg.effectiveSimilarity()
+                        + " fusedPQ=true",
+                sql);
+    }
+
+    @Test
+    void buildCreateVectorIndexSqlOmitsClauseWhenNumShardsIsZero() throws Exception {
+        Config cfg = Config.parse(new String[]{"--index-num-shards", "0"});
+
+        String sql = VectorBench.buildCreateVectorIndexSql(cfg);
+
+        org.junit.jupiter.api.Assertions.assertFalse(
+                sql.contains("numShards"),
+                "numShards clause must be omitted when indexNumShards <= 1, got: " + sql);
+    }
+
+    @Test
+    void buildCreateVectorIndexSqlUsesCustomNumShards() throws Exception {
+        Config cfg = Config.parse(new String[]{"--index-num-shards", "8"});
+
+        String sql = VectorBench.buildCreateVectorIndexSql(cfg);
+
+        org.junit.jupiter.api.Assertions.assertTrue(
+                sql.endsWith("numShards 8"),
+                "expected trailing `numShards 8`, got: " + sql);
+    }
+
+    @Test
+    void buildCreateVectorIndexSqlReflectsCustomTableAndIndexParams() throws Exception {
+        Config cfg = Config.parse(new String[]{
+                "--table", "my_vectors",
+                "--m", "32",
+                "--beam-width", "200",
+                "--similarity", "cosine",
+                "--index-num-shards", "2"
+        });
+
+        String sql = VectorBench.buildCreateVectorIndexSql(cfg);
+
+        assertEquals(
+                "CREATE VECTOR INDEX vidx ON my_vectors(vec)"
+                        + " WITH m=32 beamWidth=200 similarity=cosine"
+                        + " fusedPQ=true numShards 2",
+                sql);
+    }
+
+    @Test
     void configResumeFromParsedFromCli() throws Exception {
         Config cfg = Config.parse(new String[]{"--resume-from", "500000"});
         assertEquals(500000, cfg.resumeFrom);


### PR DESCRIPTION
Fixes #221.

## Summary

- `VectorBench` now emits `numShards N` in the `CREATE VECTOR INDEX` DDL, defaulting to **4** (covers 1/2/4-replica IS deployments cleanly since `shardId % numInstances == instanceId`). Override with `--index-num-shards <n>`; set to `1` to disable sharding.
- DDL construction is extracted into a single `buildCreateVectorIndexSql(Config)` helper so the pre-ingest and post-ingest call sites can't drift.
- Drop the dead `IndexingServerConfiguration.PROPERTY_DEFAULT_NUM_SHARDS` / `indexing.vector.default.numShards` config key — it was defined but never read, and the DDL property is the authoritative source of truth for shard count.
- GKE bench agent doc gets a one-liner noting that sharding is on by default and `--index-num-shards 1` is the override for single-replica runs.

## Why

`IndexingServiceEngine.isInsertAcceptedLocally` short-circuits to `true` when `numShards <= 1`, so before this change a 2-replica IS cluster was indexing every vector on every pod (issue #221 observed `vector_count ≈ total_rows` on both pods instead of ~half each).

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` → BUILD SUCCESS
- [x] Grep sweep: no remaining references to `PROPERTY_DEFAULT_NUM_SHARDS` or `indexing.vector.default.numShards`
- [ ] End-to-end repro on a multi-replica IS deployment: after ingest, `describe-index` on both pods should report roughly `total_rows / numInstances * (numShards/numInstances)` instead of `total_rows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)