### PR TITLE
issue #251: fix executeBatchAsync race that silently dropped rows from this.batch

### DIFF
--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
@@ -635,24 +635,35 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
             return res;
         }
 
+        // Issue #251: snapshot and clear `this.batch` synchronously on the
+        // calling thread, mirroring the synchronous executeBatch() pattern.
+        // The previous implementation cleared the batch inside the async
+        // whenComplete callback, racing with the caller's next addBatch:
+        // res.complete() unblocked .get() before batch.clear() had run, and a
+        // fast caller (the VectorBench ingestion worker) re-populated
+        // this.batch with the next batch's rows in that window. The delayed
+        // clear then wiped them, silently dropping rows from the next
+        // executeBatch — observed as a 9-row gap in a 100M ingest.
+        final List<List<Object>> snapshot = new ArrayList<>(this.batch);
+        this.batch.clear();
+
         parent.getConnection().executeUpdatesAsync(
                 parent.getTableSpace(), sql,
-                tx, false, true, this.batch)
+                tx, false, true, snapshot)
                 .whenComplete((dmsresults, error) -> {
                     if (error != null) {
                         res.completeExceptionally(SQLExceptionUtils.wrapException(error));
-                    } else {
-                        int[] results = new int[batch.size()];
-                        int i = 0;
-                        for (DMLResult dmlresult : dmsresults) {
-                            results[i++] = (int) dmlresult.updateCount;
-                            parent.bindToTransaction(dmlresult.transactionId);
-                            lastUpdateCount += dmlresult.updateCount;
-                            lastKey = dmlresult.key;
-                        }
-                        res.complete(results);
+                        return;
                     }
-                    batch.clear();
+                    int[] results = new int[snapshot.size()];
+                    int i = 0;
+                    for (DMLResult dmlresult : dmsresults) {
+                        results[i++] = (int) dmlresult.updateCount;
+                        parent.bindToTransaction(dmlresult.transactionId);
+                        lastUpdateCount += dmlresult.updateCount;
+                        lastKey = dmlresult.key;
+                    }
+                    res.complete(results);
                 });
 
         return res;

--- a/herddb-jdbc/src/test/java/herddb/jdbc/BatchTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/BatchTest.java
@@ -21,14 +21,20 @@
 package herddb.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import herddb.client.ClientConfiguration;
 import herddb.client.HDBClient;
 import herddb.server.Server;
 import herddb.server.StaticClientSideMetadataProvider;
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -122,6 +128,159 @@ public class BatchTest {
             }
         }
 
