### PR TITLE
issue #255: rotate live shard on compaction nodeId reservation

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -1672,8 +1672,49 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     int allocateCompactionNodeIds(int count) {
-        int start = nextNodeId.getAndAdd(count);
-        return start;
+        // The bump of nextNodeId must be atomic with a rotation of the active
+        // live shard. Without rotation, the next addVector call would allocate
+        // nodeId = nextNodeId (post-bump) but compute
+        // local = nodeId - active.startNodeId on the OLD shard, opening a
+        // `count`-wide gap in the shard's local ordinal space. Phase B would
+        // then iterate the shard's graph and call pqv.get(ordinal) with an
+        // ordinal far beyond the PQ training-set size, throwing
+        // IndexOutOfBoundsException (issue #255).
+        //
+        // We hold stateLock.writeLock() to exclude addVector (which holds the
+        // read lock). This method is called from VectorIndexCompactor.rebuildSegment
+        // which does NOT hold checkpointLock or stateLock, so the lock order is
+        // deadlock-free.
+        stateLock.writeLock().lock();
+        try {
+            int start = nextNodeId.getAndAdd(count);
+            List<LiveGraphShard> shards = this.liveShards;
+            if (dimension != 0 && shards != null && !shards.isEmpty()
+                    && shards.get(shards.size() - 1).nodeToPk.size() > 0) {
+                int sealedSize = shards.get(shards.size() - 1).nodeToPk.size();
+                // createEmptyLiveShard reads nextNodeId.get() AFTER the bump,
+                // so the new shard's startNodeId equals the post-bump value
+                // and future ingest produces local = 0, 1, 2, ... contiguously.
+                LiveGraphShard fresh = createEmptyLiveShard(
+                        dimension, beamWidth, neighborOverflow, alpha,
+                        nextNodeId.get());
+                List<LiveGraphShard> newList = new ArrayList<>(shards);
+                newList.add(fresh);
+                synchronized (this) {
+                    this.liveShards = newList;
+                }
+                LOGGER.log(Level.INFO,
+                        "vector store {0}: rotated live graph shard before "
+                                + "compaction nodeId reservation, now {1} shards "
+                                + "({2} vectors in sealed shard, reserved range "
+                                + "[{3},{4}))",
+                        new Object[]{indexName, newList.size(), sealedSize,
+                                start, start + count});
+            }
+            return start;
+        } finally {
+            stateLock.writeLock().unlock();
+        }
     }
 
     void releaseCompactionNodeIds(int startNodeId, int count) {

--- a/herddb-core/src/test/java/herddb/index/vector/Issue255CompactionOrdinalGapTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue255CompactionOrdinalGapTest.java
@@ -1,0 +1,189 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #255.
+ *
+ * <p>{@link PersistentVectorStore#allocateCompactionNodeIds(int)} bumps the
+ * shared {@code nextNodeId} counter so the compactor can stage a contiguous
+ * range of vectors in {@code vectorStorage}. Before the fix the bump was
+ * lock-free and not coordinated with the live-shard rotation, so a
+ * concurrent {@code addVector} would allocate a global nodeId far beyond the
+ * active shard's {@code startNodeId} and call
+ * {@code shard.builder.addGraphNode(local, vec)} with a {@code local} value
+ * thousands or millions higher than any prior local id. The next Phase B
+ * checkpoint trained PQ on {@code shard.nodeToPk.size()} vectors but the
+ * graph contained ordinals far beyond that count, so
+ * {@code FusedPQ.writeInline} → {@code PQVectors.get(ordinal)} threw
+ * {@link IndexOutOfBoundsException}.
+ */
+public class Issue255CompactionOrdinalGapTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        return store;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Direct invariant test: after {@code allocateCompactionNodeIds} the
+     * subsequent {@code addVector} must produce a 0-based local ordinal in a
+     * fresh shard, not a {@code count}-wide gap in the previously-active shard.
+     * Phase B checkpoint must then succeed without {@link IndexOutOfBoundsException}.
+     */
+    @Test
+    public void allocationDuringIngestDoesNotPoisonPhaseBCheckpoint() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            Random rng = new Random(7);
+            int dim = 16;
+
+            // Seed the active live shard so it has a few vectors but is well
+            // below the rotation cap.
+            for (int i = 0; i < 10; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, dim));
+            }
+
+            // Simulate a graph-merge compaction reserving a large nodeId range.
+            // The reservation size mirrors what real compactions consume on the
+            // failing benchmark workload (hundreds of thousands of nodeIds).
+            int reservation = 200_000;
+            int reservedStart = store.allocateCompactionNodeIds(reservation);
+            try {
+                // After the fix, the next ingest must land on a fresh shard
+                // whose startNodeId == reservedStart + reservation. Without the
+                // fix it would land on the OLD shard with a 200K-wide gap.
+                for (int i = 0; i < 10; i++) {
+                    store.addVector(Bytes.from_int(1_000_000 + i), vec(rng, dim));
+                }
+
+                // Phase B builds a FusedPQ segment per live shard. Without the
+                // fix the active shard's local ordinal space would be
+                // {0..9, 200000..200009} but PQ would only train on 20 vectors,
+                // so writer.write → FusedPQ.writeInline → pqv.get(200000) →
+                // IndexOutOfBoundsException. With the fix, both shards are
+                // contiguous (sealed: 0..9, fresh: 0..9) so the checkpoint
+                // succeeds.
+                assertTrue("checkpoint must succeed after compaction nodeId reservation",
+                        store.checkpoint());
+            } finally {
+                store.releaseCompactionNodeIds(reservedStart, reservation);
+            }
+
+            // All inserted vectors must be searchable.
+            int found = 0;
+            Random probe = new Random(42);
+            for (int q = 0; q < 50; q++) {
+                List<Map.Entry<Bytes, Float>> hits = store.search(vec(probe, dim), 30);
+                for (Map.Entry<Bytes, Float> h : hits) {
+                    int pk = h.getKey().to_int();
+                    if (pk < 10 || (pk >= 1_000_000 && pk < 1_000_010)) {
+                        found++;
+                    }
+                }
+            }
+            assertTrue("inserted vectors must be searchable, found=" + found, found > 0);
+        }
+    }
+
+    /**
+     * Same scenario but with a real background compaction cycle: ingest
+     * sealed segments, fire compaction, then ingest a few more vectors and
+     * checkpoint. Without the fix the post-compaction checkpoint throws
+     * inside {@code writeShardAsFusedPQSegment}.
+     */
+    @Test
+    public void postCompactionIngestThenCheckpointSucceeds() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            Random rng = new Random(13);
+            int dim = 16;
+
+            // Build several sealed on-disk segments so compaction has work to do.
+            for (int c = 0; c < 5; c++) {
+                for (int i = 0; i < 300; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            assertTrue(store.getSegmentCount() >= 4);
+
+            // Add a few more vectors to the active live shard.
+            for (int i = 0; i < 10; i++) {
+                store.addVector(Bytes.from_int(900_000 + i), vec(rng, dim));
+            }
+
+            // Run a synchronous compaction cycle.
+            store.runCompactionCycle();
+            assertEquals(1, store.getCompactionSuccessesTotal());
+
+            // Continue ingesting after compaction and then checkpoint.
+            for (int i = 0; i < 10; i++) {
+                store.addVector(Bytes.from_int(950_000 + i), vec(rng, dim));
+            }
+            assertTrue("post-compaction checkpoint must succeed", store.checkpoint());
+        }
+    }
+}

