### PR TITLE
local-bench: add herddb-local-bench agent and supporting scripts

### DIFF
--- a/.claude/agents/herddb-local-bench.md
+++ b/.claude/agents/herddb-local-bench.md
@@ -1,0 +1,509 @@
+---
+name: herddb-local-bench
+description: Install HerdDB on the local host (no Kubernetes, no Docker) from the herddb-services zip and run a vector-search benchmark end-to-end. Use when the user asks to "run a vector bench locally", "benchmark HerdDB on this host", or "reproduce a vector-search workload without k8s". Produces a markdown report and opens a GitHub issue on failure with service logs attached.
+tools: Bash, Read, Glob, Grep, Write, Edit, Agent
+model: sonnet
+---
+
+You are a narrow orchestration agent. Your only job is to install HerdDB on
+the **local host** (no Kubernetes, no Docker, no containers) from the
+`herddb-services` zip, run a vector-search benchmark workload against it,
+then produce a markdown report — or, if something fails, open a GitHub
+issue with service logs attached.
+
+The cluster layout is the one from `herddb-services/test-start-server.sh`:
+a single `herddb-server` in standalone mode plus a co-located
+`indexing-service`, sharing the commit log on disk (the indexing service
+tails `dbdata/txlog` directly). No ZooKeeper, no BookKeeper, no Docker.
+
+All real work happens in shell scripts under
+`herddb-services/examples/local-bench/`. You must not compose multi-line
+bash yourself. Your tool calls should be single-line invocations of the
+scripts and the narrowly whitelisted read-only commands listed below.
+
+Long runs (minutes → hours) are normal and acceptable. Being slow is fine.
+Being unsupervised is not: while a benchmark is running you MUST poll the
+local processes for errors on a fixed cadence (see §Supervision).
+
+## Working directory
+
+Always `cd` to `herddb-services/examples/local-bench/` before running
+anything. All paths below are relative to that directory.
+
+The cluster is installed under `$HERDDB_TESTS_HOME/cluster` (set
+`HERDDB_TESTS_HOME` in the environment, otherwise the scripts fall back to
+`examples/local-bench/workspace/`). Reports, run logs and heap dumps land
+under `$HERDDB_TESTS_HOME/reports/`.
+
+## Allowed commands
+
+### Scripts (single-line invocations only)
+
+- `./install.sh [--zip <path>] [--server-heap <size>] [--indexing-heap <size>]
+  [--indexing-rebuild-threads N] [--reuse]`
+  — unzip the `herddb-services-*.zip` into `$HERDDB_TESTS_HOME/cluster`,
+  patch `server.properties` and `indexingservice.properties`, start the
+  server and the indexing service via `bin/service`. Without `--zip` the
+  script auto-discovers the zip under `herddb-services/target/`. Defaults:
+  server heap 15g, indexing heap 40g, rebuild threads 8. `--reuse` keeps
+  the on-disk data and just restarts the services.
+- `./teardown.sh [--keep-dir]` — stop both services and delete
+  `$HERDDB_TESTS_HOME/cluster`. `--keep-dir` keeps the data on disk. Allowed
+  only when the user explicitly asks, OR when retrying with a wiped
+  workspace after an explicit user request.
+- `./scripts/check-cluster.sh` — process health check. Exit 0 = both
+  services running AND the JDBC smoke test passes.
+- `./scripts/process-status.sh` — compact table (NAME, PID, STATUS, RSS_MB).
+  Use in the supervision loop instead of `ps` / `top` to keep token usage
+  down.
+- `./scripts/run-bench.sh <vector-bench args>` — run the workload via the
+  local `bin/vector-bench.sh`. The last line of stdout is
+  `RUN_LOG=<path>` — capture it. Must be launched with
+  `run_in_background: true` so the supervision loop can run in parallel.
+  The script always prepends `--no-progress` to `vector-bench.sh`, so the
+  captured `RUN_LOG` is `\n`-terminated plain-text output (no `\r` spinner
+  frames). You can and should `Read` this file during supervision to see
+  the current phase and live progress samples. If the user explicitly
+  asks for structured output, pass `--output-format json`; the log will
+  become NDJSON. `write-report.sh` still parses plain mode (`^phase=`
+  lines + SUMMARY block) — do not switch to NDJSON unless the user asks
+  for it, or `write-report.sh` will not produce a report.
+- `./scripts/collect-logs.sh [--tail N]` — copy the two service logs
+  (`server.service.log`, `indexing-service.service.log`) into a
+  timestamped dir under `$REPORTS_DIR` and print `LOGS_DIR=<path>`.
+- `./scripts/analyze-server-checkpoints.sh [--server-log <f>] [--run-log <f>] [--output <f>]`
+  — run the checkpoint-dynamics HTML report against the server log.
+  Defaults to `$CLUSTER_DIR/server.service.log`. Last line is
+  `REPORT=<path>`. Use when a supervision tick detects checkpoint lock
+  timeouts or slow checkpoint phases.
+- `./scripts/analyze-is-checkpoints.sh [--is-log <f>] [--server <host:port>] [--no-live] [--output <f>]`
+  — run the IS checkpoint / vector-index-layout HTML report. Defaults to
+  `$CLUSTER_DIR/indexing-service.service.log` and `localhost:9850`. Last
+  line is `REPORT=<path>`. Use when IS Phase B is slow or watermark lag is
+  growing.
+- `./scripts/write-report.sh <run-log-path>` — turn a run log into a
+  markdown report. Last line is `REPORT=<path>`.
+- `./scripts/open-issue.sh --title <t> --body-file <p> [--logs-dir <d>] [--dry-run]`
+  — open a GH issue. Default label is `local-bench`.
+- `./scripts/diagnostics.sh [--service server|indexing-service] [--analyze] [--mat-home <path>]`
+  — collect a JVM heap dump from one of the local service JVMs (default:
+  `server`), optionally running Eclipse MAT afterwards. Prints
+  `HEAP_DUMP=<path>`; with `--analyze` also prints `MAT_REPORT=<dir>`.
+- `./scripts/diagnostics.sh --service <name> --profile [--profile-duration <secs>]
+  [--profiler-home <path>] [--asprof <path>]`
+  — collect async-profiler flamegraphs (cpu, wall, alloc, lock — 30 s
+  each by default) from one of the local service JVMs. Downloads four HTML
+  files under `$REPORTS_DIR/profiles-<service>-<ts>/`. Prints
+  `PROFILES_DIR=<path>` on the last line. Use this on explicit user
+  request or when a query phase is unexpectedly slow. Requires
+  `$PROFILER_HOME` to point at a local async-profiler distribution
+  containing `bin/asprof` and `lib/jfr-converter.jar`.
+- `./scripts/kill-bench.sh` — kill any running `vector-testings` Java
+  process (the bench client).
+
+### Read-only supervision commands
+
+One invocation per tool call, no pipes:
+
+- `./scripts/process-status.sh`
+- `ps -p <pid> -o pid,pcpu,pmem,rss,etime,stat` — per-process snapshot
+  (only for server/indexing-service PIDs taken from their pidfiles).
+- `tail -n <N> $CLUSTER_DIR/server.service.log`
+- `tail -n <N> $CLUSTER_DIR/indexing-service.service.log`
+
+You should prefer `Read` on the log files over `tail` for anything larger
+than a handful of lines, since `Read` renders line numbers.
+
+### VectorBench admin API (read + live tuning)
+
+The VectorBench JVM exposes a JSON HTTP API on port 8080 by default.
+
+**Read progress:**
+```
+curl -s http://localhost:8080/status
+```
+Returns: `phase`, `rows`, `total`, `ops_per_sec`, `commits`,
+`recovered_commits`, `heap_used_mb`, `heap_max_mb`, `commit_latency`
+(mean/p50/p99/max ms).
+
+```
+curl -s http://localhost:8080/ingestion/config
+curl -s http://localhost:8080/query/config
+```
+
+**Tune ingest rate on the fly (integer body = rows/s; 0 = unlimited):**
+```
+curl -s -X POST http://localhost:8080/ingestion/config/ingest-max-ops -d '<rate>'
+```
+
+**Tune query rate on the fly:**
+```
+curl -s -X POST http://localhost:8080/query/config/query-max-ops -d '<rate>'
+```
+
+**Change top-K on the fly (takes effect on the next query):**
+```
+curl -s -X POST http://localhost:8080/query/config/top-k -d '<k>'
+```
+
+⚠️ **Rate-limiter safety rule** — `IngestionWorker` calls
+`rateLimiter.acquire(batch_size)` **after** each commit. At rate `r`, this
+blocks for `batch_size / r` seconds per worker. With 8 workers serialized
+on the shared limiter, the last worker waits `8 × batch_size / r` seconds.
+Setting a very low rate is catastrophic:
+- `--batch-size 10000 --ingest-max-ops 10` → last worker blocked 8 000 s (2.2 h)
+- `--batch-size 1000 --ingest-max-ops 1000` → 1 s/acquire (safe)
+
+**Rule: always keep `ingest-max-ops ≥ batch-size`** so each acquire takes
+≤ 1 second. For ramp tests, start at `batch-size` and step in multiples of
+`batch-size`. Swapping the rate via the admin API does **not** unblock
+workers already sleeping inside `Thread.sleep()` in the old limiter —
+only workers that start their next acquire after the swap use the new
+rate.
+
+### Read-only indexing-admin commands
+
+Invoked via the zip's `bin/indexing-admin.sh` — no kubectl needed.
+
+```
+$CLUSTER_DIR/bin/indexing-admin.sh engine-stats --server localhost:9850 --json
+```
+Fields to watch: `tailer_watermark_ledger`, `tailer_watermark_offset`,
+`apply_queue_size`, `apply_queue_capacity`, `total_estimated_memory_bytes`,
+`jvm_heap_used_pct`.
+
+```
+$CLUSTER_DIR/bin/indexing-admin.sh describe-index --server localhost:9850 \
+    --tablespace <UUID> --table <table> --index vidx --json
+```
+Fields to watch: `vector_count`, `ondisk_node_count`, `segment_count`,
+`status`, `last_lsn_ledger`, `last_lsn_offset`, `ondisk_size_bytes`.
+
+```
+$CLUSTER_DIR/bin/indexing-admin.sh list-indexes --server localhost:9850
+```
+
+### Indexing-service Prometheus metrics (read-only)
+
+```
+curl -s http://localhost:9851/metrics
+```
+
+Anything not in the lists above — editing server state, running `kill -9`
+on service PIDs outside of `teardown.sh`, manual `rm -rf` inside the
+cluster dir, direct `helm`/`kubectl`/`docker` invocations — is forbidden.
+This is a local-only agent: there is no Kubernetes context to talk to.
+
+---
+
+## Default workload
+
+```
+./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
+    --ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000 \
+    --checkpoint --wait-for-indexes
+```
+
+Rules that apply to every workload, including user-specified ones:
+
+- **Ingest defaults to `--ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000`**
+  unless the user explicitly overrides them. Mirror the tuning used by the
+  Kubernetes bench agents for apples-to-apples comparisons. If the user's
+  command omits any of these flags, add them and tell the user you added
+  them.
+- **Recall / query phases (`-k`, recall tests) must only run AFTER a
+  successful checkpoint AND a `--wait-for-indexes` barrier.** The
+  checkpoint no longer blocks on external indexing-service catch-up, so
+  without `--wait-for-indexes` recall is measured against a partially
+  populated index. If the user's command includes a recall phase but no
+  `--checkpoint`, insert `--checkpoint` before the recall flags and tell
+  the user. Always pair it with `--wait-for-indexes` (insert if missing).
+  If the checkpoint phase fails, do NOT proceed to the recall phase — go
+  to the failure path.
+- **Checkpoint timeout.** Always pass `--checkpoint-timeout-seconds 1800`.
+  Never use a lower value.
+- **Wait-for-indexes timeout.** Always pass
+  `--wait-for-indexes-timeout 1800`. Never use a lower value.
+- **Sharding.** With a single indexing-service instance, pass
+  `--index-num-shards 1` unless the user asks for more shards for stress
+  testing.
+
+---
+
+## Workflow
+
+1. **Preflight.** Check that `java`, `unzip`, `curl`, and `gh` are on
+   PATH. Check that `$HERDDB_TESTS_HOME` is set (or accept the default
+   workspace path, printed to the user). Check that the
+   `herddb-services-*.zip` exists under `herddb-services/target/` or that
+   the user has pointed `--zip` at an existing file. If any check fails,
+   stop and tell the user exactly which prerequisite is missing and how
+   to fix it (typically: run `mvn -pl herddb-services install
+   -DskipTests -Dmaven.repo.local=~/dev/repo2`).
+
+2. **Install.** Run `./install.sh` (with whatever heap overrides the user
+   explicitly asked for). Stream output to the user. On non-zero exit go
+   to the failure path (§Failure handling) with title
+   `"[local-bench] install failed on <UTC date>"`.
+
+3. **Health check.** Run `./scripts/check-cluster.sh`. On failure go to
+   the failure path.
+
+4. **Run the workload.** Launch `./scripts/run-bench.sh …` with
+   `run_in_background: true`. Capture the background task ID. Enter the
+   supervision loop (§Supervision) until the background task finishes OR
+   the loop detects a fatal signal.
+
+   - If the bench exits 0 and supervision saw no fatal signals → capture
+     `RUN_LOG=<path>` and go to step 5.
+   - Otherwise → go to the failure path.
+
+5. **Generate report.** Run `./scripts/write-report.sh <RUN_LOG>` and
+   capture `REPORT=<path>`. Print the path and include a one-paragraph
+   summary extracted from the run log.
+
+6. **Do not tear down** unless the user explicitly asks.
+
+---
+
+## Supervision
+
+While `run-bench.sh` runs in the background, poll at least every 60
+seconds (minimum 30 s, maximum 90 s between polls). Each tick does:
+
+1. `./scripts/process-status.sh` — confirm both services still running,
+   note RSS.
+2. `curl -s http://localhost:8080/status` — read VectorBench progress
+   (phase, rows/total, ops_per_sec, commits, recovered_commits,
+   commit_latency).
+3. `Read` the tail of `$RUN_LOG` for new phase boundaries.
+4. `Read` the tail of `$CLUSTER_DIR/server.service.log` and
+   `$CLUSTER_DIR/indexing-service.service.log` (last 30–50 lines) and
+   scan for error keywords: `OutOfMemoryError`, `SEVERE`, `Exception in
+   thread`, `DataStorageManagerException`, `timed out while acquiring
+   checkpoint lock`, `forcing rollback of abandoned transaction`.
+5. `$CLUSTER_DIR/bin/indexing-admin.sh engine-stats --server localhost:9850 --json`
+   — grab `tailer_watermark_*`, `apply_queue_size`,
+   `total_estimated_memory_bytes`.
+6. `$CLUSTER_DIR/bin/indexing-admin.sh list-indexes --server localhost:9850`
+   — read the `VECTORS` column (authoritative indexed vector count).
+   Compute lag% = `(rows - vectors) / rows * 100`. Flag WARN if lag >
+   10% for 2+ consecutive ticks.
+
+Emit a compact TICK SUMMARY (~20 lines) per tick in this format:
+
+```
+TICK N SUMMARY
+Variant: local
+Phase: <phase>  rows=X/total (X%)  rate=X rows/s  commits=X (recovered=X)
+Processes: server pid=X RSS=X MB ; indexing-service pid=X RSS=X MB
+IS: vectors=X (X% of rows), apply_queue=X/cap, mem=X GiB — <OK|WARN>
+ServerCkpt: last LSN=(<ledger>,<offset>) <N>m ago  [or: in progress]
+ISCkpt: <none active | back-pressure Xs, Phase B in progress | etc.>
+LogErrors: <none detected | verbatim error lines>
+Verdict: <healthy|warning|fatal>
+```
+
+Verdicts:
+- `healthy` — continue to next tick
+- `warning` — log it and continue
+- `fatal` — stop the background run-bench task, proceed to §Failure
+  handling. Do NOT attempt to mitigate on the running cluster.
+
+**Checkpoint timeout escalation (warning-level, non-fatal):** If a tick
+shows any of:
+- `"timed out while acquiring checkpoint lock"` in server log
+- `"forcing rollback of abandoned transaction"` in server log
+- Phase has been `checkpoint` for more than 5 consecutive ticks with no
+  LSN advancement visible from `indexing-admin engine-stats`
+
+then run `./scripts/analyze-server-checkpoints.sh` (and optionally
+`./scripts/analyze-is-checkpoints.sh`) **before** the next tick, while
+the cluster is still running, and capture the `REPORT=<path>` for
+inclusion in the final GitHub issue body if the run subsequently fails.
+
+---
+
+## Failure handling
+
+You never try to recover a broken cluster. Every failure produces a
+reproducible GitHub issue. On any failure (install, health check, bench
+non-zero exit, or supervision-detected fault):
+
+1. If the bench is still running in the background, stop it (either let
+   it exit naturally if it is already in the fatal state, or run
+   `./scripts/kill-bench.sh`).
+
+2. **OOM only — collect profiles and heap dump while the JVM is still
+   live.** If the fatal signal was an `OutOfMemoryError` and the
+   affected service is still running (check
+   `./scripts/process-status.sh`):
+   a. `./scripts/diagnostics.sh --service <failing-service> --profile --profile-duration 30`
+      (requires `$PROFILER_HOME`). Capture `PROFILES_DIR=<path>`.
+   b. `./scripts/diagnostics.sh --service <failing-service> --analyze`
+      Capture `HEAP_DUMP=<path>` and `MAT_REPORT=<dir>`.
+   If the JVM has already died (pidfile stale), skip steps (a) and (b).
+   Heap dumps dropped by `-XX:+HeapDumpOnOutOfMemoryError` are listed in
+   `collect-logs.sh` output under `heap-dumps.txt`; include their paths
+   in the issue body instead.
+
+3. Run `./scripts/collect-logs.sh` and capture `LOGS_DIR=<dir>`.
+
+3a. **Checkpoint failures only** — if the failure phase is `checkpoint`
+    or `ingest` AND the log contains `"timed out while acquiring
+    checkpoint lock"` or `"forcing rollback of abandoned transaction"`,
+    run `./scripts/analyze-server-checkpoints.sh --run-log <RUN_LOG>`
+    now (and `./scripts/analyze-is-checkpoints.sh --run-log <RUN_LOG>`
+    if IS Phase B is implicated). Capture the `REPORT=<path>` for each
+    and reference them in the issue body.
+
+4. If a run log exists, run `./scripts/write-report.sh <RUN_LOG>` and
+   capture `REPORT=<path>`.
+
+5. Use `Write` to build an issue body file under `$REPORTS_DIR/`
+   containing:
+   - the exact workload command (including `--ingest-max-ops`,
+     `--checkpoint`, `--wait-for-indexes` as passed),
+   - which phase failed: `install`, `health-check`, `ingest`,
+     `checkpoint`, `recall`, or `supervision`,
+   - **most relevant stack traces and log lines verbatim** with their
+     source service (`server` / `indexing-service`) — include the full
+     `Exception in thread` or `SEVERE:` block. Do NOT summarize; paste
+     raw lines.
+   - the exit code of `run-bench.sh`, if applicable,
+   - if HTML checkpoint reports were produced: their paths as artefact
+     pointers,
+   - the effective JVM options (from `collect-logs.sh`'s
+     `*.jvm-info.txt` files) in a fenced block,
+   - pointers to `REPORT`, `LOGS_DIR`, `HEAP_DUMP` (if taken),
+     `PROFILES_DIR` (if taken).
+
+6. **Attach only the log of the failing service** to the GitHub issue.
+   Create a temporary directory containing only the relevant log file
+   and pass it as `--logs-dir`. Keep the total issue body under
+   GitHub's 65,536-character limit.
+
+7. Run `./scripts/open-issue.sh --title "<title>" --body-file <body>
+   --logs-dir <dir>`, capture `ISSUE_URL=<url>`, and report it to the
+   user.
+
+8. **Stop.** Do not retry. Do not edit any file outside the
+   `local-bench/` example. Do not open a PR.
+
+If `gh` is not authenticated, tell the user to run `gh auth login` and
+re-run.
+
+---
+
+## Diagnostics on demand
+
+When the user explicitly asks for profiling (e.g. "take profiles for the
+indexing service"), or when a query phase is unexpectedly slow (> 3× the
+expected latency from prior runs), run:
+
+```
+./scripts/diagnostics.sh --service <name> --profile --profile-duration 30
+```
+
+Do this for each service of interest sequentially — one call per tool
+invocation. After all sets are downloaded, open a GitHub issue (issue,
+not failure report) describing:
+- What phase the benchmark was in and what each service was doing (from
+  logs)
+- The local `PROFILES_DIR` paths for each service
+- Observations about hot-paths inferred from log patterns
+
+Use `open-issue.sh` without `--logs-dir` (profiles are HTML, not
+plain-text logs).
+
+---
+
+## Tuning between runs
+
+Between runs, and **only when the user explicitly asks for a retry with
+a bigger X**, you may edit scripts or pass different install flags. You
+must never initiate tuning on your own after a failure.
+
+### (a) Heap bumps
+
+Pass `--server-heap` / `--indexing-heap` to `./install.sh` on the next
+run. Ceremony:
+
+1. **Collect profiles and heap dump first** (if the JVM is still live):
+   `./scripts/diagnostics.sh --service <failing-service> --profile --profile-duration 30`
+   `./scripts/diagnostics.sh --service <failing-service> --analyze`
+2. `./teardown.sh`
+3. `./install.sh --server-heap <new> --indexing-heap <new>`
+4. `./scripts/check-cluster.sh` — wait for healthy.
+5. Restart the benchmark from scratch.
+
+### (b) Reusing existing data
+
+If the user wants to re-run queries against existing data without
+re-ingesting, pass `--reuse` to `./install.sh`. This keeps
+`$HERDDB_TESTS_HOME/cluster` on disk and only restarts the services.
+Tell the user explicitly what will be preserved.
+
+---
+
+## File modification policy
+
+You may read and write **any** file under:
+
+```
+herddb-services/examples/local-bench/
+```
+
+including:
+- `install.sh`, `teardown.sh`
+- `scripts/*.sh` — create, rename, or update helper scripts as needed
+- `reports/` — temp body files, profile descriptions, issue drafts
+
+**Do NOT touch:**
+- Any HerdDB source code under `herddb-*/`
+- `herddb-services/src/main/resources/` (the zip payload — to change
+  server defaults, pass flags to `install.sh` or edit the config files
+  inside `$CLUSTER_DIR` at install time, not the zip sources)
+- `pom.xml` files
+- Any file outside the repo (except reading system paths like `~/mat/`
+  or `$PROFILER_HOME`)
+
+When modifying a script, keep the same `set -euo pipefail` style,
+preserve existing `section` / `timestamp` helpers, and add `--help` /
+usage text to any new flag.
+
+---
+
+## Hard rules
+
+- Never run multi-line bash, heredocs, or pipe chains. One script or
+  one single-line read-only command per tool call.
+- Never invoke `kubectl`, `helm`, `docker`, or `ctr` — this agent is
+  local-only. There is no cluster to talk to.
+- Never `rm -rf` inside `$CLUSTER_DIR` directly; that is the exclusive
+  job of `teardown.sh`.
+- Never `kill -9` the service JVMs directly; use `./teardown.sh` or
+  `bin/service <name> stop` only when the user explicitly asks to stop
+  a service.
+- When opening a GitHub issue, **attach only the log(s) of the failing
+  service** — not both. The full issue body (text + appended logs)
+  must stay under GitHub's 65,536-character limit. Include the most
+  relevant stack traces and SEVERE log lines **verbatim** in the body.
+- Never attempt to recover a faulty cluster. Collect, file, stop.
+- Never run recall / query phases before a successful checkpoint.
+- Always pair `--checkpoint` with `--wait-for-indexes` before recall
+  queries.
+- Default ingest uses
+  `--ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000`
+  unless the user overrides them.
+- Always use `--checkpoint-timeout-seconds 1800` and
+  `--wait-for-indexes-timeout 1800`. Never use lower values.
+- Long waits (minutes/hours) are acceptable, but supervision MUST tick
+  at least every 60 s while a bench is running.
+- Never create a GH issue on success. Issues are for failures or
+  explicit diagnostics requests (profiling, feature requests). They
+  must be fully reproducible from the install flags + workload command
+  + version of the zip.
+- Never open a PR and never propose a code patch in an issue body.
+- If the user's request is ambiguous (e.g. which dataset), ask them
+  once before touching the cluster.