+    }
+
+    /**
+     * Issue #251 regression: {@code executeBatchAsync} used to clear the
+     * internal {@code batch} field inside an async {@code whenComplete}
+     * callback. The callback ran on a netty thread <em>after</em>
+     * {@code res.complete(results)} unblocked the caller's {@code .get()},
+     * so a fast caller that called {@code addBatch(...)} immediately
+     * afterwards could mutate {@code this.batch} <em>before</em> the
+     * callback wiped it. The bench's ingestion worker hit this race and
+     * silently dropped 9 rows out of a 100 M batch ingest.
+     *
+     * <p>The fix snapshots the batch on the calling thread <em>before</em>
+     * submitting the request and clears {@code this.batch} synchronously,
+     * mirroring {@link java.sql.PreparedStatement#executeBatch()}'s
+     * {@code finally}-block clear. After this fix:
+     * <ul>
+     *   <li>{@code .get()}'s {@code int[]} result has length equal to the
+     *       <em>snapshot</em> size, never inflated by a concurrent
+     *       {@code addBatch}.</li>
+     *   <li>A row added between {@code executeBatchAsync()} and
+     *       {@code .get()} is preserved in {@code this.batch} for the
+     *       <em>next</em> flush — never wiped by the previous async
+     *       callback.</li>
+     * </ul>
+     */
+    @Test
+    public void executeBatchAsyncClearsBatchSynchronouslyOnCallerThread() throws Exception {
+        try (Server server = new Server(TestUtils.newServerConfigurationWithAutoPort(folder.newFolder().toPath()))) {
+            server.start();
+            server.waitForStandaloneBoot();
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()))) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+                try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client);
+                     Connection con = dataSource.getConnection();
+                     PreparedStatement create = con.prepareStatement("CREATE TABLE mytable (n1 int primary key, val int)");
+                     PreparedStatement stmt = con.prepareStatement("INSERT INTO mytable (n1, val) values(?, ?)")) {
+                    create.executeUpdate();
+
+                    PreparedStatementAsync async = stmt.unwrap(PreparedStatementAsync.class);
+                    Field batchField = HerdDBPreparedStatement.class.getDeclaredField("batch");
+                    batchField.setAccessible(true);
+                    @SuppressWarnings("unchecked")
+                    List<List<Object>> internalBatch = (List<List<Object>>) batchField.get(stmt);
+
+                    // Stage row 1 and start the async send. With the fix,
+                    // executeBatchAsync snapshots `this.batch` and clears it
+                    // BEFORE returning — so the field is empty by the time we
+                    // resume on this thread.
+                    stmt.setInt(1, 1);
+                    stmt.setInt(2, 100);
+                    stmt.addBatch();
+                    assertEquals("addBatch must populate the buffer", 1, internalBatch.size());
+
+                    CompletableFuture<int[]> future = async.executeBatchAsync();
+                    assertEquals("executeBatchAsync must clear `this.batch` synchronously "
+                                    + "before returning to the caller (issue #251)",
+                            0, internalBatch.size());
+
+                    // Now race with the (still in-flight) async callback by
+                    // adding row 2. With the bug, the callback's read of
+                    // `batch.size()` would see 2 instead of 1, and its later
+                    // `batch.clear()` would wipe row 2 — losing it from the
+                    // next flush. With the fix, this addBatch lands in an
+                    // empty `this.batch` and is preserved for the next call.
+                    stmt.setInt(1, 2);
+                    stmt.setInt(2, 200);
+                    stmt.addBatch();
+
+                    int[] results1 = future.get();
+                    assertEquals("first flush sent exactly 1 row (the snapshot taken before "
+                                    + "the racy addBatch); a length of 2 would mean the callback "
+                                    + "read this.batch.size() AFTER the racy addBatch — the bug",
+                            1, results1.length);
+                    assertEquals(1, results1[0]);
+
+                    // The racy addBatch must still be in the buffer — verify
+                    // by flushing. With the bug, the previous callback's
+                    // batch.clear() would have wiped it after our addBatch.
+                    assertEquals("row added during the in-flight batch must survive — "
+                                    + "the previous callback must not wipe it",
+                            1, internalBatch.size());
+
+                    int[] results2 = async.executeBatchAsync().get();
+                    assertEquals(1, results2.length);
+                    assertEquals(1, results2[0]);
+
+                    try (ResultSet rs = stmt.executeQuery("SELECT n1 FROM mytable ORDER BY n1")) {
+                        assertTrue(rs.next());
+                        assertEquals(1, rs.getInt(1));
+                        assertTrue(rs.next());
+                        assertEquals(2, rs.getInt(1));
+                        assertFalse("exactly 2 rows persisted — no rows lost to the race",
+                                rs.next());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Issue #251 regression — stress-style guard against the
+     * executeBatchAsync race. The bench's ingestion worker reuses a single
+     * {@link PreparedStatement} across many sequential batches; with the
+     * previous code, a tight loop that committed N batches could lose
+     * occasional rows because the async callback's {@code batch.clear()}
+     * raced with the worker's next {@code addBatch}. After the fix, all
+     * rows must land in the table.
+     */
+    @Test
+    public void executeBatchAsyncTightLoopLosesNoRows() throws Exception {
+        final int batches = 500;
+        final int rowsPerBatch = 10;
+        final long expected = (long) batches * rowsPerBatch;
+
+        try (Server server = new Server(TestUtils.newServerConfigurationWithAutoPort(folder.newFolder().toPath()))) {
+            server.start();
+            server.waitForStandaloneBoot();
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()))) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+                try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client);
+                     Connection con = dataSource.getConnection();
+                     PreparedStatement create = con.prepareStatement("CREATE TABLE mytable (n1 int primary key, val int)");
+                     PreparedStatement stmt = con.prepareStatement("INSERT INTO mytable (n1, val) values(?, ?)")) {
+                    create.executeUpdate();
+                    con.setAutoCommit(false);
+
+                    PreparedStatementAsync async = stmt.unwrap(PreparedStatementAsync.class);
+                    AtomicLong nextId = new AtomicLong(1);
+                    for (int b = 0; b < batches; b++) {
+                        for (int r = 0; r < rowsPerBatch; r++) {
+                            stmt.setInt(1, (int) nextId.getAndIncrement());
+                            stmt.setInt(2, r);
+                            stmt.addBatch();
+                        }
+                        int[] results = async.executeBatchAsync().get();
+                        assertEquals(rowsPerBatch, results.length);
+                        for (int n : results) {
+                            // INSERT must always confirm 1 row per batch entry
+                            assertEquals(1, n);
+                        }
+                        con.commit();
+                    }
+
+                    try (Statement s = con.createStatement();
+                         ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM mytable")) {
+                        assertTrue(rs.next());
+                        assertEquals("all rows from " + batches + " batches must be persisted",
+                                expected, rs.getLong(1));
+                    }
+                }
+            }
+        }
     }
 
     @Test

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -108,19 +108,67 @@ public class IngestionWorker implements Runnable {
     }
 
     /**
+     * Marker exception used by {@link #flushBatch} to signal that the server
+     * acknowledged the batch but reported fewer inserted rows than were
+     * submitted. Re-attempting the same batch would produce primary-key
+     * collisions on the rows that did succeed, so {@link #commitWithRetry}
+     * surfaces this immediately instead of looping.
+     *
+     * <p>Issue #251: a 100 M ingest finished with the bench's row counter at
+     * exactly 100 M but {@code COUNT(*)} returning 99,999,991. The previous
+     * code bumped {@code rowsCommitted} by {@code batch.size()} as soon as
+     * {@code conn.commit()} returned, without verifying that
+     * {@code executeBatchAsync()} actually reported one insert per submitted
+     * row. This exception is the bench's loud failure mode for that scenario.
+     */
+    static final class BatchPartialSuccessException extends SQLException {
+        private static final long serialVersionUID = 1L;
+
+        BatchPartialSuccessException(String message) {
+            super(message);
+        }
+    }
+
+    /**
      * Flush accumulated batch using executeBatchAsync and commit.
      *
      * @param ps prepared statement with accumulated batch
      * @param conn connection for commit
+     * @param expectedRows the number of rows in the batch — must equal the sum
+     *        of the per-row update counts returned by the server, otherwise the
+     *        server silently dropped some inserts and we throw
+     *        {@link BatchPartialSuccessException}.
      * @param batchStartNanos nanosecond timestamp when batch started
      * @return latency in nanoseconds (batch + commit)
-     * @throws SQLException if batch execution or commit fails
+     * @throws SQLException if batch execution or commit fails, or if the server
+     *         reports a partial-success batch ({@link BatchPartialSuccessException})
      * @throws ExecutionException if async batch execution fails
      * @throws InterruptedException if async batch execution is interrupted
      */
