### PR TITLE
issue #241: fix InMemoryBlockCacheObjectStorage eviction/retain race

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Decorator that holds a bounded in-heap cache of whole multipart blocks in front of an inner
@@ -53,8 +54,18 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
 
     private final ObjectStorage inner;
     private final Cache<BlockKey, ByteBuf> cache;
-    private final ConcurrentHashMap<BlockKey, CompletableFuture<ByteBuf>> inFlight = new ConcurrentHashMap<>();
+    // Primary-per-key dedup. Only the marker Void — the actual ByteBuf flows
+    // through the cache, never through this map, so followers cannot slice a
+    // ByteBuf whose refcount has already been dropped by the primary's finally.
+    private final ConcurrentHashMap<BlockKey, CompletableFuture<Void>> inFlight = new ConcurrentHashMap<>();
     private final long maxBytes;
+    // Hit/miss counters maintained manually because the fast path uses
+    // asMap().computeIfPresent — Caffeine documents that "no stats are
+    // modified by non-computing operations invoked on the asMap view", so
+    // recordStats() alone would leave hitCount/missCount at zero. Eviction
+    // counters still come from Caffeine (the removal listener path is unchanged).
+    private final AtomicLong hits = new AtomicLong();
+    private final AtomicLong misses = new AtomicLong();
 
     public InMemoryBlockCacheObjectStorage(ObjectStorage inner, long maxBytes) {
         this.inner = Objects.requireNonNull(inner, "inner");
@@ -73,6 +84,14 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
                         value.release();
                     }
                 })
+                // Force maintenance (and therefore the removal listener) to run on
+                // the calling thread instead of Caffeine's default ForkJoinPool.
+                // Async maintenance can leave evicted pooled ByteBufs with refCnt > 0
+                // long after the eviction was requested; with a direct executor every
+                // eviction / invalidate call fully releases the buffer before it
+                // returns. This matches the refcount discipline the cache consumers
+                // rely on and keeps {@code close()} deterministic.
+                .executor(Runnable::run)
                 .recordStats()
                 .build();
     }
@@ -81,9 +100,25 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
         return maxBytes;
     }
 
-    /** Current Caffeine stats snapshot. Safe to call from gauge samplers. */
+    /**
+     * Current cache stats snapshot. Safe to call from gauge samplers.
+     * <p>
+     * {@code hitCount}/{@code missCount} come from the manual counters updated
+     * on every {@code readRange}; {@code evictionCount}/{@code evictionWeight}
+     * come from Caffeine's own recordStats tracking. Load counters are always
+     * zero because this cache populates via {@code cache.put(...)} from an
+     * async loader, not via Caffeine's computing methods.
+     */
     public CacheStats stats() {
-        return cache.stats();
+        CacheStats caffeine = cache.stats();
+        return CacheStats.of(
+                hits.get(),
+                misses.get(),
+                0L,
+                0L,
+                0L,
+                caffeine.evictionCount(),
+                caffeine.evictionWeight());
     }
 
     /** Approximate number of cached blocks. */
@@ -129,57 +164,124 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
         int offsetInBlock = (int) (offset % blockSize);
         BlockKey key = new BlockKey(path, blockIndex);
 
