### PR TITLE
VectorBench: --resume-from=auto, admin HTTP API, dynamic rate limits

### DIFF
--- a/vector-testings/VECTOR_BENCH.md
+++ b/vector-testings/VECTOR_BENCH.md
@@ -1,0 +1,232 @@
+# VectorBench
+
+VectorBench drives an end-to-end vector-search workload against a HerdDB
+server (or cluster): schema setup, bulk ingestion of float-array vectors,
+vector-index creation, ANN queries, and recall computation. This document
+lists every CLI option and documents the embedded admin HTTP API that
+lets you inspect and tune a running bench without a JVM restart.
+
+## CLI parameters
+
+Invocation: `java -jar vector-testings-*.jar [options]`.
+
+### Connection
+
+| Option | Default | Description |
+|---|---|---|
+| `-u`, `--url <jdbc-url>` | `jdbc:herddb:server:localhost:7000` | HerdDB JDBC URL. |
+| `--user <name>` | `sa` | JDBC username. |
+| `--password <secret>` | `hdb` | JDBC password. |
+| `--table <name>` | `vector_bench` | Table to create and populate. |
+| `--client-timeout <seconds>` | `28800` | JDBC client request timeout; appended to the URL as `client.timeout=…ms`. |
+
+### Dataset
+
+| Option | Default | Description |
+|---|---|---|
+| `--dataset <preset>` | `SIFT1M` | Built-in dataset preset, or `CUSTOM` for a descriptor-driven dataset. |
+| `--dataset-dir <path>` | `./datasets` | Local cache directory for dataset files. |
+| `--dataset-url <url>` | — | Override the download URL for the selected preset. |
+| `--rows <N>` | `100000` | Vectors to ingest. For `CUSTOM`, auto-derived from the descriptor if left at default. |
+
+### Ingestion
+
+| Option | Default | Description |
+|---|---|---|
+| `--ingest-threads <N>` | `4` | Concurrent ingestion workers. |
+| `--batch-size <N>` | `500` | Rows per JDBC batch commit. |
+| `--ingest-max-ops <N>` | `100000` | Global ingestion rate cap in rows/s (`0` = unlimited). **Runtime-tunable** via admin API. |
+| `--ingest-commit-retries <N>` | `3` | Retries per failed batch commit (exponential back-off 10s/20s/40s…). |
+| `--resume-from <N \| auto>` | `0` | Skip first `N` vectors and start row IDs from `N`. Pass `auto` (case-insensitive) to resolve `N` from `SELECT COUNT(*)` on the table just before ingestion. |
+| `--skip-ingest` | off | Skip the ingestion phase. |
+| `--drop-table` | off | Drop the table before recreating it. |
+
+### Index
+
+| Option | Default | Description |
+|---|---|---|
+| `-m`, `--m <N>` | `16` | jVector HNSW fan-out. |
+| `--beam-width <N>` | `100` | Build-time beam width. |
+| `--index-num-shards <N>` | `4` | Vector index shard count (`1` = unsharded). |
+| `--index-before-ingest` | off | Create the index before ingestion rather than after. |
+| `--skip-index` | off | Skip the index-creation phase. |
+| `--similarity <fn>` | dataset default | One of `euclidean`, `cosine`, `dot`. |
+
+### Query
+
+| Option | Default | Description |
+|---|---|---|
+| `--query-threads <N>` | `4` | Concurrent query workers. |
+| `--queries <N>` | `1000` | Total queries to run. Cycled if the dataset has fewer query vectors. |
+| `-k <N>` | `10` | Top-K. **Runtime-tunable** via admin API. |
+| `--query-max-ops <N>` | `10` | Global query rate cap in queries/s (`0` = unlimited). **Runtime-tunable** via admin API. |
+
+### Lifecycle / operations
+
+| Option | Default | Description |
+|---|---|---|
+| `--checkpoint` | off | Run `EXECUTE CHECKPOINT 'herd'` after ingestion and after index creation. |
+| `--checkpoint-timeout-seconds <N>` | `300` | Checkpoint timeout. |
+| `--wait-for-indexes` | off | Run `EXECUTE WAITFORINDEXES 'herd'` before queries (required for reliable recall with tailer indexes). |
+| `--wait-for-indexes-timeout <N>` | `600` | Tailer catch-up timeout. |
+| `--skip-verify` | off | Skip the post-ingest `COUNT(*)` verification. |
+
+### Output & telemetry
+
+| Option | Default | Description |
+|---|---|---|
+| `--output-format <text\|json>` | `text` | `json` emits NDJSON (one object per line) and implies `--no-progress`. |
+| `--no-progress` | off | Disable the animated spinner; one line per progress sample. Implicit when `VECTOR_BENCH_NO_PROGRESS=1` or when output is JSON. |
+| `--status-interval-seconds <N>` | `60` | Period of the `[status]` dump that queries `syslogstatus`, `systablestats`, `sysindexstatus`. `0` disables. |
+| `--config <path>` | — | Load defaults from a properties file (CLI flags still override). |
+
+### Admin HTTP API (system property)
+
+| Property | Default | Description |
+|---|---|---|
+| `-Dvectorbench.admin.port=<N>` | `8080` | Port for the embedded admin HTTP server. Set `0` or a negative value to disable. |
+
+## Admin HTTP API
+
+When enabled, VectorBench starts an embedded Jetty server on
+`-Dvectorbench.admin.port` (default `8080`). The API is JSON; all responses
+are `application/json`. Errors return a `{ "error": "<message>" }` body with
+HTTP `400` for bad requests or `404` for unknown endpoints.
+
+### `GET /ingestion/config`
+
+Returns the current ingestion configuration. Reflects live values, so after
+a `POST` override the new rate is visible here.
+
+```json
+{
+  "ingest-max-ops": 100000,
+  "ingest-threads": 4,
+  "batch-size": 500,
+  "rows": 100000,
+  "resume-from": 0,
+  "ingest-commit-retries": 3
+}
+```
+
+### `POST /ingestion/config/ingest-max-ops`
+
+Override `--ingest-max-ops` while the bench is running. Body can be JSON
+`{"value": <int>}` or a bare integer.
+
+```
+$ curl -X POST -d '{"value": 5000}' http://localhost:8080/ingestion/config/ingest-max-ops
+{"ingest-max-ops":5000,...}
+```
+
+- `value >= 0` required; negative values return `400`.
+- `0` means unlimited (internally a very-high-rate limiter).
+- Internally replaces the Guava `RateLimiter` with a fresh instance so
+  workers see the new rate on their next batch without any lingering
+  pay-forward reservation from the old rate.
+
+### `GET /query/config`
+
+```json
+{
+  "query-max-ops": 10,
+  "query-threads": 4,
+  "queries": 1000,
+  "top-k": 10
+}
+```
+
+### `POST /query/config/query-max-ops`
+
+Same semantics as the ingestion override. Body: JSON `{"value": <int>}` or
+bare integer. Negative values return `400`; `0` means unlimited.
+
+```
+$ curl -X POST -d '250' http://localhost:8080/query/config/query-max-ops
+{"query-max-ops":250,...}
+```
+
+### `POST /query/config/top-k`
+
+Override `-k` (top-K) at runtime. Workers re-read `topK` between queries
+and re-prepare the SQL statement when the value changes.
+
+```
+$ curl -X POST -d '{"value": 32}' http://localhost:8080/query/config/top-k
+{"top-k":32,...}
+```
+
+- `value > 0` required; `0` and negatives return `400`.
+- Note: changing top-K mid-run mixes results of different K across the
+  recall computation; use with care.
+
+### `GET /status`
+
+Returns a snapshot of the currently-running phase. Fields depend on phase:
+
+Idle (before ingestion or between phases):
+
+```json
+{ "phase": "idle" }
+```
+
+During ingestion:
+
+```json
+{
+  "phase": "ingestion",
+  "rows": 42000,
+  "total": 100000,
+  "ops_per_sec": 12500.3,
+  "commits": 84,
+  "recovered_commits": 0,
+  "heap_used_mb": 512,
+  "heap_max_mb": 2048,
+  "commit_latency": {
+    "mean_ms": 18.2,
+    "p50_ms": 15.4,
+    "p99_ms": 52.1,
+    "max_ms": 78.0
+  }
+}
+```
+
+During queries:
+
+```json
+{
+  "phase": "query",
+  "queries_done": 450,
+  "total": 1000,
+  "qps": 9.5,
+  "top_k": 10,
+  "latency": {
+    "mean_ms": 104.8,
+    "p50_ms": 98.3,
+    "p95_ms": 187.5,
+    "p99_ms": 205.1,
+    "max_ms": 312.0
+  }
+}
+```
+
+## Notes on rate-change semantics
+
+Guava's `RateLimiter` uses pay-forward reservation: a single large
+`acquire(N)` call at a low rate can reserve many seconds into the future
+and block the *next* caller for that time, even if the rate is raised in
+the meantime. VectorBench avoids this by **replacing the limiter** on every
+`POST /…/…-max-ops`, so workers that re-read the reference see a fresh
+limiter with no lingering reservation. The worst case is a single
+already-in-flight `acquire()` finishing its wait on the old limiter; the
+next iteration uses the new one.
+
+## Example: throttle ingestion during a production incident
+
+```
+# Drop to 1 000 rows/s immediately
+curl -X POST -d '1000' http://bench-host:8080/ingestion/config/ingest-max-ops
+
+# …restore full speed once the incident is resolved
+curl -X POST -d '0' http://bench-host:8080/ingestion/config/ingest-max-ops
+```