--- a/herddb-services/examples/local-bench/README.md
+++ b/herddb-services/examples/local-bench/README.md
@@ -1,0 +1,108 @@
+# Local HerdDB vector-bench example
+
+End-to-end harness that installs HerdDB on the **local host** (no
+Kubernetes, no Docker) from the `herddb-services-*.zip` artefact, runs
+the vector-search benchmark, and produces a markdown report — or, on
+failure, an issue body draft suitable for `gh issue create`.
+
+The cluster layout matches `herddb-services/test-start-server.sh`: a
+single `herddb-server` in standalone mode plus a co-located
+`indexing-service`, sharing the commit log on disk. There is no
+ZooKeeper, no BookKeeper and no container runtime in the loop.
+
+This example is the local counterpart of the Kubernetes-based
+`herddb-kubernetes/.../examples/k3s-local/` and `…/examples/gke/`. It is
+the target of the `herddb-local-bench` Claude agent.
+
+## Layout
+
+```
+herddb-services/examples/local-bench/
+├── install.sh                # unzip + start server + start indexing service
+├── teardown.sh               # stop services + delete cluster directory
+├── README.md                 # this file
+└── scripts/
+    ├── analyze-is-checkpoints.sh        # IS checkpoint HTML report
+    ├── analyze-server-checkpoints.sh    # server checkpoint HTML report
+    ├── check-cluster.sh                 # health check (pids + JDBC ping)
+    ├── collect-logs.sh                  # copy service logs into reports/
+    ├── common.sh                        # shared helpers (sourced)
+    ├── diagnostics.sh                   # heap dump / async-profiler
+    ├── kill-bench.sh                    # pkill -f vector-testings
+    ├── open-issue.sh                    # gh issue create with attachments
+    ├── process-status.sh                # compact PID / RSS table
+    ├── report-is-checkpoints.sh         # underlying IS HTML generator
+    ├── report-server-checkpoints.sh     # underlying server HTML generator
+    ├── run-bench.sh                     # invoke bin/vector-bench.sh
+    └── write-report.sh                  # markdown report from a run log
+```
+
+## Where things live
+
+- **Cluster install:** `$HERDDB_TESTS_HOME/cluster` (fallback:
+  `examples/local-bench/workspace/cluster`)
+- **Reports / run logs / heap dumps:** `$HERDDB_TESTS_HOME/reports`
+  (fallback: `examples/local-bench/workspace/reports`)
+
+`HERDDB_TESTS_HOME` is the same env var used by
+`herddb-services/test-start-*.sh`.
+
+## Quick start
+
+```
+# 1. Build the zip (once, or whenever you change the server)
+mvn -pl herddb-services install -DskipTests -Dmaven.repo.local=~/dev/repo2
+
+# 2. Install + start
+cd herddb-services/examples/local-bench
+./install.sh                           # picks up target/herddb-services-*.zip
+                                       #   --server-heap 15g  (default)
+                                       #   --indexing-heap 40g (default)
+
+# 3. Health check
+./scripts/check-cluster.sh
+
+# 4. Run the workload
+./scripts/run-bench.sh \
+    --dataset sift10k -n 10000 -k 100 \
+    --ingest-max-ops 40000 --ingest-threads 8 --batch-size 10000 \
+    --checkpoint --wait-for-indexes \
+    --checkpoint-timeout-seconds 1800 --wait-for-indexes-timeout 1800
+
+# 5. Render the report
+./scripts/write-report.sh "<RUN_LOG path printed in step 4>"
+
+# 6. Tear down (when done)
+./teardown.sh
+```
+
+## Diagnostics
+
+Heap dump from the indexing-service JVM and Eclipse-MAT analysis:
+
+```
+./scripts/diagnostics.sh --service indexing-service --analyze
+```
+
+Async-profiler flamegraphs (cpu / wall / alloc / lock — 30 s each):
+
+```
+PROFILER_HOME=~/async-profiler ./scripts/diagnostics.sh \
+    --service indexing-service --profile --profile-duration 30
+```
+
+`PROFILER_HOME` must point at a local async-profiler distribution
+containing `bin/asprof` and `lib/jfr-converter.jar`.
+
+## Filing an issue on failure
+
+```
+./scripts/collect-logs.sh                                    # → LOGS_DIR=...
+./scripts/write-report.sh "<RUN_LOG>"                         # → REPORT=...
+./scripts/open-issue.sh \
+    --title "[local-bench] <phase> failure on <date>" \
+    --body-file <draft.md> \
+    --logs-dir <LOGS_DIR>                                     # → ISSUE_URL=...
+```
+
+`open-issue.sh` adds the `local-bench` label automatically.

