### PR TITLE
issue #204: clear BK commit log 'failed' flag on successful ledger rotation

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -534,6 +534,17 @@ public class BookkeeperCommitLog extends CommitLog {
                     signalLogFailed();
                 }
             }
+            // New ledger is live and durably recorded in ZK.  If a transient
+            // per-entry BK write error (e.g. BKNotEnoughBookiesException during
+            // a ZK session outage) previously set the log-level `failed` flag,
+            // clear it now: this rotation IS the recovery path.  Without this,
+            // log.log() would keep returning LogNotAvailableException on the
+            // freshly-opened ledger and ingest would stay frozen even though
+            // the cluster has recovered (issue #204).  Fatal cases do not
+            // reach this point: BKLedgerFencedException keeps failed=true via
+            // handleBookKeeperFailure, and persistent ledger-creation/ZK-save
+            // failures throw out of openNewLedger before this line.
+            failed = false;
             pendingLedgerId = null;
             return writer;
         } catch (LogNotAvailableException err) {

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -245,29 +245,28 @@ public class BookKeeperCommitLogTest {
                 writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
 
                 this.testEnv.pauseBookie();
-                // this is deemed to fail and we will close the log
+                // The write fails because the single bookie is paused; the
+                // callback's signalLogFailed() then marks the log as failed.
                 TestUtils.assertThrows(LogNotAvailableException.class, ()
                         -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
                 );
                 assertTrue(writer.isFailed());
 
-                // this one will fail as well
-                TestUtils.assertThrows(LogNotAvailableException.class, ()
-                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
-                );
-
-                // no way to recover this instance of BookkeeperCommitLog
-                // we will bounce the leader and it will restart with a full recovery
-                // in a production env you do not have only one bookie, and the failure
-                // of a single bookie will be handled with an ensemble change
                 this.testEnv.resumeBookie();
 
-                TestUtils.assertThrows(LogNotAvailableException.class, ()
-                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
-                );
+                // Regression for issue #204: before the fix, `failed = true`
+                // was sticky — the commit log permanently rejected writes on
+                // any freshly-opened ledger even after the cluster recovered.
+                // After the fix, the next log call rotates the ledger via
+                // getValidWriter -> openNewLedger, which clears `failed` on
+                // successful ledger creation and lets the write through.
+                LogSequenceNumber lsnOnNewLedger = writer.log(LogEntryFactory.beginTransaction(2), true)
+                        .getLogSequenceNumber();
+                assertNotNull(lsnOnNewLedger);
+                assertFalse(writer.isFailed());
             }
 
-            // check expected reads
+            // check expected reads: one entry on ledger 1 (tx=1) plus one entry on ledger 2 (tx=2)
             try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
                 List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
                 reader.recovery(LogSequenceNumber.START_OF_TIME, (lsn, entry) -> {
@@ -275,9 +274,12 @@ public class BookKeeperCommitLogTest {
                         list.add(new AbstractMap.SimpleImmutableEntry<>(lsn, entry));
                     }
                 }, false);
-                assertEquals(1, list.size());
+                assertEquals(2, list.size());
 
                 assertTrue(list.get(0).getKey().after(LogSequenceNumber.START_OF_TIME));
+                assertTrue(list.get(1).getKey().after(list.get(0).getKey()));
+                // second entry must live on a fresh ledger created by the recovery rotation
+                assertTrue(list.get(1).getKey().ledgerId != list.get(0).getKey().ledgerId);
             }
 
         }
@@ -306,9 +308,8 @@ public class BookKeeperCommitLogTest {
                 writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
 
                 this.testEnv.pauseBookie();
-                // this is deemed to fail and we will close the log
 
-                // writer won't see the failure, because this is a deferred write
+                // writer won't see the failure yet, because this is a deferred write
                 writer.log(LogEntryFactory.beginTransaction(2), false).getLogSequenceNumber();
 
                 // this one will fail as well, and we will catch the error, because this is a sync write
@@ -317,18 +318,21 @@ public class BookKeeperCommitLogTest {
                         -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
                 );
 
-                // no way to recover this instance of BookkeeperCommitLog
-                // we will bounce the leader and it will restart with a full recovery
-                // in a production env you do not have only one bookie, and the failure
-                // of a single bookie will be handled with an ensemble change
                 this.testEnv.resumeBookie();
 
-                TestUtils.assertThrows(LogNotAvailableException.class, ()
-                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
-                );
+                // Once the bookie is back the log auto-recovers by rolling a new
+                // ledger on the next call.  See issue #204: before the fix the
+                // per-entry failure set a sticky `failed=true` flag that kept
+                // subsequent writes rejected even after the cluster recovered.
+                LogSequenceNumber lsnOnNewLedger = writer.log(LogEntryFactory.beginTransaction(2), true)
+                        .getLogSequenceNumber();
+                assertNotNull(lsnOnNewLedger);
+                assertFalse(writer.isFailed());
             }
 
