### PR TITLE
issue #223: pre-size jvector GraphIndexBuilder base layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eolivelli/jvector
-          ref: feature/bytebuffer-zero-copy-vectors
+          ref: reduce-denseintmap-lock-contention
           path: jvector
       - name: 'Build jvector'
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector

--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: eolivelli/jvector
-          ref: feature/bytebuffer-zero-copy-vectors
+          ref: reduce-denseintmap-lock-contention
           path: jvector
       - name: 'Build jvector'
         run: mvn -B install -DskipTests -Drat.skip=true --file jvector/pom.xml && rm -rf jvector

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2675,9 +2675,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
             VectorStorageRandomAccessVectorValues allMravv =
                     new VectorStorageRandomAccessVectorValues(allStorage, dim, allVectors.size());
             BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(allMravv, similarityFunction);
+            // Pre-size the base-layer DenseIntMap to totalVectors so the parallel insert
+            // below never hits the spine-grow lock in jvector (issue #223).
             GraphIndexBuilder mergedBuilder = new GraphIndexBuilder(
-                    bsp, dim, m, beamWidth, neighborOverflow, alpha, ADD_HIERARCHY, REFINE_FINAL_GRAPH,
-                    PhysicalCoreExecutor.pool(), CHECKPOINT_POOL);
+                    bsp, dim, List.of(m), beamWidth, neighborOverflow, alpha,
+                    ADD_HIERARCHY, REFINE_FINAL_GRAPH,
+                    PhysicalCoreExecutor.pool(), CHECKPOINT_POOL, totalVectors);
 
             int progressInterval = Math.max(1000, totalVectors / 10);
             java.util.concurrent.ForkJoinTask<?> graphTask = CHECKPOINT_POOL.submit(() ->
@@ -3151,8 +3154,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
         VectorStorageRandomAccessVectorValues ravv =
                 new VectorStorageRandomAccessVectorValues(vectorStorage, dim, -1, startNodeId);
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, similarityFunction);
+        // Pass cap as initialCapacity so the jvector base-layer DenseIntMap is pre-sized
+        // for the shard and concurrent addGraphNode avoids the spine-grow lock (issue #223).
         GraphIndexBuilder b = new GraphIndexBuilder(
-                bsp, dim, m, bw, no, a, ADD_HIERARCHY, REFINE_FINAL_GRAPH);
+                bsp, dim, List.of(m), bw, no, a, ADD_HIERARCHY, REFINE_FINAL_GRAPH,
+                PhysicalCoreExecutor.pool(), ForkJoinPool.commonPool(), cap);
         return new LiveGraphShard(p2n, n2p, ravv, b, startNodeId);
     }
 


### PR DESCRIPTION
## Summary

- Adopt the new `initialCapacity` hint on `GraphIndexBuilder` introduced by jvector branch [`reduce-denseintmap-lock-contention`](https://github.com/eolivelli/jvector/pull/2) (commit `87e3bfff`), which rewrites `DenseIntMap` as a lock-free spine-of-segments. A herddb lock-profile showed ~92% of lock-wait time inside that map during concurrent graph build.
- `PersistentVectorStore.createEmptyLiveShard` — pass `cap = computeEffectiveMaxLiveGraphSize()` as the hint. This is the same bound already used to pre-size the two `ConcurrentHashMap`s next to the builder.
- `PersistentVectorStore.writeFusedPQGraphToTempFile` — pass `totalVectors = allNodeToPk.size()`, the exact node count about to be inserted in the compaction/merge path.
- CI (`ci.yml` + `kubernetes-tests.yml`) now checks out the new jvector branch so the 11-arg constructor resolves at compile time. Artifact version (`4.0.0-rc.9-herddb-SNAPSHOT`) is unchanged, so no pom bump is required.

Closes #223.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` (green locally)
- [ ] CI (`ci.yml` + `kubernetes-tests.yml`) runs against the new jvector branch
- [ ] `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` (hammer gate for index/checkpoint/concurrency changes)
- [ ] Vector indexing smoke on k3s-local / GKE confirms no lock-profile regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)