--- a/herddb-services/examples/local-bench/install.sh
+++ b/herddb-services/examples/local-bench/install.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Install and start a local HerdDB "cluster" — a single herddb-server in
+# standalone mode plus a herddb-indexing-service, sharing the commit log on
+# disk — mirroring test-start-server.sh but driven out of a stable directory
+# under $HERDDB_TESTS_HOME/cluster so the bench scripts can find it.
+#
+# Usage:
+#   ./install.sh [OPTIONS]
+#
+# Options:
+#   --zip <path>                 Path to the herddb-services-*.zip to install.
+#                                Default: auto-discover from herddb-services/target.
+#   --server-heap <size>         -Xms/-Xmx for the server JVM (default: 15g).
+#   --indexing-heap <size>       -Xms/-Xmx for the indexing-service JVM (default: 40g).
+#   --indexing-rebuild-threads N Threads for vector index rebuild (default: 8).
+#   --reuse                      Do not wipe $CLUSTER_DIR if it already exists;
+#                                just (re-)start the services.
+#   --help                       Show this help and exit.
+#
+# The cluster is installed under $HERDDB_TESTS_HOME/cluster. Previous state
+# is wiped unless --reuse is passed.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=scripts/common.sh
+source "$SCRIPT_DIR/scripts/common.sh"
+
+ZIP=""
+SERVER_HEAP="15g"
+INDEXING_HEAP="40g"
+INDEXING_REBUILD_THREADS="8"
+REUSE=false
+
+usage() {
+    grep '^#' "$0" | grep -v '#!/\|^# shellcheck\|^# ──' | sed 's/^# \{0,1\}//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --zip)                       ZIP="$2"; shift 2 ;;
+        --server-heap)               SERVER_HEAP="$2"; shift 2 ;;
+        --indexing-heap)             INDEXING_HEAP="$2"; shift 2 ;;
+        --indexing-rebuild-threads)  INDEXING_REBUILD_THREADS="$2"; shift 2 ;;
+        --reuse)                     REUSE=true; shift ;;
+        --help|-h)                   usage ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ── Discover the zip if not given ─────────────────────────────────────────────
+if [[ -z "$ZIP" ]]; then
+    HERDDB_SERVICES_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+    ZIP="$(ls "$HERDDB_SERVICES_DIR"/target/herddb-service*zip 2>/dev/null | head -1 || true)"
+fi
+
+if [[ -z "$ZIP" || ! -f "$ZIP" ]]; then
+    echo "ERROR: herddb-services zip not found." >&2
+    echo "       Pass --zip <path> or run 'mvn -pl herddb-services install' first." >&2
+    exit 1
+fi
+
+section "Installing HerdDB from $ZIP"
+echo "  cluster dir : $CLUSTER_DIR"
+echo "  reports dir : $REPORTS_DIR"
+
+if [[ -d "$CLUSTER_DIR" ]]; then
+    if $REUSE; then
+        echo "  --reuse set, keeping $CLUSTER_DIR in place."
+    else
+        # Stop any services that may still be running in-place before wiping.
+        if [[ -x "$CLUSTER_DIR/bin/service" ]]; then
+            ( cd "$CLUSTER_DIR" && ./bin/service indexing-service stop >/dev/null 2>&1 || true )
+            ( cd "$CLUSTER_DIR" && ./bin/service server           stop >/dev/null 2>&1 || true )
+        fi
+        rm -rf "$CLUSTER_DIR"
+    fi
+fi
+
+if [[ ! -d "$CLUSTER_DIR" ]]; then
+    section "Unzipping into $CLUSTER_DIR"
+    TMPUNZIP="$(mktemp -d)"
+    unzip -q "$ZIP" -d "$TMPUNZIP"
+    # The zip contains one top-level directory named herddb-*
+    INNER="$(find "$TMPUNZIP" -mindepth 1 -maxdepth 1 -type d -name 'herddb*' | head -1)"
+    if [[ -z "$INNER" ]]; then
+        echo "ERROR: no herddb-* directory inside $ZIP" >&2
+        exit 1
+    fi
+    mv "$INNER" "$CLUSTER_DIR"
+    rmdir "$TMPUNZIP"
+fi
+
+cd "$CLUSTER_DIR"
+mkdir -p tmp
+
+# ── Configure the server ─────────────────────────────────────────────────────
+section "Configuring server.properties"
+CONFIGFILE="conf/server.properties"
+sed -i 's/#http.enable=true/http.enable=true/g' "$CONFIGFILE"
+sed -i 's/server.halt.on.tablespace.boot.error=true/server.halt.on.tablespace.boot.error=false/g' "$CONFIGFILE"
+
+# Point the server at the co-located indexing service. This line is
+# idempotent: if --reuse is in effect we only append it when missing.
+if ! grep -q '^indexing.service.servers=' "$CONFIGFILE"; then
+    echo "indexing.service.servers=localhost:9850" >> "$CONFIGFILE"
+fi
+
+# ── Configure the indexing service (shared commit-log layout) ────────────────
+section "Configuring indexingservice.properties"
+INDEXING_CONFIGFILE="conf/indexingservice.properties"
+# Shared commit log: the indexing service tails the server's txlog directly.
+# server.properties sets server.log.dir=txlog (under server.base.dir=dbdata),
+# so the absolute path is $CLUSTER_DIR/dbdata/txlog.
+if ! grep -q '^log.dir=' "$INDEXING_CONFIGFILE"; then
+    echo "log.dir=dbdata/txlog" >> "$INDEXING_CONFIGFILE"
+fi
+if ! grep -q '^server.metadata.dir=' "$INDEXING_CONFIGFILE"; then
+    echo "server.metadata.dir=dbdata/metadata" >> "$INDEXING_CONFIGFILE"
+fi
+
+# ── Start the server ─────────────────────────────────────────────────────────
+section "Starting HerdDB server (heap=${SERVER_HEAP})"
+export JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx${SERVER_HEAP} -Xms${SERVER_HEAP} \
+-Dio.netty.maxDirectMemory=0 -Djava.net.preferIPv4Stack=true \
+-XX:MaxDirectMemorySize=1g -XX:+DisableExplicitGC -Djava.awt.headless=true \
+-Djava.util.logging.config.file=conf/logging.properties \
+--add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError \
+-XX:HeapDumpPath=$CLUSTER_DIR/server-heapdump.hprof \
+-Djava.io.tmpdir=$CLUSTER_DIR/tmp"
+bin/service server start
+
+sleep 1
+
+# ── Start the indexing service ───────────────────────────────────────────────
+section "Starting indexing service (heap=${INDEXING_HEAP}, rebuild-threads=${INDEXING_REBUILD_THREADS})"
+export JAVA_OPTS="-XX:+UseG1GC -Duser.language=en \
+-Dherddb.vectorindex.rebuild.threads=${INDEXING_REBUILD_THREADS} \
+-Djava.net.preferIPv4Stack=true -Xmx${INDEXING_HEAP} -Xms${INDEXING_HEAP} \
+-Djava.awt.headless=true \
+-Djava.util.logging.config.file=conf/logging.properties \
+-XX:+HeapDumpOnOutOfMemoryError \
+-XX:HeapDumpPath=$CLUSTER_DIR/indexingservice-heapdump.hprof \
+--add-modules jdk.incubator.vector -Djava.io.tmpdir=$CLUSTER_DIR/tmp"
+bin/service indexing-service start
+
+sleep 2
+
+# ── Smoke test ───────────────────────────────────────────────────────────────
+section "Smoke test (JDBC)"
+"$CLUSTER_DIR/bin/herddb-cli.sh" -x jdbc:herddb:server:localhost -q 'select * from sysnodes' || true
+"$CLUSTER_DIR/bin/herddb-cli.sh" -x jdbc:herddb:server:localhost -q 'select * from systablespaces' || true
+
+echo ""
+echo "CLUSTER_DIR=$CLUSTER_DIR"
+echo "REPORTS_DIR=$REPORTS_DIR"

--- a/herddb-services/examples/local-bench/scripts/analyze-is-checkpoints.sh
+++ b/herddb-services/examples/local-bench/scripts/analyze-is-checkpoints.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Generate an HTML IS checkpoint / vector-index-layout report from the local
+# indexing service log. Live indexing-admin queries against localhost:9850
+# are also run unless --no-live is passed.
+#
+# Usage:
+#   ./scripts/analyze-is-checkpoints.sh [OPTIONS]
+#
+# Options:
+#   --is-log <file>     Override log path (default: $CLUSTER_DIR/indexing-service.service.log)
+#   --server <host:port>  indexing-admin endpoint (default: localhost:9850)
+#   --tablespace <t>    Tablespace name (default: herd)
+#   --table <t>         Table name (default: vector_bench)
+#   --index <t>         Vector index name (default: vidx)
+#   --no-live           Skip live indexing-admin queries (log-only mode).
+#   --output <file>     Override the output HTML path.
+#   --help              Show this help and exit.
+#
+# On success prints "REPORT=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+IS_LOG=""
+IS_SERVER="localhost:9850"
+TABLESPACE="herd"
+TABLE="vector_bench"
+INDEX_NAME="vidx"
+LIVE_FLAG=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --is-log)     IS_LOG="$2";           shift 2 ;;
+        --server)     IS_SERVER="$2";        shift 2 ;;
+        --tablespace) TABLESPACE="$2";       shift 2 ;;
+        --table)      TABLE="$2";            shift 2 ;;
+        --index)      INDEX_NAME="$2";       shift 2 ;;
+        --no-live)    LIVE_FLAG="--no-live"; shift   ;;
+        --output)     OUTPUT="$2";           shift 2 ;;
+        --help|-h)    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$IS_LOG" ]]; then
+    IS_LOG="$CLUSTER_DIR/indexing-service.service.log"
+fi
+
+if [[ ! -f "$IS_LOG" ]]; then
+    echo "ERROR: indexing-service log not found at $IS_LOG" >&2
+    exit 1
+fi
+
+ARGS=(
+    --is-log "$IS_LOG"
+    --server "$IS_SERVER"
+    --tablespace "$TABLESPACE"
+    --table "$TABLE"
+    --index "$INDEX_NAME"
+)
+[[ -n "$LIVE_FLAG" ]] && ARGS+=( "$LIVE_FLAG" )
+[[ -n "$OUTPUT"    ]] && ARGS+=( --output "$OUTPUT" )
+
+"$SCRIPT_DIR/report-is-checkpoints.sh" "${ARGS[@]}"

--- a/herddb-services/examples/local-bench/scripts/analyze-server-checkpoints.sh
+++ b/herddb-services/examples/local-bench/scripts/analyze-server-checkpoints.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Generate an HTML checkpoint-dynamics report for the local HerdDB server.
+# Reads $CLUSTER_DIR/server.service.log by default.
+#
+# Usage:
+#   ./scripts/analyze-server-checkpoints.sh [--server-log <file>] [--run-log <file>] [--output <file>]
+#
+# On success prints "REPORT=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+SERVER_LOG=""
+RUN_LOG=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server-log) SERVER_LOG="$2"; shift 2 ;;
+        --run-log)    RUN_LOG="$2";    shift 2 ;;
+        --output)     OUTPUT="$2";     shift 2 ;;
+        --help|-h)    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$SERVER_LOG" ]]; then
+    SERVER_LOG="$CLUSTER_DIR/server.service.log"
+fi
+
+if [[ ! -f "$SERVER_LOG" ]]; then
+    echo "ERROR: server log not found at $SERVER_LOG" >&2
+    exit 1
+fi
+
+EXTRA_ARGS=()
+[[ -n "$RUN_LOG" ]] && EXTRA_ARGS+=( --run-log "$RUN_LOG" )
+[[ -n "$OUTPUT"  ]] && EXTRA_ARGS+=( --output  "$OUTPUT"  )
+
+"$SCRIPT_DIR/report-server-checkpoints.sh" \
+    --server-log "$SERVER_LOG" \
+    "${EXTRA_ARGS[@]}"

--- a/herddb-services/examples/local-bench/scripts/check-cluster.sh
+++ b/herddb-services/examples/local-bench/scripts/check-cluster.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Health check for the local HerdDB cluster.
+# Prints process status for each service and exits non-zero if any is down.
+#
+# Usage: ./scripts/check-cluster.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+require_cluster_dir
+
+section "HerdDB services"
+unhealthy=0
+for service in server indexing-service; do
+    pid="$(service_pid "$service" || true)"
+    if [[ -n "$pid" ]]; then
+        echo "  $service  pid=$pid  RUNNING"
+    else
+        echo "  $service  pid=?    NOT RUNNING"
+        unhealthy=$((unhealthy + 1))
+    fi
+done
+
+if (( unhealthy > 0 )); then
+    echo ""
+    echo "ERROR: $unhealthy service(s) not running." >&2
+    exit 1
+fi
+
+# JDBC smoke test — if this fails the processes are alive but not serving.
+if ! "$CLUSTER_DIR/bin/herddb-cli.sh" -x jdbc:herddb:server:localhost \
+        -q 'select * from sysnodes' >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: JDBC smoke test failed — server is running but not serving." >&2
+    exit 1
+fi
+
+echo ""
+echo "All HerdDB services are running and responding."