-    private long flushBatch(PreparedStatement ps, Connection conn, long batchStartNanos)
+    private long flushBatch(PreparedStatement ps, Connection conn, int expectedRows, long batchStartNanos)
             throws SQLException, ExecutionException, InterruptedException {
-        ps.unwrap(PreparedStatementAsync.class).executeBatchAsync().get();
+        int[] updateCounts = ps.unwrap(PreparedStatementAsync.class).executeBatchAsync().get();
+        long inserted = 0;
+        for (int n : updateCounts) {
+            // Update count of -2 (SUCCESS_NO_INFO) is treated as one row
+            // inserted; HerdDB itself returns 1 for INSERT, but we accept the
+            // JDBC convention so this guard does not flake on driver upgrades.
+            inserted += (n == java.sql.Statement.SUCCESS_NO_INFO) ? 1L : Math.max(0, n);
+        }
+        if (inserted != expectedRows) {
+            // Don't commit a partial batch and don't let commitWithRetry replay
+            // it — the rows that did succeed would collide on PK. Roll back so
+            // the connection is reusable for the worker's diagnostic exit path.
+            try {
+                conn.rollback();
+            } catch (SQLException ignored) {
+                // best-effort; the BatchPartialSuccessException below carries the real signal
+            }
+            throw new BatchPartialSuccessException(String.format(
+                    "Server confirmed %d of %d row inserts in batch (updateCounts=%s)"
+                            + " — silent partial success, refusing to over-count rowsCommitted",
+                    inserted, expectedRows, java.util.Arrays.toString(updateCounts)));
+        }
         conn.commit();
         return System.nanoTime() - batchStartNanos;
     }
