### PR TITLE
issue #220: make --ingest-max-ops a true global ops/s cap

### DIFF
--- a/vector-testings/pom.xml
+++ b/vector-testings/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jhdf</groupId>
             <artifactId>jhdf</artifactId>
             <version>0.10.0</version>

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -19,6 +19,7 @@
  */
 package herddb.vectortesting;
 
+import com.google.common.util.concurrent.RateLimiter;
 import herddb.jdbc.PreparedStatementAsync;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -56,6 +57,7 @@ public class IngestionWorker implements Runnable {
     private final AtomicLong commitsTotal;
     private final AtomicLong commitsRecovered;
     private final AtomicLong rowsCommitted;
+    private final RateLimiter ingestRateLimiter;
 
     /**
      * Base of the exponential back-off between commit retries, in milliseconds.
@@ -66,7 +68,8 @@ public class IngestionWorker implements Runnable {
 
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
-                           AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted) {
+                           AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted,
+                           RateLimiter ingestRateLimiter) {
         this.config = config;
         this.queue = queue;
         this.done = done;
@@ -77,6 +80,7 @@ public class IngestionWorker implements Runnable {
         this.commitsTotal = commitsTotal;
         this.commitsRecovered = commitsRecovered;
         this.rowsCommitted = rowsCommitted;
+        this.ingestRateLimiter = ingestRateLimiter;
     }
 
     private static String formatEta(double seconds) {
@@ -232,20 +236,19 @@ public class IngestionWorker implements Runnable {
                     long now = System.currentTimeMillis();
                     if (pendingBatch.size() >= config.batchSize
                             || (!pendingBatch.isEmpty() && now - lastCommitTime >= maxCommitIntervalMs)) {
+                        int batchRows = pendingBatch.size();
                         long latencyNanos = commitWithRetry(ps, conn, pendingBatch, batchStartNanos);
                         metrics.record(latencyNanos);
-                        rowsIngested += pendingBatch.size();
+                        rowsIngested += batchRows;
                         pendingBatch.clear();
                         lastCommitTime = now;
-                    }
 
-                    // Throttle if max ops/s is configured
-                    if (config.ingestMaxOpsPerSecond > 0) {
-                        double expectedElapsedSecs = (double) rowsIngested / config.ingestMaxOpsPerSecond;
-                        double actualElapsedSecs = (System.nanoTime() - ingestStartNanos) / 1e9;
-                        double sleepSecs = expectedElapsedSecs - actualElapsedSecs;
-                        if (sleepSecs > 0.001) {
-                            Thread.sleep((long) (sleepSecs * 1000));
+                        if (ingestRateLimiter != null) {
+                            // Shared across all ingestion workers, so --ingest-max-ops is a
+                            // true global cap. Guava's acquire() is uninterruptible; wait
+                            // time is bounded by batchRows / rate, so worker shutdown via
+                            // done.get() remains responsive on the next poll() iteration.
+                            ingestRateLimiter.acquire(batchRows);
                         }
                     }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -19,6 +19,7 @@
  */
 package herddb.vectortesting;
 
+import com.google.common.util.concurrent.RateLimiter;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
@@ -220,11 +221,16 @@ public class VectorBench {
 
             long ingestStart = System.nanoTime();
 
+            RateLimiter ingestRateLimiter = config.ingestMaxOpsPerSecond > 0
+                    ? RateLimiter.create(config.ingestMaxOpsPerSecond)
+                    : null;
+
             ExecutorService ingestPool = Executors.newFixedThreadPool(config.ingestThreads);
             List<Future<?>> ingestFutures = new ArrayList<>(config.ingestThreads);
             for (int t = 0; t < config.ingestThreads; t++) {
                 ingestFutures.add(ingestPool.submit(new IngestionWorker(config, ingestQueue, producerDone, rowId,
-                        ingestMetrics, ingestStatus, ingestStart, commitsTotal, commitsRecovered, rowsCommitted)));
+                        ingestMetrics, ingestStatus, ingestStart, commitsTotal, commitsRecovered, rowsCommitted,
+                        ingestRateLimiter)));
             }
 
             // Progress display thread runs during the entire ingestion

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerRateLimitTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerRateLimitTest.java
@@ -1,0 +1,87 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.google.common.util.concurrent.RateLimiter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for issue #220: {@code --ingest-max-ops} must be a global cap
+ * across all ingestion workers, not a per-thread cap. The guarantee comes from
+ * constructing a single {@link RateLimiter} in {@code VectorBench} and passing
+ * the same reference into every {@link IngestionWorker}; this test verifies
+ * that a shared limiter does in fact throttle aggregate throughput across
+ * multiple threads.
+ */
+class IngestionWorkerRateLimitTest {
+
+    @Test
+    void sharedRateLimiterBoundsAggregateThroughput() throws Exception {
+        final double rate = 500.0; // permits/s
+        final int threads = 4;
+        final int acquisitionsPerThread = 250;
+        final int totalAcquisitions = threads * acquisitionsPerThread;
+
+        RateLimiter limiter = RateLimiter.create(rate);
+        // Consume the initial burst so it doesn't skew the measurement.
+        limiter.acquire(1);
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        for (int j = 0; j < acquisitionsPerThread; j++) {
+                            limiter.acquire(1);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            long t0 = System.nanoTime();
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS), "workers did not finish in time");
+            double elapsedSecs = (System.nanoTime() - t0) / 1e9;
+
+            // With a truly global limiter, total elapsed >= totalAcquisitions / rate.
+            // If the limiter were per-thread, elapsed would be ~acquisitionsPerThread / rate
+            // (i.e. 4x faster). Allow a 10% tolerance for scheduling jitter.
+            double expectedMinSecs = (totalAcquisitions / rate) * 0.90;
+            assertTrue(elapsedSecs >= expectedMinSecs,
+                    "shared RateLimiter failed to bound aggregate throughput: elapsed="
+                            + elapsedSecs + "s, expected >= " + expectedMinSecs + "s");
+        } finally {
+            pool.shutdownNow();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
@@ -149,7 +149,8 @@ class IngestionWorkerTest {
                 System.nanoTime(),
                 commitsTotal,
                 commitsRecovered,
-                rowsCommitted
+                rowsCommitted,
+                null // no rate limiting in flush/retry tests
         );
         worker.backoffBaseMillis = 0L; // keep tests fast
         return worker;


### PR DESCRIPTION
## Summary

Fixes #220. The vector-bench `--ingest-max-ops` flag was documented as a
global rate cap ("Max ingestion ops/s across all threads") but each
`IngestionWorker` threw its own local `rowsIngested` counter into the
throttle math, so the effective global rate was
`ingestMaxOpsPerSecond × ingestThreads`. Users reported ~4× (with
`--ingest-threads 4`) the throughput they asked for.

- Build one `com.google.common.util.concurrent.RateLimiter` in
  `VectorBench.runBenchmark()` when `config.ingestMaxOpsPerSecond > 0`
  and pass the same instance to every `IngestionWorker`.
- Replace the per-worker manual `Thread.sleep` throttle with
  `rateLimiter.acquire(batchRows)` called once after each successful
  batch commit. Guava's `acquire()` is uninterruptible, but the wait is
  bounded by `batchRows / rate`, so worker shutdown via `done.get()`
  stays responsive on the next `poll()`.
- Add `guava` to `vector-testings/pom.xml` (version managed by the parent
  `<dependencyManagement>`).
- Update `IngestionWorkerTest.createTestWorker(...)` to pass a `null`
  limiter (no throttling in the existing retry/flush tests).
- Add `IngestionWorkerRateLimitTest` as a regression gate: 4 threads ×
  250 acquisitions against a shared `RateLimiter.create(500)` must take
  ≥ ~1.8s — a per-thread limiter would finish in ~0.5s.

## Behavior note

With the default `ingestMaxOpsPerSecond = 100_000` and the default
`ingestThreads = 4`, the observed cap drops from ~400k rows/s to
100k rows/s. That's the point: the flag now matches its help text.
Users who relied on the implicit N× behavior can pass
`--ingest-max-ops 400000` (or `0` for unlimited).

## Test plan

- [x] `mvn -B -pl vector-testings -am checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [x] `mvn -B -pl vector-testings test` — 52/52 pass, including new `IngestionWorkerRateLimitTest` (2.04s)
- [ ] Manual smoke: run bench with `--ingest-max-ops 1000 --ingest-threads 4` against a local server and confirm the logged ingest rate hovers around 1000 rows/s (not ~4000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)