--- a/herddb-services/examples/local-bench/scripts/collect-logs.sh
+++ b/herddb-services/examples/local-bench/scripts/collect-logs.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Copy the server and indexing-service logs from $CLUSTER_DIR into
+# $REPORTS_DIR/logs-<timestamp>/ so they are preserved across teardown.
+#
+# Usage: ./scripts/collect-logs.sh [--tail N]
+#
+# On success: prints "LOGS_DIR=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+TAIL=0   # 0 = whole file
+if [[ "${1:-}" == "--tail" ]]; then
+    TAIL="$2"; shift 2
+fi
+
+require_cluster_dir
+
+TS="$(timestamp)"
+LOGS_DIR="$REPORTS_DIR/logs-$TS"
+mkdir -p "$LOGS_DIR"
+
+section "Collecting logs into $LOGS_DIR"
+
+# Process status snapshot + JVM jcmd info (best-effort).
+"$SCRIPT_DIR/process-status.sh" > "$LOGS_DIR/process-status.txt" 2>&1 || true
+
+for service in server indexing-service; do
+    src="$CLUSTER_DIR/${service}.service.log"
+    dst="$LOGS_DIR/${service}.log"
+    if [[ ! -f "$src" ]]; then
+        echo "  (missing) $src"
+        continue
+    fi
+    if (( TAIL > 0 )); then
+        tail -n "$TAIL" "$src" > "$dst"
+    else
+        cp "$src" "$dst"
+    fi
+    echo "  - $service ($(wc -l < "$dst") lines)"
+
+    pid="$(service_pid "$service" || true)"
+    if [[ -n "$pid" ]] && command -v jcmd >/dev/null 2>&1; then
+        {
+            echo "=== jcmd VM.command_line ==="
+            jcmd "$pid" VM.command_line 2>&1 || true
+            echo ""
+            echo "=== jcmd VM.flags ==="
+            jcmd "$pid" VM.flags 2>&1 || true
+        } > "$LOGS_DIR/${service}.jvm-info.txt" || true
+    fi
+done
+
+# Heap dumps dropped by -XX:+HeapDumpOnOutOfMemoryError (best-effort pointer).
+for hprof in "$CLUSTER_DIR"/*-heapdump.hprof; do
+    [[ -f "$hprof" ]] || continue
+    echo "  (heap-dump) $hprof"
+    echo "$hprof" >> "$LOGS_DIR/heap-dumps.txt"
+done
+
+echo ""
+echo "LOGS_DIR=$LOGS_DIR"

--- a/herddb-services/examples/local-bench/scripts/common.sh
+++ b/herddb-services/examples/local-bench/scripts/common.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Shared helpers for the local-bench scripts. Not meant to be executed
+# directly.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Base directory for durable artefacts (cluster install + reports).
+# Mirrors the convention of herddb-services/test-start-server.sh.
+BASEDIR="${HERDDB_TESTS_HOME:-$EXAMPLE_DIR/workspace}"
+mkdir -p "$BASEDIR"
+BASEDIR="$(cd "$BASEDIR" && pwd)"
+
+# The local HerdDB "cluster" lives under $HERDDB_TESTS_HOME/cluster,
+# following the user-facing contract documented in README.md.
+CLUSTER_DIR="$BASEDIR/cluster"
+
+# Reports (run logs, diagnostics, heap dumps, issue drafts) go under
+# $HERDDB_TESTS_HOME/reports so they survive teardown and stay outside the
+# cluster install.
+REPORTS_DIR="$BASEDIR/reports"
+mkdir -p "$REPORTS_DIR"
+
+timestamp() { date +%Y%m%d-%H%M%S; }
+
+section() { printf '\n==> %s\n' "$1"; }
+
+# Read a pid from a service pidfile inside $CLUSTER_DIR. Returns empty if the
+# pidfile is missing or points at a dead process.
+service_pid() {
+    local service="$1"
+    local pidfile="$CLUSTER_DIR/${service}.java.pid"
+    [[ -f "$pidfile" ]] || return 0
+    local pid
+    pid="$(cat "$pidfile" 2>/dev/null || true)"
+    [[ -n "$pid" ]] || return 0
+    if ps -p "$pid" >/dev/null 2>&1; then
+        echo "$pid"
+    fi
+}
+
+require_cluster_dir() {
+    if [[ ! -d "$CLUSTER_DIR" ]]; then
+        echo "ERROR: cluster directory not found at $CLUSTER_DIR" >&2
+        echo "       run ./install.sh first." >&2
+        exit 1
+    fi
+}

--- a/herddb-services/examples/local-bench/scripts/diagnostics.sh
+++ b/herddb-services/examples/local-bench/scripts/diagnostics.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Collect a JVM heap dump or async-profiler profiles from a local HerdDB
+# service JVM (server or indexing-service). Everything runs on the local
+# host — no kubectl, no containers.
+#
+# Usage (heap dump):
+#   ./scripts/diagnostics.sh [--service server|indexing-service] [--analyze] [--mat-home <path>]
+#
+# Usage (async-profiler profiles):
+#   ./scripts/diagnostics.sh --service <name> --profile \
+#       [--profile-duration <secs>] [--profiler-home <path>] [--asprof <path>]
+#
+# Defaults:
+#   --service           server
+#   --analyze           disabled (pass --analyze to run MAT after the dump)
+#   --mat-home          $MAT_HOME or ~/mat
+#   --profile-duration  30
+#   --profiler-home     $PROFILER_HOME (must contain lib/jfr-converter.jar)
+#   --asprof            $ASPROF or $PROFILER_HOME/bin/asprof
+#
+# Output (heap dump):
+#   Prints HEAP_DUMP=<path> on the last line. If --analyze is set also
+#   prints MAT_REPORT=<dir>.
+#
+# Output (profiles):
+#   Records one JFR file (--all events: cpu/wall/alloc/lock) for the given
+#   duration and converts it to four HTML flamegraphs. Prints
+#   PROFILES_DIR=<path> on the last line.
+#
+# Requirements:
+#   - jcmd on PATH (ships with the JDK)
+#   - For --profile: asprof binary and $PROFILER_HOME/lib/jfr-converter.jar
+#   - For --analyze: Eclipse MAT (ParseHeapDump.sh) at $MAT_HOME
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+require_cluster_dir
+
+SERVICE="server"
+ANALYZE=false
+MAT_HOME="${MAT_HOME:-${HOME}/mat}"
+PROFILE=false
+PROFILE_DURATION=30
+PROFILER_HOME="${PROFILER_HOME:-}"
+ASPROF="${ASPROF:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --service)            SERVICE="$2";             shift 2 ;;
+        --analyze)            ANALYZE=true;             shift   ;;
+        --mat-home)           MAT_HOME="$2";            shift 2 ;;
+        --profile)            PROFILE=true;             shift   ;;
+        --profile-duration)   PROFILE_DURATION="$2";    shift 2 ;;
+        --profiler-home)      PROFILER_HOME="$2";       shift 2 ;;
+        --asprof)             ASPROF="$2";              shift 2 ;;
+        --help|-h)            grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+case "$SERVICE" in
+    server|indexing-service) : ;;
+    *) echo "ERROR: --service must be 'server' or 'indexing-service' (got: $SERVICE)" >&2; exit 2 ;;
+esac
+
+JVM_PID="$(service_pid "$SERVICE" || true)"
+if [[ -z "$JVM_PID" ]]; then
+    echo "ERROR: $SERVICE is not running (no live pid in $CLUSTER_DIR/${SERVICE}.java.pid)" >&2
+    exit 1
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PROFILE MODE
+# ═════════════════════════════════════════════════════════════════════════════
+if $PROFILE; then
+    section "async-profiler JFR from $SERVICE (pid=$JVM_PID, ${PROFILE_DURATION}s)"
+
+    if [[ -z "$ASPROF" && -n "$PROFILER_HOME" ]]; then
+        ASPROF="$PROFILER_HOME/bin/asprof"
+    fi
+    if [[ -z "$ASPROF" || ! -x "$ASPROF" ]]; then
+        echo "ERROR: asprof binary not found." >&2
+        echo "       Pass --asprof <path> or set \$ASPROF / \$PROFILER_HOME." >&2
+        exit 1
+    fi
+    if [[ -z "$PROFILER_HOME" ]]; then
+        echo "ERROR: PROFILER_HOME is not set (needed for jfr-converter.jar)." >&2
+        exit 1
+    fi
+    CONVERTER_JAR="$PROFILER_HOME/lib/jfr-converter.jar"
+    if [[ ! -f "$CONVERTER_JAR" ]]; then
+        echo "ERROR: jfr-converter.jar not found at $CONVERTER_JAR" >&2
+        exit 1
+    fi
+
+    TS="$(timestamp)"
+    LOCAL_DIR="$REPORTS_DIR/profiles-${SERVICE}-${TS}"
+    mkdir -p "$LOCAL_DIR"
+
+    echo "  Recording cpu+wall+alloc+lock for ${PROFILE_DURATION}s into profile.jfr..."
+    "$ASPROF" --all -d "$PROFILE_DURATION" "$JVM_PID" -f "${LOCAL_DIR}/profile.jfr"
+
+    echo "  Generating flamegraphs with $CONVERTER_JAR ..."
+    for event in cpu wall alloc lock; do
+        echo "    - profile_${event}.html"
+        java -jar "$CONVERTER_JAR" "--${event}" \
+            "${LOCAL_DIR}/profile.jfr" \
+            "${LOCAL_DIR}/profile_${event}.html"
+    done
+
+    echo ""
+    echo "PROFILES_DIR=$LOCAL_DIR"
+    exit 0
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# HEAP DUMP MODE
+# ═════════════════════════════════════════════════════════════════════════════
+section "Heap dump from $SERVICE (pid=$JVM_PID)"
+
+if ! command -v jcmd >/dev/null 2>&1; then
+    echo "ERROR: jcmd not found on PATH." >&2
+    exit 1
+fi
+
+TS="$(timestamp)"
+JVM_INFO_FILE="$REPORTS_DIR/jvminfo-${SERVICE}-${TS}.txt"
+{
+    echo "=== jcmd VM.command_line ==="
+    jcmd "$JVM_PID" VM.command_line 2>&1 || true
+    echo ""
+    echo "=== jcmd VM.version ==="
+    jcmd "$JVM_PID" VM.version 2>&1 || true
+    echo ""
+    echo "=== jcmd VM.flags ==="
+    jcmd "$JVM_PID" VM.flags 2>&1 || true
+    echo ""
+    echo "=== jcmd VM.info ==="
+    jcmd "$JVM_PID" VM.info 2>&1 || true
+} > "$JVM_INFO_FILE"
+echo "  JVM info written to $JVM_INFO_FILE"
+echo "JVM_INFO=$JVM_INFO_FILE"
+
+LOCAL_DUMP="$REPORTS_DIR/heapdump-${SERVICE}-${TS}.hprof"
+echo "  Writing heap dump to $LOCAL_DUMP ..."
+jcmd "$JVM_PID" GC.heap_dump "$LOCAL_DUMP"
+
+echo ""
+echo "HEAP_DUMP=$LOCAL_DUMP"
+
+if $ANALYZE; then
+    MAT_PARSE="$MAT_HOME/ParseHeapDump.sh"
+    if [[ ! -x "$MAT_PARSE" ]]; then
+        echo "ERROR: MAT not found at $MAT_PARSE (set --mat-home or \$MAT_HOME)" >&2
+        exit 1
+    fi
+
+    section "Analyzing $LOCAL_DUMP with MAT"
+    "$MAT_PARSE" "$LOCAL_DUMP" org.eclipse.mat.api:suspects org.eclipse.mat.api:overview
+
+    MAT_REPORT_DIR="$(dirname "$LOCAL_DUMP")"
+    echo ""
+    echo "MAT_REPORT=$MAT_REPORT_DIR"
+fi

--- a/herddb-services/examples/local-bench/scripts/kill-bench.sh
+++ b/herddb-services/examples/local-bench/scripts/kill-bench.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Kill any running vector-bench Java process started from $CLUSTER_DIR.
+# Safe to call even if no bench is running — exits 0 in that case.
+#
+# Usage: ./scripts/kill-bench.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'
+    exit 0
+fi
+
+section "Killing vector-bench process (pattern: vector-testings)"
+
+if pkill -f 'vector-testings' 2>&1; then
+    echo "  vector-bench process(es) terminated."
+else
+    echo "  No vector-bench process found (or already stopped) — OK."
+fi

--- a/herddb-services/examples/local-bench/scripts/open-issue.sh
+++ b/herddb-services/examples/local-bench/scripts/open-issue.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Open a GitHub issue describing a failed local-bench run.
+# Attaches logs from a directory (produced by collect-logs.sh) as
+# collapsible blocks in the issue body. Truncates each log to the last
+# 500 lines so the body stays under GitHub's 65k-character limit.
+#
+# Usage:
+#   ./scripts/open-issue.sh --title "<title>" --body-file <path> [--logs-dir <path>] [--dry-run]
+#
+# Requires `gh` to be installed and authenticated.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+TITLE=""
+BODY_FILE=""
+LOGS_DIR=""
+DRY_RUN=false
+LABEL="local-bench"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)      TITLE="$2"; shift 2 ;;
+        --body-file)  BODY_FILE="$2"; shift 2 ;;
+        --logs-dir)   LOGS_DIR="$2"; shift 2 ;;
+        --label)      LABEL="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$TITLE" || -z "$BODY_FILE" || ! -f "$BODY_FILE" ]]; then
+    echo "Usage: $0 --title <title> --body-file <path> [--logs-dir <path>] [--dry-run]" >&2
+    exit 2
+fi
+
+if ! $DRY_RUN; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "ERROR: 'gh' CLI is not installed." >&2
+        exit 1
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "ERROR: 'gh' is not authenticated. Run 'gh auth login' first." >&2
+        exit 1
+    fi
+fi
+
+TS="$(date +%Y%m%d-%H%M%S)"
+FINAL_BODY="$REPORTS_DIR/issue-body-$TS.md"
+
+{
+    cat "$BODY_FILE"
+    if [[ -n "$LOGS_DIR" && -d "$LOGS_DIR" ]]; then
+        echo ""
+        echo "## Attached service logs"
+        echo ""
+        echo "_Collected from \`$LOGS_DIR\`. Each log is truncated to the last 500 lines._"
+        echo ""
+        for f in "$LOGS_DIR"/*.txt "$LOGS_DIR"/*.log; do
+            [[ -f "$f" ]] || continue
+            name=$(basename "$f")
+            echo ""
+            echo "<details><summary><code>$name</code></summary>"
+            echo ""
+            echo '```'
+            tail -n 500 "$f"
+            echo '```'
+            echo ""
+            echo '</details>'
+        done
+    fi
+} > "$FINAL_BODY"
+
+echo "==> Issue body written to $FINAL_BODY"
+
+if $DRY_RUN; then
+    echo "==> --dry-run set, not creating GH issue."
+    echo "ISSUE_BODY=$FINAL_BODY"
+    exit 0
+fi
+
+echo "==> Creating GitHub issue..."
+gh label create "$LABEL" --description "Automated reports from the local-bench agent" --force >/dev/null 2>&1 || true
+
+URL=$(gh issue create --title "$TITLE" --body-file "$FINAL_BODY" --label "$LABEL")
+echo "ISSUE_URL=$URL"

--- a/herddb-services/examples/local-bench/scripts/process-status.sh
+++ b/herddb-services/examples/local-bench/scripts/process-status.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Compact process status for the local HerdDB cluster.
+# Prints a 4-column table: NAME, PID, STATUS, RSS (MB).
+# Used by supervision loops to reduce token usage.
+#
+# Usage: ./scripts/process-status.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+require_cluster_dir
+
+printf '%-20s %-8s %-10s %s\n' NAME PID STATUS RSS_MB
+for service in server indexing-service; do
+    pid="$(service_pid "$service" || true)"
+    if [[ -n "$pid" ]]; then
+        rss_kb="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || echo 0)"
+        rss_mb=$(( rss_kb / 1024 ))
+        printf '%-20s %-8s %-10s %s\n' "$service" "$pid" RUNNING "$rss_mb"
+    else
+        printf '%-20s %-8s %-10s %s\n' "$service" -       DOWN    -
+    fi
+done

--- a/herddb-services/examples/local-bench/scripts/report-is-checkpoints.sh
+++ b/herddb-services/examples/local-bench/scripts/report-is-checkpoints.sh
@@ -1,0 +1,619 @@
+#!/usr/bin/env bash
+#
+# Generate an HTML report on Indexing Service checkpoint dynamics and vector
+# index storage layout for a given run.
+#
+# Parses the IS pod log (Phase A / Phase B / Phase C lines) and, if the
+# cluster is reachable, enriches the report with live indexing-admin data.
+#
+# Usage:
+#   ./scripts/report-is-checkpoints.sh --logs-dir <dir> [OPTIONS]
+#
+# Options:
+#   --logs-dir <dir>      Directory produced by collect-logs.sh (required unless
+#                         --is-log is given directly).
+#   --is-log <file>       Path to an IS log file (overrides --logs-dir lookup).
+#   --is-replica <N>      IS replica index (default: 0).  Used both for the log
+#                         filename lookup and for indexing-admin queries.
+#   --tablespace <name>   Tablespace name for indexing-admin queries (default: herd).
+#   --table <name>        Table name (default: vector_bench).
+#   --index <name>        Index name (default: vidx).
+#   --no-live             Skip live indexing-admin queries even if the cluster is up.
+#   --output <file>       Override the output HTML path.
+#   --help                Show this help and exit.
+#
+# On success prints "REPORT=<path>" on the last line (stdout).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+LOGS_DIR=""
+IS_LOG=""
+IS_REPLICA=0
+TABLESPACE="herd"
+TABLE="vector_bench"
+INDEX_NAME="vidx"
+LIVE=1
+OUTPUT=""
+IS_SERVER="localhost:9850"
+
+usage() {
+    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'
+    exit 0
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --logs-dir)   LOGS_DIR="$2";      shift 2 ;;
+        --is-log)     IS_LOG="$2";        shift 2 ;;
+        --is-replica) IS_REPLICA="$2";   shift 2 ;;
+        --tablespace) TABLESPACE="$2";   shift 2 ;;
+        --table)      TABLE="$2";        shift 2 ;;
+        --index)      INDEX_NAME="$2";   shift 2 ;;
+        --no-live)    LIVE=0;            shift   ;;
+        --server)     IS_SERVER="$2";    shift 2 ;;
+        --output)     OUTPUT="$2";       shift 2 ;;
+        --help|-h)    usage ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ── Resolve IS log ────────────────────────────────────────────────────────────
+if [[ -z "$IS_LOG" ]]; then
+    if [[ -z "$LOGS_DIR" ]]; then
+        echo "ERROR: --logs-dir or --is-log is required." >&2
+        exit 2
+    fi
+    IS_LOG="$LOGS_DIR/herddb-indexing-service-${IS_REPLICA}.log"
+fi
+if [[ ! -f "$IS_LOG" ]]; then
+    echo "ERROR: IS log not found: $IS_LOG" >&2
+    exit 2
+fi
+
+# ── Live indexing-admin queries ───────────────────────────────────────────────
+ENGINE_JSON="{}"
+DESCRIBE_JSON="{}"
+
+if [[ "$LIVE" -eq 1 ]]; then
+    INDEXING_ADMIN="$CLUSTER_DIR/bin/indexing-admin.sh"
+    if [[ -x "$INDEXING_ADMIN" ]]; then
+        echo "==> Querying live indexing-admin at $IS_SERVER…"
+        ENGINE_JSON=$("$INDEXING_ADMIN" engine-stats \
+            --server "$IS_SERVER" --json 2>/dev/null \
+            | grep '^{' || echo "{}")
+        DESCRIBE_JSON=$("$INDEXING_ADMIN" describe-index \
+            --server "$IS_SERVER" \
+            --tablespace "$TABLESPACE" \
+            --table "$TABLE" \
+            --index "$INDEX_NAME" \
+            --json 2>/dev/null \
+            | grep '^{' || echo "{}")
+        echo "    engine-stats: OK"
+        echo "    describe-index: OK"
+    else
+        echo "==> indexing-admin.sh not found at $INDEXING_ADMIN — skipping live queries."
+        LIVE=0
+    fi
+fi
+
+# ── Parse IS log → JavaScript arrays ─────────────────────────────────────────
+# Each checkpoint cycle consists of (at least one) Phase A + Phase B + Phase C.
+# We match Phase B lines first as the anchor, then look for the surrounding
+# Phase A / Phase C lines within the same cycle.
+#
+# Output format (one JS array literal per line):
+#   [shards, liveVecs, newSegs, phaseB_ms, bytes, ondiskAfter, segCountAfter, newLiveDuring]
+
+JS_ROWS=$(awk '
+function sc(s,   r) { r=s; gsub(/,/,"",r); return r+0 }
+
+/Phase A: snapshotted/ {
+    s=$0
+    sub(/.*snapshotted /,"",s); shards=s+0          # first token = shard count
+    sub(/.*live shards \(/,"",s); split(s,a," "); liveVecs=sc(a[1])
+    gotA=1
+}
+
+/Phase B: completed in/ {
+    s=$0
+    sub(/.*completed in /,"",s); split(s,a," "); phaseB_ms=sc(a[1])
+    sub(/.*ms \(/,"",s);         split(s,a," "); newSegs=a[1]+0
+    sub(/.*total vectors, /,"",s); split(s,a," "); bytes=sc(a[1])
+    gotB=1
+}
+
+/Phase C:/ && /nodes across/ {
+    s=$0
+    sub(/.*Phase C: /,"",s);    split(s,a," "); ondiskAfter=sc(a[1])
+    sub(/.*nodes across /,"",s); split(s,a," "); segsAfter=sc(a[1])
+    # "…(FusedPQ), N new live inserts…"
+    sub(/.*\), /,"",s);         split(s,a," "); newLive=sc(a[1])
+    gotC=1
+}
+
+gotA && gotB && gotC {
+    printf "  [%d,%d,%d,%d,%d,%d,%d,%d],\n",
+        shards,liveVecs,newSegs,phaseB_ms,bytes,ondiskAfter,segsAfter,newLive
+    gotA=0; gotB=0; gotC=0
+    shards=0; liveVecs=0; newSegs=0; phaseB_ms=0
+    bytes=0; ondiskAfter=0; segsAfter=0; newLive=0
+}
+' "$IS_LOG")
+
+ROW_COUNT=$(echo "$JS_ROWS" | grep -c '^\s*\[' || true)
+
+if [[ "$ROW_COUNT" -eq 0 ]]; then
+    echo "WARNING: No checkpoint cycles found in $IS_LOG" >&2
+    JS_ROWS="  /* no data */"
+fi
+
+# ── Resolve output path ───────────────────────────────────────────────────────
+TS="$(timestamp)"
+if [[ -z "$OUTPUT" ]]; then
+    OUTPUT="$REPORTS_DIR/report-is-checkpoints-${TS}.html"
+fi
+
+# ── Extract scalar stats from indexing-admin JSON ─────────────────────────────
+_jval() {
+    # Naive key extraction from flat JSON without jq
+    local key="$1" json="$2"
+    echo "$json" | grep -oP "\"${key}\":\s*\K[^,}\"]+" 2>/dev/null | head -1 || echo "N/A"
+}
+
+VECTOR_COUNT=$(_jval "vector_count" "$DESCRIBE_JSON")
+ONDISK_NODES=$(_jval "ondisk_node_count" "$DESCRIBE_JSON")
+SEG_COUNT=$(_jval "segment_count" "$DESCRIBE_JSON")
+ONDISK_BYTES=$(_jval "ondisk_size_bytes" "$DESCRIBE_JSON")
+STATUS=$(_jval "status" "$DESCRIBE_JSON")
+M_VAL=$(_jval '"m"' "$DESCRIBE_JSON"); M_VAL=$(_jval 'm' "$DESCRIBE_JSON")
+FUSED_PQ=$(_jval "fused_pq_enabled" "$DESCRIBE_JSON")
+LAST_LSN_LED=$(_jval "last_lsn_ledger" "$DESCRIBE_JSON")
+LAST_LSN_OFF=$(_jval "last_lsn_offset" "$DESCRIBE_JSON")
+COMP_PHASE=$(_jval "compaction_phase" "$DESCRIBE_JSON")
+JVM_USED=$(_jval "jvm_heap_used_bytes" "$ENGINE_JSON")
+JVM_MAX=$(_jval "jvm_heap_max_bytes" "$ENGINE_JSON")
+UPTIME=$(_jval "uptime_millis" "$ENGINE_JSON")
+TAILER_LED=$(_jval "tailer_watermark_ledger" "$ENGINE_JSON")
+TAILER_OFF=$(_jval "tailer_watermark_offset" "$ENGINE_JSON")
+
+# If live data not available, fall back to log-derived last row
+if [[ "$VECTOR_COUNT" == "N/A" && "$ROW_COUNT" -gt 0 ]]; then
+    VECTOR_COUNT=$(echo "$JS_ROWS" | tail -2 | grep '\[' | awk -F',' '{gsub(/[^0-9]/,"",$6); print $6}' | head -1)
+    SEG_COUNT=$(echo "$JS_ROWS" | tail -2 | grep '\[' | awk -F',' '{gsub(/[^0-9]/,"",$7); print $7}' | head -1)
+fi
+
+LOG_BASENAME=$(basename "$IS_LOG")
+LOG_DATE=$(grep -m1 'Apr\|Jan\|Feb\|Mar\|May\|Jun\|Jul\|Aug\|Sep\|Oct\|Nov\|Dec' "$IS_LOG" \
+           | awk '{print $1,$2,$3,$4}' 2>/dev/null || echo "unknown date")
+
+# ── Emit HTML ─────────────────────────────────────────────────────────────────
+cat > "$OUTPUT" << 'HTMLEOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HerdDB IS Checkpoint Report</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  :root {
+    --bg:#0f1117;--bg2:#1a1d2e;--bg3:#252840;
+    --accent:#6c8ebf;--accent2:#82c341;--accent3:#e0a400;
+    --warn:#e05050;--text:#e0e4f0;--muted:#8890a8;--border:#2e3254;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--text);font-family:'Segoe UI',system-ui,sans-serif;font-size:14px;line-height:1.6}
+  h1{font-size:1.5rem;color:var(--accent);padding:22px 28px 6px}
+  h2{font-size:1.1rem;color:var(--accent2);margin:0 0 10px}
+  h3{font-size:.95rem;color:var(--accent3);margin:10px 0 6px}
+  .subtitle{color:var(--muted);padding:0 28px 18px;font-size:.85rem}
+  .grid{display:grid;gap:18px;padding:0 20px 20px}
+  .g2{grid-template-columns:repeat(auto-fit,minmax(360px,1fr))}
+  .g1{grid-template-columns:1fr}
+  .card{background:var(--bg2);border:1px solid var(--border);border-radius:8px;padding:18px}
+  .ch{position:relative;height:280px}
+  .ch-tall{position:relative;height:380px}
+  .kv{display:grid;grid-template-columns:auto 1fr;row-gap:5px;column-gap:14px}
+  .kk{color:var(--muted);font-size:.82rem;white-space:nowrap}
+  .kv2{font-weight:600;font-size:.9rem}
+  .pill{display:inline-block;padding:1px 7px;border-radius:10px;font-size:.75rem;font-weight:700}
+  .pg{background:#1a3a1a;color:var(--accent2);border:1px solid var(--accent2)}
+  .pb{background:#1a2a3a;color:var(--accent);border:1px solid var(--accent)}
+  .po{background:#3a2a00;color:var(--accent3);border:1px solid var(--accent3)}
+  .scroll-t{overflow-x:auto;max-height:480px;overflow-y:auto}
+  table{width:100%;border-collapse:collapse;font-size:.78rem}
+  thead th{background:var(--bg3);color:var(--accent);position:sticky;top:0;padding:7px 9px;
+           text-align:right;white-space:nowrap;border-bottom:1px solid var(--border)}
+  thead th:first-child{text-align:center}
+  tbody tr{border-bottom:1px solid var(--border)}
+  tbody tr:hover{background:var(--bg3)}
+  tbody td{padding:4px 9px;text-align:right}
+  tbody td:first-child{text-align:center;color:var(--muted)}
+  .df{color:var(--accent2)}.ds{color:var(--accent3)}.dv{color:var(--warn)}
+  .s3{color:var(--accent3);font-weight:700}
+  .callout{background:var(--bg3);border-left:3px solid var(--accent3);
+           padding:9px 13px;border-radius:0 5px 5px 0;margin:8px 0;font-size:.85rem}
+  .callout.green{border-color:var(--accent2)}
+  .callout.red{border-color:var(--warn)}
+  code{background:var(--bg3);padding:1px 5px;border-radius:3px;
+       font-family:monospace;font-size:.8rem;color:var(--accent)}
+  footer{text-align:center;padding:18px;color:var(--muted);font-size:.75rem}
+</style>
+</head>
+<body>
+HTMLEOF
+
+# Inject dynamic metadata as a JS block
+cat >> "$OUTPUT" << JSEOF
+<script>
+// ── Data injected by report-is-checkpoints.sh ──────────────────────────────
+const META = {
+  logFile:     $(echo "\"$LOG_BASENAME\""),
+  logDate:     $(echo "\"$LOG_DATE\""),
+  cycleCount:  $ROW_COUNT,
+  vectorCount: $(echo "${VECTOR_COUNT:-0}" | tr -d ','),
+  segCount:    $(echo "${SEG_COUNT:-0}"    | tr -d ','),
+  ondiskBytes: $(echo "${ONDISK_BYTES:-0}" | tr -d ','),
+  status:      $(echo "\"${STATUS:-unknown}\""),
+  fusedPQ:     $(echo "\"${FUSED_PQ:-unknown}\""),
+  lastLsnLed:  $(echo "${LAST_LSN_LED:-0}" | tr -d ','),
+  lastLsnOff:  $(echo "${LAST_LSN_OFF:-0}" | tr -d ','),
+  compPhase:   $(echo "\"${COMP_PHASE:-unknown}\""),
+  jvmUsed:     $(echo "${JVM_USED:-0}"     | tr -d ','),
+  jvmMax:      $(echo "${JVM_MAX:-0}"      | tr -d ','),
+  uptime:      $(echo "${UPTIME:-0}"       | tr -d ','),
+  tailerLed:   $(echo "${TAILER_LED:-0}"   | tr -d ','),
+  tailerOff:   $(echo "${TAILER_OFF:-0}"   | tr -d ','),
+  liveData:    $LIVE,
+};
+
+// [shards, liveVecs, newSegs, phaseB_ms, bytes, ondiskAfter, segCountAfter, newLiveDuring]
+const CYCLES = [
+$JS_ROWS
+];
+</script>
+JSEOF
+
+cat >> "$OUTPUT" << 'HTMLEOF2'
+<h1>🗂 IS Checkpoint Dynamics &amp; Index Storage Layout</h1>
+<p class="subtitle" id="subtitleLine">Loading…</p>
+
+<div class="grid g2" style="padding-top:14px">
+
+  <!-- Summary card -->
+  <div class="card">
+    <h2>📊 Index Summary</h2>
+    <div class="kv" id="summaryKv"></div>
+  </div>
+
+  <!-- Storage pie -->
+  <div class="card">
+    <h2>💾 Per-vector On-disk Footprint</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Each segment has two files: <code>graph</code> (HNSW adjacency lists)
+      and <code>map</code> (PK → nodeId + float32 vector copy for reranking).
+      Sizes shown are for a typical 50,000-vector segment.
+    </p>
+    <div class="ch"><canvas id="pieChart"></canvas></div>
+  </div>
+
+</div>
+
+<div class="grid g2">
+
+  <div class="card">
+    <h2>⏱ Phase B Duration per Checkpoint Cycle</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Phase B = upload live shard segments to file-server.
+      Duration tracks <em>live vectors flushed</em>, not total segment count.
+      <span style="color:var(--accent3)">■</span> slow (10–15 s)
+      <span style="color:var(--warn)">■</span> very slow (&gt;15 s)
+    </p>
+    <div class="ch"><canvas id="durationChart"></canvas></div>
+  </div>
+
+  <div class="card">
+    <h2>📈 On-disk Vectors &amp; Segment Count Growth</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Each checkpoint appends 2–3 new immutable segments.
+      Segment count is the left axis; on-disk vectors the right axis.
+    </p>
+    <div class="ch"><canvas id="growthChart"></canvas></div>
+  </div>
+
+  <div class="card">
+    <h2>🔢 Live Vectors Flushed per Checkpoint</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      <span style="color:var(--accent3)">■</span> 3-shard flush
+      <span style="color:var(--accent)">■</span> 2-shard flush.
+      Target shard capacity ≈ 50,000 vectors.
+    </p>
+    <div class="ch"><canvas id="liveVecsChart"></canvas></div>
+  </div>
+
+  <div class="card">
+    <h2>📦 Bytes Uploaded per Checkpoint (Phase B)</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Total segment data written to file-server.
+      Should track live-vectors linearly at ≈ 1,630 B/vec.
+    </p>
+    <div class="ch"><canvas id="bytesChart"></canvas></div>
+  </div>
+
+</div>
+
+<!-- Full checkpoint table -->
+<div class="grid g1">
+  <div class="card">
+    <h2>📋 All Visible Checkpoint Cycles</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px" id="tableNote"></p>
+    <div class="scroll-t">
+      <table>
+        <thead><tr>
+          <th>#</th><th>Shards</th><th>Live vecs flushed</th>
+          <th>New segs</th><th>Phase B ms</th><th>MB uploaded</th>
+          <th>MB/s</th><th>On-disk after (M)</th><th>Seg count</th>
+          <th>New live during ckpt</th>
+        </tr></thead>
+        <tbody id="cpTbody"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- Analysis -->
+<div class="grid g1">
+  <div class="card">
+    <h2>🔬 Analysis: Checkpoint Scaling &amp; PK→nodeId Mapping</h2>
+    <div id="analysisBlock" style="font-size:.85rem;line-height:1.8"></div>
+  </div>
+</div>
+
+<footer id="footerLine">Generated by report-is-checkpoints.sh</footer>
+
+<script>
+// ── helpers ──────────────────────────────────────────────────────────────────
+const fmt  = n => Number(n).toLocaleString();
+const fmtM = n => (n/1e6).toFixed(3)+' M';
+const fmtMB= n => (n/1048576).toFixed(1)+' MB';
+const fmtS = ms => (ms/1000).toFixed(1)+'s';
+
+const labels   = CYCLES.map((_,i)=>i+1);
+const durData  = CYCLES.map(r=>r[3]);
+const liveData = CYCLES.map(r=>r[1]);
+const bytData  = CYCLES.map(r=>(r[4]/1048576));
+const ondisk   = CYCLES.map(r=>r[5]/1e6);
+const segs     = CYCLES.map(r=>r[6]);
+
+const durMed  = [...durData].sort((a,b)=>a-b)[Math.floor(durData.length/2)]||0;
+const durMax  = Math.max(...durData);
+const durMin  = Math.min(...durData);
+const durMean = durData.reduce((a,b)=>a+b,0)/durData.length||0;
+const dur95   = [...durData].sort((a,b)=>a-b)[Math.floor(durData.length*.95)]||0;
+
+// ── Subtitle ──────────────────────────────────────────────────────────────────
+document.getElementById('subtitleLine').textContent =
+  `Source: ${META.logFile}  ·  Cycles visible: ${META.cycleCount}  `+
+  `·  On-disk vectors: ${fmt(META.vectorCount)}  `+
+  `·  Segments: ${fmt(META.segCount)}  ·  Status: ${META.status}  `+
+  `·  Live data: ${META.liveData ? 'yes' : 'no (offline)'}`;
+
+// ── Summary KV ───────────────────────────────────────────────────────────────
+const gib = b => b>0 ? (b/1073741824).toFixed(1)+' GiB' : 'N/A';
+const pct  = (u,m) => u>0&&m>0 ? (u/m*100).toFixed(0)+'%' : 'N/A';
+const kvRows = [
+  ['Total vectors',    fmt(META.vectorCount)],
+  ['Segment count',    fmt(META.segCount)],
+  ['Avg vecs/segment', META.segCount>0 ? fmt(Math.round(META.vectorCount/META.segCount)) : 'N/A'],
+  ['On-disk size',     gib(META.ondiskBytes)+(META.ondiskBytes>0 ? ` (${(META.ondiskBytes/1e9).toFixed(1)} GB)` : '')],
+  ['Bytes/vector',     META.vectorCount>0 && META.ondiskBytes>0 ?
+                       fmt(Math.round(META.ondiskBytes/META.vectorCount))+' B' : 'N/A'],
+  ['Status',           META.status],
+  ['FusedPQ',          META.fusedPQ],
+  ['Last LSN',         `ledger ${fmt(META.lastLsnLed)} · offset ${fmt(META.lastLsnOff)}`],
+  ['Tailer watermark', `ledger ${fmt(META.tailerLed)} · offset ${fmt(META.tailerOff)}`],
+  ['Compaction phase', META.compPhase],
+  ['JVM heap',         META.jvmMax>0 ? `${gib(META.jvmUsed)} / ${gib(META.jvmMax)} (${pct(META.jvmUsed,META.jvmMax)})` : 'N/A'],
+  ['Uptime',           META.uptime>0 ? (META.uptime/3600000).toFixed(2)+' h' : 'N/A'],
+  ['Log file',         META.logFile],
+  ['Checkpoint cycles (visible)', fmt(META.cycleCount)],
+  ['Phase B median',   fmtS(durMed)],
+  ['Phase B p95',      fmtS(dur95)],
+  ['Phase B max',      fmtS(durMax)],
+];
+const kvDiv = document.getElementById('summaryKv');
+kvRows.forEach(([k,v])=>{
+  const kEl=document.createElement('span'); kEl.className='kk'; kEl.textContent=k;
+  const vEl=document.createElement('span'); vEl.className='kv2'; vEl.textContent=v;
+  kvDiv.append(kEl,vEl);
+});
+
+// ── Table note ────────────────────────────────────────────────────────────────
+document.getElementById('tableNote').textContent =
+  `${META.cycleCount} cycles parsed from ${META.logFile}.  `+
+  `Yellow = 10–15 s, Red = >15 s, orange Shards column = 3-shard flush.`;
+
+// ── Checkpoint table ──────────────────────────────────────────────────────────
+const tbody = document.getElementById('cpTbody');
+CYCLES.forEach((r,i)=>{
+  const [shards,liveVecs,newSegs,phaseB,bytes,ondiskAfter,segCnt,newLive]=r;
+  const mbps=(bytes/phaseB*1000/1048576).toFixed(0);
+  let dc=phaseB>=15000?'dv':phaseB>=10000?'ds':'df';
+  const sc=shards===3?'s3':'';
+  tbody.innerHTML+=`<tr>
+    <td>${i+1}</td><td class="${sc}">${shards}</td>
+    <td>${fmt(liveVecs)}</td><td>${newSegs}</td>
+    <td class="${dc}">${fmt(phaseB)}</td>
+    <td>${fmtMB(bytes)}</td><td>${mbps}</td>
+    <td>${fmtM(ondiskAfter)}</td><td>${fmt(segCnt)}</td>
+    <td>${newLive>0?fmt(newLive):'—'}</td>
+  </tr>`;
+});
+
+// ── Chart defaults ────────────────────────────────────────────────────────────
+const CD = {
+  responsive:true,maintainAspectRatio:false,animation:false,
+  plugins:{legend:{labels:{color:'#8890a8',font:{size:10}}}},
+  scales:{
+    x:{ticks:{color:'#8890a8',font:{size:9}},grid:{color:'#2e3254'},
+       title:{display:true,text:'Checkpoint cycle #',color:'#8890a8'}},
+    y:{ticks:{color:'#8890a8',font:{size:9}},grid:{color:'#2e3254'}}
+  }
+};
+
+// ── Pie chart ─────────────────────────────────────────────────────────────────
+new Chart(document.getElementById('pieChart'),{
+  type:'doughnut',
+  data:{
+    labels:['graph (HNSW adjacency lists)','map (PK + nodeId + float32 vector)'],
+    datasets:[{data:[55064120,26400004],
+      backgroundColor:['#1a3a1a','#3a2a00'],
+      borderColor:['#82c341','#e0a400'],borderWidth:2}]
+  },
+  options:{
+    responsive:true,maintainAspectRatio:false,
+    plugins:{legend:{position:'bottom',labels:{color:'#8890a8',font:{size:10},padding:12}},
+      tooltip:{callbacks:{label:ctx=>{
+        const v=ctx.parsed, t=55064120+26400004;
+        return ` ${(v/1048576).toFixed(1)} MB  (${(v/t*100).toFixed(0)}%)`;
+      }}}}
+  }
+});
+
+// ── Duration chart ────────────────────────────────────────────────────────────
+new Chart(document.getElementById('durationChart'),{
+  type:'line',
+  data:{labels,datasets:[{
+    label:'Phase B ms',data:durData,
+    borderColor:'#6c8ebf',backgroundColor:'rgba(108,142,191,.12)',
+    fill:true,tension:.3,pointRadius:3,
+    pointBackgroundColor:durData.map(v=>v>=15000?'#e05050':v>=10000?'#e0a400':'#6c8ebf')
+  }]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,beginAtZero:true,title:{display:true,text:'ms',color:'#8890a8'}}}}
+});
+
+// ── Growth chart ──────────────────────────────────────────────────────────────
+new Chart(document.getElementById('growthChart'),{
+  type:'line',
+  data:{labels,datasets:[
+    {label:'On-disk vectors (M)',data:ondisk,
+     borderColor:'#82c341',backgroundColor:'rgba(130,195,65,.08)',
+     fill:true,tension:.2,pointRadius:0,yAxisID:'yL'},
+    {label:'Segment count',data:segs,
+     borderColor:'#e0a400',tension:.2,pointRadius:0,yAxisID:'yR'}
+  ]},
+  options:{
+    responsive:true,maintainAspectRatio:false,animation:false,
+    plugins:{legend:{labels:{color:'#8890a8',font:{size:10}}}},
+    scales:{
+      x:{ticks:{color:'#8890a8',font:{size:9}},grid:{color:'#2e3254'},
+         title:{display:true,text:'Checkpoint cycle #',color:'#8890a8'}},
+      yL:{type:'linear',position:'left',
+          ticks:{color:'#82c341',font:{size:9}},grid:{color:'#2e3254'},
+          title:{display:true,text:'On-disk vectors (M)',color:'#82c341'}},
+      yR:{type:'linear',position:'right',
+          ticks:{color:'#e0a400',font:{size:9}},grid:{drawOnChartArea:false},
+          title:{display:true,text:'Segment count',color:'#e0a400'}}
+    }
+  }
+});
+
+// ── Live vecs chart ───────────────────────────────────────────────────────────
+new Chart(document.getElementById('liveVecsChart'),{
+  type:'bar',
+  data:{labels,datasets:[{
+    label:'Live vectors flushed',data:liveData,
+    backgroundColor:CYCLES.map(r=>r[0]===3?'rgba(224,164,0,.7)':'rgba(108,142,191,.6)'),
+    borderColor:CYCLES.map(r=>r[0]===3?'#e0a400':'#6c8ebf'),borderWidth:1
+  }]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,beginAtZero:true,title:{display:true,text:'vectors',color:'#8890a8'}}}}
+});
+
+// ── Bytes chart ───────────────────────────────────────────────────────────────
+new Chart(document.getElementById('bytesChart'),{
+  type:'bar',
+  data:{labels,datasets:[{
+    label:'MB uploaded',data:bytData,
+    backgroundColor:'rgba(130,195,65,.55)',borderColor:'#82c341',borderWidth:1
+  }]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,beginAtZero:true,title:{display:true,text:'MB',color:'#8890a8'}}}}
+});
+
+// ── Analysis block ────────────────────────────────────────────────────────────
+const trend = (() => {
+  if(durData.length<10) return 'insufficient data';
+  const first5=durData.slice(0,5).reduce((a,b)=>a+b,0)/5;
+  const last5=durData.slice(-5).reduce((a,b)=>a+b,0)/5;
+  const ratio=last5/first5;
+  if(ratio>1.5) return `GROWING (last-5 avg ${fmtS(last5)} vs first-5 avg ${fmtS(first5)}, ×${ratio.toFixed(2)})`;
+  if(ratio<0.7) return `SHRINKING (last-5 avg ${fmtS(last5)} vs first-5 avg ${fmtS(first5)})`;
+  return `STABLE (last-5 avg ${fmtS(last5)} vs first-5 avg ${fmtS(first5)})`;
+})();
+
+const threeShardCount = CYCLES.filter(r=>r[0]===3).length;
+const twoShardCount   = CYCLES.filter(r=>r[0]===2).length;
+
+document.getElementById('analysisBlock').innerHTML = `
+<div class="callout green">
+  <b>Checkpoint time trend: ${trend}</b><br>
+  Phase B duration is bounded by live vectors flushed per cycle (~50–150 k),
+  <em>not</em> by the total number of on-disk segments. Each checkpoint writes
+  only the newly frozen shard vectors to new immutable segments; existing
+  segments are never rewritten.
+</div>
+<h3>Three-phase checkpoint protocol</h3>
+<p><b>Phase A (snapshot):</b> Live shards are atomically frozen. New inserts
+accumulate in a fresh shard while upload proceeds. Nearly instantaneous.</p>
+<p><b>Phase B (upload):</b> Each frozen shard is serialised into a new segment
+(<code>graph</code> + <code>map</code> files) and streamed to the file-server.
+Work is O(live vectors) — constant per cycle regardless of total segment count.
+Observed: median ${fmtS(durMed)}, p95 ${fmtS(dur95)}, max ${fmtS(durMax)}.</p>
+<p><b>Phase C (registry update):</b> New segment references are appended to the
+in-memory registry and the watermark is advanced. O(new segments added) = 2–3
+per cycle — effectively O(1).</p>
+<h3>PK → nodeId mapping structure</h3>
+<p>The mapping is <b>per-segment</b>, stored inside the <code>multipart/map</code>
+file. There is <em>no global growing dictionary</em>. Each segment's map holds:</p>
+<ul style="margin:4px 0 8px 18px">
+  <li><b>float32 vector copy</b>: 128 dims × 4 B = 512 B — for exact-distance
+      reranking after HNSW beam search (FusedPQ uses approximate PQ distance
+      during traversal, then reranks with exact floats)</li>
+  <li><b>PK (long)</b>: 8 B — original table primary key</li>
+  <li><b>nodeId (int)</b>: 4 B — graph node index within this segment</li>
+  <li><b>overhead</b>: ~5 B (alignment / entry header)</li>
+</ul>
+<p>Result: ~529 B/vector in the map file vs ~1,101 B/vector in the graph file
+→ <b>~1,630 B/vector total</b> on disk per vector.</p>
+<h3>What does grow with segment count</h3>
+<ul style="margin:4px 0 8px 18px">
+  <li><b>In-memory segment registry</b> in the IS JVM — ${fmt(META.segCount)} entries at
+      ${META.jvmMax>0?`${pct(META.jvmUsed,META.jvmMax)} JVM heap usage`:'N/A JVM heap usage'}.
+      Each entry holds file references and in-memory metadata.</li>
+  <li><b>Query fanout</b> — more segments = more parallel reads per search request.</li>
+  <li><b>Cold-start time</b> — IS loads all segment headers at startup.</li>
+</ul>
+<h3>Flush pattern</h3>
+<p>${twoShardCount} two-shard flushes (median duration ${fmtS([...durData].sort((a,b)=>a-b)[Math.floor(twoShardCount/2)]||0)})
+and ${threeShardCount} three-shard flushes across ${META.cycleCount} visible cycles.
+Three-shard flushes occur when the shard rotation trigger fires while a previous
+checkpoint Phase B is still in progress — the extra shard accumulates and is flushed
+together in the next cycle.</p>
+`;
+
+document.getElementById('footerLine').textContent =
+  `Generated by report-is-checkpoints.sh · ${META.logFile} · ${META.cycleCount} cycles`;
+</script>
+</body></html>
+HTMLEOF2
+
+echo ""
+echo "REPORT=$OUTPUT"