--- a/vector-testings/pom.xml
+++ b/vector-testings/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <jetty.version>9.4.51.v20230217</jetty.version>
     </properties>
 
     <dependencies>
@@ -65,6 +66,16 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/vector-testings/src/main/java/herddb/vectortesting/AdminApiServer.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/AdminApiServer.java
@@ -1,0 +1,239 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+/**
+ * Embedded Jetty server exposing a JSON admin API for live inspection and
+ * tuning of a running {@link VectorBench}. Controlled by system property
+ * {@code vectorbench.admin.port} (default 8080; 0 or negative disables).
+ *
+ * <p>Endpoints (see {@code VECTOR_BENCH.md} for full docs):
+ * <ul>
+ *   <li>{@code GET /ingestion/config}</li>
+ *   <li>{@code POST /ingestion/config/ingest-max-ops}</li>
+ *   <li>{@code GET /query/config}</li>
+ *   <li>{@code POST /query/config/query-max-ops}</li>
+ *   <li>{@code GET /status}</li>
+ * </ul>
+ */
+public class AdminApiServer {
+
+    public static final String PORT_SYSTEM_PROPERTY = "vectorbench.admin.port";
+    public static final int DEFAULT_PORT = 8080;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final BenchRuntime runtime;
+    private final int port;
+    private Server server;
+
+    public AdminApiServer(BenchRuntime runtime, int port) {
+        this.runtime = runtime;
+        this.port = port;
+    }
+
+    /** Reads the port from the system property; returns {@code 0} to disable. */
+    public static int readPortFromSystemProperty() {
+        String raw = System.getProperty(PORT_SYSTEM_PROPERTY);
+        if (raw == null || raw.isBlank()) {
+            return DEFAULT_PORT;
+        }
+        try {
+            return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid " + PORT_SYSTEM_PROPERTY + "=" + raw);
+        }
+    }
+
+    /**
+     * Starts the server. Returns the bound port (useful when {@code 0} was
+     * passed to pick an ephemeral port in tests). Throws if start fails.
+     */
+    public int start() throws Exception {
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(port);
+        server.addConnector(connector);
+
+        ServletContextHandler ctx = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        ctx.setContextPath("/");
+        ctx.addServlet(new ServletHolder(new AdminServlet(runtime)), "/*");
+        server.setHandler(ctx);
+
+        server.start();
+        return connector.getLocalPort();
+    }
+
+    public void stop() {
+        if (server == null) {
+            return;
+        }
+        try {
+            server.stop();
+        } catch (Exception e) {
+            // Stopping is best-effort — swallow so we don't mask the primary
+            // failure during benchmark shutdown.
+            System.err.println("AdminApiServer stop failed: " + e.getMessage());
+        }
+    }
+
+    /** Single servlet dispatching by method + path. */
+    static final class AdminServlet extends HttpServlet {
+
+        private static final long serialVersionUID = 1L;
+
+        // The servlet is never actually serialized (we only register it in an
+        // embedded Jetty in-process), but HttpServlet implements Serializable
+        // so SpotBugs flags non-transient non-Serializable fields.
+        private final transient BenchRuntime runtime;
+
+        AdminServlet(BenchRuntime runtime) {
+            this.runtime = runtime;
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                throws ServletException, IOException {
+            String path = pathOf(req);
+            switch (path) {
+                case "/ingestion/config" -> writeJson(resp, HttpServletResponse.SC_OK, ingestionConfig());
+                case "/query/config" -> writeJson(resp, HttpServletResponse.SC_OK, queryConfig());
+                case "/status" -> writeJson(resp, HttpServletResponse.SC_OK, runtime.getStatusSupplier().get());
+                default -> writeError(resp, HttpServletResponse.SC_NOT_FOUND, "no such endpoint: GET " + path);
+            }
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+                throws ServletException, IOException {
+            String path = pathOf(req);
+            try {
+                switch (path) {
+                    case "/ingestion/config/ingest-max-ops" -> {
+                        int value = readIntValue(req);
+                        runtime.setIngestMaxOps(value);
+                        writeJson(resp, HttpServletResponse.SC_OK, ingestionConfig());
+                    }
+                    case "/query/config/query-max-ops" -> {
+                        int value = readIntValue(req);
+                        runtime.setQueryMaxOps(value);
+                        writeJson(resp, HttpServletResponse.SC_OK, queryConfig());
+                    }
+                    case "/query/config/top-k" -> {
+                        int value = readIntValue(req);
+                        if (value <= 0) {
+                            throw new IllegalArgumentException("top-k must be > 0, got " + value);
+                        }
+                        runtime.setTopK(value);
+                        writeJson(resp, HttpServletResponse.SC_OK, queryConfig());
+                    }
+                    default -> writeError(resp, HttpServletResponse.SC_NOT_FOUND, "no such endpoint: POST " + path);
+                }
+            } catch (IllegalArgumentException e) {
+                writeError(resp, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+            }
+        }
+
+        private Map<String, Object> ingestionConfig() {
+            Config c = runtime.config();
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("ingest-max-ops", c.ingestMaxOpsPerSecond);
+            m.put("ingest-threads", c.ingestThreads);
+            m.put("batch-size", c.batchSize);
+            m.put("rows", c.numRows);
+            m.put("resume-from", c.resumeFrom);
+            m.put("ingest-commit-retries", c.ingestCommitRetries);
+            return m;
+        }
+
+        private Map<String, Object> queryConfig() {
+            Config c = runtime.config();
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("query-max-ops", c.queryMaxOpsPerSecond);
+            m.put("query-threads", c.queryThreads);
+            m.put("queries", c.queryCount);
+            m.put("top-k", c.topK);
+            return m;
+        }
+
+        private static String pathOf(HttpServletRequest req) {
+            String p = req.getPathInfo();
+            if (p == null || p.isEmpty()) {
+                p = req.getServletPath();
+            }
+            if (p == null) {
+                p = "/";
+            }
+            if (p.length() > 1 && p.endsWith("/")) {
+                p = p.substring(0, p.length() - 1);
+            }
+            return p;
+        }
+
+        /**
+         * Accepts either JSON {@code {"value": 1234}} or a plain numeric body
+         * so simple {@code curl} invocations work without quoting gymnastics.
+         */
+        private static int readIntValue(HttpServletRequest req) throws IOException {
+            String body = new String(req.getInputStream().readAllBytes(),
+                    req.getCharacterEncoding() != null ? req.getCharacterEncoding() : "UTF-8").trim();
+            if (body.isEmpty()) {
+                throw new IllegalArgumentException("empty request body");
+            }
+            if (body.startsWith("{")) {
+                JsonNode node = MAPPER.readTree(body);
+                JsonNode value = node.get("value");
+                if (value == null || !value.canConvertToInt()) {
+                    throw new IllegalArgumentException("expected JSON field 'value' of type int");
+                }
+                return value.asInt();
+            }
+            try {
+                return Integer.parseInt(body);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("body is neither JSON {value:int} nor a bare integer: " + body);
+            }
+        }
+
+        private static void writeJson(HttpServletResponse resp, int status, Object payload) throws IOException {
+            resp.setStatus(status);
+            resp.setContentType("application/json; charset=utf-8");
+            MAPPER.writeValue(resp.getOutputStream(), payload);
+        }
+
+        private static void writeError(HttpServletResponse resp, int status, String message) throws IOException {
+            writeJson(resp, status, Map.of("error", message));
+        }
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/BenchRuntime.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/BenchRuntime.java
@@ -1,0 +1,125 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import com.google.common.util.concurrent.RateLimiter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+// Note: setting a new rate via setIngestMaxOps / setQueryMaxOps replaces the
+// underlying RateLimiter with a fresh instance. This is deliberate — Guava's
+// SmoothBursty uses pay-forward reservation semantics, so a large multi-permit
+// acquire at a low rate reserves far into the future and would keep blocking
+// subsequent callers even after the rate is raised. Swapping the reference
+// means any *new* acquire() picks up the fresh limiter without that baggage,
+// so an admin-issued rate raise unblocks queued workers on their next call.
+
+/**
+ * Shared mutable state exposed to the admin HTTP API.
+ *
+ * <p>All fields are populated or updated from the main {@link VectorBench} flow
+ * and read concurrently by Jetty request handlers. Rate limiters and the
+ * status supplier are thread-safe references; {@link Config} is treated as
+ * monotonic (only int/long fields are written from the admin API and reads
+ * see either the old or new value — acceptable for the handful of settings
+ * exposed via HTTP).
+ */
+public class BenchRuntime {
+
+    /**
+     * Effectively-unlimited rate passed to Guava when the user sets
+     * {@code 0} on one of the {@code *-max-ops} flags. One billion permits/s
+     * is well above anything a single JVM can actually push through JDBC, so
+     * {@code acquire()} becomes a no-op but the limiter is still there for
+     * live override via the admin API.
+     */
+    public static final double UNLIMITED_RATE = 1_000_000_000.0;
+
+    private final Config config;
+    private final AtomicReference<RateLimiter> ingestRateLimiterRef;
+    private final AtomicReference<RateLimiter> queryRateLimiterRef;
+    private final AtomicReference<Supplier<Map<String, Object>>> statusSupplier =
+            new AtomicReference<>(() -> Collections.singletonMap("phase", "idle"));
+
+    public BenchRuntime(Config config) {
+        this.config = config;
+        this.ingestRateLimiterRef = new AtomicReference<>(RateLimiter.create(
+                config.ingestMaxOpsPerSecond > 0 ? config.ingestMaxOpsPerSecond : UNLIMITED_RATE));
+        this.queryRateLimiterRef = new AtomicReference<>(RateLimiter.create(
+                config.queryMaxOpsPerSecond > 0 ? config.queryMaxOpsPerSecond : UNLIMITED_RATE));
+    }
+
+    public Config config() {
+        return config;
+    }
+
+    public RateLimiter ingestRateLimiter() {
+        return ingestRateLimiterRef.get();
+    }
+
+    public RateLimiter queryRateLimiter() {
+        return queryRateLimiterRef.get();
+    }
+
+    /**
+     * Update the ingest rate. {@code 0} means unlimited (maps to
+     * {@link #UNLIMITED_RATE} on the underlying limiter). Creates a fresh
+     * limiter so no prior pay-forward reservation from the old rate carries
+     * over — raising the rate unblocks queued workers on their next call.
+     */
+    public void setIngestMaxOps(int opsPerSecond) {
+        if (opsPerSecond < 0) {
+            throw new IllegalArgumentException("ingest-max-ops must be >= 0, got " + opsPerSecond);
+        }
+        double rate = opsPerSecond > 0 ? opsPerSecond : UNLIMITED_RATE;
+        ingestRateLimiterRef.set(RateLimiter.create(rate));
+        config.ingestMaxOpsPerSecond = opsPerSecond;
+    }
+
+    public void setQueryMaxOps(int opsPerSecond) {
+        if (opsPerSecond < 0) {
+            throw new IllegalArgumentException("query-max-ops must be >= 0, got " + opsPerSecond);
+        }
+        double rate = opsPerSecond > 0 ? opsPerSecond : UNLIMITED_RATE;
+        queryRateLimiterRef.set(RateLimiter.create(rate));
+        config.queryMaxOpsPerSecond = opsPerSecond;
+    }
+
+    /**
+     * Update {@link Config#topK}. Workers re-read the value between queries
+     * and re-prepare their SQL statement on change.
+     */
+    public void setTopK(int topK) {
+        if (topK <= 0) {
+            throw new IllegalArgumentException("top-k must be > 0");
+        }
+        config.topK = topK;
+    }
+
+    public Supplier<Map<String, Object>> getStatusSupplier() {
+        return statusSupplier.get();
+    }
+
+    public void setStatusSupplier(Supplier<Map<String, Object>> supplier) {
+        statusSupplier.set(supplier);
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -47,7 +47,7 @@ public class Config {
     int batchSize = 500;
     int queryThreads = 4;
     int queryCount = 1000;
-    int topK = 10;
+    volatile int topK = 10;
     boolean topKExplicit = false;
     int indexM = 16;
     int indexBeamWidth = 100;
@@ -61,7 +61,9 @@ public class Config {
     String similarity = null; // null = use dataset default
     boolean indexBeforeIngest = true;
     long resumeFrom = 0L; // skip first N vectors; row IDs start from N
-    int ingestMaxOpsPerSecond = 100_000; // 0 = unlimited
+    boolean resumeFromAuto = false; // when true, resolve resumeFrom from SELECT COUNT(*) before ingest
+    volatile int ingestMaxOpsPerSecond = 100_000; // 0 = unlimited
+    volatile int queryMaxOpsPerSecond = 10; // 0 = unlimited
     int ingestCommitRetries = 3;
     int checkpointTimeoutSeconds = 300;
     boolean waitForIndexes = false;
@@ -104,8 +106,10 @@ public class Config {
         opts.addOption(null, "similarity", true, "Similarity function: euclidean, cosine, dot (default: from dataset)");
         opts.addOption(null, "client-timeout", true, "Client request timeout in seconds (default: 7200)");
         opts.addOption(null, "index-before-ingest", false, "Create vector index before ingestion instead of after");
-        opts.addOption(null, "resume-from", true, "Skip first N vectors and start row IDs from N (default: 0)");
+        opts.addOption(null, "resume-from", true,
+                "Skip first N vectors and start row IDs from N, or 'auto' to query COUNT(*) from the table (default: 0)");
         opts.addOption(null, "ingest-max-ops", true, "Max ingestion ops/s across all threads, 0=unlimited (default: 100000)");
+        opts.addOption(null, "query-max-ops", true, "Max query ops/s across all threads, 0=unlimited (default: 10)");
         opts.addOption(null, "ingest-commit-retries", true,
                 "Retries per failed batch commit before failing the run (default: 3, "
                         + "exponential back-off 10s/20s/40s...)");
@@ -224,10 +228,13 @@ public class Config {
             cfg.indexBeforeIngest = true;
         }
         if (cmd.hasOption("resume-from")) {
-            cfg.resumeFrom = Long.parseLong(cmd.getOptionValue("resume-from"));
+            parseResumeFrom(cfg, cmd.getOptionValue("resume-from"));
         }
         if (cmd.hasOption("ingest-max-ops")) {
             cfg.ingestMaxOpsPerSecond = Integer.parseInt(cmd.getOptionValue("ingest-max-ops"));
+        }
+        if (cmd.hasOption("query-max-ops")) {
+            cfg.queryMaxOpsPerSecond = Integer.parseInt(cmd.getOptionValue("query-max-ops"));
         }
         if (cmd.hasOption("ingest-commit-retries")) {
             cfg.ingestCommitRetries = Integer.parseInt(cmd.getOptionValue("ingest-commit-retries"));
@@ -357,10 +364,13 @@ public class Config {
             indexBeforeIngest = Boolean.parseBoolean(props.getProperty("index-before-ingest"));
         }
         if (props.containsKey("resume-from")) {
-            resumeFrom = Long.parseLong(props.getProperty("resume-from"));
+            parseResumeFrom(this, props.getProperty("resume-from"));
         }
         if (props.containsKey("ingest-max-ops")) {
             ingestMaxOpsPerSecond = Integer.parseInt(props.getProperty("ingest-max-ops"));
+        }
+        if (props.containsKey("query-max-ops")) {
+            queryMaxOpsPerSecond = Integer.parseInt(props.getProperty("query-max-ops"));
         }
         if (props.containsKey("ingest-commit-retries")) {
             ingestCommitRetries = Integer.parseInt(props.getProperty("ingest-commit-retries"));
@@ -382,6 +392,16 @@ public class Config {
         }
         if (props.containsKey("status-interval-seconds")) {
             statusIntervalSeconds = Integer.parseInt(props.getProperty("status-interval-seconds"));
+        }
+    }
+
+    private static void parseResumeFrom(Config cfg, String raw) {
+        if (raw != null && raw.trim().equalsIgnoreCase("auto")) {
+            cfg.resumeFromAuto = true;
+            cfg.resumeFrom = 0L;
+        } else {
+            cfg.resumeFromAuto = false;
+            cfg.resumeFrom = Long.parseLong(raw);
         }
     }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class IngestionWorker implements Runnable {
 
@@ -57,7 +58,13 @@ public class IngestionWorker implements Runnable {
     private final AtomicLong commitsTotal;
     private final AtomicLong commitsRecovered;
     private final AtomicLong rowsCommitted;
-    private final RateLimiter ingestRateLimiter;
+    /**
+     * Supplier is re-read per batch so an admin-issued rate change replaces
+     * the underlying {@link RateLimiter} and this worker's <em>next</em>
+     * acquire uses the fresh instance. Returning {@code null} means "no rate
+     * limiting" (test-only path).
+     */
+    private final Supplier<RateLimiter> ingestRateLimiter;
 
     /**
      * Base of the exponential back-off between commit retries, in milliseconds.
@@ -69,7 +76,7 @@ public class IngestionWorker implements Runnable {
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
                            AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted,
-                           RateLimiter ingestRateLimiter) {
+                           Supplier<RateLimiter> ingestRateLimiter) {
         this.config = config;
         this.queue = queue;
         this.done = done;
@@ -243,12 +250,16 @@ public class IngestionWorker implements Runnable {
                         pendingBatch.clear();
                         lastCommitTime = now;
 
-                        if (ingestRateLimiter != null) {
+                        RateLimiter currentLimiter = ingestRateLimiter.get();
+                        if (currentLimiter != null) {
                             // Shared across all ingestion workers, so --ingest-max-ops is a
                             // true global cap. Guava's acquire() is uninterruptible; wait
                             // time is bounded by batchRows / rate, so worker shutdown via
                             // done.get() remains responsive on the next poll() iteration.
-                            ingestRateLimiter.acquire(batchRows);
+                            // We re-read the supplier each batch: if the admin API lowered
+                            // the rate and reserved far into the future, swapping the
+                            // limiter means this next call uses the fresh one.
+                            currentLimiter.acquire(batchRows);
                         }
                     }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/QueryWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/QueryWorker.java
@@ -19,13 +19,16 @@
  */
 package herddb.vectortesting;
 
+import com.google.common.util.concurrent.RateLimiter;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class QueryWorker implements Runnable {
 
@@ -36,9 +39,16 @@ public class QueryWorker implements Runnable {
     private final MetricsCollector metrics;
     private final List<List<Integer>> allResults;
     private final AtomicReference<String> statusLine;
+    /**
+     * Re-read per iteration so an admin-issued rate change (which swaps the
+     * underlying {@link RateLimiter}) takes effect on the next query without
+     * restarting the worker.
+     */
+    private final Supplier<RateLimiter> queryRateLimiter;
 
     public QueryWorker(Config config, List<float[]> queryVectors, int startIdx, int endIdx,
-                       MetricsCollector metrics, List<List<Integer>> allResults, AtomicReference<String> statusLine) {
+                       MetricsCollector metrics, List<List<Integer>> allResults,
+                       AtomicReference<String> statusLine, Supplier<RateLimiter> queryRateLimiter) {
         this.config = config;
         this.queryVectors = queryVectors;
         this.startIdx = startIdx;
@@ -46,15 +56,33 @@ public class QueryWorker implements Runnable {
         this.metrics = metrics;
         this.allResults = allResults;
         this.statusLine = statusLine;
+        this.queryRateLimiter = queryRateLimiter;
     }
 
     @Override
     public void run() {
-        String sql = "SELECT id FROM " + config.tableName
-                + " ORDER BY ann_of(vec, CAST(? AS FLOAT ARRAY)) DESC LIMIT " + config.topK;
         try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password)) {
-            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            PreparedStatement ps = null;
+            int preparedK = -1;
+            try {
                 for (int i = startIdx; i < endIdx; i++) {
+                    // Re-read topK per iteration so the admin API's
+                    // /query/config/top-k override takes effect without a restart.
+                    int k = config.topK;
+                    if (ps == null || k != preparedK) {
+                        if (ps != null) {
+                            ps.close();
+                        }
+                        String sql = "SELECT id FROM " + config.tableName
+                                + " ORDER BY ann_of(vec, CAST(? AS FLOAT ARRAY)) DESC LIMIT " + k;
+                        ps = conn.prepareStatement(sql);
+                        preparedK = k;
+                    }
+
+                    RateLimiter currentLimiter = queryRateLimiter.get();
+                    if (currentLimiter != null) {
+                        currentLimiter.acquire(1);
+                    }
                     long start = System.nanoTime();
                     ps.setObject(1, queryVectors.get(i));
                     List<Integer> ids = new ArrayList<>();
@@ -63,9 +91,9 @@ public class QueryWorker implements Runnable {
                             ids.add(rs.getInt(1));
                         }
                     }
-                    if (ids.size() != config.topK) {
+                    if (ids.size() != k) {
                         System.err.println("FATAL: query " + i + " returned " + ids.size()
-                                + " results, expected " + config.topK);
+                                + " results, expected " + k);
                         System.exit(1);
                     }
                     long elapsed = System.nanoTime() - start;
@@ -84,8 +112,12 @@ public class QueryWorker implements Runnable {
                                 s.maxNanos() / 1_000_000.0));
                     }
                 }
+            } finally {
+                if (ps != null) {
+                    ps.close();
+                }
             }
-        } catch (Exception e) {
+        } catch (SQLException e) {
             System.err.println("Query error in range [" + startIdx + ", " + endIdx + "): " + e.getMessage());
             e.printStackTrace();
         }

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -19,7 +19,6 @@
  */
 package herddb.vectortesting;
 
-import com.google.common.util.concurrent.RateLimiter;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
@@ -98,16 +97,31 @@ public class VectorBench {
         long benchmarkStartNs = System.nanoTime();
         Config config = Config.parse(args);
         BenchOutput out = BenchOutput.create(config);
+        BenchRuntime runtime = new BenchRuntime(config);
+        AdminApiServer adminServer = null;
+        int adminPort = AdminApiServer.readPortFromSystemProperty();
+        if (adminPort > 0) {
+            adminServer = new AdminApiServer(runtime, adminPort);
+            int bound = adminServer.start();
+            out.info("Admin API listening on http://0.0.0.0:" + bound
+                    + " (set -D" + AdminApiServer.PORT_SYSTEM_PROPERTY + "=0 to disable)");
+        } else {
+            out.info("Admin API disabled (" + AdminApiServer.PORT_SYSTEM_PROPERTY + "=" + adminPort + ")");
+        }
         try {
-            runBenchmark(config, out, benchmarkStartNs);
+            runBenchmark(config, out, benchmarkStartNs, runtime);
         } catch (Exception e) {
             // Top-level catch so NDJSON consumers get a structured error event before the JVM exits.
             out.error(e);
             throw e;
+        } finally {
+            if (adminServer != null) {
+                adminServer.stop();
+            }
         }
     }
 
-    private static void runBenchmark(Config config, BenchOutput out, long benchmarkStartNs) throws Exception {
+    private static void runBenchmark(Config config, BenchOutput out, long benchmarkStartNs, BenchRuntime runtime) throws Exception {
         out.config(config);
 
         // Summary accumulators
@@ -200,6 +214,16 @@ public class VectorBench {
 
         // Phase 4: Ingestion
         if (!config.skipIngest) {
+            if (config.resumeFromAuto) {
+                try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
+                     Statement stmt = conn.createStatement();
+                     java.sql.ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + config.tableName)) {
+                    rs.next();
+                    config.resumeFrom = rs.getLong(1);
+                }
+                out.info("resume-from=auto resolved to " + config.resumeFrom
+                        + " rows (from SELECT COUNT(*) on " + config.tableName + ")");
+            }
             long toIngest = actualRows - config.resumeFrom;
             if (toIngest <= 0) {
                 out.info("resumeFrom (" + config.resumeFrom + ") >= rows (" + actualRows + "), nothing to ingest.");
@@ -221,17 +245,43 @@ public class VectorBench {
 
             long ingestStart = System.nanoTime();
 
-            RateLimiter ingestRateLimiter = config.ingestMaxOpsPerSecond > 0
-                    ? RateLimiter.create(config.ingestMaxOpsPerSecond)
-                    : null;
+            // Shared across all ingestion workers so --ingest-max-ops is a true
+            // global cap. Live-override via POST /ingestion/config/ingest-max-ops
+            // swaps the limiter inside BenchRuntime; workers re-read the
+            // supplier per batch so the swap takes effect on the next acquire.
 
             ExecutorService ingestPool = Executors.newFixedThreadPool(config.ingestThreads);
             List<Future<?>> ingestFutures = new ArrayList<>(config.ingestThreads);
             for (int t = 0; t < config.ingestThreads; t++) {
                 ingestFutures.add(ingestPool.submit(new IngestionWorker(config, ingestQueue, producerDone, rowId,
                         ingestMetrics, ingestStatus, ingestStart, commitsTotal, commitsRecovered, rowsCommitted,
-                        ingestRateLimiter)));
+                        runtime::ingestRateLimiter)));
             }
+
+            // Feed the admin /status endpoint with a live snapshot of ingestion progress.
+            runtime.setStatusSupplier(() -> {
+                Runtime rt = Runtime.getRuntime();
+                long rows = rowId.get() - config.resumeFrom;
+                double elapsed = (System.nanoTime() - ingestStart) / 1e9;
+                double opsPerSec = elapsed > 0 ? rows / elapsed : 0.0;
+                LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+                m.put("phase", "ingestion");
+                m.put("rows", rows);
+                m.put("total", config.numRows);
+                m.put("ops_per_sec", opsPerSec);
+                m.put("commits", commitsTotal.get());
+                m.put("recovered_commits", commitsRecovered.get());
+                m.put("heap_used_mb", (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024));
+                m.put("heap_max_mb", rt.maxMemory() / (1024 * 1024));
+                MetricsCollector.Stats s = ingestMetrics.computeStats();
+                LinkedHashMap<String, Object> latency = new LinkedHashMap<>();
+                latency.put("mean_ms", round2(s.meanNanos() / 1e6));
+                latency.put("p50_ms", round2(s.p50Nanos() / 1e6));
+                latency.put("p99_ms", round2(s.p99Nanos() / 1e6));
+                latency.put("max_ms", round2(s.maxNanos() / 1e6));
+                m.put("commit_latency", latency);
+                return m;
+            });
 
             // Progress display thread runs during the entire ingestion
             AtomicBoolean ingestDone = new AtomicBoolean(false);
@@ -457,11 +507,32 @@ public class VectorBench {
         for (int t = 0; t < config.queryThreads; t++) {
             int start = t * qChunk;
             int end = (t == config.queryThreads - 1) ? actualQueries : start + qChunk;
-            queryPool.submit(new QueryWorker(config, queryVectors, start, end, queryMetrics, queryResults, queryStatus));
+            queryPool.submit(new QueryWorker(config, queryVectors, start, end, queryMetrics, queryResults, queryStatus,
+                    runtime::queryRateLimiter));
         }
         queryPool.shutdown();
 
         long queryStart = System.nanoTime();
+        runtime.setStatusSupplier(() -> {
+            double elapsed = (System.nanoTime() - queryStart) / 1e9;
+            long done = queryMetrics.getCount();
+            double qps = elapsed > 0 ? done / elapsed : 0.0;
+            MetricsCollector.Stats s = queryMetrics.computeStats();
+            LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+            m.put("phase", "query");
+            m.put("queries_done", done);
+            m.put("total", (long) actualQueries);
+            m.put("qps", qps);
+            m.put("top_k", config.topK);
+            LinkedHashMap<String, Object> latency = new LinkedHashMap<>();
+            latency.put("mean_ms", round2(s.meanNanos() / 1e6));
+            latency.put("p50_ms", round2(s.p50Nanos() / 1e6));
+            latency.put("p95_ms", round2(s.p95Nanos() / 1e6));
+            latency.put("p99_ms", round2(s.p99Nanos() / 1e6));
+            latency.put("max_ms", round2(s.maxNanos() / 1e6));
+            m.put("latency", latency);
+            return m;
+        });
         while (!queryPool.awaitTermination(500, TimeUnit.MILLISECONDS)) {
             double elapsed = (System.nanoTime() - queryStart) / 1e9;
             long queriesDone = queryMetrics.getCount();

--- a/vector-testings/src/test/java/herddb/vectortesting/AdminApiServerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/AdminApiServerTest.java
@@ -1,0 +1,447 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for {@link AdminApiServer}. Each test starts the server on
+ * an ephemeral port, makes synchronous HTTP requests with bounded timeouts,
+ * then stops the server — no sleeps, no shared state, no port collisions.
+ */
+class AdminApiServerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private BenchRuntime runtime;
+    private AdminApiServer server;
+    private HttpClient client;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() throws Exception {
+        Config cfg = new Config();
+        cfg.ingestMaxOpsPerSecond = 100_000;
+        cfg.queryMaxOpsPerSecond = 10;
+        cfg.topK = 10;
+        cfg.queryThreads = 4;
+        cfg.queryCount = 1000;
+        cfg.ingestThreads = 4;
+        cfg.batchSize = 500;
+        cfg.numRows = 100_000L;
+        cfg.resumeFrom = 0L;
+        cfg.ingestCommitRetries = 3;
+        runtime = new BenchRuntime(cfg);
+        server = new AdminApiServer(runtime, 0); // port 0 = ephemeral
+        int port = server.start();
+        baseUrl = "http://127.0.0.1:" + port;
+        client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void stop() {
+        server.stop();
+    }
+
+    @Test
+    void getIngestionConfigReturnsExpectedFields() throws Exception {
+        HttpResponse<String> resp = get("/ingestion/config");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(100_000, json.get("ingest-max-ops").asInt());
+        assertEquals(4, json.get("ingest-threads").asInt());
+        assertEquals(500, json.get("batch-size").asInt());
+        assertEquals(100_000L, json.get("rows").asLong());
+        assertEquals(0L, json.get("resume-from").asLong());
+        assertEquals(3, json.get("ingest-commit-retries").asInt());
+    }
+
+    @Test
+    void getQueryConfigReturnsExpectedFields() throws Exception {
+        HttpResponse<String> resp = get("/query/config");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(10, json.get("query-max-ops").asInt());
+        assertEquals(4, json.get("query-threads").asInt());
+        assertEquals(1000, json.get("queries").asInt());
+        assertEquals(10, json.get("top-k").asInt());
+    }
+
+    @Test
+    void postIngestMaxOpsUpdatesConfigAndRateLimiter() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-max-ops", "{\"value\": 5000}");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(5000, json.get("ingest-max-ops").asInt());
+        assertEquals(5000, runtime.config().ingestMaxOpsPerSecond);
+        // Guava RateLimiter.getRate() returns exactly the value passed to setRate().
+        assertEquals(5000.0, runtime.ingestRateLimiter().getRate(), 1e-6);
+    }
+
+    @Test
+    void postIngestMaxOpsWithZeroMeansUnlimited() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-max-ops", "{\"value\": 0}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(0, runtime.config().ingestMaxOpsPerSecond);
+        assertEquals(BenchRuntime.UNLIMITED_RATE, runtime.ingestRateLimiter().getRate(), 1.0);
+    }
+
+    @Test
+    void postQueryMaxOpsUpdatesConfigAndRateLimiter() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/query-max-ops", "{\"value\": 250}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(250, runtime.config().queryMaxOpsPerSecond);
+        assertEquals(250.0, runtime.queryRateLimiter().getRate(), 1e-6);
+    }
+
+    @Test
+    void postTopKUpdatesConfig() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/top-k", "{\"value\": 32}");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(32, json.get("top-k").asInt());
+        assertEquals(32, runtime.config().topK);
+    }
+
+    @Test
+    void postTopKRejectsNonPositive() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/top-k", "{\"value\": 0}");
+        assertEquals(400, resp.statusCode());
+        // Config must be untouched on reject.
+        assertEquals(10, runtime.config().topK);
+    }
+
+    @Test
+    void postAcceptsPlainNumericBody() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-max-ops", "1234");
+        assertEquals(200, resp.statusCode());
+        assertEquals(1234, runtime.config().ingestMaxOpsPerSecond);
+    }
+
+    @Test
+    void postWithInvalidBodyReturnsBadRequest() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-max-ops", "not-a-number");
+        assertEquals(400, resp.statusCode());
+        // Unchanged from @BeforeEach setup.
+        assertEquals(100_000, runtime.config().ingestMaxOpsPerSecond);
+    }
+
+    @Test
+    void postWithEmptyBodyReturnsBadRequest() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-max-ops", "");
+        assertEquals(400, resp.statusCode());
+    }
+
+    @Test
+    void unknownEndpointReturns404() throws Exception {
+        HttpResponse<String> resp = get("/does/not/exist");
+        assertEquals(404, resp.statusCode());
+    }
+
+    @Test
+    void statusEndpointReturnsSuppliedMap() throws Exception {
+        AtomicReference<Integer> callCount = new AtomicReference<>(0);
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("phase", "ingestion");
+        snapshot.put("rows", 42L);
+        snapshot.put("ops_per_sec", 1234.5);
+        runtime.setStatusSupplier(() -> {
+            callCount.set(callCount.get() + 1);
+            return snapshot;
+        });
+
+        HttpResponse<String> resp = get("/status");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals("ingestion", json.get("phase").asText());
+        assertEquals(42L, json.get("rows").asLong());
+        assertEquals(1234.5, json.get("ops_per_sec").asDouble());
+        assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void statusEndpointDefaultsToIdle() throws Exception {
+        // Fresh runtime — no supplier set.
+        HttpResponse<String> resp = get("/status");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals("idle", json.get("phase").asText());
+    }
+
+    @Test
+    void serverStartsAndStopsCleanly() throws Exception {
+        // Separately start a second server on another ephemeral port to verify
+        // lifecycle independence. Stops at end to free the port.
+        BenchRuntime r2 = new BenchRuntime(new Config());
+        AdminApiServer s2 = new AdminApiServer(r2, 0);
+        int port = s2.start();
+        assertTrue(port > 0);
+        try {
+            HttpClient c = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
+            HttpResponse<String> resp = c.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/status"))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build(), BodyHandlers.ofString());
+            assertEquals(200, resp.statusCode());
+            assertNotNull(resp.body());
+        } finally {
+            s2.stop();
+        }
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build(), BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> postJson(String path, String body) throws Exception {
+        return client.send(HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(5))
+                .header("Content-Type", "application/json")
+                .POST(BodyPublishers.ofString(body))
+                .build(), BodyHandlers.ofString());
+    }
+
+    @Test
+    void benchRuntimeConstructorMapsUnlimitedToLargeRate() {
+        Config c = new Config();
+        c.ingestMaxOpsPerSecond = 0;
+        c.queryMaxOpsPerSecond = 0;
+        BenchRuntime r = new BenchRuntime(c);
+        assertEquals(BenchRuntime.UNLIMITED_RATE, r.ingestRateLimiter().getRate(), 1.0);
+        assertEquals(BenchRuntime.UNLIMITED_RATE, r.queryRateLimiter().getRate(), 1.0);
+    }
+
+    @Test
+    void benchRuntimeConstructorKeepsConfiguredRate() {
+        Config c = new Config();
+        c.ingestMaxOpsPerSecond = 7777;
+        c.queryMaxOpsPerSecond = 111;
+        BenchRuntime r = new BenchRuntime(c);
+        assertEquals(7777.0, r.ingestRateLimiter().getRate(), 1e-6);
+        assertEquals(111.0, r.queryRateLimiter().getRate(), 1e-6);
+    }
+
+    @Test
+    void readPortFromSystemPropertyDefaultIsEightyEighty() {
+        // Guard: we never mutate the real system property during tests to avoid
+        // cross-test contamination, but we can read the default when it's unset.
+        // This test only runs assertions if the property is not set externally.
+        String existing = System.getProperty(AdminApiServer.PORT_SYSTEM_PROPERTY);
+        if (existing == null) {
+            assertEquals(AdminApiServer.DEFAULT_PORT, AdminApiServer.readPortFromSystemProperty());
+        } else {
+            // Respect externally-set property; just assert it parses cleanly.
+            assertEquals(Integer.parseInt(existing), AdminApiServer.readPortFromSystemProperty());
+        }
+    }
+
+    @Test
+    void postIngestMaxOpsRejectsNegative() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-max-ops", "{\"value\": -1}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(100_000, runtime.config().ingestMaxOpsPerSecond);
+        assertEquals(100_000.0, runtime.ingestRateLimiter().getRate(), 1e-6);
+    }
+
+    @Test
+    void postQueryMaxOpsRejectsNegative() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/query-max-ops", "{\"value\": -5}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(10, runtime.config().queryMaxOpsPerSecond);
+        assertEquals(10.0, runtime.queryRateLimiter().getRate(), 1e-6);
+    }
+
+    @Test
+    void postTopKRejectsNegative() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/top-k", "{\"value\": -3}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(10, runtime.config().topK);
+    }
+
+    /**
+     * Behavioral test: after POST lowers the rate, subsequent acquisitions
+     * are throttled to match; after POST raises the rate, they complete
+     * quickly.
+     *
+     * <p>Guava {@code RateLimiter.acquire()} uses pay-forward semantics: each
+     * call waits for the previously-reserved ticket, not for its own permits.
+     * So a single {@code acquire(N)} can return instantly even on a starved
+     * limiter. The reliable way to observe the rate is a loop of sequential
+     * {@code acquire(1)} calls. With N iterations at {@code rate} permits/s,
+     * the total elapsed time converges to {@code (N-1) / rate} seconds
+     * regardless of starting burst, because the first call's wait time is
+     * absorbed into the loop-start fixed cost.
+     *
+     * <p>Bounds are asymmetric and generous (roughly an order of magnitude
+     * apart) so scheduler jitter or a cold JIT cannot collapse them.
+     */
+    @Test
+    void liveRateChangeTakesEffectImmediately() throws Exception {
+        // Clamp to 2 permits/s via the admin API.
+        postJson("/query/config/query-max-ops", "{\"value\": 2}");
+        assertEquals(2.0, runtime.queryRateLimiter().getRate(), 1e-6);
+
+        // 5 sequential acquires at 2 permits/s → ~4 × 500ms = 2000ms elapsed.
+        // Lower bound 1500ms leaves ~500ms margin for jitter.
+        long t0 = System.nanoTime();
+        for (int i = 0; i < 5; i++) {
+            runtime.queryRateLimiter().acquire(1);
+        }
+        long slowNanos = System.nanoTime() - t0;
+        assertTrue(slowNanos >= 1_500_000_000L,
+                "5 acquires at 2 ops/s should take >= 1.5s, got " + (slowNanos / 1e6) + " ms");
+
+        // Raise the rate to 10000 via the admin API.
+        postJson("/query/config/query-max-ops", "{\"value\": 10000}");
+        assertEquals(10000.0, runtime.queryRateLimiter().getRate(), 1e-6);
+
+        // Drain any accumulated reservation from the slow period — at 10k
+        // permits/s this itself takes at most a few ms.
+        runtime.queryRateLimiter().acquire(1);
+
+        // 5 sequential acquires at 10k permits/s → ~0.5ms elapsed. 500ms
+        // ceiling is ~1000× the expected value, comfortably above any GC
+        // or cache-miss pause on normal CI.
+        long t1 = System.nanoTime();
+        for (int i = 0; i < 5; i++) {
+            runtime.queryRateLimiter().acquire(1);
+        }
+        long fastNanos = System.nanoTime() - t1;
+        assertTrue(fastNanos < 500_000_000L,
+                "5 acquires after rate raise should take < 500ms, got " + (fastNanos / 1e6) + " ms");
+    }
+
+    /** Mirrors {@link #liveRateChangeTakesEffectImmediately()} for the ingest side. */
+    @Test
+    void liveIngestRateChangeTakesEffectImmediately() throws Exception {
+        postJson("/ingestion/config/ingest-max-ops", "{\"value\": 2}");
+        assertEquals(2.0, runtime.ingestRateLimiter().getRate(), 1e-6);
+
+        long t0 = System.nanoTime();
+        for (int i = 0; i < 5; i++) {
+            runtime.ingestRateLimiter().acquire(1);
+        }
+        long slowNanos = System.nanoTime() - t0;
+        assertTrue(slowNanos >= 1_500_000_000L,
+                "5 acquires at 2 ops/s should take >= 1.5s, got " + (slowNanos / 1e6) + " ms");
+
+        postJson("/ingestion/config/ingest-max-ops", "{\"value\": 10000}");
+        assertEquals(10000.0, runtime.ingestRateLimiter().getRate(), 1e-6);
+        runtime.ingestRateLimiter().acquire(1);
+
+        long t1 = System.nanoTime();
+        for (int i = 0; i < 5; i++) {
+            runtime.ingestRateLimiter().acquire(1);
+        }
+        long fastNanos = System.nanoTime() - t1;
+        assertTrue(fastNanos < 500_000_000L,
+                "5 acquires after rate raise should take < 500ms, got " + (fastNanos / 1e6) + " ms");
+    }
+
+    /**
+     * Critical non-flaky guarantee: after a large pay-forward reservation on
+     * a very low rate, raising the rate via admin must NOT leave workers
+     * stuck waiting on the old reservation. {@link BenchRuntime} handles
+     * this by replacing the {@link com.google.common.util.concurrent.RateLimiter}
+     * on every {@code setRate} call, so a worker that re-reads the limiter
+     * reference sees a fresh one with no lingering reservation.
+     *
+     * <p>Scenario: set rate to 2/s, make a big acquire that reserves ~50s
+     * into the future. Raise rate to 10000. A new acquire from the swapped
+     * limiter must complete in well under 1s — nowhere near the ~50s that a
+     * held-over reservation would cause.
+     */
+    @Test
+    void rateRaiseUnblocksFutureAcquiresDespiteBigPayForwardReservation() throws Exception {
+        postJson("/query/config/query-max-ops", "{\"value\": 2}");
+        com.google.common.util.concurrent.RateLimiter slow = runtime.queryRateLimiter();
+
+        // First acquire returns fast (no prior reservation) but reserves
+        // 100 permits * 500ms = 50 seconds into the future for the NEXT caller.
+        slow.acquire(100);
+
+        // Second acquire on the SAME limiter would now block ~50s — that's
+        // the pay-forward penalty. We don't actually call it; we verify the
+        // swap on setRate prevents this.
+
+        // Raise rate via admin. BenchRuntime swaps the limiter.
+        postJson("/query/config/query-max-ops", "{\"value\": 10000}");
+        com.google.common.util.concurrent.RateLimiter fast = runtime.queryRateLimiter();
+
+        // Different instance: proves the swap happened.
+        assertTrue(slow != fast, "rate change must swap the RateLimiter instance, not mutate in place");
+
+        // New acquires from the swapped limiter must NOT inherit the 50s
+        // reservation. Allow a 500ms ceiling — vastly under the 50s that
+        // would fire if the reservation had carried over.
+        long t0 = System.nanoTime();
+        fast.acquire(1);
+        fast.acquire(1);
+        long elapsedNanos = System.nanoTime() - t0;
+        assertTrue(elapsedNanos < 500_000_000L,
+                "new limiter should not inherit old reservation; took " + (elapsedNanos / 1e6) + " ms");
+    }
+
+    @Test
+    void supplierWithConcurrentMapInStatusIsSerializedUnchanged() throws Exception {
+        // Guard: LinkedHashMap iteration order must be preserved through
+        // Jackson — tests ordering stability of /status payloads.
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+        m.put("phase", "query");
+        m.put("queries_done", 5L);
+        m.put("extra", Collections.singletonMap("nested", "value"));
+        runtime.setStatusSupplier(() -> m);
+        HttpResponse<String> resp = get("/status");
+        assertEquals(200, resp.statusCode());
+        // Ordering check: "phase" key appears before "queries_done" in the raw JSON.
+        int phaseIdx = resp.body().indexOf("\"phase\"");
+        int queriesIdx = resp.body().indexOf("\"queries_done\"");
+        assertTrue(phaseIdx >= 0 && queriesIdx > phaseIdx,
+                "expected phase before queries_done in " + resp.body());
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
@@ -150,7 +150,7 @@ class IngestionWorkerTest {
                 commitsTotal,
                 commitsRecovered,
                 rowsCommitted,
-                null // no rate limiting in flush/retry tests
+                () -> null // no rate limiting in flush/retry tests
         );
         worker.backoffBaseMillis = 0L; // keep tests fast
         return worker;

--- a/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
@@ -78,6 +78,48 @@ class VectorBenchTest {
     void configResumeFromDefaultIsZero() throws Exception {
         Config cfg = Config.parse(new String[]{});
         assertEquals(0, cfg.resumeFrom);
+        assertEquals(false, cfg.resumeFromAuto);
+    }
+
+    @Test
+    void configResumeFromAutoSetsFlag() throws Exception {
+        Config cfg = Config.parse(new String[]{"--resume-from", "auto"});
+        assertEquals(0, cfg.resumeFrom);
+        assertEquals(true, cfg.resumeFromAuto);
+    }
+
+    @Test
+    void configResumeFromAutoIsCaseInsensitive() throws Exception {
+        Config cfg = Config.parse(new String[]{"--resume-from", "AUTO"});
+        assertEquals(true, cfg.resumeFromAuto);
+
+        Config cfg2 = Config.parse(new String[]{"--resume-from", "Auto"});
+        assertEquals(true, cfg2.resumeFromAuto);
+    }
+
+    @Test
+    void configResumeFromNumericLeavesAutoFalse() throws Exception {
+        Config cfg = Config.parse(new String[]{"--resume-from", "42"});
+        assertEquals(42L, cfg.resumeFrom);
+        assertEquals(false, cfg.resumeFromAuto);
+    }
+
+    @Test
+    void configQueryMaxOpsDefaultIsTen() throws Exception {
+        Config cfg = Config.parse(new String[]{});
+        assertEquals(10, cfg.queryMaxOpsPerSecond);
+    }
+
+    @Test
+    void configQueryMaxOpsOverride() throws Exception {
+        Config cfg = Config.parse(new String[]{"--query-max-ops", "250"});
+        assertEquals(250, cfg.queryMaxOpsPerSecond);
+    }
+
+    @Test
+    void configQueryMaxOpsZeroMeansUnlimited() throws Exception {
+        Config cfg = Config.parse(new String[]{"--query-max-ops", "0"});
+        assertEquals(0, cfg.queryMaxOpsPerSecond);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **`--resume-from=auto`** — resolves the ingestion offset from `SELECT COUNT(*)` on the tank at the start of the ingestion phase (O(1) thanks to HerdDB's autocommit aggregate fast-path). No more guessing the right integer after a pod restart or Ctrl-C.
- **Embedded Jetty admin API** on `-Dvectorbench.admin.port` (default `8080`, `<=0` disables) with JSON endpoints for live inspection and tuning:
  - `GET /ingestion/config` / `GET /query/config` / `GET /status`
  - `POST /ingestion/config/ingest-max-ops`
  - `POST /query/config/query-max-ops`
  - `POST /query/config/top-k`
- **New `--query-max-ops` flag** (default **10** queries/s) adds a global query rate cap using the same Guava `RateLimiter` pattern used for ingestion.
- **Dynamic rate limiting** — rate overrides swap the `RateLimiter` instance (not `setRate()` in place), so Guava's pay-forward reservation semantics cannot strand workers after an admin-issued rate raise. An already in-flight `acquire()` finishes on the old limiter; the next iteration picks up the swapped one.
- **Runtime-tunable `-k`** — `QueryWorker` re-reads `config.topK` per query and re-prepares its SQL when the value changes.
- **`VECTOR_BENCH.md`** documents every CLI flag, system property, and admin endpoint.

## Non-flaky tests

`AdminApiServerTest` (24 tests) spins up Jetty on an ephemeral port per test, hits endpoints synchronously with bounded timeouts. The behavioral rate-change tests use asymmetric order-of-magnitude bounds (1.5s floor at 2 ops/s vs 500ms ceiling at 10000 ops/s) so scheduler jitter cannot collapse them. Verified 5× consecutive runs with identical timings.

The critical non-flaky guarantee for the user's concern *\"how does it work with the real Workers? I don't want them to get stuck\"* is covered by `rateRaiseUnblocksFutureAcquiresDespiteBigPayForwardReservation` — reserves 50s into the future on a slow limiter, raises the rate, verifies two subsequent acquires complete in <500ms (proving the swap prevents pay-forward carryover).

## Test plan

- [x] `mvn -pl vector-testings test` → 82/82 pass
- [x] `mvn -B -pl vector-testings checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` → BUILD SUCCESS, 0 Checkstyle, 0 SpotBugs violations
- [x] Behavioral rate-limiter tests run 5× consecutively with no variance
- [ ] Manual smoke test against a local HerdDB: verify `curl` to each endpoint returns the expected shape during ingestion and query phases
- [ ] Manual: throttle down, then raise, mid-run and confirm workers recover within a single batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)