### PR TITLE
README: rewrite as "HerdDB + JVector" with architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ chart usage.
 ```mermaid
 flowchart LR
   subgraph Clients
-    CLI["JDBC / SQL client<br/>(vector-search queries<br/>load-balanced across shadows)"]
+    CLI["JDBC / SQL client"]
   end
 
   subgraph "Control plane"
@@ -81,10 +81,10 @@ flowchart LR
     OBJ[("S3 / GCS / MinIO")]
   end
 
-  CLI -->|SQL + DML| Leader
-  CLI -. vector search .-> ISvcP
-  CLI -. vector search .-> ISvcS1
-  CLI -. vector search .-> ISvcS2
+  CLI -->|SQL + DML + vector search| Leader
+  Leader -. vector search (LB) .-> ISvcP
+  Leader -. vector search (LB) .-> ISvcS1
+  Leader -. vector search (LB) .-> ISvcS2
 
   Leader -->|append| BK
   Replica -->|tail| BK
@@ -99,10 +99,10 @@ flowchart LR
 
   Leader -. elect / heartbeat .-> ZK
   Replica -. discover .-> ZK
+  Leader -. discover indexing instances .-> ZK
   ISvcP -. publish IndexStatus .-> ZK
   ISvcS1 -. watch .-> ZK
   ISvcS2 -. watch .-> ZK
-  CLI -. discover .-> ZK
 ```
 
 The rest of this section zooms in on individual layers.
@@ -171,8 +171,9 @@ flowchart LR
   automatic fan-out of SQL reads across followers.
 - **Indexing-service shadow replicas** (§4 below) are the tier that
   **does** transparently scale **vector-search read throughput**:
-  the JDBC client load-balances each search query across
-  `{primary, shadow1, shadow2, …}` for the target index.
+  the HerdDB server load-balances each search query across
+  `{primary, shadow1, shadow2, …}` for the target index on behalf
+  of the JDBC client.
 
 ### 3. Shared object storage + file-server cache tier
 
@@ -232,10 +233,11 @@ indexes on its own schedule.
   a new LSN is published, they reload `IndexStatus` from shared
   storage and serve search traffic against it. Shadows therefore
   lag the primary by **at most one checkpoint interval**.
-- The **JDBC client** discovers instances via ZooKeeper and, for each
-  vector-search query, **load-balances across `{primary, shadow1,
-  shadow2, …}`** for the target index, failing over within the pool
-  on `NOT_READY` or retryable errors.
+- The **HerdDB server** discovers indexing-service instances via
+  ZooKeeper and, for each vector-search query received over JDBC,
+  **load-balances across `{primary, shadow1, shadow2, …}`** for
+  the target index, failing over within the pool on `NOT_READY`
+  or retryable errors. JDBC clients see a single SQL endpoint.
 
 ```mermaid
 flowchart LR
@@ -253,7 +255,8 @@ flowchart LR
     S3["Shadow N"]
   end
 
-  Client["JDBC client<br/>(vector-search LB)"]
+  JDBC["JDBC client"]
+  Server["HerdDB server<br/>(vector-search LB)"]
 
   WAL --> P
   P -->|write segments + status| OBJ
@@ -265,10 +268,11 @@ flowchart LR
   OBJ -. reload IndexStatus .-> S2
   OBJ -. reload IndexStatus .-> S3
 
-  Client -. search .-> P
-  Client -. search .-> S1
-  Client -. search .-> S2
-  Client -. search .-> S3
+  JDBC -->|SQL search| Server
+  Server -. gRPC search .-> P
+  Server -. gRPC search .-> S1
+  Server -. gRPC search .-> S2
+  Server -. gRPC search .-> S3
 ```
 
 Scope is strictly horizontal **read** scalability. Shadow-to-primary

--- a/README.md
+++ b/README.md
@@ -1,44 +1,326 @@
-# What is HerdDB ?
+# HerdDB + JVector
 