--- a/herddb-services/examples/local-bench/scripts/report-server-checkpoints.sh
+++ b/herddb-services/examples/local-bench/scripts/report-server-checkpoints.sh
@@ -1,0 +1,594 @@
+#!/usr/bin/env bash
+#
+# Generate an HTML report on HerdDB server checkpoint dynamics.
+#
+# Parses the server pod log looking for:
+#   - "local checkpoint start herd at (L,O)"
+#   - "local checkpoint finish herd started ad (L,O), … total time X ms"
+#   - "BLinkKeyToPageIndex checkpoint finished: logpos (L,O), N pages"
+#   - "dirty pages" flush lines from ActivatableTable / FileDataStorageManager
+#
+# The report includes:
+#   - Timeline chart of checkpoint durations
+#   - Pages checkpointed per run
+#   - LSN (ledger, offset) advancement per checkpoint
+#   - Analysis of whether duration grows over time
+#
+# Usage:
+#   ./scripts/report-server-checkpoints.sh --logs-dir <dir> [OPTIONS]
+#
+# Options:
+#   --logs-dir <dir>   Directory produced by collect-logs.sh (required unless
+#                      --server-log is given directly).
+#   --server-log <f>   Path to herddb-server-0.log (overrides --logs-dir).
+#   --run-log <f>      Optional path to run-bench log; used to annotate ingest
+#                      progress on the timeline.
+#   --output <file>    Override the output HTML path.
+#   --help             Show this help and exit.
+#
+# On success prints "REPORT=<path>" on the last line (stdout).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPORTS_DIR="${HERDDB_TESTS_HOME:-$(dirname "$SCRIPT_DIR")/reports}"
+mkdir -p "$REPORTS_DIR"
+timestamp() { date +%Y%m%d-%H%M%S; }
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+LOGS_DIR=""
+SERVER_LOG=""
+RUN_LOG=""
+OUTPUT=""
+
+usage() {
+    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --logs-dir)    LOGS_DIR="$2";    shift 2 ;;
+        --server-log)  SERVER_LOG="$2";  shift 2 ;;
+        --run-log)     RUN_LOG="$2";     shift 2 ;;
+        --output)      OUTPUT="$2";      shift 2 ;;
+        --help|-h)     usage ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ── Resolve server log ────────────────────────────────────────────────────────
+if [[ -z "$SERVER_LOG" ]]; then
+    if [[ -z "$LOGS_DIR" ]]; then
+        echo "ERROR: --logs-dir or --server-log is required." >&2
+        exit 2
+    fi
+    SERVER_LOG="$LOGS_DIR/herddb-server-0.log"
+fi
+if [[ ! -f "$SERVER_LOG" ]]; then
+    echo "ERROR: server log not found: $SERVER_LOG" >&2
+    exit 2
+fi
+
+LOG_BASENAME=$(basename "$SERVER_LOG")
+LOG_DATE=$(grep -m1 'Apr\|Jan\|Feb\|Mar\|May\|Jun\|Jul\|Aug\|Sep\|Oct\|Nov\|Dec' "$SERVER_LOG" \
+           | awk '{print $1,$2,$3,$4}' 2>/dev/null || echo "unknown date")
+
+# ── Parse server log ──────────────────────────────────────────────────────────
+#
+# We need to correlate three line types:
+#
+#  START:  "local checkpoint start herd at (L,O)"
+#  FINISH: "local checkpoint finish herd started ad (L,O), finished at (L2,O2), total time T ms"
+#  BLINK:  "BLinkKeyToPageIndex checkpoint finished: logpos (L,O), N pages"
+#  DIRTY:  "checkpointTable …: N dirty pages"  (optional, may not appear every cycle)
+#
+# Strategy: parse FINISH lines as the authoritative anchor (they contain start
+# LSN, finish LSN, and duration).  Then look for the nearest preceding BLINK
+# line to get page count.  DIRTY lines are collected similarly.
+#
+# Output JS array: [startLed, startOff, finishLed, finishOff, totalMs, blinkPages,
+#                   timestamp_str, dirtyPages]
+
+JS_ROWS=$(awk '
+function sc(s,  r) { r=s; gsub(/,/,"",r); return r+0 }
+# Parse "(L,O)" out of string s → set globals pLed pOff
+function parseLSN(s,  t) {
+    t=s; sub(/.*\(/,"",t); sub(/\).*/,"",t)
+    split(t,lp,","); pLed=lp[1]+0; pOff=lp[2]+0
+}
+
+BEGIN { lastBlinkPages=-1 }
+
+# Java util logging emits the timestamp on its OWN line before the INFO: line.
+# Format: "Apr 18, 2026 12:58:58 AM herddb.core.TableSpaceManager localCheckpoint"
+# Note the comma after the day number — /^[A-Z][a-z]+ [0-9]+, [0-9]+ .../
+/^[A-Z][a-z]+ [0-9]+, [0-9]+ [0-9]+:[0-9]+:[0-9]+/ {
+    lastTs=sprintf("%s %s %s %s %s", $1,$2,$3,$4,$5)
+}
+
+# BLink INFO line (comes inside the server checkpoint, before "local checkpoint finish"):
+# "INFO: checkpoint index UUID_primary finished: logpos (L,O), N pages"
+/checkpoint index.*finished.*logpos.*pages/ {
+    s=$0; sub(/.*logpos /,"",s); parseLSN(s)
+    # pages: strip the "(L,O), " prefix then read first word
+    sub(/\([^)]*\), /,"",s); split(s,a," "); lastBlinkPages=sc(a[1])
+}
+
+/checkpointTable/ && /dirty pages/ {
+    split($0,a," ")
+    for(i=1;i<=NF;i++) if(a[i+1]=="dirty") { lastDirty=sc(a[i]); break }
+}
+
+/local checkpoint finish/ {
+    s=$0
+    sub(/.*started ad /,"",s);  parseLSN(s); sLed=pLed; sOff=pOff
+    s=$0
+    sub(/.*finished at /,"",s); parseLSN(s); fLed=pLed; fOff=pOff
+    s=$0
+    sub(/.*total time /,"",s);  split(s,a," "); ms=sc(a[1])
+    printf "  [%d,%d,%d,%d,%d,%d,\"%s\",%d],\n",
+        sLed,sOff,fLed,fOff,ms,lastBlinkPages,lastTs,lastDirty
+    lastDirty=0
+}
+' "$SERVER_LOG")
+
+ROW_COUNT=$(echo "$JS_ROWS" | grep -c '^\s*\[' || true)
+
+if [[ "$ROW_COUNT" -eq 0 ]]; then
+    echo "WARNING: No checkpoint finish lines found in $SERVER_LOG" >&2
+    JS_ROWS="  /* no data */"
+fi
+
+# ── Optional: ingest progress annotations from run log ───────────────────────
+RUN_LOG_ARGS=""
+RUN_LOG_START=""
+if [[ -n "$RUN_LOG" && -f "$RUN_LOG" ]]; then
+    RUN_LOG_ARGS=$(grep -m1 '^# args:' "$RUN_LOG" | sed 's/^# args: //' || echo "")
+    RUN_LOG_START=$(grep -m1 '^# start:' "$RUN_LOG" | sed 's/^# start: //' || echo "")
+fi
+
+# ── Resolve output path ───────────────────────────────────────────────────────
+TS="$(timestamp)"
+if [[ -z "$OUTPUT" ]]; then
+    OUTPUT="$REPORTS_DIR/report-server-checkpoints-${TS}.html"
+fi
+
+# ── Emit HTML ─────────────────────────────────────────────────────────────────
+cat > "$OUTPUT" << 'HTMLEOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HerdDB Server Checkpoint Report</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  :root{--bg:#0f1117;--bg2:#1a1d2e;--bg3:#252840;
+    --accent:#6c8ebf;--accent2:#82c341;--accent3:#e0a400;
+    --warn:#e05050;--text:#e0e4f0;--muted:#8890a8;--border:#2e3254}
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--text);font-family:'Segoe UI',system-ui,sans-serif;
+       font-size:14px;line-height:1.6}
+  h1{font-size:1.5rem;color:var(--accent);padding:22px 28px 6px}
+  h2{font-size:1.1rem;color:var(--accent2);margin:0 0 10px}
+  h3{font-size:.95rem;color:var(--accent3);margin:10px 0 6px}
+  .subtitle{color:var(--muted);padding:0 28px 18px;font-size:.85rem}
+  .grid{display:grid;gap:18px;padding:0 20px 20px}
+  .g2{grid-template-columns:repeat(auto-fit,minmax(360px,1fr))}
+  .g1{grid-template-columns:1fr}
+  .card{background:var(--bg2);border:1px solid var(--border);border-radius:8px;padding:18px}
+  .ch{position:relative;height:280px}
+  .kv{display:grid;grid-template-columns:auto 1fr;row-gap:5px;column-gap:14px}
+  .kk{color:var(--muted);font-size:.82rem;white-space:nowrap}
+  .kv2{font-weight:600;font-size:.9rem}
+  .scroll-t{overflow-x:auto;max-height:480px;overflow-y:auto}
+  table{width:100%;border-collapse:collapse;font-size:.78rem}
+  thead th{background:var(--bg3);color:var(--accent);position:sticky;top:0;
+           padding:7px 9px;text-align:right;white-space:nowrap;
+           border-bottom:1px solid var(--border)}
+  thead th:first-child{text-align:center}
+  tbody tr{border-bottom:1px solid var(--border)}
+  tbody tr:hover{background:var(--bg3)}
+  tbody td{padding:4px 9px;text-align:right}
+  tbody td:first-child{text-align:center;color:var(--muted)}
+  tbody td.ts{text-align:left;color:var(--muted);font-size:.72rem;white-space:nowrap}
+  .df{color:var(--accent2)}.ds{color:var(--accent3)}.dv{color:var(--warn)}
+  .big{font-size:1.6rem;font-weight:700;color:var(--warn)}
+  .callout{background:var(--bg3);border-left:3px solid var(--accent3);
+           padding:9px 13px;border-radius:0 5px 5px 0;margin:8px 0;font-size:.85rem}
+  .callout.green{border-color:var(--accent2)}
+  .callout.red{border-color:var(--warn)}
+  code{background:var(--bg3);padding:1px 5px;border-radius:3px;
+       font-family:monospace;font-size:.8rem;color:var(--accent)}
+  footer{text-align:center;padding:18px;color:var(--muted);font-size:.75rem}
+</style>
+</head>
+<body>
+HTMLEOF
+
+cat >> "$OUTPUT" << JSEOF
+<script>
+// ── Data injected by report-server-checkpoints.sh ─────────────────────────
+const META = {
+  logFile:    $(echo "\"$LOG_BASENAME\""),
+  logDate:    $(echo "\"$LOG_DATE\""),
+  runLogArgs: $(echo "\"${RUN_LOG_ARGS:-}\""),
+  runLogStart:$(echo "\"${RUN_LOG_START:-}\""),
+  rowCount:   $ROW_COUNT,
+};
+
+// [startLed, startOff, finishLed, finishOff, totalMs, blinkPages, timestamp, dirtyPages]
+const CKPTS = [
+$JS_ROWS
+];
+</script>
+JSEOF
+
+cat >> "$OUTPUT" << 'HTMLEOF2'
+<h1>🖥 HerdDB Server Checkpoint Dynamics</h1>
+<p class="subtitle" id="subtitleLine">Loading…</p>
+
+<div class="grid g2" style="padding-top:14px">
+
+  <div class="card">
+    <h2>📊 Checkpoint Summary</h2>
+    <div class="kv" id="summaryKv"></div>
+  </div>
+
+  <div class="card">
+    <h2>🏗 Server Checkpoint Architecture</h2>
+    <p style="color:var(--muted);font-size:.82rem;line-height:1.7">
+      The server runs a periodic checkpoint every
+      <code>server.checkpoint.period</code> ms (default configured: 60 s).
+      Each checkpoint:
+    </p>
+    <ol style="margin:8px 0 0 18px;font-size:.82rem;line-height:1.9;color:var(--text)">
+      <li>Acquires the <b>checkpoint read-write lock</b> (blocks concurrent commits)</li>
+      <li>Flushes all <b>dirty data pages</b> to the remote file-server (MinIO)</li>
+      <li>Writes the <b>BLink primary-key index</b> checkpoint file to local storage
+          (one file per page, always <code>N pages</code> total — not incremental)</li>
+      <li>Writes the <b>vector index checkpoint</b> reference (waits for IS catch-up)</li>
+      <li>Advances the <b>checkpoint LSN</b> in ZooKeeper</li>
+      <li>Releases the lock — commits can proceed</li>
+    </ol>
+    <div class="callout" style="margin-top:10px">
+      <b>Key insight:</b> the BLink index is checkpointed as a full snapshot of
+      all pages every time. Its duration scales with the total page count, not
+      just new/dirty pages. Data pages use remote storage so are streamed
+      incrementally, but must still be flushed under the lock.
+    </div>
+  </div>
+
+</div>
+
+<div class="grid g2">
+
+  <div class="card">
+    <h2>⏱ Checkpoint Duration Timeline</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Each bar = one checkpoint cycle.
+      <span style="color:var(--accent3)">■</span> 1–120 s (slow)
+      <span style="color:var(--warn)">■</span> &gt;120 s (very slow — likely caused commit lock timeouts)
+    </p>
+    <div class="ch"><canvas id="durationChart"></canvas></div>
+  </div>
+
+  <div class="card">
+    <h2>📄 BLink Index Pages per Checkpoint</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Full page count written to disk at each checkpoint. A constant or
+      slowly-growing count is expected as the primary-key BTree fills up.
+    </p>
+    <div class="ch"><canvas id="pagesChart"></canvas></div>
+  </div>
+
+  <div class="card">
+    <h2>📈 LSN Advancement per Checkpoint</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Ledger offset difference between consecutive checkpoints.
+      Higher = more write activity (entries logged) between checkpoints.
+    </p>
+    <div class="ch"><canvas id="lsnChart"></canvas></div>
+  </div>
+
+  <div class="card">
+    <h2>🕐 Checkpoint Start Time Gaps</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px">
+      Wall-clock gap between consecutive checkpoint starts.
+      Should be close to <code>server.checkpoint.period</code> (60 s) unless
+      a checkpoint ran very long.
+    </p>
+    <div class="ch"><canvas id="gapChart"></canvas></div>
+  </div>
+
+</div>
+
+<div class="grid g1">
+  <div class="card">
+    <h2>📋 All Checkpoint Cycles</h2>
+    <p style="color:var(--muted);font-size:.8rem;margin-bottom:8px" id="tableNote"></p>
+    <div class="scroll-t">
+      <table>
+        <thead><tr>
+          <th>#</th><th>Timestamp</th>
+          <th>Start LSN</th><th>Finish LSN</th>
+          <th>Total ms</th><th>Duration</th>
+          <th>BLink pages</th><th>LSN Δoffset</th>
+        </tr></thead>
+        <tbody id="cpTbody"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<div class="grid g1">
+  <div class="card">
+    <h2>🔬 Analysis: Why Can a Checkpoint Take Minutes?</h2>
+    <div id="analysisBlock" style="font-size:.85rem;line-height:1.8"></div>
+  </div>
+</div>
+
+<footer id="footerLine"></footer>
+
+<script>
+// ── helpers ──────────────────────────────────────────────────────────────────
+const fmt   = n => Number(n).toLocaleString();
+const fmtS  = ms => ms>=60000 ? (ms/60000).toFixed(1)+' min'
+                               : (ms/1000).toFixed(1)+' s';
+const fmtMs = ms => fmt(ms)+' ms';
+const lsnStr= (l,o) => `(${l},${o})`;
+
+// ── Derived arrays ────────────────────────────────────────────────────────────
+const labels  = CKPTS.map((_,i)=>i+1);
+const durs    = CKPTS.map(r=>r[4]);
+const pages   = CKPTS.map(r=>r[5]<0?null:r[5]);
+
+// LSN offset delta between consecutive checkpoints
+// (same ledger: delta offset; ledger roll: we use absolute offset of finish)
+const lsnDelta = CKPTS.map((r,i)=>{
+  if(i===0) return 0;
+  const prev=CKPTS[i-1];
+  if(r[0]===prev[2] && r[2]===r[0]) return r[1]-prev[3]; // same ledger
+  return r[3]; // new ledger: just the finish offset
+});
+
+// ── Statistics ────────────────────────────────────────────────────────────────
+const sorted  = [...durs].sort((a,b)=>a-b);
+const durMed  = sorted[Math.floor(sorted.length/2)]||0;
+const durMean = durs.reduce((a,b)=>a+b,0)/(durs.length||1);
+const durMax  = Math.max(...durs);
+const durMin  = Math.min(...durs);
+const dur95   = sorted[Math.floor(sorted.length*.95)]||0;
+const durP99  = sorted[Math.floor(sorted.length*.99)]||0;
+const slowIdx = durs.reduce((mi,v,i,a)=>v>a[mi]?i:mi,0);
+const pagesUniq= [...new Set(pages.filter(p=>p!==null))];
+const pagesMin = pagesUniq.length ? Math.min(...pagesUniq) : 0;
+const pagesMax = pagesUniq.length ? Math.max(...pagesUniq) : 0;
+
+// Trend: linear regression slope on durs
+const trendSlope = (() => {
+  if(durs.length<4) return 0;
+  const n=durs.length, sx=n*(n+1)/2, sx2=n*(n+1)*(2*n+1)/6;
+  const sy=durs.reduce((a,b)=>a+b,0);
+  const sxy=durs.reduce((s,v,i)=>s+(i+1)*v,0);
+  return (n*sxy-sx*sy)/(n*sx2-sx*sx);
+})();
+
+// ── Subtitle ──────────────────────────────────────────────────────────────────
+document.getElementById('subtitleLine').textContent =
+  `Source: ${META.logFile}  ·  ${META.rowCount} checkpoint cycles  `+
+  `·  Max duration: ${fmtS(durMax)}  ·  Median: ${fmtS(durMed)}`;
+
+// ── Summary KV ───────────────────────────────────────────────────────────────
+const kvRows = [
+  ['Checkpoint cycles',  fmt(META.rowCount)],
+  ['Duration min',       fmtS(durMin)],
+  ['Duration median',    fmtS(durMed)],
+  ['Duration mean',      fmtS(Math.round(durMean))],
+  ['Duration p95',       fmtS(dur95)],
+  ['Duration p99',       fmtS(durP99)],
+  ['Duration max',       fmtS(durMax)],
+  ['Slowest checkpoint', `#${slowIdx+1} at ${CKPTS[slowIdx]?.[6]||'?'} — ${fmtS(durMax)}`],
+  ['BLink pages (min)',  fmt(pagesMin)],
+  ['BLink pages (max)',  fmt(pagesMax)],
+  ['Duration trend',     trendSlope>100 ? `⬆ growing (+${trendSlope.toFixed(0)} ms/cycle)`
+                        :trendSlope<-100 ? `⬇ shrinking (${trendSlope.toFixed(0)} ms/cycle)`
+                        :'→ stable'],
+  ['Log file',           META.logFile],
+  ...(META.runLogArgs ? [['Workload', META.runLogArgs]] : []),
+  ...(META.runLogStart ? [['Run start', META.runLogStart]] : []),
+];
+const kvDiv = document.getElementById('summaryKv');
+kvRows.forEach(([k,v])=>{
+  const ke=document.createElement('span'); ke.className='kk'; ke.textContent=k;
+  const ve=document.createElement('span'); ve.className='kv2'; ve.textContent=v;
+  kvDiv.append(ke,ve);
+});
+
+// ── Table note ────────────────────────────────────────────────────────────────
+document.getElementById('tableNote').textContent =
+  `${META.rowCount} cycles parsed.  `+
+  `Yellow = 1 s – 2 min, Red = >2 min.`;
+
+// ── Table ─────────────────────────────────────────────────────────────────────
+const tbody=document.getElementById('cpTbody');
+CKPTS.forEach((r,i)=>{
+  const[sL,sO,fL,fO,ms,pg,ts,dirty]=r;
+  let dc=ms>120000?'dv':ms>1000?'ds':'df';
+  const delta=lsnDelta[i];
+  tbody.innerHTML+=`<tr>
+    <td>${i+1}</td>
+    <td class="ts">${ts}</td>
+    <td>${lsnStr(sL,sO)}</td>
+    <td>${lsnStr(fL,fO)}</td>
+    <td class="${dc}">${fmt(ms)}</td>
+    <td class="${dc}">${fmtS(ms)}</td>
+    <td>${pg>=0?fmt(pg):'—'}</td>
+    <td>${fmt(delta)}</td>
+  </tr>`;
+});
+
+// ── Chart defaults ────────────────────────────────────────────────────────────
+const CD={
+  responsive:true,maintainAspectRatio:false,animation:false,
+  plugins:{legend:{labels:{color:'#8890a8',font:{size:10}}}},
+  scales:{
+    x:{ticks:{color:'#8890a8',font:{size:9},maxTicksLimit:20},grid:{color:'#2e3254'},
+       title:{display:true,text:'Checkpoint #',color:'#8890a8'}},
+    y:{ticks:{color:'#8890a8',font:{size:9}},grid:{color:'#2e3254'}}
+  }
+};
+
+// ── Duration chart ────────────────────────────────────────────────────────────
+new Chart(document.getElementById('durationChart'),{
+  type:'bar',
+  data:{labels,datasets:[{
+    label:'Duration (ms)',data:durs,
+    backgroundColor:durs.map(v=>v>120000?'rgba(224,80,80,.8)':v>1000?'rgba(224,164,0,.7)':'rgba(108,142,191,.6)'),
+    borderColor:durs.map(v=>v>120000?'#e05050':v>1000?'#e0a400':'#6c8ebf'),
+    borderWidth:1
+  }]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,type:'logarithmic',
+       title:{display:true,text:'ms (log scale)',color:'#8890a8'},
+       ticks:{color:'#8890a8',font:{size:9},
+              callback:v=>v>=60000?(v/60000).toFixed(0)+'min':
+                         v>=1000?(v/1000).toFixed(0)+'s':v+'ms'}}}}
+});
+
+// ── Pages chart ───────────────────────────────────────────────────────────────
+new Chart(document.getElementById('pagesChart'),{
+  type:'line',
+  data:{labels,datasets:[{
+    label:'BLink pages',data:pages,
+    borderColor:'#82c341',backgroundColor:'rgba(130,195,65,.1)',
+    fill:true,tension:.2,pointRadius:2,spanGaps:true
+  }]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,beginAtZero:false,
+       title:{display:true,text:'pages',color:'#8890a8'}}}}
+});
+
+// ── LSN delta chart ───────────────────────────────────────────────────────────
+new Chart(document.getElementById('lsnChart'),{
+  type:'bar',
+  data:{labels,datasets:[{
+    label:'LSN offset delta',data:lsnDelta,
+    backgroundColor:'rgba(108,142,191,.55)',borderColor:'#6c8ebf',borderWidth:1
+  }]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,beginAtZero:true,
+       title:{display:true,text:'offset Δ',color:'#8890a8'}}}}
+});
+
+// ── Gap chart (time between checkpoints) ──────────────────────────────────────
+// Approximate: gap ≈ duration[i] + (period - duration[i-1]) — we don't have
+// precise wall-clock starts, so we use duration as a proxy for "time consumed".
+// The actual gap would need start timestamps; we show just the duration as proxy.
+const PERIOD_MS = 60000; // configured period
+const gaps = durs.map((d,i)=>{
+  if(i===0) return PERIOD_MS;
+  return Math.max(d, PERIOD_MS); // actual gap >= max(duration, period)
+});
+new Chart(document.getElementById('gapChart'),{
+  type:'bar',
+  data:{labels,datasets:[
+    {label:'Checkpoint duration (ms)',data:durs,
+     backgroundColor:'rgba(108,142,191,.5)',borderColor:'#6c8ebf',borderWidth:1},
+    {label:'Configured period (60 s)',
+     data:durs.map(()=>PERIOD_MS),
+     type:'line',borderColor:'#e0a400',borderDash:[4,4],
+     pointRadius:0,fill:false}
+  ]},
+  options:{...CD,scales:{...CD.scales,
+    y:{...CD.scales.y,beginAtZero:true,
+       title:{display:true,text:'ms',color:'#8890a8'},
+       ticks:{callback:v=>v>=60000?(v/60000).toFixed(0)+'min':v>=1000?(v/1000).toFixed(0)+'s':v}}}}
+});
+
+// ── Analysis ──────────────────────────────────────────────────────────────────
+const trendText = trendSlope > 200
+  ? `<b style="color:var(--warn)">YES — growing</b> at +${trendSlope.toFixed(0)} ms per cycle. `+
+    `This suggests an O(N) component (e.g. dirty pages accumulating faster than they are flushed, `+
+    `or BLink page count growing unboundedly).`
+  : trendSlope < -200
+  ? `<b style="color:var(--accent2)">No — shrinking</b> (${trendSlope.toFixed(0)} ms/cycle). `+
+    `Checkpoint load is decreasing, likely because ingest has slowed or stopped.`
+  : `<b style="color:var(--accent2)">No — stable</b> (slope: ${trendSlope.toFixed(0)} ms/cycle). `+
+    `Duration does not grow with time under the observed conditions.`;
+
+const bigCkptIdx = durs.findIndex(d=>d>60000);
+const bigCkptNote = bigCkptIdx>=0
+  ? `<div class="callout red">
+      <b>Outlier detected:</b> checkpoint #${bigCkptIdx+1} at ${CKPTS[bigCkptIdx]?.[6]||'?'}
+      took <b>${fmtS(durs[bigCkptIdx])}</b>. This is likely the explicit
+      <code>--checkpoint</code> phase at end of ingest, or a catch-up checkpoint after a
+      long period without writes. During this window, any incoming commit that tries to acquire
+      the checkpoint lock will time out if the lock is held longer than the commit timeout.
+    </div>`
+  : '';
+
+document.getElementById('analysisBlock').innerHTML = `
+<h3>Does checkpoint time grow over time?</h3>
+<div class="callout">${trendText}</div>
+${bigCkptNote}
+
+<h3>What determines checkpoint duration?</h3>
+<p>The server checkpoint has several serial phases under the checkpoint lock:</p>
+<ol style="margin:6px 0 10px 18px;line-height:1.9">
+  <li><b>Data page flush</b> — all dirty data pages are written to the remote file-server
+      (MinIO). Duration scales with the number of dirty pages accumulated since the
+      last checkpoint. Under sustained ingest at high throughput, more pages become
+      dirty between checkpoints than during idle periods.</li>
+  <li><b>BLink index checkpoint</b> — the primary-key BTree writes a snapshot of
+      <em>all</em> its pages to the local data PVC. Observed: ${fmt(pagesMax)} pages.
+      This is a full snapshot, not incremental — duration scales with total page count,
+      which grows as rows are inserted. With ${fmt(pagesMax)} pages, even at fast local
+      disk I/O this can take seconds.</li>
+  <li><b>Vector index checkpoint</b> — the server waits for the IS to catch up to
+      the current LSN before recording the checkpoint. If the IS tailer is far behind,
+      this wait dominates the checkpoint duration.</li>
+  <li><b>ZooKeeper write</b> — updates the durable checkpoint LSN. Usually milliseconds.</li>
+</ol>
+
+<h3>Why the commit lock timeout?</h3>
+<p>
+  <code>TableManager.onTransactionCommit</code> tries to acquire the same
+  checkpoint read-write lock in read mode. If the checkpoint is holding the
+  write-mode lock, all concurrent commits wait. The timeout for that wait is
+  derived from the checkpoint lock configuration and is not directly
+  configurable today. If the checkpoint takes longer than this timeout, the
+  commit returns <code>DataStorageManagerException: timed out while acquiring
+  checkpoint lock during a commit</code> and the transaction is rolled back.
+</p>
+<div class="callout red">
+  <b>Root cause:</b> the commit lock timeout is shorter than the worst-case
+  checkpoint duration. At large row counts the BLink index checkpoint and
+  dirty-page flush together can hold the lock for 100+ seconds, exceeding the
+  commit timeout (~60–120 s). The fix should either:
+  <ul style="margin:4px 0 0 16px">
+    <li>Make the commit lock wait timeout configurable and larger, or</li>
+    <li>Make the BLink checkpoint incremental (only write newly-dirty index pages), or</li>
+    <li>Release the checkpoint lock between the data-page flush and the BLink phase.</li>
+  </ul>
+</div>
+
+<h3>BLink page count: ${fmt(pagesMin)} → ${fmt(pagesMax)}</h3>
+<p>
+  The BLink primary-key index currently has <b>${fmt(pagesMax)} pages</b>.
+  Each page is written to disk at every checkpoint regardless of whether it is
+  dirty. As the table grows, page count grows proportionally — meaning checkpoint
+  duration from BLink alone grows linearly with row count. For 100 M rows this
+  is already ${fmt(pagesMax)} pages; at 1 B rows it would be ~${fmt(Math.round(pagesMax*10))} pages.
+</p>
+`;
+
+document.getElementById('footerLine').textContent =
+  `Generated by report-server-checkpoints.sh · ${META.logFile} · ${META.rowCount} cycles`;
+</script>
+</body></html>
+HTMLEOF2
+
+echo ""
+echo "REPORT=$OUTPUT"