--- a/herddb-services/examples/local-bench/scripts/report-is-checkpoints.sh
+++ b/herddb-services/examples/local-bench/scripts/report-is-checkpoints.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 #
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # Generate an HTML report on Indexing Service checkpoint dynamics and vector
 # index storage layout for a given run.
 #

--- a/herddb-services/examples/local-bench/scripts/report-server-checkpoints.sh
+++ b/herddb-services/examples/local-bench/scripts/report-server-checkpoints.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 #
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # Generate an HTML report on HerdDB server checkpoint dynamics.
 #
 # Parses the server pod log looking for:


### PR DESCRIPTION
## Summary

Fixes #255.

`VectorIndexCompactor.rebuildSegment` reserves a contiguous global nodeId range via `PersistentVectorStore.allocateCompactionNodeIds`, which until now was a lock-free `nextNodeId.getAndAdd(count)`. Concurrent `addVector` calls allocate from the same `nextNodeId`, so a bump that lands in the middle of an active live shard's lifetime opens a `count`-wide gap in the shard's local ordinal space (`local = nodeId - startNodeId`). The next Phase B checkpoint then iterates the shard's HNSW graph and calls `PQVectors.get(ordinal)` with an ordinal far beyond the PQ training-set size, throwing `IndexOutOfBoundsException`; subsequent retries hit a related `NullPointerException` in `ProductQuantization.extractTrainingVectors` because `VectorStorageShardView.getVector` reads slots that were already released by `VectorIndexCompactor.releaseCompactionNodeIds`.

The fix makes `allocateCompactionNodeIds` atomic with a forced live-shard rotation under `stateLock.writeLock()`. Ingest holds the matching read lock, so the window where `nextNodeId` has moved but the active shard has not is now zero. The fresh shard is created with `startNodeId = nextNodeId.get()` (post-bump), so subsequent ingest produces contiguous local ordinals 0, 1, 2, ... and Phase B writes succeed.

A latent related risk (32-bit `nextNodeId` exhaustion, never recycled across compactions) is tracked separately in #256.

## Test plan
- [x] New regression test `Issue255CompactionOrdinalGapTest` reproduces both the IOOBE and the NPE on the unfixed code, passes after the fix.
- [x] All 68 vector-index tests pass (`VectorIndexCompactor*Test`, `Issue234*`, `Issue235*`, `PersistentVectorStore*Test`).
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` clean for the touched module.
- [x] Hammer suite (`DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test`) green twice in a row, per `CLAUDE.md`'s requirement for index/checkpoint/concurrency changes.
- [ ] End-to-end: re-run the failing `run-bench.sh --dataset bigann -n 100000000 ...` from the issue and confirm the IS no longer enters the checkpoint-backoff loop. Optional follow-up; reproducer is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)