### PR TITLE
issue #242: detach gRPC Context in RemoteFileServiceClient

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -39,6 +39,7 @@ import herddb.remote.proto.WriteFileRequest;
 import herddb.remote.proto.WriteFileResponse;
 import herddb.server.RemoteFileClient;
 import io.grpc.ClientInterceptor;
+import io.grpc.Context;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
@@ -62,6 +63,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -210,6 +212,27 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                 .withMaxOutboundMessageSize(CHANNEL_MAX_MESSAGE_SIZE);
     }
 
+    /**
+     * Runs {@code action} under {@link Context#ROOT} so any gRPC stub built and
+     * invoked inside it does not inherit a deadline from the caller's current
+     * {@link Context}. gRPC resolves the effective deadline as the minimum of
+     * the stub deadline set via {@code .withDeadlineAfter(...)} and the
+     * propagated context deadline — without detaching, an incoming 600 s search
+     * RPC on the Indexing Service would clamp every downstream readFileRange
+     * call to whatever remained on that context, causing
+     * {@code DEADLINE_EXCEEDED: context timed out} on large segment loads
+     * (issue #242). Detaching gives each client call the full
+     * {@code clientTimeoutSeconds} budget configured on the stub.
+     */
+    private static <T> T runDetached(Supplier<T> action) {
+        Context previous = Context.ROOT.attach();
+        try {
+            return action.get();
+        } finally {
+            Context.ROOT.detach(previous);
+        }
+    }
+
     @Override
     public synchronized void updateServers(List<String> newServers) {
         if (newServers.isEmpty()) {
@@ -344,38 +367,40 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     private CompletableFuture<Long> writeFileAsync(String path, ByteString content) {
         // Writes are not idempotent — no retry
-        CompletableFuture<Long> future = new CompletableFuture<>();
-        RemoteFileServiceGrpc.RemoteFileServiceStub stub;
-        try {
-            stub = writeStubForPath(path);
-        } catch (Exception e) {
-            future.completeExceptionally(e);
+        return runDetached(() -> {
+            CompletableFuture<Long> future = new CompletableFuture<>();
+            RemoteFileServiceGrpc.RemoteFileServiceStub stub;
+            try {
+                stub = writeStubForPath(path);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+                return future;
+            }
+            stub.writeFile(
+                    WriteFileRequest.newBuilder()
+                            .setPath(path)
+                            .setContent(content)
+                            .build(),
+                    new StreamObserver<WriteFileResponse>() {
+                        private long writtenSize;
+
+                        @Override
+                        public void onNext(WriteFileResponse response) {
+                            writtenSize = response.getWrittenSize();
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            future.completeExceptionally(t);
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            future.complete(writtenSize);
+                        }
+                    });
             return future;
-        }
-        stub.writeFile(
-                WriteFileRequest.newBuilder()
-                        .setPath(path)
-                        .setContent(content)
-                        .build(),
-                new StreamObserver<WriteFileResponse>() {
-                    private long writtenSize;
-
-                    @Override
-                    public void onNext(WriteFileResponse response) {
-                        writtenSize = response.getWrittenSize();
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        future.completeExceptionally(t);
-                    }
-
-                    @Override
-                    public void onCompleted() {
-                        future.complete(writtenSize);
-                    }
-                });
-        return future;
+        });
     }
 
     public CompletableFuture<byte[]> readFileAsync(String path) {
@@ -383,30 +408,32 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     private CompletableFuture<byte[]> doReadFileAsync(String path) {
-        CompletableFuture<byte[]> future = new CompletableFuture<>();
-        readStubForPath(path).readFile(
-                ReadFileRequest.newBuilder().setPath(path).build(),
-                new StreamObserver<ReadFileResponse>() {
-                    private byte[] result;
+        return runDetached(() -> {
+            CompletableFuture<byte[]> future = new CompletableFuture<>();
+            readStubForPath(path).readFile(
+                    ReadFileRequest.newBuilder().setPath(path).build(),
+                    new StreamObserver<ReadFileResponse>() {
+                        private byte[] result;
 
-                    @Override
-                    public void onNext(ReadFileResponse response) {
-                        if (response.getFound()) {
-                            result = response.getContent().toByteArray();
+                        @Override
+                        public void onNext(ReadFileResponse response) {
+                            if (response.getFound()) {
+                                result = response.getContent().toByteArray();
+                            }
                         }
-                    }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        future.completeExceptionally(t);
-                    }
+                        @Override
+                        public void onError(Throwable t) {
+                            future.completeExceptionally(t);
+                        }
 
-                    @Override
-                    public void onCompleted() {
-                        future.complete(result);
-                    }
-                });
-        return future;
+                        @Override
+                        public void onCompleted() {
+                            future.complete(result);
+                        }
+                    });
+            return future;
+        });
     }
 
     /**
@@ -418,41 +445,43 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     private CompletableFuture<ByteBuf> doReadFileAsByteBufAsync(String path) {
-        CompletableFuture<ByteBuf> future = new CompletableFuture<>();
-        readStubForPath(path).readFile(
-                ReadFileRequest.newBuilder().setPath(path).build(),
-                new StreamObserver<ReadFileResponse>() {
-                    private ByteBuf result;
+        return runDetached(() -> {
+            CompletableFuture<ByteBuf> future = new CompletableFuture<>();
+            readStubForPath(path).readFile(
+                    ReadFileRequest.newBuilder().setPath(path).build(),
+                    new StreamObserver<ReadFileResponse>() {
+                        private ByteBuf result;
 
-                    @Override
-                    public void onNext(ReadFileResponse response) {
-                        if (response.getFound()) {
-                            ByteString content = response.getContent();
-                            int size = content.size();
-                            ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(size);
-                            // Single copy from the protobuf LiteralByteString into the
-                            // pooled direct buffer; matches doReadFileRangeAsByteBufAsync.
-                            content.copyTo(buf.nioBuffer(0, size));
-                            buf.writerIndex(size);
-                            result = buf;
+                        @Override
+                        public void onNext(ReadFileResponse response) {
+                            if (response.getFound()) {
+                                ByteString content = response.getContent();
+                                int size = content.size();
+                                ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(size);
+                                // Single copy from the protobuf LiteralByteString into the
+                                // pooled direct buffer; matches doReadFileRangeAsByteBufAsync.
+                                content.copyTo(buf.nioBuffer(0, size));
+                                buf.writerIndex(size);
+                                result = buf;
+                            }
                         }
-                    }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        if (result != null) {
-                            result.release();
-                            result = null;
+                        @Override
+                        public void onError(Throwable t) {
+                            if (result != null) {
+                                result.release();
+                                result = null;
+                            }
+                            future.completeExceptionally(t);
                         }
-                        future.completeExceptionally(t);
-                    }
 
-                    @Override
-                    public void onCompleted() {
-                        future.complete(result);
-                    }
-                });
-        return future;
+                        @Override
+                        public void onCompleted() {
+                            future.complete(result);
+                        }
+                    });
+            return future;
+        });
     }
 
     public CompletableFuture<Boolean> deleteFileAsync(String path) {
@@ -460,28 +489,30 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     private CompletableFuture<Boolean> doDeleteFileAsync(String path) {
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        writeStubForPath(path).deleteFile(
-                DeleteFileRequest.newBuilder().setPath(path).build(),
-                new StreamObserver<DeleteFileResponse>() {
-                    private boolean deleted;
+        return runDetached(() -> {
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            writeStubForPath(path).deleteFile(
+                    DeleteFileRequest.newBuilder().setPath(path).build(),
+                    new StreamObserver<DeleteFileResponse>() {
+                        private boolean deleted;
 
-                    @Override
-                    public void onNext(DeleteFileResponse response) {
-                        deleted = response.getDeleted();
-                    }
+                        @Override
+                        public void onNext(DeleteFileResponse response) {
+                            deleted = response.getDeleted();
+                        }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        future.completeExceptionally(t);
-                    }
+                        @Override
+                        public void onError(Throwable t) {
+                            future.completeExceptionally(t);
+                        }
 
-                    @Override
-                    public void onCompleted() {
-                        future.complete(deleted);
-                    }
-                });
-        return future;
+                        @Override
+                        public void onCompleted() {
+                            future.complete(deleted);
+                        }
+                    });
+            return future;
+        });
     }
 
     public CompletableFuture<List<String>> listFilesAsync(String prefix) {
@@ -489,42 +520,44 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     private CompletableFuture<List<String>> doListFilesAsync(String prefix) {
-        ServerSnapshot s = this.snapshot;
-        List<CompletableFuture<List<String>>> futures = new ArrayList<>();
-        for (String server : s.readChannels.keySet()) {
-            RemoteFileServiceGrpc.RemoteFileServiceStub stub = readStubForServer(server);
-            CompletableFuture<List<String>> serverFuture = new CompletableFuture<>();
-            List<String> paths = Collections.synchronizedList(new ArrayList<>());
-            stub.listFiles(
-                    ListFilesRequest.newBuilder().setPrefix(prefix).build(),
-                    new StreamObserver<ListFilesEntry>() {
-                        @Override
-                        public void onNext(ListFilesEntry entry) {
-                            paths.add(entry.getPath());
-                        }
+        return runDetached(() -> {
+            ServerSnapshot s = this.snapshot;
+            List<CompletableFuture<List<String>>> futures = new ArrayList<>();
+            for (String server : s.readChannels.keySet()) {
+                RemoteFileServiceGrpc.RemoteFileServiceStub stub = readStubForServer(server);
+                CompletableFuture<List<String>> serverFuture = new CompletableFuture<>();
+                List<String> paths = Collections.synchronizedList(new ArrayList<>());
+                stub.listFiles(
+                        ListFilesRequest.newBuilder().setPrefix(prefix).build(),
+                        new StreamObserver<ListFilesEntry>() {
+                            @Override
+                            public void onNext(ListFilesEntry entry) {
+                                paths.add(entry.getPath());
+                            }
 
-                        @Override
-                        public void onError(Throwable t) {
-                            serverFuture.completeExceptionally(t);
-                        }
+                            @Override
+                            public void onError(Throwable t) {
+                                serverFuture.completeExceptionally(t);
+                            }
 
-                        @Override
-                        public void onCompleted() {
-                            serverFuture.complete(paths);
+                            @Override
+                            public void onCompleted() {
+                                serverFuture.complete(paths);
+                            }
+                        });
+                futures.add(serverFuture);
+            }
+            return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenApply(v -> {
+                        // Deduplicate: multiple servers may return the same logical path
+                        // for different blocks of the same multipart file
+                        LinkedHashSet<String> seen = new LinkedHashSet<>();
+                        for (CompletableFuture<List<String>> f : futures) {
+                            seen.addAll(f.join());
                         }
+                        return new ArrayList<>(seen);
                     });
-            futures.add(serverFuture);
-        }
-        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                .thenApply(v -> {
-                    // Deduplicate: multiple servers may return the same logical path
-                    // for different blocks of the same multipart file
-                    LinkedHashSet<String> seen = new LinkedHashSet<>();
-                    for (CompletableFuture<List<String>> f : futures) {
-                        seen.addAll(f.join());
-                    }
-                    return new ArrayList<>(seen);
-                });
+        });
     }
 
     /**
@@ -532,29 +565,31 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
      * Routes via consistent hash of {@code path#block{blockIndex}}.
      */
     public CompletableFuture<Void> writeFileBlockAsync(String path, long blockIndex, byte[] content) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        writeStubForBlock(path, blockIndex).writeFileBlock(
-                WriteFileBlockRequest.newBuilder()
-                        .setPath(path)
-                        .setBlockIndex(blockIndex)
-                        .setContent(UnsafeByteOperations.unsafeWrap(content))
-                        .build(),
-                new StreamObserver<WriteFileBlockResponse>() {
-                    @Override
-                    public void onNext(WriteFileBlockResponse response) {
-                    }
+        return runDetached(() -> {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            writeStubForBlock(path, blockIndex).writeFileBlock(
+                    WriteFileBlockRequest.newBuilder()
+                            .setPath(path)
+                            .setBlockIndex(blockIndex)
+                            .setContent(UnsafeByteOperations.unsafeWrap(content))
+                            .build(),
+                    new StreamObserver<WriteFileBlockResponse>() {
+                        @Override
+                        public void onNext(WriteFileBlockResponse response) {
+                        }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        future.completeExceptionally(t);
-                    }
+                        @Override
+                        public void onError(Throwable t) {
+                            future.completeExceptionally(t);
+                        }
 
-                    @Override
-                    public void onCompleted() {
-                        future.complete(null);
-                    }
-                });
-        return future;
+                        @Override
+                        public void onCompleted() {
+                            future.complete(null);
+                        }
+                    });
+            return future;
+        });
     }
 
     /**
@@ -567,29 +602,31 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                 ? UnsafeByteOperations.unsafeWrap(content.array(),
                         content.arrayOffset() + content.readerIndex(), content.readableBytes())
                 : UnsafeByteOperations.unsafeWrap(content.nioBuffer());
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        writeStubForBlock(path, blockIndex).writeFileBlock(
-                WriteFileBlockRequest.newBuilder()
-                        .setPath(path)
-                        .setBlockIndex(blockIndex)
-                        .setContent(bs)
-                        .build(),
-                new StreamObserver<WriteFileBlockResponse>() {
-                    @Override
-                    public void onNext(WriteFileBlockResponse response) {
-                    }
+        return runDetached(() -> {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            writeStubForBlock(path, blockIndex).writeFileBlock(
+                    WriteFileBlockRequest.newBuilder()
+                            .setPath(path)
+                            .setBlockIndex(blockIndex)
+                            .setContent(bs)
+                            .build(),
+                    new StreamObserver<WriteFileBlockResponse>() {
+                        @Override
+                        public void onNext(WriteFileBlockResponse response) {
+                        }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        future.completeExceptionally(t);
-                    }
+                        @Override
+                        public void onError(Throwable t) {
+                            future.completeExceptionally(t);
+                        }
 
-                    @Override
-                    public void onCompleted() {
-                        future.complete(null);
-                    }
-                });
-        return future;
+                        @Override
+                        public void onCompleted() {
+                            future.complete(null);
+                        }
+                    });
+            return future;
+        });
     }
 
     /**
@@ -628,7 +665,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     private CompletableFuture<byte[]> doReadFileRangeAsync(String path, long offset, int length, int blockSize) {
-        return retryAsync(() -> {
+        return retryAsync(() -> runDetached(() -> {
             long blockIndex = offset / blockSize;
             CompletableFuture<byte[]> future = new CompletableFuture<>();
             readStubForBlock(path, blockIndex).readFileRange(
@@ -670,7 +707,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                         }
                     });
             return future;
-        }, "readFileRange", path, 0);
+        }), "readFileRange", path, 0);
     }
 
     /**
@@ -727,7 +764,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     private CompletableFuture<ByteBuf> doReadFileRangeAsByteBufAsync(String path, long offset,
                                                                     int length, int blockSize) {
-        return retryAsync(() -> {
+        return retryAsync(() -> runDetached(() -> {
             long blockIndex = offset / blockSize;
             CompletableFuture<ByteBuf> future = new CompletableFuture<>();
             readStubForBlock(path, blockIndex).readFileRange(
@@ -791,7 +828,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                         }
                     });
             return future;
-        }, "readFileRange", path, 0);
+        }), "readFileRange", path, 0);
     }
 
     /**
@@ -837,41 +874,43 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     private CompletableFuture<Integer> doDeleteByPrefixAsync(String prefix) {
-        ServerSnapshot s = this.snapshot;
-        List<CompletableFuture<Integer>> futures = new ArrayList<>();
-        for (String server : s.writeChannels.keySet()) {
-            RemoteFileServiceGrpc.RemoteFileServiceStub stub = writeStubForServer(server);
-            CompletableFuture<Integer> serverFuture = new CompletableFuture<>();
-            stub.deleteByPrefix(
-                    DeleteByPrefixRequest.newBuilder().setPrefix(prefix).build(),
-                    new StreamObserver<DeleteByPrefixResponse>() {
-                        private int count;
+        return runDetached(() -> {
+            ServerSnapshot s = this.snapshot;
+            List<CompletableFuture<Integer>> futures = new ArrayList<>();
+            for (String server : s.writeChannels.keySet()) {
+                RemoteFileServiceGrpc.RemoteFileServiceStub stub = writeStubForServer(server);
+                CompletableFuture<Integer> serverFuture = new CompletableFuture<>();
+                stub.deleteByPrefix(
+                        DeleteByPrefixRequest.newBuilder().setPrefix(prefix).build(),
+                        new StreamObserver<DeleteByPrefixResponse>() {
+                            private int count;
 
-                        @Override
-                        public void onNext(DeleteByPrefixResponse response) {
-                            count = response.getDeletedCount();
-                        }
+                            @Override
+                            public void onNext(DeleteByPrefixResponse response) {
+                                count = response.getDeletedCount();
+                            }
 
-                        @Override
-                        public void onError(Throwable t) {
-                            serverFuture.completeExceptionally(t);
-                        }
+                            @Override
+                            public void onError(Throwable t) {
+                                serverFuture.completeExceptionally(t);
+                            }
 
-                        @Override
-                        public void onCompleted() {
-                            serverFuture.complete(count);
+                            @Override
+                            public void onCompleted() {
+                                serverFuture.complete(count);
+                            }
+                        });
+                futures.add(serverFuture);
+            }
+            return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenApply(v -> {
+                        int total = 0;
+                        for (CompletableFuture<Integer> f : futures) {
+                            total += f.join();
                         }
+                        return total;
                     });
-            futures.add(serverFuture);
-        }
-        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                .thenApply(v -> {
-                    int total = 0;
-                    for (CompletableFuture<Integer> f : futures) {
-                        total += f.join();
-                    }
-                    return total;
-                });
+        });
     }
 
     // --- Synchronous APIs (wrappers around async) ---

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientContextIsolationTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientContextIsolationTest.java
@@ -1,0 +1,147 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import io.grpc.Context;
+import io.grpc.StatusRuntimeException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression for issue #242: the outgoing RPCs of {@link RemoteFileServiceClient}
+ * must not inherit the caller's gRPC {@link Context} deadline.
+ *
+ * <p>Previously, an incoming {@code search} RPC on the Indexing Service installed
+ * a thread-local {@code Context} whose deadline (typically 600 s) propagated into
+ * every downstream {@code readFileRange} call issued on the same thread. gRPC
+ * resolves the effective deadline as the minimum of the stub deadline set via
+ * {@code .withDeadlineAfter(...)} and the propagated context deadline, so a
+ * 1800 s per-call budget was silently clamped to whatever remained on the
+ * search's context — causing {@code DEADLINE_EXCEEDED: context timed out}
+ * failures on large (≥300 MB) segment loads.
+ *
+ * <p>The fix wraps each stub invocation in {@code Context.ROOT.call(...)} so the
+ * effective deadline is strictly the client's own configuration. This test
+ * installs an already-expired context on the caller and asserts that the call
+ * still succeeds. Retries are disabled ({@code maxRetries = 0}) so the bug
+ * surfaces on the first attempt and is not masked by a retry scheduled on a
+ * fresh thread without the caller's context.
+ */
+public class RemoteFileServiceClientContextIsolationTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+    private ScheduledExecutorService contextDeadlineScheduler;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new RemoteFileServer(0, folder.newFolder("data").toPath());
+        server.start();
+        Map<String, Object> config = new HashMap<>();
+        // Disable retries so a first-attempt DEADLINE_EXCEEDED is not masked by
+        // a retry scheduled on a fresh thread (where the caller's Context
+        // thread-local is no longer installed).
+        config.put(RemoteFileServiceClient.CONFIG_CLIENT_RETRIES, 0);
+        client = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), config);
+        contextDeadlineScheduler = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.stop();
+        }
+        if (contextDeadlineScheduler != null) {
+            contextDeadlineScheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    public void readFileDoesNotInheritCallerContextDeadline() throws Exception {
+        byte[] content = "context isolation readFile".getBytes(StandardCharsets.UTF_8);
+        client.writeFile("ts1/ctx/readfile.page", content);
+
+        Context.CancellableContext expired = Context.current()
+                .withDeadlineAfter(1, TimeUnit.MILLISECONDS, contextDeadlineScheduler);
+        // Wait well past the deadline so gRPC cannot possibly still treat the
+        // context as live when the call is initiated.
+        Thread.sleep(50);
+
+        Context previous = expired.attach();
+        try {
+            byte[] read = client.readFile("ts1/ctx/readfile.page");
+            assertNotNull("readFile should not inherit caller context deadline", read);
+            assertArrayEquals(content, read);
+        } finally {
+            expired.detach(previous);
+            expired.cancel(null);
+        }
+    }
+
+    @Test
+    public void readFileRangeDoesNotInheritCallerContextDeadline() throws Exception {
+        // readFileRange is the path that actually fails in production (issue #242).
+        // Use a multipart file so the block-routed readFileRange code path is
+        // exercised end-to-end.
+        byte[] content = "context isolation readFileRange payload".getBytes(StandardCharsets.UTF_8);
+        int blockSize = 4 * 1024 * 1024;
+        client.writeFileBlock("ts1/ctx/range.page", 0, content);
+
+        Context.CancellableContext expired = Context.current()
+                .withDeadlineAfter(1, TimeUnit.MILLISECONDS, contextDeadlineScheduler);
+        Thread.sleep(50);
+
+        Context previous = expired.attach();
+        try {
+            byte[] read = client.readFileRange("ts1/ctx/range.page", 0, content.length, blockSize);
+            assertNotNull("readFileRange should not inherit caller context deadline", read);
+            assertArrayEquals(content, read);
+        } catch (StatusRuntimeException e) {
+            // Without the fix, this fails with DEADLINE_EXCEEDED because the
+            // stub's .withDeadlineAfter(...) is clamped to the (expired)
+            // context deadline. Fail with a clear message for future readers.
+            fail("readFileRange inherited caller context deadline (issue #242): " + e);
+        } finally {
+            expired.detach(previous);
+            expired.cancel(null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Detach to `Context.ROOT` around every outgoing RPC in `RemoteFileServiceClient`, so the stub's `.withDeadlineAfter(clientTimeoutSeconds, ...)` is the only deadline in force — no inheritance from the caller's gRPC Context (e.g. the incoming IS `search` RPC with `indexing.service.timeout = 600 s`).
- Add `RemoteFileServiceClientContextIsolationTest`: installs an already-expired caller Context and asserts `readFile` / `readFileRange` still succeed. Without the fix this test fails with `DEADLINE_EXCEEDED: context timed out` — the exact signature reported on the gist1m benchmark.

## Root cause (issue #242)

`IndexingServiceImpl.search()` runs the whole vector search on the gRPC serving thread. Inside it, `RemoteRandomAccessReader.fetchBlockFromRemote()` calls `RemoteFileServiceClient.readFileRangeAsByteBuf(...)` on that same thread. gRPC resolves the effective deadline as the **minimum** of the stub deadline set via `.withDeadlineAfter(1800s, ...)` and the propagated Context deadline — so a 600 s search Context silently clamped the 1800 s client budget, and a 389 MB segment load drained the remaining budget and failed with `DEADLINE_EXCEEDED`. The `io.grpc.Context$CancellableContext$1CancelOnExpiration` frame in the stack trace is only emitted by inherited-context expiry, not by `.withDeadlineAfter()`.

The cascade: IS Phase C held the checkpoint lock while retrying segment loads (500+ s stall, all queries blocked), and per-query stalls of 160+ s whenever any segment was evicted from `SegmentBlockCache` and had to be reloaded mid-query.

## Scope

Implements **only** suggestion #2 from the issue. Other suggestions (cache sizing, heap ByteBufs, pre-fetching, Phase C rework) remain valid follow-ups but are not required once deadline inheritance is broken — the client already has its own per-call 1800 s deadline.

## Test plan

- [x] `mvn -pl herddb-remote-file-service test` — 248 tests green (includes new `RemoteFileServiceClientContextIsolationTest` and the existing `testDeadlineIsPerCall`).
- [x] `mvn -pl herddb-indexing-service test` — 260 tests green.
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — full reactor green.
- [x] `DirectMultipleConcurrentUpdatesSuite*` hammer tests — 12/12 green, two passes.
- [ ] End-to-end re-run of the `gist1m` benchmark to confirm no `DEADLINE_EXCEEDED: context timed out` during the query phase and p99 back under 10 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)