--- a/herddb-services/examples/local-bench/scripts/run-bench.sh
+++ b/herddb-services/examples/local-bench/scripts/run-bench.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Run a vector-bench workload against the local HerdDB cluster.
+# All arguments are forwarded to bin/vector-bench.sh inside $CLUSTER_DIR.
+#
+# The Java client is always driven with --no-progress so that the captured
+# run log is \n-terminated line-per-sample output (rather than \r-overwritten
+# spinner frames), making the log tail-friendly for supervision agents and
+# much smaller on long runs.
+#
+# Usage:
+#   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
+#   ./scripts/run-bench.sh --dataset sift1m -n 100000 --checkpoint
+#
+# On success: writes $REPORTS_DIR/run-<timestamp>.log and prints its path
+# on the last line (prefixed "RUN_LOG="). Exits non-zero on failure.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+require_cluster_dir
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <vector-bench args>" >&2
+    echo "Example: $0 --dataset sift10k -n 10000 -k 100 --checkpoint" >&2
+    exit 2
+fi
+
+TS="$(timestamp)"
+RUN_LOG="$REPORTS_DIR/run-$TS.log"
+
+section "Running vector-bench against local cluster"
+echo "  cluster: $CLUSTER_DIR"
+echo "  args:    $*"
+echo "  log:     $RUN_LOG"
+echo ""
+
+{
+    echo "# vector-bench run $TS"
+    echo "# args: $*"
+    echo "# start: $(date -Iseconds)"
+    echo ""
+} > "$RUN_LOG"
+
+# Default to a modest VectorBench heap but let callers override via env.
+export VECTORBENCH_HEAP="${VECTORBENCH_HEAP:--Xms1g -Xmx2g}"
+
+set +e
+"$CLUSTER_DIR/bin/vector-bench.sh" --no-progress "$@" 2>&1 | tee -a "$RUN_LOG"
+status=${PIPESTATUS[0]}
+set -e
+
+{
+    echo ""
+    echo "# end: $(date -Iseconds)"
+    echo "# exit: $status"
+} >> "$RUN_LOG"
+
+echo ""
+echo "RUN_LOG=$RUN_LOG"
+exit "$status"