-HerdDB is a **distributed Database**, data is distributed among a cluster of server **without the need of a shared storage**.
+*A horizontally scalable vector search database built on HerdDB, JVector,
+Apache BookKeeper, Apache ZooKeeper and Apache Calcite.*
 
-HerdDB primary language is **SQL** and clients are encouraged to use both the JDBC Driver API and the low level API.
+## Origins
 
-HerdDB is **embeddable** in any Java Virtual Machine, each node will access directly to local data without the use of the network.
+This project started as a fork of [`diennea/herddb`](https://github.com/diennea/herddb)
+— an embeddable, SQL-first distributed database — and has since evolved
+independently. Focus has shifted toward **vector search at scale on
+Kubernetes**: a standalone indexing service, shadow read replicas, and
+object-store-backed shared storage have been added on top of the original
+tablespace / WAL / checkpoint core.
 
-HerdDB replication functions are built upon **Apache ZooKeeper** and **Apache BookKeeper**.
+The upstream project remains a separate codebase; this fork is not a
+drop-in replacement and the two are no longer wire-compatible in all
+configurations.
 
-HerdDB is internally very similar to a NoSQL database and, basically, it is a **key-value DB** with an SQL abstraction layer which enables every user to leverage existing known-how and to port existing applications.
+## Built on production-grade OSS
 
-*HerdDB has been designed for fast "writes" and for primary key read/update data access patterns.*
+HerdDB + JVector does not reinvent the hard parts of a distributed
+stateful system. It composes well-known, widely-deployed open-source
+components:
 
-HerdDB supports **transactions** and "committed read" isolation level
+| Component | Role | Version | Project |
+|---|---|---|---|
+| HerdDB core | SQL engine, WAL, tablespaces, checkpointing, BLink PK index | fork base | https://github.com/diennea/herddb |
+| JVector (DataStax / IBM) | On-disk HNSW graph + Fused-PQ vector index | `4.0.0-rc.9-herddb` | https://github.com/datastax/jvector |
+| Apache BookKeeper | Distributed, replicated, low-latency commit log | `4.17.3` | https://bookkeeper.apache.org |
+| Apache ZooKeeper | Cluster metadata, tablespace leader election, instance discovery | `3.9.3` | https://zookeeper.apache.org |
+| Apache Calcite | SQL parser and cost-based query planner | `1.40.0` | https://calcite.apache.org |
+| AWS SDK for Java v2 | S3 / S3-compatible object storage client | `2.42.34` | https://aws.amazon.com/sdk-for-java/ |
 
-HerdDB uses **Apache Calcite** as SQL parser and SQL Planner
+All of these are battle-tested in production at other projects; this
+repository glues them together rather than re-implementing them.
 
-## Basic concepts
+## Cloud-native deployment
 
-Data, as in any **SQL database**, is organized in tables and tables are grouped inside **Tablespaces**.
+HerdDB + JVector is designed to run on **Kubernetes on public clouds**.
 
-A Tablespace is the fundamental architectural brick upon which the replication is built and some DB features are available only among tables of the same tablespace:
-- transactions may span only tables of the same tablespace
-- subqueries may span only tables of the same tablespace
+- **GKE** is currently the only environment actively tested end-to-end
+  (via an in-repo benchmark harness — see [Agentic QA](#agentic-qa)
+  below).
+- The object-store code path uses the AWS SDK v2 S3 client, so **AWS
+  S3** is expected to work with minor configuration changes; other
+  S3-compatible stores (MinIO is used in local tests) have also been
+  exercised.
+- **Docker images** are built from [`herddb-docker/`](./herddb-docker/)
+  (base image `eclipse-temurin:25-jdk`).
+- A **Helm chart** plus ready-to-use `values.yaml` for GKE and for a
+  local k3s-in-docker stack ships under
+  [`herddb-kubernetes/src/main/helm/herddb/`](./herddb-kubernetes/src/main/helm/herddb/).
 
-Replication is configured at tablespace level, so for each tablespace only one server is designed to be the 'leader' (manager) at a specific point in time, then you may configure a set of 'replicas'.
-The system automatically replicates data between replicas and handles server failures transparently.
+See [KUBERNETES.md](./KUBERNETES.md) for image build instructions and
+chart usage.
 
-## Overview
+## Architecture at a glance
 
-[Introducing HerdDB - Pulsar Summit 2020](https://www.youtube.com/watch?v=K7xQZ9V9Ml0) - Enrico Olivelli
+```mermaid
+flowchart LR
+  subgraph Clients
+    CLI["JDBC / SQL client<br/>(vector-search queries<br/>load-balanced across shadows)"]
+  end
 
-[![Introducing HerdDB - Youtube link](https://img.youtube.com/vi/K7xQZ9V9Ml0/0.jpg)](https://www.youtube.com/watch?v=K7xQZ9V9Ml0)
+  subgraph "Control plane"
+    ZK[("Apache ZooKeeper<br/>metadata + discovery")]
+  end
 
-[Other talks and deep dives](https://github.com/diennea/herddb/wiki/Talks-&-Publications)
+  subgraph "HerdDB servers"
+    Leader["Server<br/>(tablespace leader)"]
+    Replica["Server<br/>(follower replica)"]
+  end
 
-## Getting Involved
+  subgraph "Indexing service"
+    ISvcP["Primary<br/>(writes index)"]
+    ISvcS1["Shadow 1<br/>(read-only)"]
+    ISvcS2["Shadow 2<br/>(read-only)"]
+  end
 
-Join the [mailing list](http://lists.herddb.org/mailman/listinfo)
+  subgraph "Storage tier"
+    BK[("Apache BookKeeper<br/>commit log ensemble")]
+    RFS["Remote File Service<br/>(gRPC + block cache)"]
+    OBJ[("S3 / GCS / MinIO")]
+  end
+
+  CLI -->|SQL + DML| Leader
+  CLI -. vector search .-> ISvcP
+  CLI -. vector search .-> ISvcS1
+  CLI -. vector search .-> ISvcS2
+
+  Leader -->|append| BK
+  Replica -->|tail| BK
+  ISvcP -->|tail WAL| BK
+
+  Leader --> RFS
+  Replica --> RFS
+  ISvcP --> RFS
+  ISvcS1 --> RFS
+  ISvcS2 --> RFS
+  RFS --> OBJ
+
+  Leader -. elect / heartbeat .-> ZK
+  Replica -. discover .-> ZK
+  ISvcP -. publish IndexStatus .-> ZK
+  ISvcS1 -. watch .-> ZK
+  ISvcS2 -. watch .-> ZK
+  CLI -. discover .-> ZK
+```
+
+The rest of this section zooms in on individual layers.
+
+## Component deep-dives
+
+### 1. Replicated commit log (BookKeeper)
+
+The tablespace leader appends every DML and DDL to a BookKeeper ledger.
+Followers — and the indexing service — tail the same ledger
+independently, so a single logical WAL feeds both the SQL replica tier
+and the vector indexing tier.
+
+```mermaid
+flowchart LR
+  Leader["HerdDB leader<br/>(tablespace owner)"]
+  subgraph Ensemble["BookKeeper ensemble (E=3, Qw=2, Qa=2)"]
+    B1[(Bookie 1)]
+    B2[(Bookie 2)]
+    B3[(Bookie 3)]
+  end
+  Replica["HerdDB follower"]
+  ISvc["Indexing service<br/>(primary + shadows)"]
+
+  Leader -->|fsynced add| B1
+  Leader -->|fsynced add| B2
+  Leader -->|fsynced add| B3
+  B1 -. tail .-> Replica
+  B2 -. tail .-> Replica
+  B1 -. tail .-> ISvc
+  B2 -. tail .-> ISvc
+```
+
+Ensemble, write-quorum and ack-quorum are tuned per deployment
+(see the example `values.yaml` files). BookKeeper gives strong
+durability and low write latency without requiring shared block
+storage.
+
+Details: [CHECKPOINT.md §2](./CHECKPOINT.md) describes how checkpoints
+interact with the WAL and how commit-log truncation is coordinated.
+
+### 2. Tablespace leader / follower replication
+
+Data is grouped into **tablespaces**. Each tablespace has exactly one
+leader at any point in time and any number of follower replicas,
+elected via ZooKeeper.
+
+```mermaid
+flowchart LR
+  ZK[("ZooKeeper<br/>leader election")]
+  subgraph Tablespace["Tablespace 'default'"]
+    L["Leader"]
+    F1["Follower 1"]
+    F2["Follower 2"]
+  end
+  L <-->|heartbeat / lease| ZK
+  F1 <-->|watch| ZK
+  F2 <-->|watch| ZK
+```
+
+**Two distinct read-scaling tiers — don't conflate them:**
+
+- **Server follower replicas** exist primarily for **durability and
+  fast failover**. They can serve SQL reads, but the client is
+  responsible for picking which replica to hit; there is no built-in
+  automatic fan-out of SQL reads across followers.
+- **Indexing-service shadow replicas** (§4 below) are the tier that
+  **does** transparently scale **vector-search read throughput**:
+  the JDBC client load-balances each search query across
+  `{primary, shadow1, shadow2, …}` for the target index.
+
+### 3. Shared object storage + file-server cache tier
+
+Table pages and vector segments are stored in a shared object store
+(S3, GCS, MinIO). The **Remote File Service** is a stateless gRPC
+tier that fronts the object store, routing page IDs across backends
+with Murmur3 consistent hashing and caching recently-read segment
+blocks in an off-heap, byte-weighted Caffeine LRU.
+
+```mermaid
+flowchart LR
+  subgraph Clients["HerdDB + Indexing servers"]
+    H1["Server / Indexer"]
+    H2["Server / Indexer"]
+  end
+
+  subgraph RFSTier["Remote File Service (stateless, horizontal)"]
+    R1["rfs-0<br/>block cache"]
+    R2["rfs-1<br/>block cache"]
+    R3["rfs-2<br/>block cache"]
+  end
+
+  OBJ[("S3 / GCS / MinIO<br/>(durable shared store)")]
+
+  H1 -->|consistent-hash<br/>by page-id| R1
+  H1 --> R2
+  H1 --> R3
+  H2 --> R1
+  H2 --> R2
+  H2 --> R3
+
+  R1 --> OBJ
+  R2 --> OBJ
+  R3 --> OBJ
+```
+
+Because page content is immutable once written, the cache is trivially
+coherent: the file-server tier can be scaled out horizontally, and
+shadow replicas that hit the same hot working set benefit from warm
+caches.
+
+Details: [REMOTE_FILE_SERVER.md](./REMOTE_FILE_SERVER.md).
+
+### 4. Indexing service: primary + shadow replicas
+
+The indexing service is a standalone gRPC process. It **tails the
+HerdDB WAL** independently of the database, materialising vector
+indexes on its own schedule.
+
+- The **primary** owns an index: it ingests DML from the WAL, builds
+  live JVector shards, freezes them during checkpoint, writes on-disk
+  segments (FusedPQ) to the shared Remote File Service, and publishes
+  a new `IndexStatus` / durable LSN to ZooKeeper after every successful
+  checkpoint.
+- **Shadow replicas** are read-only siblings tied to a specific
+  primary's `instanceId`. They watch the primary's state znode; when
+  a new LSN is published, they reload `IndexStatus` from shared
+  storage and serve search traffic against it. Shadows therefore
+  lag the primary by **at most one checkpoint interval**.
+- The **JDBC client** discovers instances via ZooKeeper and, for each
+  vector-search query, **load-balances across `{primary, shadow1,
+  shadow2, …}`** for the target index, failing over within the pool
+  on `NOT_READY` or retryable errors.
+
+```mermaid
+flowchart LR
+  WAL[("BookKeeper WAL")]
+  ZK[("ZooKeeper<br/>/indexingServices/instances")]
+  OBJ[("Shared object store<br/>(segments + IndexStatus)")]
+
+  subgraph Primary["Indexing service — primary (write)"]
+    P["Tails WAL → builds JVector shards → checkpoints"]
+  end
+
+  subgraph Shadows["Indexing service — shadows (read-only, horizontal)"]
+    S1["Shadow 1"]
+    S2["Shadow 2"]
+    S3["Shadow N"]
+  end
+
+  Client["JDBC client<br/>(vector-search LB)"]
+
+  WAL --> P
+  P -->|write segments + status| OBJ
+  P -->|publish durable LSN| ZK
+  ZK -. notify .-> S1
+  ZK -. notify .-> S2
+  ZK -. notify .-> S3
+  OBJ -. reload IndexStatus .-> S1
+  OBJ -. reload IndexStatus .-> S2
+  OBJ -. reload IndexStatus .-> S3
+
+  Client -. search .-> P
+  Client -. search .-> S1
+  Client -. search .-> S2
+  Client -. search .-> S3
+```
+
+Scope is strictly horizontal **read** scalability. Shadow-to-primary
+promotion is explicitly out of scope, and shadows require
+`indexing.storage.type=remote` (i.e. shared storage) — any other
+configuration fails fast at boot.
+
+Details: [VECTOR.md](./VECTOR.md) (architecture, SQL, shard
+lifecycle), [VECTOR_SEARCH_METRICS.md](./VECTOR_SEARCH_METRICS.md)
+(observability).
+
+## Documentation index
+
+All detailed documentation lives alongside the code in the repo root:
+
+| Document | What it covers |
+|---|---|
+| [VECTOR.md](./VECTOR.md) | Vector index architecture, SQL syntax, indexing service, shard lifecycle, configuration. |
+| [VECTOR_SEARCH_METRICS.md](./VECTOR_SEARCH_METRICS.md) | Prometheus metrics and Grafana dashboard for the end-to-end vector read path (server / index server / file server / client). |
+| [CHECKPOINT.md](./CHECKPOINT.md) | Checkpoint phases (A / B / C), lock coupling with concurrent DML, per-index specifics, WAL truncation. |
+| [BLINK.md](./BLINK.md) | Primary-key B-link tree: legacy vs incremental on-disk formats, recovery, selection flag. |
+| [REMOTE_FILE_SERVER.md](./REMOTE_FILE_SERVER.md) | gRPC remote page storage, consistent hashing, metadata vs page layout, block cache. |
+| [AUTHENTICATION.md](./AUTHENTICATION.md) | JDBC and gRPC auth mechanisms, including SASL OAUTHBEARER / OIDC JWT. |
+| [KUBERNETES.md](./KUBERNETES.md) | Building Docker images, pushing to a registry, deploying via the Helm chart. |
+| [CLAUDE.md](./CLAUDE.md) | Contributor guidelines — CI gates, hammer-test regression suite, exception-handling policy. |
+
+## Agentic QA
+
+Cluster-level regressions are caught by two Claude Code agent
+definitions checked into the repository. Each one stands up a full
+stack (HerdDB + indexing service + Remote File Service + BookKeeper +
+ZooKeeper + object store) and runs a vector-search benchmark workload
+end-to-end, producing a markdown report — or, on failure, opening a
+GitHub issue with pod logs attached.
+
+| Agent | Target | Object store |
+|---|---|---|
+| [`.claude/agents/herddb-k3s-bench.md`](./.claude/agents/herddb-k3s-bench.md) | local k3s-in-docker | MinIO |
+| [`.claude/agents/herddb-gke-bench.md`](./.claude/agents/herddb-gke-bench.md) | existing GKE cluster | Google Cloud Storage |
+
+These are developer-facing regression harnesses, not a user feature.
+The underlying shell scripts they drive live under
+[`herddb-kubernetes/src/main/helm/herddb/examples/`](./herddb-kubernetes/src/main/helm/herddb/examples/)
+and can also be run by hand.
+
+## Getting involved
+
+Join the [mailing list](http://lists.herddb.org/mailman/listinfo).
 
 ## License
 
-HerdDB is under [Apache 2 license](http://www.apache.org/licenses/LICENSE-2.0.html).
+HerdDB + JVector is distributed under the
+[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/README.md
+++ b/README.md
@@ -378,10 +378,6 @@ The underlying shell scripts they drive live under
 [`herddb-kubernetes/src/main/helm/herddb/examples/`](./herddb-kubernetes/src/main/helm/herddb/examples/)
 and can also be run by hand.
 
-## Getting involved
-
-Join the [mailing list](http://lists.herddb.org/mailman/listinfo).
-
 ## License
 
 HerdDB + JVector is distributed under the

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ HerdDB + JVector is designed to run on **Kubernetes on public clouds**.
   S3** is expected to work with minor configuration changes; other
   S3-compatible stores (MinIO is used in local tests) have also been
   exercised.
-- **Docker images** are built from [`herddb-docker/`](./herddb-docker/)
-  (base image `eclipse-temurin:25-jdk`).
+- **Docker images** are built from [`herddb-docker/`](./herddb-docker/).
 - A **Helm chart** plus ready-to-use `values.yaml` for GKE and for a
   local k3s-in-docker stack ships under
   [`herddb-kubernetes/src/main/helm/herddb/`](./herddb-kubernetes/src/main/helm/herddb/).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ flowchart LR
 
   subgraph "HerdDB servers"
     Leader["Server<br/>(tablespace leader)"]
-    Replica["Server<br/>(follower replica)"]
+    Replica["Server<br/>(read-only replica,<br/>no WAL tailing)"]
   end
 
   subgraph "Indexing service"
@@ -82,12 +82,12 @@ flowchart LR
   end
 
   CLI -->|SQL + DML + vector search| Leader
+  CLI -. read-only SQL .-> Replica
   Leader -. vector search (LB) .-> ISvcP
   Leader -. vector search (LB) .-> ISvcS1
   Leader -. vector search (LB) .-> ISvcS2
 
   Leader -->|append| BK
-  Replica -->|tail| BK
   ISvcP -->|tail WAL| BK
 
   Leader --> RFS
@@ -98,7 +98,7 @@ flowchart LR
   RFS --> OBJ
 
   Leader -. elect / heartbeat .-> ZK
-  Replica -. discover .-> ZK
+  Replica -. watch checkpoint state .-> ZK
   Leader -. discover indexing instances .-> ZK
   ISvcP -. publish IndexStatus .-> ZK
   ISvcS1 -. watch .-> ZK
@@ -112,9 +112,10 @@ The rest of this section zooms in on individual layers.
 ### 1. Replicated commit log (BookKeeper)
 
 The tablespace leader appends every DML and DDL to a BookKeeper ledger.
-Followers — and the indexing service — tail the same ledger
-independently, so a single logical WAL feeds both the SQL replica tier
-and the vector indexing tier.
+In the vector-search deployment profile the **indexing service primary**
+tails this ledger to materialise vector indexes on its own schedule —
+the SQL read-only replicas described in §2 do **not** tail the WAL;
+they read committed data from shared storage instead.
 
 ```mermaid
 flowchart LR
@@ -124,14 +125,11 @@ flowchart LR
     B2[(Bookie 2)]
     B3[(Bookie 3)]
   end
-  Replica["HerdDB follower"]
-  ISvc["Indexing service<br/>(primary + shadows)"]
+  ISvc["Indexing service primary<br/>(tails WAL → vector index)"]
 
   Leader -->|fsynced add| B1
   Leader -->|fsynced add| B2
   Leader -->|fsynced add| B3
-  B1 -. tail .-> Replica
-  B2 -. tail .-> Replica
   B1 -. tail .-> ISvc
   B2 -. tail .-> ISvc
 ```
@@ -141,39 +139,58 @@ Ensemble, write-quorum and ack-quorum are tuned per deployment
 durability and low write latency without requiring shared block
 storage.
 
+In the classic HerdDB deployment profile (see §5) WAL-tailing
+follower replicas also subscribe to this ledger; that mode is not
+the recommended topology for vector-search workloads.
+
 Details: [CHECKPOINT.md §2](./CHECKPOINT.md) describes how checkpoints
 interact with the WAL and how commit-log truncation is coordinated.
 
-### 2. Tablespace leader / follower replication
+### 2. Read-only replicas on shared storage (vector-search profile)
 
-Data is grouped into **tablespaces**. Each tablespace has exactly one
-leader at any point in time and any number of follower replicas,
-elected via ZooKeeper.
+In the vector-search deployment profile, SQL read scalability is
+provided by **read-only replicas** that do *not* tail the commit log.
+The leader checkpoints committed pages to the Remote File Service;
+replicas read the same pages directly from shared storage and therefore
+stay stateless — they can be scaled out horizontally, added and
+removed freely, and they never need to replay a WAL.
 
 ```mermaid
 flowchart LR
-  ZK[("ZooKeeper<br/>leader election")]
+  ZK[("ZooKeeper<br/>leader election<br/>+ checkpoint state")]
   subgraph Tablespace["Tablespace 'default'"]
-    L["Leader"]
-    F1["Follower 1"]
-    F2["Follower 2"]
+    L["Leader<br/>(writes WAL,<br/>checkpoints pages)"]
+    R1["Read-only replica 1"]
+    R2["Read-only replica 2"]
   end
+  RFS["Remote File Service<br/>(shared pages)"]
+
+  L -->|write pages at checkpoint| RFS
+  R1 -. read pages .-> RFS
+  R2 -. read pages .-> RFS
+
   L <-->|heartbeat / lease| ZK
-  F1 <-->|watch| ZK
-  F2 <-->|watch| ZK
+  L -. publish durable LSN .-> ZK
+  R1 -. watch checkpoint state .-> ZK
+  R2 -. watch checkpoint state .-> ZK
 ```
+
+Because replicas source their data from the shared file server,
+they lag the leader by at most one checkpoint interval — the same
+bound that applies to indexing-service shadows (§4). Point-in-time
+read-your-writes consistency is **not** provided on these replicas.
 
 **Two distinct read-scaling tiers — don't conflate them:**
 
-- **Server follower replicas** exist primarily for **durability and
-  fast failover**. They can serve SQL reads, but the client is
-  responsible for picking which replica to hit; there is no built-in
-  automatic fan-out of SQL reads across followers.
-- **Indexing-service shadow replicas** (§4 below) are the tier that
-  **does** transparently scale **vector-search read throughput**:
-  the HerdDB server load-balances each search query across
-  `{primary, shadow1, shadow2, …}` for the target index on behalf
-  of the JDBC client.
+- **SQL read-only replicas** transparently scale *plain SQL* reads
+  across the cluster by sharing pages through the file-server tier.
+- **Indexing-service shadow replicas** (§4 below) transparently scale
+  *vector-search* read throughput. The HerdDB server load-balances
+  each search query across `{primary, shadow1, shadow2, …}` for the
+  target index on behalf of the JDBC client.
+
+For the classic WAL-tailing follower model used in non-vector
+deployments, see §5.
 
 ### 3. Shared object storage + file-server cache tier
 
@@ -283,6 +300,49 @@ configuration fails fast at boot.
 Details: [VECTOR.md](./VECTOR.md) (architecture, SQL, shard
 lifecycle), [VECTOR_SEARCH_METRICS.md](./VECTOR_SEARCH_METRICS.md)
 (observability).
+
+### 5. Classic HerdDB replication (WAL-tailing followers)
+
+The original HerdDB replication model is still supported, and is the
+right choice for non-vector workloads where an indexing service would
+just be dead weight. In this profile each tablespace has a leader and
+one or more **follower replicas** that tail the same BookKeeper ledger
+the leader writes to, applying every entry locally and keeping a
+fully-materialised copy of the tablespace on their own storage.
+
+```mermaid
+flowchart LR
+  ZK[("ZooKeeper<br/>leader election")]
+  Leader["Leader<br/>(writes WAL)"]
+  BK[("BookKeeper WAL")]
+  F1["Follower 1<br/>(tails WAL,<br/>applies locally)"]
+  F2["Follower 2<br/>(tails WAL,<br/>applies locally)"]
+
+  Leader -->|append| BK
+  BK -. tail .-> F1
+  BK -. tail .-> F2
+
+  Leader <-->|lease| ZK
+  F1 <-->|watch| ZK
+  F2 <-->|watch| ZK
+```
+
+Trade-offs vs §2:
+
+- No dependency on shared object storage or a file-server tier —
+  followers keep their own pages, so the deployment works with only
+  local disks plus BookKeeper + ZooKeeper.
+- Followers can be promoted to leader on failover; they hold the
+  full WAL position, not a checkpoint snapshot.
+- Does not scale *horizontally* the way §2 does: each added follower
+  replays the full WAL and pays its own storage cost.
+- There is no vector-indexing service in this profile; the `VECTOR`
+  SQL features are not available.
+
+This is the replication model documented extensively in the upstream
+HerdDB project and in [CHECKPOINT.md](./CHECKPOINT.md). It is *not*
+the recommended topology for vector-search workloads — use §2 + §4
+for those.
 
 ## Documentation index
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ components:
 | Apache BookKeeper | Distributed, replicated, low-latency commit log | `4.17.3` | https://bookkeeper.apache.org |
 | Apache ZooKeeper | Cluster metadata, tablespace leader election, instance discovery | `3.9.3` | https://zookeeper.apache.org |
 | Apache Calcite | SQL parser and cost-based query planner | `1.40.0` | https://calcite.apache.org |
-| AWS SDK for Java v2 | S3 / S3-compatible object storage client | `2.42.34` | https://aws.amazon.com/sdk-for-java/ |
 
 All of these are battle-tested in production at other projects; this
 repository glues them together rather than re-implementing them.


### PR DESCRIPTION
## Summary

- Turn the top-level `README.md` from a stub describing upstream HerdDB into an entry point for this fork: new title `HerdDB + JVector`, a short "Origins" note pointing back to [`diennea/herddb`](https://github.com/diennea/herddb), and a table of OSS building blocks (HerdDB, JVector, Apache BookKeeper / ZooKeeper / Calcite, AWS SDK v2) with pinned versions pulled from the poms.
- Add a top-level mermaid architecture diagram and four zoomed-in ones: BookKeeper WAL, tablespace leader/follower, shared object store + file-server cache tier, and indexing-service primary + shadow replicas. The read-scaling discussion explicitly separates SQL follower replicas (failover-first) from indexing-service shadows (horizontal vector-search reads) so the two don't get conflated.
- Add a documentation index linking every root-level `.md`, a short "Cloud-native deployment" note (GKE is the actively tested target; AWS S3 works via the same client; Docker images + Helm chart live in the repo), and a short "Agentic QA" section pointing at the in-repo k3s and GKE bench agents that exercise the full stack end-to-end.

Docs-only; no code changes.

## Test plan

- [ ] GitHub renders all five mermaid diagrams
- [ ] Every relative link in the doc index resolves (`VECTOR.md`, `VECTOR_SEARCH_METRICS.md`, `CHECKPOINT.md`, `BLINK.md`, `REMOTE_FILE_SERVER.md`, `AUTHENTICATION.md`, `KUBERNETES.md`, `CLAUDE.md`)
- [ ] Links to `.claude/agents/herddb-k3s-bench.md` and `.claude/agents/herddb-gke-bench.md` resolve
- [ ] External links point to project homepages only (no deep URLs that could rot)
- [ ] PR validation workflow is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)