-        ByteBuf cached = cache.getIfPresent(key);
-        if (cached != null) {
-            return CompletableFuture.completedFuture(slice(cached, offsetInBlock, length));
-        }
-
-        CompletableFuture<ByteBuf> pending = new CompletableFuture<>();
-        // Register the slice dependent BEFORE issuing the inner read, so that if
-        // inner.readRange completes synchronously the wrapping happens inside
-        // pending.complete — see CachingObjectStorage.loadAndCache for the same race.
-        CompletableFuture<ReadResult> resultFuture = pending.thenApply(buf -> slice(buf, offsetInBlock, length));
-
-        CompletableFuture<ByteBuf> existing = inFlight.putIfAbsent(key, pending);
-        if (existing != null) {
-            return existing.thenApply(buf -> slice(buf, offsetInBlock, length));
-        }
-
-        long blockStartOffset = blockIndex * (long) blockSize;
-        inner.readRange(path, blockStartOffset, blockSize, blockSize).whenComplete((result, err) -> {
-            if (err != null) {
-                try {
-                    pending.completeExceptionally(err);
-                } finally {
-                    inFlight.remove(key, pending);
-                }
-                return;
-            }
-            if (result.status() != ReadResult.Status.FOUND) {
-                try {
-                    pending.complete(null);
-                } finally {
-                    inFlight.remove(key, pending);
-                }
-                return;
-            }
-            ByteBuf buf = result.byteBuf();
-            // +1 for the cache's ownership; +1 to keep buf alive across pending.complete
-            // so all dependents (the original caller + any in-flight followers) can
-            // retainedSlice while the buf is still referenced. The original `result`'s
-            // refcount is dropped right after.
-            buf.retain(2);
-            cache.put(key, buf);
+        // Fast path: (get + retain) must be atomic under Caffeine's per-entry
+        // lock, otherwise the removal listener can race with the retainedSlice
+        // below — a concurrent eviction drops the shared entry's refCnt to 0
+        // and the next retain throws IllegalReferenceCountException, killing
+        // the worker thread (see issue #241). Mirrors SegmentBlockCache.
+        ByteBuf retained = cache.asMap().computeIfPresent(key, (k, v) -> {
+            v.retain();
+            return v;
+        });
+        if (retained != null) {
+            hits.incrementAndGet();
             try {
-                pending.complete(buf);
+                return CompletableFuture.completedFuture(slice(retained, offsetInBlock, length));
             } finally {
-                inFlight.remove(key, pending);
-                buf.release();   // alive-for-followers retain
-                result.release(); // original ReadResult's refcount
+                // Drop the hit-retain; the returned ReadResult's slice carries its own.
+                retained.release();
+            }
+        }
+        misses.incrementAndGet();
+
+        // Miss path: dedup via in-flight map so only one inner.readRange per
+        // key is in flight. Followers wait for the primary to signal "cache
+        // is populated" and then take a fresh atomic retain via
+        // {@code asMap().computeIfPresent} — they do NOT slice the primary's
+        // ByteBuf directly, because that ByteBuf can be released between
+        // pending.complete() and the follower's callback running (issue #241).
+        // The signal value is a Void marker — not the ByteBuf — so the
+        // follower's refcount discipline goes through the cache, which is
+        // the only safe source of a retainable reference.
+        CompletableFuture<Void> pending = new CompletableFuture<>();
+        CompletableFuture<Void> existing = inFlight.putIfAbsent(key, pending);
+        if (existing != null) {
+            return existing.thenCompose(ignored ->
+                    sliceFromCacheOrReload(path, offset, length, blockSize, key, offsetInBlock));
+        }
+
+        return loadAndPublish(path, offset, length, blockSize, key, offsetInBlock,
+                blockIndex, pending);
+    }
+
+    /**
+     * Follower fast-path after the primary signalled. Takes an atomic retain
+     * from the cache; if the entry was evicted in between (rare), reloads
+     * directly via the inner storage rather than re-entering the dedup path —
+     * recursing through {@link #readRange} risks an unbounded synchronous
+     * chain when the signalling thenCompose fires on an already-complete
+     * future.
+     */
+    private CompletableFuture<ReadResult> sliceFromCacheOrReload(
+            String path, long offset, int length, int blockSize,
+            BlockKey key, int offsetInBlock) {
+        ByteBuf retained = cache.asMap().computeIfPresent(key, (k, v) -> {
+            v.retain();
+            return v;
+        });
+        if (retained != null) {
+            hits.incrementAndGet();
+            try {
+                return CompletableFuture.completedFuture(slice(retained, offsetInBlock, length));
+            } finally {
+                retained.release();
+            }
+        }
+        // Rare: entry evicted between the primary's cache.put and here.
+        // Duplicate the inner read (bypassing the in-flight map) rather than
+        // recursing; correctness beats strict dedup in this corner case.
+        misses.incrementAndGet();
+        return loadAndPublish(path, offset, length, blockSize, key, offsetInBlock,
+                offset / blockSize, /* pending = */ null);
+    }
+
+    /**
+     * Issues a fresh {@code inner.readRange}, publishes the result into the
+     * cache, signals the optional {@code pending} future, and returns the
+     * caller's sliced ReadResult.
+     */
+    private CompletableFuture<ReadResult> loadAndPublish(String path, long offset, int length,
+            int blockSize, BlockKey key, int offsetInBlock, long blockIndex,
+            CompletableFuture<Void> pending) {
+        long blockStartOffset = blockIndex * (long) blockSize;
+        CompletableFuture<ReadResult> out = new CompletableFuture<>();
+        inner.readRange(path, blockStartOffset, blockSize, blockSize).whenComplete((result, err) -> {
+            try {
+                if (err != null) {
+                    out.completeExceptionally(err);
+                    return;
+                }
+                if (result.status() != ReadResult.Status.FOUND) {
+                    out.complete(ReadResult.notFound());
+                    return;
+                }
+                ByteBuf buf = result.byteBuf();
+                // +1 for the cache's ownership (released by the removal
+                // listener on eviction). slice(buf, ...) then takes its own
+                // retainedSlice. After result.release() drops the inner
+                // ReadResult's original ref, the final state is
+                // refCnt = (cache) + (caller's slice) = 2.
+                buf.retain();
+                cache.put(key, buf);
+                try {
+                    out.complete(slice(buf, offsetInBlock, length));
+                } finally {
+                    result.release();
+                }
+            } catch (RuntimeException e) {
+                out.completeExceptionally(e);
+            } finally {
+                if (pending != null) {
+                    // Remove the in-flight placeholder BEFORE signalling
+                    // followers so a follower's thenCompose, which fires
+                    // synchronously on this thread, cannot re-read a stale
+                    // in-flight entry pointing at an already-complete pending.
+                    inFlight.remove(key, pending);
+                    pending.complete(null);
+                }
             }
         });
-
-        return resultFuture;
+        return out;
     }
 
     @Override
@@ -221,6 +323,12 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
     @Override
     public void close() throws Exception {
         cache.invalidateAll();
+        // Force pending maintenance so the removal listener fires on every
+        // still-cached entry before we return — otherwise Caffeine may
+        // process removals asynchronously, leaving pooled ByteBufs with
+        // refCnt > 0 after close(). Mirrors SegmentBlockCache's close-path
+        // idiom.
+        cache.cleanUp();
         inner.close();
     }
 

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/InMemoryBlockCacheObjectStorageHammerTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/InMemoryBlockCacheObjectStorageHammerTest.java
@@ -1,0 +1,474 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetector.Level;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Multi-threaded hammer test for {@link InMemoryBlockCacheObjectStorage} that
+ * exercises the retained-slice + shared-entry refcount discipline under
+ * concurrent readRange / invalidate / eviction pressure.
+ *
+ * <p>Reproduces the race reported in issue
+ * <a href="https://github.com/eolivelli/herddb/issues/241">#241</a>:
+ * {@code cache.getIfPresent(key)} on the readRange fast path returned a pooled
+ * {@link ByteBuf} whose refcount Caffeine's removal listener could drop to 0
+ * before the caller's {@code retainedSlice(...)} ran, producing
+ * {@link io.netty.util.IllegalReferenceCountException} on the file server and
+ * killing worker threads.
+ *
+ * <p>Invariants verified:
+ * <ul>
+ *   <li>Every {@link ReadResult} handed to a reader is fully readable
+ *       (refcount &gt; 0) until the reader releases it.</li>
+ *   <li>Releasing a result never throws or fails (no double release, no
+ *       retain-after-release).</li>
+ *   <li>No leaked inner-allocated {@link ByteBuf} — Netty's
+ *       {@link ResourceLeakDetector} set to PARANOID flags any lost
+ *       reference, and the test tracks every allocation and asserts
+ *       {@code refCnt() == 0} after close.</li>
+ *   <li>Size-based eviction actually fires during the run — without that the
+ *       test would not have exercised the race window.</li>
+ * </ul>
+ *
+ * <p>The fake {@link ObjectStorage} deliberately allocates <em>pooled direct</em>
+ * buffers (as {@link InMemoryBlockCacheObjectStorageTest.CountingFake} does and
+ * as the real production path does via the S3 /
+ * {@code LocalObjectStorage} readers), because mis-handling ref-counts on
+ * pooled buffers is what actually blows up in production.
+ */
+public class InMemoryBlockCacheObjectStorageHammerTest {
+
+    private static final int BLOCK_SIZE = 1024;
+    private static final int DISTINCT_BLOCKS = 64;
+    private static final int PATHS = 4;
+    private static final int THREADS = 16;
+    private static final int ITERATIONS_PER_THREAD = 4_000;
+
+    private Level previousLeakLevel;
+
+    @Before
+    public void enableParanoidLeakDetection() {
+        this.previousLeakLevel = ResourceLeakDetector.getLevel();
+        ResourceLeakDetector.setLevel(Level.PARANOID);
+    }
+
+    @After
+    public void restoreLeakDetection() {
+        if (previousLeakLevel != null) {
+            ResourceLeakDetector.setLevel(previousLeakLevel);
+        }
+    }
+
+    /**
+     * Heavy eviction pressure + heavy concurrent reads on a key space much
+     * larger than the cache budget. Directly targets the fast-path race in
+     * {@code readRange}: {@code cache.getIfPresent()} followed by
+     * {@code retainedSlice()} while the removal listener concurrently releases
+     * the shared entry.
+     */
+    @Test(timeout = 120_000)
+    public void evictionHammerStaysLeakFreeAndBalanced() throws Exception {
+        // 4 KB cache, 64 possible blocks => ~94 % eviction rate under uniform
+        // random access. Plenty of removal-listener fires per worker iteration.
+        final long cacheBytes = 4L * BLOCK_SIZE;
+        runHammer(cacheBytes, /* enableDisruptor = */ false);
+    }
+
+    /**
+     * Same pressure as {@link #evictionHammerStaysLeakFreeAndBalanced}, plus a
+     * disruptor thread that rotates through every explicit invalidation path
+     * ({@code writeBlock}, {@code write}, {@code deleteLogical},
+     * {@code deleteByPrefix}). Those all funnel into Caffeine's removal
+     * listener, so this exercises invalidation-triggered releases concurrent
+     * with reader slices.
+     */
+    @Test(timeout = 120_000)
+    public void evictionAndInvalidationHammerStaysLeakFreeAndBalanced() throws Exception {
+        final long cacheBytes = 8L * BLOCK_SIZE;
+        runHammer(cacheBytes, /* enableDisruptor = */ true);
+    }
+
+    private static void runHammer(long cacheBytes, boolean enableDisruptor) throws Exception {
+        TrackingFake inner = new TrackingFake();
+        // Pre-populate the fake with a tagged block for every (path, index) the
+        // workers will touch, so every read should succeed.
+        for (int p = 0; p < PATHS; p++) {
+            for (int b = 0; b < DISTINCT_BLOCKS; b++) {
+                inner.putBlock(path(p), b, makeTaggedBlock(path(p), b));
+            }
+        }
+
+        AtomicBoolean failure = new AtomicBoolean();
+        List<Throwable> errors = new ArrayList<>();
+        CountDownLatch ready = new CountDownLatch(THREADS + (enableDisruptor ? 1 : 0));
+        CountDownLatch go = new CountDownLatch(1);
+        CountDownLatch workersDone = new CountDownLatch(THREADS);
+        AtomicBoolean stop = new AtomicBoolean();
+        AtomicLong iterationsDone = new AtomicLong();
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, cacheBytes)) {
+
+            ExecutorService pool = Executors.newFixedThreadPool(THREADS + 1);
+            try {
+                if (enableDisruptor) {
+                    pool.submit(() -> {
+                        ready.countDown();
+                        try {
+                            go.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                        Random rnd = new Random(4242);
+                        int tick = 0;
+                        // Run until all workers are done — otherwise the thread
+                        // would spin forever and the pool would time out.
+                        while (!stop.get() && !Thread.currentThread().isInterrupted()
+                                && workersDone.getCount() > 0) {
+                            try {
+                                int pathIdx = rnd.nextInt(PATHS);
+                                int mode = tick++ & 0x3;
+                                switch (mode) {
+                                    case 0: {
+                                        int b = rnd.nextInt(DISTINCT_BLOCKS);
+                                        cache.writeBlock(path(pathIdx), b,
+                                                makeTaggedBlock(path(pathIdx), b)).get();
+                                        break;
+                                    }
+                                    case 1: {
+                                        // Full-path write invalidates every
+                                        // cached block for this path.
+                                        cache.write(path(pathIdx),
+                                                makeTaggedBlock(path(pathIdx), 0)).get();
+                                        break;
+                                    }
+                                    case 2: {
+                                        cache.deleteLogical(path(pathIdx)).get();
+                                        // Re-seed so readers can still find
+                                        // something afterwards.
+                                        for (int b = 0; b < DISTINCT_BLOCKS; b++) {
+                                            inner.putBlock(path(pathIdx), b,
+                                                    makeTaggedBlock(path(pathIdx), b));
+                                        }
+                                        break;
+                                    }
+                                    default: {
+                                        cache.deleteByPrefix(path(pathIdx)).get();
+                                        for (int b = 0; b < DISTINCT_BLOCKS; b++) {
+                                            inner.putBlock(path(pathIdx), b,
+                                                    makeTaggedBlock(path(pathIdx), b));
+                                        }
+                                        break;
+                                    }
+                                }
+                                Thread.sleep(1);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                return;
+                            } catch (RuntimeException re) {
+                                synchronized (errors) {
+                                    errors.add(re);
+                                }
+                                failure.set(true);
+                                return;
+                            } catch (java.util.concurrent.ExecutionException ee) {
+                                synchronized (errors) {
+                                    errors.add(ee.getCause() != null ? ee.getCause() : ee);
+                                }
+                                failure.set(true);
+                                return;
+                            }
+                        }
+                    });
+                }
+
+                for (int t = 0; t < THREADS; t++) {
+                    final int seed = t + 1;
+                    pool.submit(() -> {
+                        Random rnd = new Random(seed);
+                        ready.countDown();
+                        try {
+                            go.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                        try {
+                            for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                                int pathIdx = rnd.nextInt(PATHS);
+                                int blockIdx = rnd.nextInt(DISTINCT_BLOCKS);
+                                String path = path(pathIdx);
+                                long offset = (long) blockIdx * BLOCK_SIZE;
+
+                                ReadResult rr = cache.readRange(path, offset,
+                                        BLOCK_SIZE, BLOCK_SIZE).get();
+                                try {
+                                    if (rr.status() == ReadResult.Status.NOT_FOUND) {
+                                        // Can happen briefly if the disruptor
+                                        // has just deleted the path — accept.
+                                        continue;
+                                    }
+                                    ByteBuf slice = rr.byteBuf();
+                                    if (slice.refCnt() <= 0) {
+                                        throw new AssertionError(
+                                                "slice had refCnt=" + slice.refCnt());
+                                    }
+                                    // Validate payload matches what the fake
+                                    // wrote for (path, blockIdx). If the read
+                                    // returned stale / truncated data, the tag
+                                    // check will fire.
+                                    byte expectedTag = tagByte(path, blockIdx);
+                                    byte head = slice.getByte(0);
+                                    byte tail = slice.getByte(BLOCK_SIZE - 1);
+                                    if (head != expectedTag || tail != expectedTag) {
+                                        throw new AssertionError(
+                                                "corrupted bytes for " + path + "@" + blockIdx
+                                                        + " head=" + head + " tail=" + tail
+                                                        + " expected=" + expectedTag);
+                                    }
+                                } finally {
+                                    rr.release();
+                                }
+                                iterationsDone.incrementAndGet();
+                            }
+                        } catch (RuntimeException | AssertionError e) {
+                            synchronized (errors) {
+                                errors.add(e);
+                            }
+                            failure.set(true);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        } catch (java.util.concurrent.ExecutionException ee) {
+                            synchronized (errors) {
+                                errors.add(ee.getCause() != null ? ee.getCause() : ee);
+                            }
+                            failure.set(true);
+                        } finally {
+                            workersDone.countDown();
+                        }
+                    });
+                }
+
+                assertTrue("workers ready", ready.await(10, TimeUnit.SECONDS));
+                go.countDown();
+                pool.shutdown();
+                assertTrue("pool finished in time",
+                        pool.awaitTermination(90, TimeUnit.SECONDS));
+            } finally {
+                stop.set(true);
+                pool.shutdownNow();
+            }
+
+            synchronized (errors) {
+                if (!errors.isEmpty()) {
+                    AssertionError ae = new AssertionError(
+                            "worker(s) failed: " + errors.size() + " error(s); first="
+                                    + errors.get(0));
+                    ae.initCause(errors.get(0));
+                    throw ae;
+                }
+            }
+            assertEquals("no worker flagged failure", false, failure.get());
+            assertTrue("workers should have made progress", iterationsDone.get() > 0);
+            assertTrue(
+                    "size-based eviction must have fired; otherwise this test did not "
+                            + "exercise the race window (evictionCount="
+                            + cache.stats().evictionCount() + ")",
+                    cache.stats().evictionCount() > 0);
+        }
+
+        // After close(), every buffer the fake allocated must be fully
+        // released (refCnt == 0). Anything alive is a leak — in particular,
+        // a slice whose release got silently swallowed because the underlying
+        // block had already been freed to the pool.
+        int stillAlive = 0;
+        for (ByteBuf buf : inner.allocations) {
+            if (buf.refCnt() != 0) {
+                stillAlive++;
+            }
+        }
+        if (stillAlive != 0) {
+            fail("leak: " + stillAlive + " / " + inner.allocations.size()
+                    + " fake-allocated buffers still have refCnt > 0 after close()");
+        }
+    }
+
+    private static String path(int idx) {
+        return "seg" + idx;
+    }
+
+    /** Deterministic byte that depends on (path, blockIdx). Every byte of the block gets this tag. */
+    private static byte tagByte(String path, long blockIdx) {
+        int h = path.hashCode();
+        h = 31 * h + Long.hashCode(blockIdx);
+        return (byte) (h & 0xFF);
+    }
+
+    private static byte[] makeTaggedBlock(String path, long blockIdx) {
+        byte tag = tagByte(path, blockIdx);
+        byte[] b = new byte[BLOCK_SIZE];
+        Arrays.fill(b, tag);
+        return b;
+    }
+
+    /**
+     * Fake ObjectStorage that matches production's pooled-direct allocation
+     * pattern and tracks every allocation so the hammer test can assert
+     * zero leaks after {@code cache.close()}.
+     */
+    static class TrackingFake implements ObjectStorage {
+        final Map<String, byte[]> blocks = new ConcurrentHashMap<>();
+        final AtomicInteger readRangeCalls = new AtomicInteger();
+        final ConcurrentLinkedQueue<ByteBuf> allocations = new ConcurrentLinkedQueue<>();
+
+        void putBlock(String path, long blockIndex, byte[] bytes) {
+            blocks.put(key(path, blockIndex), bytes);
+        }
+
+        private static String key(String path, long blockIndex) {
+            return path + ObjectStorage.MULTIPART_SUFFIX + "/" + blockIndex;
+        }
+
+        @Override
+        public CompletableFuture<Void> write(String path, byte[] content) {
+            // Mimic a logical "clear multipart" by dropping every block of this path.
+            String prefix = path + ObjectStorage.MULTIPART_SUFFIX + "/";
+            List<String> toDrop = new ArrayList<>();
+            for (String k : blocks.keySet()) {
+                if (k.startsWith(prefix)) {
+                    toDrop.add(k);
+                }
+            }
+            toDrop.forEach(blocks::remove);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> read(String path) {
+            return CompletableFuture.completedFuture(ReadResult.notFound());
+        }
+
+        @Override
+        public CompletableFuture<Void> writeBlock(String path, long blockIndex, byte[] content) {
+            blocks.put(key(path, blockIndex), content);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> readRange(String path, long offset, int length,
+                int blockSize) {
+            readRangeCalls.incrementAndGet();
+            long blockIndex = offset / blockSize;
+            int offsetInBlock = (int) (offset % blockSize);
+            byte[] block = blocks.get(key(path, blockIndex));
+            if (block == null) {
+                return CompletableFuture.completedFuture(ReadResult.notFound());
+            }
+            if (offsetInBlock >= block.length) {
+                return CompletableFuture.completedFuture(ReadResult.notFound());
+            }
+            int end = Math.min(offsetInBlock + length, block.length);
+            byte[] sliceBytes = Arrays.copyOfRange(block, offsetInBlock, end);
+            ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(sliceBytes.length);
+            buf.writeBytes(sliceBytes);
+            allocations.add(buf);
+            return CompletableFuture.completedFuture(ReadResult.found(buf));
+        }
+
+        @Override
+        public CompletableFuture<Boolean> deleteLogical(String path) {
+            String prefix = path + ObjectStorage.MULTIPART_SUFFIX + "/";
+            List<String> toDrop = new ArrayList<>();
+            for (String k : blocks.keySet()) {
+                if (k.startsWith(prefix)) {
+                    toDrop.add(k);
+                }
+            }
+            toDrop.forEach(blocks::remove);
+            return CompletableFuture.completedFuture(!toDrop.isEmpty());
+        }
+
+        @Override
+        public CompletableFuture<List<String>> listLogical(String prefix) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+
+        @Override
+        public CompletableFuture<Boolean> delete(String path) {
+            return CompletableFuture.completedFuture(blocks.remove(path) != null);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> list(String prefix) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+
+        @Override
+        public CompletableFuture<Integer> deleteByPrefix(String prefix) {
+            List<String> toDrop = new ArrayList<>();
+            for (String k : blocks.keySet()) {
+                int mp = k.indexOf(ObjectStorage.MULTIPART_SUFFIX + "/");
+                String logical = mp >= 0 ? k.substring(0, mp) : k;
+                if (logical.startsWith(prefix)) {
+                    toDrop.add(k);
+                }
+            }
+            toDrop.forEach(blocks::remove);
+            int distinct = (int) toDrop.stream()
+                    .map(k -> {
+                        int mp = k.indexOf(ObjectStorage.MULTIPART_SUFFIX + "/");
+                        return mp >= 0 ? k.substring(0, mp) : k;
+                    }).distinct().count();
+            return CompletableFuture.completedFuture(distinct);
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #241 — `InMemoryBlockCacheObjectStorage.readRange` races cache eviction against reader slices, producing `IllegalReferenceCountException: refCnt: 0, increment: 1` and killing the file server's `remote-file-read-exec` workers. In the reported gist1m benchmark run the thread deaths stalled IS Phase C for 535 s while the checkpoint lock was held.

Root cause: `cache.getIfPresent(key)` returns a pooled `ByteBuf`, the removal listener fires on a concurrent eviction and drops refCnt to 0, then the caller's `retainedSlice(...)` tries to retain a released buffer.

## Fix

- **Fast path**: replace `cache.getIfPresent(...)` with `cache.asMap().computeIfPresent(key, (k, v) -> { v.retain(); return v; })` so the retain happens under Caffeine's per-entry lock, atomic with the entry-present check. Mirrors the idiom already used by `SegmentBlockCache`.
- **Miss path**: the in-flight dedup map now carries a `Void` marker instead of the `ByteBuf`. Followers wait for the primary's signal and re-enter the atomic fast path (with a best-effort reload fallback if the entry was evicted in between) — they never slice the primary's buffer directly, which closes the window where the primary's `finally { buf.release() }` could run before a follower's callback.
- **Stats**: `hits` / `misses` tracked manually because Caffeine does not record stats for `asMap()` computing operations; gauge semantics in `RemoteFileServer.registerBlockCacheGauges` preserved.
- **Close determinism**: Caffeine `executor` set to `Runnable::run` (synchronous maintenance) and `close()` explicitly calls `cleanUp()` so no pooled `ByteBuf` lingers with `refCnt > 0` after shutdown.

## Hammer test

New `InMemoryBlockCacheObjectStorageHammerTest` modelled on `SegmentBlockCacheHammerTest`:
- 16 workers × 4 000 iterations against a key space much larger than the cache budget → ~90 % eviction rate per read.
- `ResourceLeakDetector.Level.PARANOID` + per-buffer refcount accounting asserts zero leaks.
- Second `@Test` also spins a disruptor thread cycling through every invalidation path (`writeBlock`, `write`, `deleteLogical`, `deleteByPrefix`) concurrently with readers.
- On `master` the test reliably reproduces the reported `IllegalReferenceCountException` within a few hundred ms.
- On this branch the test ran green over 40+ consecutive invocations.

## Test plan

- [x] New hammer test reproduces the original failure on unfixed code (stack trace matches the issue report verbatim)
- [x] Hammer test is green on this branch (40+ consecutive runs, zero flakes)
- [x] Existing `InMemoryBlockCacheObjectStorageTest` still green (stats assertions preserved)
- [x] Related tests green: `SegmentBlockCacheTest`, `SegmentBlockCacheHammerTest`, `RemoteFileServiceClientByteBufTest`, `RemoteFileBlockParallelismTest` (42 tests, 0 failures)
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)