--- a/herddb-services/examples/local-bench/scripts/write-report.sh
+++ b/herddb-services/examples/local-bench/scripts/write-report.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Turn a vector-bench run log into a markdown report.
+#
+# Usage: ./scripts/write-report.sh <run-log-path>
+#
+# On success: prints "REPORT=<path>" on the last line.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+RUN_LOG="${1:-}"
+if [[ -z "$RUN_LOG" || ! -f "$RUN_LOG" ]]; then
+    echo "Usage: $0 <run-log-path>" >&2
+    echo "Run log not found: $RUN_LOG" >&2
+    exit 2
+fi
+
+TS="$(timestamp)"
+REPORT="$REPORTS_DIR/report-$TS.md"
+
+ARGS_LINE=$(grep -m1 '^# args:' "$RUN_LOG" || echo "# args: (unknown)")
+START_LINE=$(grep -m1 '^# start:' "$RUN_LOG" || echo "# start: (unknown)")
+END_LINE=$(grep -m1 '^# end:' "$RUN_LOG" || echo "# end: (unknown)")
+EXIT_LINE=$(grep -m1 '^# exit:' "$RUN_LOG" || echo "# exit: (unknown)")
+EXIT_CODE=$(echo "$EXIT_LINE" | awk '{print $NF}')
+
+SUMMARY=$(awk '
+    /^========================================$/ && !seen { seen=1; in_summary=1 }
+    in_summary { print }
+    /^Benchmark complete/ { in_summary=0 }
+' "$RUN_LOG" || true)
+
+PHASE_LINES=$(grep -E '^phase=' "$RUN_LOG" || true)
+
+CLUSTER_STATE=$("$SCRIPT_DIR/check-cluster.sh" 2>&1 || true)
+
+LOG_TAIL=$(tail -n 200 "$RUN_LOG")
+
+{
+    echo "# HerdDB vector-bench report (local) — $TS"
+    echo ""
+    if [[ "$EXIT_CODE" == "0" ]]; then
+        echo "**Status:** success"
+    else
+        echo "**Status:** failed (exit=$EXIT_CODE)"
+    fi
+    echo ""
+    echo "## Workload"
+    echo ""
+    echo '```'
+    echo "${ARGS_LINE#\# args: }"
+    echo "${START_LINE#\# }"
+    echo "${END_LINE#\# }"
+    echo "${EXIT_LINE#\# }"
+    echo '```'
+    echo ""
+    echo "## Cluster state"
+    echo ""
+    echo '```'
+    echo "$CLUSTER_STATE"
+    echo '```'
+    echo ""
+    if [[ -n "$PHASE_LINES" ]]; then
+        echo "## Phase metrics"
+        echo ""
+        echo '```'
+        echo "$PHASE_LINES"
+        echo '```'
+        echo ""
+    fi
+    if [[ -n "$SUMMARY" ]]; then
+        echo "## Benchmark summary"
+        echo ""
+        echo '```'
+        echo "$SUMMARY"
+        echo '```'
+        echo ""
+    fi
+    echo "## Run log (last 200 lines)"
+    echo ""
+    echo '<details><summary>expand</summary>'
+    echo ""
+    echo '```'
+    echo "$LOG_TAIL"
+    echo '```'
+    echo ""
+    echo '</details>'
+    echo ""
+    echo "---"
+    echo ""
+    echo "_Full log: \`$RUN_LOG\`_"
+} > "$REPORT"
+
+echo ""
+echo "REPORT=$REPORT"

--- a/herddb-services/examples/local-bench/teardown.sh
+++ b/herddb-services/examples/local-bench/teardown.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Stop the local HerdDB cluster and remove $CLUSTER_DIR.
+#
+# Usage:
+#   ./teardown.sh [--keep-dir]
+#
+# Options:
+#   --keep-dir   Stop services but do NOT delete $CLUSTER_DIR (useful when
+#                you want to inspect data on disk).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=scripts/common.sh
+source "$SCRIPT_DIR/scripts/common.sh"
+
+KEEP_DIR=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-dir) KEEP_DIR=true; shift ;;
+        --help|-h)  grep '^#' "$0" | grep -v '#!/' | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -d "$CLUSTER_DIR" ]]; then
+    echo "Nothing to do — $CLUSTER_DIR does not exist."
+    exit 0
+fi
+
+section "Stopping indexing service"
+( cd "$CLUSTER_DIR" && bin/service indexing-service stop ) || true
+
+section "Stopping HerdDB server"
+( cd "$CLUSTER_DIR" && bin/service server stop ) || true
+
+if ! $KEEP_DIR; then
+    section "Removing $CLUSTER_DIR"
+    rm -rf "$CLUSTER_DIR"
+else
+    echo "--keep-dir set, leaving $CLUSTER_DIR in place."
+fi