@@ -128,9 +176,9 @@ public class IngestionWorker implements Runnable {
     /**
      * Package-private method for testing flushBatch behavior.
      */
-    long testFlushBatch(PreparedStatement ps, Connection conn, long batchStartNanos)
+    long testFlushBatch(PreparedStatement ps, Connection conn, int expectedRows, long batchStartNanos)
             throws SQLException, ExecutionException, InterruptedException {
-        return flushBatch(ps, conn, batchStartNanos);
+        return flushBatch(ps, conn, expectedRows, batchStartNanos);
     }
 
     /**
@@ -151,13 +199,19 @@ public class IngestionWorker implements Runnable {
         Exception lastError = null;
         for (int attempt = 0; attempt <= maxRetries; attempt++) {
             try {
-                long latencyNanos = flushBatch(ps, conn, batchStartNanos);
+                long latencyNanos = flushBatch(ps, conn, batch.size(), batchStartNanos);
                 commitsTotal.incrementAndGet();
                 rowsCommitted.addAndGet(batch.size());
                 if (attempt > 0) {
                     commitsRecovered.incrementAndGet();
                 }
                 return latencyNanos;
+            } catch (BatchPartialSuccessException e) {
+                // Don't retry — replaying the batch would PK-collide on the rows
+                // the server already accepted. Surface immediately so the bench
+                // fails fast with the diagnostic from flushBatch.
+                safelyClearBatch(ps);
+                throw e;
             } catch (SQLException | ExecutionException e) {
                 lastError = e;
                 safelyRollback(conn);

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -364,9 +364,11 @@ public class VectorBench {
                 statusThread.start();
             }
 
+            long vectorsEmitted = 0;
             try (DatasetLoader.VectorStream stream = loader.streamBaseVectors(config.resumeFrom, toIngest)) {
                 for (float[] vec : stream) {
                     ingestQueue.put(vec);
+                    vectorsEmitted++;
                 }
             }
             producerDone.set(true);
@@ -386,6 +388,20 @@ public class VectorBench {
                     Throwable cause = e.getCause() != null ? e.getCause() : e;
                     throw new IllegalStateException("Ingest worker failed: " + cause.getMessage(), cause);
                 }
+            }
+
+            // Issue #251: a short dataset stream silently caps ingest at fewer
+            // rows than the user asked for. Without this check, both the
+            // assigned/committed counters and the COUNT(*) verification would
+            // agree on a smaller number — the bench would print "Verification
+            // OK" for an under-ingested table. Surface the gap up-front so the
+            // operator can fix the dataset rather than chasing phantom row loss.
+            if (vectorsEmitted != toIngest) {
+                throw new IllegalStateException(String.format(
+                        "Dataset stream emitted %d vectors but %d were requested "
+                                + "(skip=%d, target=%d) — dataset file may be shorter "
+                                + "than expected or truncated",
+                        vectorsEmitted, toIngest, config.resumeFrom, actualRows));
             }
 
             long rowsAssigned = rowId.get() - config.resumeFrom;
@@ -422,6 +438,7 @@ public class VectorBench {
             // Verify row count matches ingested records
             if (!config.skipVerify) {
                 long expectedRows = config.resumeFrom + rowsCommitted.get();
+                long rowsAssignedSnapshot = rowId.get() - config.resumeFrom;
                 long[] actualCount = {0};
                 runWithProgress(out, "verification", "=== VERIFICATION (COUNT) ===", () -> {
                     try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
@@ -432,8 +449,18 @@ public class VectorBench {
                     }
                 });
                 if (actualCount[0] != expectedRows) {
-                    throw new IllegalStateException("Row count mismatch after ingestion: expected "
-                            + expectedRows + " but table has " + actualCount[0]);
+                    // Issue #251: include every counter we have so an operator can
+                    // pinpoint where the gap appeared (producer / worker accounting /
+                    // server). Diagnostic information is irrecoverable once the bench
+                    // exits, so attach it to the exception message itself.
+                    throw new IllegalStateException(String.format(
+                            "Row count mismatch after ingestion: expected %d but table has %d "
+                                    + "(missing=%d) — bench counters: vectors_emitted=%d "
+                                    + "rows_assigned=%d rows_committed=%d commits_total=%d "
+                                    + "commits_recovered=%d resume_from=%d",
+                            expectedRows, actualCount[0], expectedRows - actualCount[0],
+                            vectorsEmitted, rowsAssignedSnapshot, rowsCommitted.get(),
+                            commitsTotal.get(), commitsRecovered.get(), config.resumeFrom));
                 }
                 out.info(String.format("Verification OK: %d rows in table", actualCount[0]));
             }

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWorkerTest.java
@@ -47,11 +47,12 @@ class IngestionWorkerTest {
     @Test
     void testFlushBatchSuccess() throws Exception {
         FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1};
         FakeConnection conn = new FakeConnection();
 
         IngestionWorker worker = createTestWorker();
         long startNanos = System.nanoTime();
-        long latencyNanos = worker.testFlushBatch(ps, conn, startNanos);
+        long latencyNanos = worker.testFlushBatch(ps, conn, 1, startNanos);
 
         assertTrue(ps.batchExecuted, "Batch should have been executed");
         assertTrue(conn.committed, "Connection should have been committed");
@@ -71,7 +72,7 @@ class IngestionWorkerTest {
         long startNanos = System.nanoTime();
 
         ExecutionException ex = assertThrows(ExecutionException.class,
-                () -> worker.testFlushBatch(ps, conn, startNanos));
+                () -> worker.testFlushBatch(ps, conn, 1, startNanos));
         assertTrue(ex.getCause() instanceof RuntimeException);
         assertEquals("Batch execution failed", ex.getCause().getMessage());
     }
@@ -82,6 +83,7 @@ class IngestionWorkerTest {
     @Test
     void testFlushBatchCommitFailure() {
         FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1};
         FakeConnection conn = new FakeConnection();
         conn.failOnCommit = true;
 
@@ -89,7 +91,7 @@ class IngestionWorkerTest {
         long startNanos = System.nanoTime();
 
         SQLException ex = assertThrows(SQLException.class,
-                () -> worker.testFlushBatch(ps, conn, startNanos));
+                () -> worker.testFlushBatch(ps, conn, 1, startNanos));
         assertEquals("Commit failed", ex.getMessage());
     }
 
@@ -106,7 +108,7 @@ class IngestionWorkerTest {
         long startNanos = System.nanoTime();
 
         ExecutionException ex = assertThrows(ExecutionException.class,
-                () -> worker.testFlushBatch(ps, conn, startNanos));
+                () -> worker.testFlushBatch(ps, conn, 1, startNanos));
         assertTrue(ex.getCause() instanceof InterruptedException);
     }
 
@@ -116,17 +118,69 @@ class IngestionWorkerTest {
     @Test
     void testFlushBatchLatencyMeasurement() throws Exception {
         FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1};
         FakeConnection conn = new FakeConnection();
 
         IngestionWorker worker = createTestWorker();
         long startNanos = System.nanoTime();
-        long latencyNanos = worker.testFlushBatch(ps, conn, startNanos);
+        long latencyNanos = worker.testFlushBatch(ps, conn, 1, startNanos);
         long endNanos = System.nanoTime();
 
         // Latency should be between start and end times, and positive
         assertTrue(latencyNanos > 0, "Latency should be positive");
         assertTrue(latencyNanos <= endNanos - startNanos + 1_000_000,
                 "Latency should be less than total elapsed time (plus 1ms margin)");
+    }
+
+    /**
+     * Issue #251: when {@code executeBatchAsync().get()} returns an
+     * {@code int[]} whose sum is less than the submitted batch size, the
+     * server silently dropped some inserts. {@code flushBatch} must throw a
+     * {@link IngestionWorker.BatchPartialSuccessException} <em>before</em>
+     * calling {@code commit()} so the bench's {@code rowsCommitted} counter
+     * never over-counts.
+     */
+    @Test
+    void flushBatchThrowsOnPartialSuccess() {
+        FakePreparedStatement ps = new FakePreparedStatement();
+        // server reports 3 of 4 rows inserted (one row silently dropped)
+        ps.batchUpdateCounts = new int[]{1, 1, 0, 1};
+        FakeConnection conn = new FakeConnection();
+
+        IngestionWorker worker = createTestWorker();
+
+        IngestionWorker.BatchPartialSuccessException ex = assertThrows(
+                IngestionWorker.BatchPartialSuccessException.class,
+                () -> worker.testFlushBatch(ps, conn, 4, System.nanoTime()));
+        assertTrue(ex.getMessage().contains("Server confirmed 3 of 4 row inserts"),
+                "diagnostic should report inserted-vs-expected counts; got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("[1, 1, 0, 1]"),
+                "diagnostic should include raw updateCounts array; got: " + ex.getMessage());
+        assertEquals(false, conn.committed, "must NOT commit when server reported partial success");
+        assertTrue(conn.rollbackCount >= 1, "must rollback the partial batch on the connection");
+    }
+
+    /**
+     * Issue #251 (defensive): the JDBC spec allows {@code SUCCESS_NO_INFO}
+     * (-2) as an update count. HerdDB itself returns 1 for INSERT, but the
+     * bench should not flake on a future driver upgrade that emits the
+     * generic value — {@link java.sql.Statement#SUCCESS_NO_INFO} counts as
+     * one row inserted.
+     */
+    @Test
+    void flushBatchAcceptsSuccessNoInfo() throws Exception {
+        FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{
+                java.sql.Statement.SUCCESS_NO_INFO,
+                1,
+                java.sql.Statement.SUCCESS_NO_INFO};
+        FakeConnection conn = new FakeConnection();
+
+        IngestionWorker worker = createTestWorker();
+        long latency = worker.testFlushBatch(ps, conn, 3, System.nanoTime());
+
+        assertTrue(latency > 0);
+        assertTrue(conn.committed, "SUCCESS_NO_INFO is treated as one row, no partial-success exception");
     }
 
     private IngestionWorker createTestWorker() {
@@ -165,6 +219,7 @@ class IngestionWorkerTest {
     @Test
     void testCommitRetrySucceedsAfterTransient() throws Exception {
         FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1, 1};
         FakeConnection conn = new FakeConnection();
         conn.commitFailsRemaining = 2; // two failures then success
 
@@ -226,6 +281,7 @@ class IngestionWorkerTest {
     @Test
     void testCommitWithRetryIncrementsRowsCommitted() throws Exception {
         FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1, 1, 1, 1, 1, 1, 1};
         FakeConnection conn = new FakeConnection();
 
         AtomicLong commitsTotal = new AtomicLong(0);
@@ -252,6 +308,7 @@ class IngestionWorkerTest {
     @Test
     void testRowsCommittedBumpedOnceDespiteRetries() throws Exception {
         FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1, 1};
         FakeConnection conn = new FakeConnection();
         conn.commitFailsRemaining = 2;
 
@@ -320,6 +377,41 @@ class IngestionWorkerTest {
         assertEquals(0L, commitsRecovered.get());
     }
 
+    /**
+     * Issue #251: when {@code flushBatch} throws
+     * {@link IngestionWorker.BatchPartialSuccessException},
+     * {@code commitWithRetry} must surface it on the first attempt — replaying
+     * a batch whose rows were partially accepted by the server would PK-collide
+     * on the rows that did succeed.
+     */
+    @Test
+    void commitWithRetryDoesNotRetryPartialSuccess() {
+        FakePreparedStatement ps = new FakePreparedStatement();
+        ps.batchUpdateCounts = new int[]{1, 0, 1}; // 2 of 3 inserts confirmed
+        FakeConnection conn = new FakeConnection();
+
+        Config config = new Config();
+        config.ingestCommitRetries = 5; // plenty of retries available, none should fire
+        AtomicLong commitsTotal = new AtomicLong(0);
+        AtomicLong commitsRecovered = new AtomicLong(0);
+        AtomicLong rowsCommitted = new AtomicLong(0);
+        IngestionWorker worker = createTestWorker(config, commitsTotal, commitsRecovered, rowsCommitted);
+
+        List<IngestionWorker.PendingRow> batch = new ArrayList<>();
+        batch.add(new IngestionWorker.PendingRow(1L, new float[]{1f}));
+        batch.add(new IngestionWorker.PendingRow(2L, new float[]{2f}));
+        batch.add(new IngestionWorker.PendingRow(3L, new float[]{3f}));
+
+        IngestionWorker.BatchPartialSuccessException ex = assertThrows(
+                IngestionWorker.BatchPartialSuccessException.class,
+                () -> worker.commitWithRetry(ps, conn, batch, System.nanoTime()));
+        assertTrue(ex.getMessage().contains("Server confirmed 2 of 3"),
+                "expected partial-success diagnostic; got: " + ex.getMessage());
+        assertEquals(0L, commitsTotal.get(), "commitsTotal must NOT count a partial-success batch");
+        assertEquals(0L, rowsCommitted.get(), "rowsCommitted must NOT include any rows from a partial-success batch");
+        assertEquals(0L, commitsRecovered.get(), "no recovery happened — must not bump commitsRecovered");
+    }
+
     private enum FailMode {
         NONE, EXECUTION_EXCEPTION, INTERRUPTED
     }
@@ -331,6 +423,14 @@ class IngestionWorkerTest {
         boolean batchExecuted = false;
         int addBatchCallCount = 0;
         FailMode failMode = FailMode.NONE;
+        /**
+         * Per-row update counts returned by {@link #executeBatchAsync()}. The
+         * real HerdDB driver always returns 1 per successful INSERT, so tests
+         * default to a stub-sized one-row array; tests that exercise
+         * commit/retry paths set this to {@code int[batch.size()]} filled with
+         * 1s, and the issue #251 partial-success tests set it explicitly.
+         */
+        int[] batchUpdateCounts = new int[]{1};
 
         @Override
         public CompletableFuture<int[]> executeBatchAsync() {
@@ -345,7 +445,7 @@ class IngestionWorkerTest {
                 return future;
             }
             batchExecuted = true;
-            return CompletableFuture.completedFuture(new int[]{1});
+            return CompletableFuture.completedFuture(batchUpdateCounts);
         }
 
         @Override

--- a/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
@@ -257,6 +257,45 @@ class VectorBenchTest {
         assertArrayEquals(new float[]{3.0f}, result.get(2), 0.001f);
     }
 
+    /**
+     * Issue #251: when the dataset on disk has fewer vectors than the bench
+     * was asked to ingest, the stream silently terminates early. The
+     * {@code vectorsEmitted != toIngest} guard added in
+     * {@code VectorBench.runBenchmark} relies on the count of vectors
+     * actually emitted by this iterator — this test pins down the underlying
+     * behaviour the guard depends on.
+     */
+    @Test
+    void streamBaseVectorsStopsAtEofWhenRequestExceedsFileSize(@TempDir File tmpDir) throws Exception {
+        File datasetDir = new File(tmpDir, "sift");
+        datasetDir.mkdirs();
+        File fvecsFile = new File(datasetDir, "sift_base.fvecs");
+        try (DataOutputStream dos = new DataOutputStream(new FileOutputStream(fvecsFile))) {
+            for (int i = 1; i <= 4; i++) { // only 4 vectors on disk
+                writeLittleEndianInt(dos, 2); // dim
+                writeLittleEndianFloat(dos, i);
+                writeLittleEndianFloat(dos, i);
+            }
+        }
+
+        DatasetLoader loader = new DatasetLoader(tmpDir.getAbsolutePath(),
+                DatasetLoader.DatasetPreset.SIFT1M, null);
+
+        long emitted = 0;
+        try (DatasetLoader.VectorStream stream = loader.streamBaseVectors(0, 100)) {
+            for (float[] v : stream) {
+                emitted++;
+                org.junit.jupiter.api.Assertions.assertEquals(2, v.length, "dim mismatch");
+            }
+        }
+
+        // The stream stopped at 4 (file EOF) instead of throwing for the
+        // remaining 96 — VectorBench must therefore audit this count itself,
+        // because committed-rows accounting alone would not detect the gap.
+        assertEquals(4L, emitted,
+                "stream must terminate at EOF without throwing — bench's vectorsEmitted check relies on this");
+    }
+
     @Test
     void configCheckpointTimeoutDefaultIs300() throws Exception {
         Config cfg = Config.parse(new String[]{});


### PR DESCRIPTION
Closes #251.

## Root cause (race in `HerdDBPreparedStatement.executeBatchAsync`)

The bigann 100M k3s bench reported `rowsCommitted = 100,000,000` while `SELECT COUNT(*)` returned 99,999,991 — 9 rows missing despite a clean server log and zero recovered commits.

The async `whenComplete` callback used to clear `this.batch` AFTER calling `res.complete(results)`. `res.complete` unblocks `.get()` on the caller, but the callback runs `batch.clear()` only afterwards on the netty thread. A fast caller — VectorBench's ingestion worker — woke up from `.get()`, returned through `commitWithRetry`, and immediately called `ps.addBatch(...)` for the next batch's rows. Those rows landed in `this.batch` BEFORE the still-pending callback ran `batch.clear()`, which then silently wiped them. The next `executeBatchAsync` only sent what was added after the (delayed) clear — losing the racy rows from the table while `pendingBatch` and `rowsCommitted` still counted them as committed.

## Fix

**JDBC (root cause):** in `HerdDBPreparedStatement.executeBatchAsync`, snapshot `this.batch` to a local list and clear the field on the calling thread BEFORE submitting the request — mirroring the synchronous `executeBatch()` pattern (lines 240-263 of the same file). The async callback only references the snapshot, never `this.batch`. Race eliminated.

**Bench (defense in depth):** the previously merged bench-side changes are kept as backstops:
- `IngestionWorker.flushBatch` sums per-row update counts and throws `BatchPartialSuccessException` on mismatch (catches any future driver-level partial-success regression).
- `VectorBench.runBenchmark` audits vectors emitted by the producer and fails fast if the dataset stream is short (catches truncated dataset files).
- The COUNT-mismatch error now prints every counter so future failures are localizable from the bench log alone.

## Tests

- **`herddb-jdbc/BatchTest.executeBatchAsyncClearsBatchSynchronouslyOnCallerThread`**: white-box reflective test that asserts `this.batch` is empty immediately after `executeBatchAsync()` returns to the caller, and that a row added between `executeBatchAsync` and `.get()` is preserved for the next flush. **Verified to FAIL on the buggy code** (`expected:<0> but was:<1>`) and pass on the fix.
- **`herddb-jdbc/BatchTest.executeBatchAsyncTightLoopLosesNoRows`**: stress-style guard that commits 500×10 batches in a tight loop on a single PreparedStatement and asserts `COUNT(*) == 5,000`.
- **`vector-testings/IngestionWorkerTest`** (3 new tests): partial-success diagnostic, `SUCCESS_NO_INFO` acceptance, no-retry guarantee for partial batches.
- **`vector-testings/VectorBenchTest`** (1 new test): pins down the EOF-stops-silently behaviour of `streamBaseVectors` that the dataset-emission audit relies on.

## Test plan

- [x] `mvn -pl herddb-jdbc -Dtest=BatchTest test` → 4/4 pass
- [x] `mvn -pl vector-testings test` → 86/86 pass
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` → BUILD SUCCESS, 0 violations
- [x] Hammer suite (per `CLAUDE.md`): `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` → 12/12 pass (4+4+4)
- [ ] Optional after merge: re-run bigann 100M k3s bench and confirm `COUNT(*) == 100,000,000` post-ingest

🤖 Generated with [Claude Code](https://claude.com/claude-code)