-            // check expected reads
+            // check expected reads: at least the 4 entries that were already
+            // acked before the bookie pause must be visible, plus the one we
+            // wrote after recovery on the new ledger.
             try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
                 List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
                 reader.recovery(LogSequenceNumber.START_OF_TIME, (lsn, entry) -> {
@@ -336,7 +340,7 @@ public class BookKeeperCommitLogTest {
                         list.add(new AbstractMap.SimpleImmutableEntry<>(lsn, entry));
                     }
                 }, false);
-                assertEquals(4, list.size());
+                assertTrue("unexpected entry count on reader: " + list.size(), list.size() >= 5);
             }
 
         }
@@ -418,21 +422,33 @@ public class BookKeeperCommitLogTest {
                     }
                 }
 
-                // even if we restart the bookie we must not be able to acknowledge the write
+                // After the bookie comes back, the log must recover by rolling
+                // a new ledger on the next call (issue #204).  The in-flight
+                // entries from the paused window are lost, but new writes work.
                 testEnv.resumeBookie();
-                TestUtils.assertThrows(LogNotAvailableException.class, ()
-                        -> writer.log(entry, true).getLogSequenceNumber()
-                );
+                LogSequenceNumber lsnAfter = writer.log(entry, true).getLogSequenceNumber();
+                assertNotNull(lsnAfter);
+                assertFalse(writer.isFailed());
             }
 
             try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
                 List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                Set<Long> ledgerIds = new HashSet<>();
                 reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
                     if (b.type != LogEntryType.NOOP) {
                         list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                        ledgerIds.add(a.ledgerId);
                     }
                 }, false);
-                assertTrue("unexpected number of entries on reader: " + list.size(), list.size() <= 80);
+                // After recovery we expect AT LEAST the post-resume sync write on a
+                // new ledger in addition to any entries that made it to BK before the
+                // pause.  The total is bounded above by the entries we tried to write.
+                assertTrue("too few entries on reader: " + list.size(), list.size() >= 1);
+                assertTrue("too many entries on reader: " + list.size(),
+                        list.size() <= numberOfEntries + 1);
+                // Expect at least two distinct ledgers: maxLedgerSize rotations during
+                // the initial loop plus the recovery rotation on the post-resume write.
+                assertTrue("expected multiple ledgers, got: " + ledgerIds, ledgerIds.size() >= 2);
             }
 
         }


### PR DESCRIPTION
## Summary

Fixes [#204](https://github.com/eolivelli/herddb/issues/204): after a long checkpoint starves ZK heartbeats on GKE, ZK expires and BookKeeper fails the last few `addEntry` calls with `BKNotEnoughBookiesException`. The server correctly fences ledger 1 and opens ledger 2 (the operator even sees `opened new ledger:2` in the log), but **all 16 ingest threads freeze forever**: `commitlog_offset=-1`, `NUM_PENDING_ADD=0`, readiness probe fails.

### Root cause

`herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java`:

- `writeEntry`'s BK callback calls `handleBookKeeperFailure` which, for any generic `BKException`, calls `signalLogFailed()` — setting the log-level `volatile boolean failed` to `true`.
- `signalLogFailed` (line 113) never clears the flag.
- `log()` (line 419) short-circuits with `LogNotAvailableException` while `failed == true`.

Execution order during the failure:
1. BK callback sets `errorOccurredDuringWrite=true` **and** `failed=true`.
2. Next `log.log()` call enters `getValidWriter()` **before** the `failed` check, detects the not-writable writer, and successfully opens ledger 2 (this all works).
3. But on return from `getValidWriter`, `log()` hits `if (failed)` and returns `LogNotAvailableException` forever. The freshly-opened ledger 2 is never written through the public API.

### Fix

One line: clear `failed` at the end of `openNewLedger` once the new ledger is live and durably recorded in ZK. Fatal paths do not reach that line —
- `BKLedgerFencedException` keeps `failed=true` via `handleBookKeeperFailure` (different branch),
- persistent `makeNewWriteHandle` or `saveActualLedgersList` failures throw out of `openNewLedger` before the clear.

Transient per-entry failures that the rotation can recover from no longer brick the commit log.

## Test updates

`testBookieFailureSyncWrites`, `testBookieFailureAsyncWrites`, and `testMaxLedgerSizeWithTemporaryError` previously asserted that the log stayed permanently unusable after a bookie pause + resume. That is exactly the behaviour issue #204 identifies as the bug. Each test now verifies instead that after the bookie comes back, the log auto-recovers by rotating to a new ledger and the next write succeeds (asserts `assertFalse(writer.isFailed())` and `assertNotNull` on the returned LSN).

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean
- [x] BK suite (`BookKeeperCommitLogTest`, `BookieNotAvailableTest`, `FencingTest`, `LedgerClosedTest`, `MultiBookieTest`) — **20/20 green**
- [x] `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` — **12/12 green**
- [ ] Re-run the bench workload from #204 and verify ingest resumes on ledger 2 after the next BK transient outage (can defer to the reporter; the unit-level regression tests above are the primary gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)