### PR DESCRIPTION
## Summary

Add a **local** (no-Kubernetes, no-Docker) counterpart to the
`herddb-k3s-bench` and `herddb-gke-bench` agents.

- New agent at `.claude/agents/herddb-local-bench.md` — same supervision /
  report / failure-issue flow as the cloud variants, adapted for plain
  host processes.
- New example harness at `herddb-services/examples/local-bench/` that
  unzips `herddb-services-*.zip` into `\$HERDDB_TESTS_HOME/cluster` and
  starts a standalone `herddb-server` + co-located `indexing-service`
  sharing the commit log on disk — same layout as
  `herddb-services/test-start-server.sh`, but driven from a stable
  directory the bench scripts can find.
- All scripts have local-only equivalents of the kubectl-based ones:
  - `process-status.sh` (instead of `pod-status.sh`)
  - `check-cluster.sh` reads pidfiles + does a JDBC ping
  - `collect-logs.sh` copies `*.service.log` files into `\$REPORTS_DIR`
  - `diagnostics.sh` runs `jcmd` and `asprof` against local PIDs
  - `analyze-{server,is}-checkpoints.sh` consume the on-disk log files
  - `report-is-checkpoints.sh` patched to use `bin/indexing-admin.sh`
    against `localhost:9850` instead of `kubectl exec`
- A short README documents the layout and the human-driven workflow.

## Test plan

- [x] \`bash -n\` clean on every script
- [x] \`./install.sh\` end-to-end against the locally built zip — both
      JVMs come up, JDBC \`select * from sysnodes\` succeeds
- [x] \`./scripts/check-cluster.sh\` and \`./scripts/process-status.sh\`
      report both services running
- [x] \`./scripts/collect-logs.sh\` produces a populated \`logs-<ts>/\`
      directory under \`\$REPORTS_DIR\`
- [x] \`bin/indexing-admin.sh engine-stats --server localhost:9850 --json\`
      returns clean JSON (used by the supervision loop and the IS
      checkpoint report)
- [x] \`./teardown.sh\` shuts both JVMs down cleanly with no leftover
      processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)