### PR TITLE
Reduce lock contention on PersistentVectorStore ingest hot path

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3158,24 +3158,44 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     /**
      * Rotates the live graph shard if the active shard has reached the max size.
+     *
+     * <p>The expensive allocation ({@link #createEmptyLiveShard} — two preallocated
+     * {@link java.util.concurrent.ConcurrentHashMap}s plus a jvector
+     * {@code GraphIndexBuilder}) runs <em>outside</em> the instance monitor so that
+     * concurrent ingest threads do not block waiting for shard construction.  Only
+     * the publish (volatile swap of {@link #liveShards}) happens under the monitor.
+     *
+     * <p>Under burst contention up to K threads may concurrently build a candidate
+     * shard; K-1 are discarded after the double-check.  That trades a small amount
+     * of wasted allocation at rotation time for eliminating the monitor hold while
+     * the builder is initialized.
      */
-    private synchronized LiveGraphShard rotateLiveShard() {
-        List<LiveGraphShard> shards = this.liveShards;
-        LiveGraphShard active = shards.get(shards.size() - 1);
-        if (active.nodeToPk.size() < computeEffectiveMaxLiveGraphSize()) {
+    private LiveGraphShard rotateLiveShard() {
+        List<LiveGraphShard> snap = this.liveShards;
+        LiveGraphShard active = snap.get(snap.size() - 1);
+        int cap = computeEffectiveMaxLiveGraphSize();
+        if (active.nodeToPk.size() < cap) {
             return active;
         }
-
-        LiveGraphShard newShard = createEmptyLiveShard(dimension, beamWidth, neighborOverflow, alpha);
-        List<LiveGraphShard> newList = new ArrayList<>(shards);
-        newList.add(newShard);
-        this.liveShards = newList;
-
-        LOGGER.log(Level.INFO,
-                "vector store {0}: rotated live graph shard, now {1} shards ({2} vectors in sealed shard)",
-                new Object[]{indexName, newList.size(), active.nodeToPk.size()});
-
-        return newShard;
+        // Allocate outside the monitor: jvector GraphIndexBuilder setup is the
+        // dominant cost in this method (see issue: lock profile hotspot).
+        LiveGraphShard candidate = createEmptyLiveShard(
+                dimension, beamWidth, neighborOverflow, alpha);
+        synchronized (this) {
+            List<LiveGraphShard> cur = this.liveShards;
+            LiveGraphShard curActive = cur.get(cur.size() - 1);
+            if (curActive.nodeToPk.size() < cap) {
+                // Another thread won the race and already published a new shard.
+                return curActive;
+            }
+            List<LiveGraphShard> newList = new ArrayList<>(cur);
+            newList.add(candidate);
+            this.liveShards = newList;
+            LOGGER.log(Level.INFO,
+                    "vector store {0}: rotated live graph shard, now {1} shards ({2} vectors in sealed shard)",
+                    new Object[]{indexName, newList.size(), curActive.nodeToPk.size()});
+            return candidate;
+        }
     }
 
     private void initEmptyLiveShards(int dim, int bw, float no, float a) {

--- a/herddb-core/src/main/java/herddb/index/vector/VectorStorage.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorStorage.java
@@ -34,23 +34,37 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * <ul>
  *   <li>{@link #get(int)} is fully lock-free: one volatile read of the array reference,
  *       one array element read.</li>
- *   <li>{@link #set(int, VectorFloat)} is synchronized only to handle array growth, which
- *       is rare (O(log N) times over the lifetime of the index).  Once the array is large
- *       enough the synchronized block exits immediately after the volatile array write.</li>
- *   <li>{@link #remove(int)} is synchronized for the same reason: a concurrent grow-and-copy
- *       inside {@code set} would copy the not-yet-nulled slot into the new array, leaking
- *       the reference.  Synchronizing remove prevents that window.</li>
+ *   <li>{@link #set(int, VectorFloat)} has a lock-free fast path when the backing array
+ *       is already large enough, guarded by a <em>seqlock</em> on {@link #growSeq}: the
+ *       writer reads {@code growSeq} before the write and again after, and retries if
+ *       the counter changed (meaning a grow started or completed concurrently).  A write
+ *       that completes without seeing any grow is guaranteed to have landed on the live
+ *       backing array (either the copy loop read our freshly-written value, or no copy
+ *       was in progress).  Growth itself is serialized by {@link #growAndSet}, which
+ *       bumps {@code growSeq} to odd before the copy and back to even after the publish.
+ *       Growth is rare (O(log N) over the store's lifetime), so retries are bounded.</li>
+ *   <li>{@link #remove(int)} is synchronized so that its {@code array.set(nodeId, null)}
+ *       excludes a concurrent {@link #growAndSet} copy loop: without the lock, a grow
+ *       running in parallel with remove could snapshot the not-yet-nulled slot into the
+ *       new array, leaking the reference.</li>
  * </ul>
  *
  * <p>Write-before-read ordering guarantee: callers must call {@code set(nodeId, vec)} before
- * passing {@code nodeId} to {@code GraphIndexBuilder.addGraphNode()}.  The synchronized
- * write in {@code set} establishes happens-before with any subsequent volatile read in
- * {@code get}, satisfying JLS 17.4.4.
+ * passing {@code nodeId} to {@code GraphIndexBuilder.addGraphNode()}.  The atomic element
+ * write in {@code set} (combined with the volatile array-reference read in {@code get})
+ * establishes happens-before with any subsequent read, satisfying JLS 17.4.4.
  */
-@SuppressFBWarnings("UG_SYNC_SET_UNSYNC_GET")
+@SuppressFBWarnings({"UG_SYNC_SET_UNSYNC_GET", "VO_VOLATILE_INCREMENT"})
 class VectorStorage {
 
     private volatile AtomicReferenceArray<VectorFloat<?>> array;
+
+    /**
+     * Seqlock counter for {@link #set}'s lock-free fast path.  Even values mean no grow
+     * is in progress; odd values mean a grow is mid-copy.  {@link #growAndSet} bumps it
+     * to odd before allocating/copying and back to even after publishing the new array.
+     */
+    private volatile int growSeq;
 
     VectorStorage(int initialCapacity) {
         array = new AtomicReferenceArray<>(Math.max(initialCapacity, 256));
@@ -67,15 +81,54 @@ class VectorStorage {
 
     /**
      * Stores {@code vec} at {@code nodeId}, growing the backing array if necessary.
+     * Lock-free in the common case (array already large enough); falls back to the
+     * synchronized {@link #growAndSet} when a grow is required or when a concurrent
+     * grow raced past our write.
      */
-    synchronized void set(int nodeId, VectorFloat<?> vec) {
+    void set(int nodeId, VectorFloat<?> vec) {
+        while (true) {
+            int seq = growSeq;
+            if ((seq & 1) != 0) {
+                // Grow in progress: the copy loop may read our not-yet-written slot.
+                // Spin until the grow publishes before we write.  The odd window
+                // covers only the copy loop, so the spin is bounded.
+                continue;
+            }
+            AtomicReferenceArray<VectorFloat<?>> a = array; // volatile read
+            if (nodeId >= a.length()) {
+                growAndSet(nodeId, vec);
+                return;
+            }
+            a.set(nodeId, vec);
+            if (growSeq == seq) {
+                // No grow overlapped our write: either no copy ran, or the copy ran
+                // entirely before our read of `seq` (so the new array already has our
+                // slot's prior value and our write on the old array is not observable
+                // to readers, but those readers saw a consistent pre-write state).
+                return;
+            }
+            // A grow started (and possibly finished) between our read of `seq` and now.
+            // Our write may have landed on the pre-grow array and been missed by the
+            // copy loop; retry on the post-grow state.
+        }
+    }
+
+    /**
+     * Synchronized slow path: grow the backing array if needed, then write the slot.
+     * Serializes with {@link #remove} and {@link #compact} so their {@code array.set}
+     * / reassignment cannot race with the grow's copy loop.  Bumps {@link #growSeq}
+     * around the grow so that lock-free {@link #set} writers can detect the overlap.
+     */
+    private synchronized void growAndSet(int nodeId, VectorFloat<?> vec) {
         if (nodeId >= array.length()) {
+            growSeq++;  // now odd: grow in progress
             int newLen = Math.max(array.length() * 2, nodeId + 1);
             AtomicReferenceArray<VectorFloat<?>> na = new AtomicReferenceArray<>(newLen);
             for (int i = 0; i < array.length(); i++) {
                 na.set(i, array.get(i));
             }
             array = na; // volatile write: visible to all threads before next set()
+            growSeq++;  // back to even: grow done
         }
         array.set(nodeId, vec);
     }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorStorageTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorStorageTest.java
@@ -177,6 +177,132 @@ public class VectorStorageTest {
         read.await();
     }
 
+    /**
+     * Stresses the lock-free fast path of {@link VectorStorage#set(int, VectorFloat)}
+     * against frequent concurrent growth: each writer thread touches nodeIds spread
+     * across a range that forces many doublings of the backing array.  Verifies that
+     * no write is lost on the final published array despite writes racing with the
+     * synchronized grow copy-loop.
+     */
+    @Test
+    public void testConcurrentWritesAcrossGrowths() throws Exception {
+        int threads = 16;
+        int perThread = 5000;
+        // Start small so that almost every write in the first stripe triggers growth.
+        VectorStorage storage = new VectorStorage(8);
+        ExecutorService exec = Executors.newFixedThreadPool(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int t = 0; t < threads; t++) {
+            final int threadIdx = t;
+            futures.add(exec.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                // Interleave nodeIds across threads to maximize grow contention:
+                // thread t writes nodeIds t, t+threads, t+2*threads, ...
+                for (int i = 0; i < perThread; i++) {
+                    int nodeId = threadIdx + i * threads;
+                    storage.set(nodeId, vec((float) nodeId));
+                }
+            }));
+        }
+        startLatch.countDown();
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        exec.shutdown();
+
+        int total = threads * perThread;
+        for (int nodeId = 0; nodeId < total; nodeId++) {
+            VectorFloat<?> v = storage.get(nodeId);
+            if (v == null) {
+                fail("Lost write at nodeId=" + nodeId + " after concurrent growth");
+            }
+            assertArrayEquals(new float[]{(float) nodeId}, toFloats(v), 0.001f);
+        }
+    }
+
+    /**
+     * Stresses set/remove interleaving under concurrent growth.  remove() is
+     * synchronized so it excludes growAndSet; the lock-free set fast path must
+     * still produce a consistent final state: every nodeId either has its
+     * last-set vector or was explicitly removed.
+     */
+    @Test
+    public void testConcurrentSetAndRemoveAcrossGrowths() throws Exception {
+        int writerThreads = 8;
+        int removerThreads = 2;
+        int perThread = 2000;
+        VectorStorage storage = new VectorStorage(8);
+        ExecutorService exec = Executors.newFixedThreadPool(writerThreads + removerThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        // Writers: each owns a disjoint range of nodeIds so set/remove on the same
+        // nodeId are produced by the same thread (matching PersistentVectorStore's
+        // nodeId-per-thread invariant).
+        for (int t = 0; t < writerThreads; t++) {
+            final int base = t * perThread;
+            futures.add(exec.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < perThread; i++) {
+                    storage.set(base + i, vec((float) (base + i)));
+                }
+            }));
+        }
+        // Removers: call remove() on a range that is NOT owned by any writer,
+        // just to keep the grow/remove monitor contention alive without racing
+        // set/remove on the same slot.
+        int removerBase = writerThreads * perThread;
+        for (int t = 0; t < removerThreads; t++) {
+            final int base = removerBase + t * perThread;
+            futures.add(exec.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < perThread; i++) {
+                    // Set then remove the same slot. After the remove the slot must be null
+                    // even if the set raced with a concurrent grow.
+                    storage.set(base + i, vec((float) -1));
+                    storage.remove(base + i);
+                }
+            }));
+        }
+        startLatch.countDown();
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        exec.shutdown();
+
+        int writerTotal = writerThreads * perThread;
+        for (int nodeId = 0; nodeId < writerTotal; nodeId++) {
+            VectorFloat<?> v = storage.get(nodeId);
+            if (v == null) {
+                fail("Lost write at nodeId=" + nodeId + " after concurrent growth + remove");
+            }
+            assertArrayEquals(new float[]{(float) nodeId}, toFloats(v), 0.001f);
+        }
+        for (int nodeId = removerBase; nodeId < removerBase + removerThreads * perThread; nodeId++) {
+            VectorFloat<?> v = storage.get(nodeId);
+            if (v != null) {
+                fail("Expected null at removed nodeId=" + nodeId + ", got " + toFloats(v)[0]);
+            }
+        }
+    }
+
     @Test
     public void testConcurrentGrowthAndRead() throws Exception {
         VectorStorage storage = new VectorStorage(4);


### PR DESCRIPTION
## Summary

Lock profiling (async-profiler) on the indexing-service ingest path showed
**86 of 112 lock-wait samples** concentrated on two intrinsic monitors of
`PersistentVectorStore` / `VectorStorage`:

| Samples | Monitor                                  | Acquiring method                       |
|---------|------------------------------------------|----------------------------------------|
| 60      | `PersistentVectorStore` instance         | `synchronized rotateLiveShard()`       |
| 26      | `VectorStorage` instance                 | `synchronized VectorStorage.set(...)`  |

Ingest arrives as striped DML (`IndexingServiceEngine.applyWorkers`, one
single-thread executor per PK-hash stripe), so N stripe workers compete for
these two monitors on the same `PersistentVectorStore` instance.

This PR eliminates both hotspots.

### Change 1 — `VectorStorage.set` lock-free fast path (seqlock)
`herddb-core/src/main/java/herddb/index/vector/VectorStorage.java`

`set` now takes a lock-free fast path when the backing array is already large
enough:
1. Read `growSeq` (volatile).
2. If odd (grow in progress), spin until even.
3. Read `array`, atomically set the slot via `AtomicReferenceArray.set`.
4. Re-read `growSeq`. If unchanged, return; otherwise retry on the new array.

`growAndSet` (new private method) performs the grow under the existing
`synchronized` monitor and brackets the copy loop with `growSeq++` (odd before
copy, even after publish) so fast-path writers detect overlap. `remove` /
`compact` remain synchronized — they share the monitor with `growAndSet` and
so can't race with the copy. Growth is O(log N) over the store's lifetime, so
retries are bounded.

### Change 2 — allocate new shard outside the monitor in `rotateLiveShard`
`herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java`

The expensive `createEmptyLiveShard` call (two preallocated
`ConcurrentHashMap`s plus a jvector `GraphIndexBuilder`) now runs *outside*
the `synchronized` block. Only the volatile `liveShards` swap (double-checked
against `computeEffectiveMaxLiveGraphSize()`) happens under the monitor. Under
burst contention K-1 candidates may be discarded after the double-check — cheap
compared to serializing K workers through the full allocation window.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean
- [x] All 116 vector-module tests (`VectorStorageTest`, `PersistentVectorStore*Test`, `VectorIndexTest`, …) green
- [x] `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` — green on two consecutive runs
- [x] New `VectorStorageTest.testConcurrentWritesAcrossGrowths` and `testConcurrentSetAndRemoveAcrossGrowths` stress the seqlock with many writers across many grows. The earlier naive `array == a` revalidation was caught by these tests (lost writes) and replaced with the seqlock before passing.
- [ ] Re-run the original ingest workload and confirm `PersistentVectorStore` / `VectorStorage` no longer dominate the lock profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)