### PR TITLE
issue #256: widen nextNodeId to long + per-shard VectorStorage

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -275,11 +275,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** All live graph shards. The LAST element is the active (unsealed) shard. */
     private volatile List<LiveGraphShard> liveShards = new ArrayList<>();
 
-    /** Monotonically increasing node-ID counter. */
-    private final AtomicInteger nextNodeId = new AtomicInteger(0);
-
-    /** Global lock-free vector storage shared by all live shards. */
-    private VectorStorage vectorStorage = new VectorStorage(0);
+    /**
+     * Monotonically increasing global node-id counter. Widened to {@code long}
+     * so it cannot silently wrap after {@code 2^31} ids are burned by ingest +
+     * compaction reservations (issue #256). Each {@link LiveGraphShard} owns
+     * its own per-shard {@link VectorStorage} keyed by a local ordinal, so
+     * the global id here never reaches a {@code VectorStorage} backing array.
+     */
+    private final AtomicLong nextNodeId = new AtomicLong(0);
 
     /** Page-ID counter. */
     private final AtomicLong newPageId = new AtomicLong(1);
@@ -1055,27 +1058,47 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * The active shard (last in the list) accepts new inserts; sealed shards are read-only.
      */
     static class LiveGraphShard {
+        /**
+         * Primary-key to <em>local ordinal</em>. Keys are bounded by
+         * {@code computeEffectiveMaxLiveGraphSize()} so they always fit in
+         * an {@code int}.
+         */
         final ConcurrentHashMap<Bytes, Integer> pkToNode;
+        /**
+         * Local ordinal to primary-key. Counterpart of {@link #pkToNode}.
+         */
         final ConcurrentHashMap<Integer, Bytes> nodeToPk;
         final RandomAccessVectorValues mravv;
         final GraphIndexBuilder builder;
         final AtomicInteger vectorCount = new AtomicInteger(0);
         /**
-         * Global nodeId of the first node added to this shard's builder.
-         * The builder uses local nodeIds {@code [0, vectorCount)}.
-         * To convert: {@code localNodeId = globalNodeId - startNodeId}.
+         * Per-shard lock-free vector storage, indexed by <em>local ordinal</em>
+         * {@code [0, vectorCount)}. Owned by this shard; dropped when the
+         * shard is checkpointed out (Phase C) so its int-indexed backing
+         * array never grows past the configured shard cap even as the
+         * global {@code nextNodeId} counter progresses (issue #256).
          */
-        final int startNodeId;
+        final VectorStorage vectorStorage;
+        /**
+         * Global nodeId of the first node added to this shard (i.e.
+         * {@code PersistentVectorStore.nextNodeId.get()} at the moment
+         * the shard was created). Retained for observability and for the
+         * local-ordinal computation {@code (int)(globalNodeId - startNodeId)}
+         * at insert time.
+         */
+        final long startNodeId;
 
         LiveGraphShard(ConcurrentHashMap<Bytes, Integer> pkToNode,
                        ConcurrentHashMap<Integer, Bytes> nodeToPk,
                        RandomAccessVectorValues mravv,
                        GraphIndexBuilder builder,
-                       int startNodeId) {
+                       VectorStorage vectorStorage,
+                       long startNodeId) {
             this.pkToNode = pkToNode;
             this.nodeToPk = nodeToPk;
             this.mravv = mravv;
             this.builder = builder;
+            this.vectorStorage = vectorStorage;
             this.startNodeId = startNodeId;
         }
     }
@@ -1142,7 +1165,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
 
         dataStorageManager.initIndex(tableSpaceUUID, indexUUID);
-        vectorStorage = new VectorStorage(computeEffectiveMaxLiveGraphSize());
 
         // Try to load existing state
         try {
@@ -1671,7 +1693,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         return nextSegmentId.getAndIncrement();
     }
 
-    int allocateCompactionNodeIds(int count) {
+    long allocateCompactionNodeIds(int count) {
         // The bump of nextNodeId must be atomic with a rotation of the active
         // live shard. Without rotation, the next addVector call would allocate
         // nodeId = nextNodeId (post-bump) but compute
@@ -1687,39 +1709,53 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // deadlock-free.
         stateLock.writeLock().lock();
         try {
-            int start = nextNodeId.getAndAdd(count);
+            long start = nextNodeId.getAndAdd(count);
             List<LiveGraphShard> shards = this.liveShards;
-            if (dimension != 0 && shards != null && !shards.isEmpty()
-                    && shards.get(shards.size() - 1).nodeToPk.size() > 0) {
-                int sealedSize = shards.get(shards.size() - 1).nodeToPk.size();
-                // createEmptyLiveShard reads nextNodeId.get() AFTER the bump,
-                // so the new shard's startNodeId equals the post-bump value
-                // and future ingest produces local = 0, 1, 2, ... contiguously.
-                LiveGraphShard fresh = createEmptyLiveShard(
-                        dimension, beamWidth, neighborOverflow, alpha,
-                        nextNodeId.get());
-                List<LiveGraphShard> newList = new ArrayList<>(shards);
-                newList.add(fresh);
-                synchronized (this) {
-                    this.liveShards = newList;
+            if (dimension != 0 && shards != null && !shards.isEmpty()) {
+                LiveGraphShard activeShard = shards.get(shards.size() - 1);
+                int sealedSize = activeShard.nodeToPk.size();
+                // Rotate whenever the bump would leave the active shard's
+                // startNodeId stale — this covers both the non-empty case
+                // (PR #257 / issue #255) AND the empty case (an active
+                // shard that was created before this bump would otherwise
+                // see the next ingest compute
+                //   local = postBumpNextNodeId - oldStartNodeId
+                // which is exactly the bump-wide gap we are trying to avoid).
+                // createEmptyLiveShard reads nextNodeId.get() AFTER the bump
+                // so the replacement shard's startNodeId equals the post-bump
+                // value and future ingest produces local = 0, 1, 2, ...
+                // contiguously.
+                if (sealedSize > 0 || activeShard.startNodeId != nextNodeId.get()) {
+                    LiveGraphShard fresh = createEmptyLiveShard(
+                            dimension, beamWidth, neighborOverflow, alpha,
+                            nextNodeId.get());
+                    List<LiveGraphShard> newList;
+                    if (sealedSize > 0) {
+                        // Preserve the non-empty shard as sealed and append
+                        // the fresh one — matches the issue-#255 behaviour.
+                        newList = new ArrayList<>(shards);
+                        newList.add(fresh);
+                    } else {
+                        // Replace the stale empty shard so we do not leak
+                        // empty shards across every compaction reservation.
+                        newList = new ArrayList<>(shards.subList(0, shards.size() - 1));
+                        newList.add(fresh);
+                    }
+                    synchronized (this) {
+                        this.liveShards = newList;
+                    }
+                    LOGGER.log(Level.INFO,
+                            "vector store {0}: rotated live graph shard before "
+                                    + "compaction nodeId reservation, now {1} shards "
+                                    + "({2} vectors in sealed shard, reserved range "
+                                    + "[{3},{4}))",
+                            new Object[]{indexName, newList.size(), sealedSize,
+                                    start, start + count});
                 }
-                LOGGER.log(Level.INFO,
-                        "vector store {0}: rotated live graph shard before "
-                                + "compaction nodeId reservation, now {1} shards "
-                                + "({2} vectors in sealed shard, reserved range "
-                                + "[{3},{4}))",
-                        new Object[]{indexName, newList.size(), sealedSize,
-                                start, start + count});
             }
             return start;
         } finally {
             stateLock.writeLock().unlock();
-        }
-    }
-
-    void releaseCompactionNodeIds(int startNodeId, int count) {
-        for (int i = 0; i < count; i++) {
-            vectorStorage.remove(startNodeId + i);
         }
     }
 
@@ -1729,10 +1765,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     VectorSimilarityFunction compactionSimilarity() {
         return similarityFunction;
-    }
-
-    VectorStorage compactionVectorStorage() {
-        return vectorStorage;
     }
 
     SegmentWriteResult writeSyntheticShard(LiveGraphShard syntheticShard,
@@ -2002,17 +2034,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
             // Check if rotation is needed BEFORE allocating the nodeId so that
             // the new shard's startNodeId (= nextNodeId.get() at creation time)
-            // matches the first nodeId assigned to it, keeping localId >= 0.
+            // matches the first nodeId assigned to it, keeping localOrd >= 0.
             if (active.nodeToPk.size() >= computeEffectiveMaxLiveGraphSize()) {
                 active = rotateLiveShard();
             }
 
-            int nodeId = nextNodeId.getAndIncrement();
-            vectorStorage.set(nodeId, vec);
+            long globalNodeId = nextNodeId.getAndIncrement();
+            // Per-shard span is bounded by computeEffectiveMaxLiveGraphSize(),
+            // so the cast always fits. Math.toIntExact turns a violated
+            // invariant into a loud ArithmeticException instead of silently
+            // wrapping (issue #256).
+            int localOrd = Math.toIntExact(globalNodeId - active.startNodeId);
+            active.vectorStorage.set(localOrd, vec);
             active.vectorCount.incrementAndGet();
-            active.pkToNode.put(pk, nodeId);
-            active.nodeToPk.put(nodeId, pk);
-            active.builder.addGraphNode(nodeId - active.startNodeId, vec);
+            active.pkToNode.put(pk, localOrd);
+            active.nodeToPk.put(localOrd, pk);
+            active.builder.addGraphNode(localOrd, vec);
             dirty.set(true);
         } finally {
             stateLock.readLock().unlock();
@@ -2052,14 +2089,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
             // Check all live shards
             for (LiveGraphShard shard : liveShards) {
-                Integer nodeId = shard.pkToNode.remove(pk);
-                if (nodeId != null) {
-                    shard.nodeToPk.remove(nodeId);
+                Integer localOrd = shard.pkToNode.remove(pk);
+                if (localOrd != null) {
+                    shard.nodeToPk.remove(localOrd);
                     dirty.set(true);
                     if (shard.builder != null) {
-                        shard.builder.markNodeDeleted(nodeId - shard.startNodeId);
+                        shard.builder.markNodeDeleted(localOrd);
                     } else {
-                        vectorStorage.remove(nodeId);
+                        shard.vectorStorage.remove(localOrd);
                         shard.vectorCount.decrementAndGet();
                     }
                     break;
@@ -2128,13 +2165,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         // Phase 3: frozen + deferred shards. Both are cleaned up by Phase C
         // under the write lock, so we must hold the read lock to prevent
-        // concurrent vectorStorage.remove() (called in Phase C) from clearing
-        // vectors while GraphSearcher accesses them via shard.mravv. Without
-        // this lock, there is a race where vectorStorage.remove() nulls a
-        // vector slot while jvector's scorer is calling getVector() on it,
-        // leading to NullPointerException (issue #129). The lock is held
-        // while invokeSearchTasks blocks on task completion: worker threads
-        // can join as additional readers because ReentrantReadWriteLock
+        // Phase C from dropping the shards (and their per-shard VectorStorage
+        // references) while GraphSearcher is still accessing them via
+        // shard.mravv. Without this lock, a race would let the shard become
+        // unreachable while jvector's scorer is calling getVector() on its
+        // storage, leading to NullPointerException (issue #129). The lock
+        // is held while invokeSearchTasks blocks on task completion: worker
+        // threads can join as additional readers because ReentrantReadWriteLock
         // allows multiple concurrent read holders.
         stateLock.readLock().lock();
         try {
@@ -2188,7 +2225,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 qv, k, shard.mravv, similarityFunction, graph, Bits.ALL);
         List<Map.Entry<Bytes, Float>> out = new ArrayList<>(result.getNodes().length);
         for (SearchResult.NodeScore ns : result.getNodes()) {
-            Bytes pk = shard.nodeToPk.get(ns.node + shard.startNodeId);
+            Bytes pk = shard.nodeToPk.get(ns.node);
             if (pk != null && (pendingDeletes == null || !pendingDeletes.contains(pk))) {
                 out.add(new AbstractMap.SimpleImmutableEntry<>(pk, ns.score));
             }
@@ -2722,7 +2759,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     maxOrd = seg.maxOrdinal;
                 }
             }
-            this.nextNodeId.set(Math.max(maxOrd + 1, nextNodeId.get()));
+            this.nextNodeId.set(Math.max((long) maxOrd + 1L, nextNodeId.get()));
 
             int totalNodes = (int) onDiskNodeToPkSize() + totalLiveSize();
             LOGGER.log(Level.INFO,
@@ -2730,17 +2767,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             + "{3} new live inserts during checkpoint",
                     new Object[]{indexName, totalNodes, newSegments.size(), totalLiveSize()});
 
-            // Release vectorStorage slots for checkpointed nodeIds
-            if (snapshotShards != null) {
-                for (LiveGraphShard shard : snapshotShards) {
-                    for (Integer nodeId : shard.nodeToPk.keySet()) {
-                        vectorStorage.remove(nodeId);
-                    }
-                }
-            }
-
-            // Shrink the backing array if most slots were freed
-            vectorStorage.compact(nextNodeId.get());
+            // No vectorStorage cleanup needed: each shard owns its own per-shard
+            // VectorStorage (issue #256). Dropping the reference to the old shards
+            // via the `this.frozenShards = null` assignment below allows the GC
+            // to reclaim the backing arrays without any per-slot bookkeeping.
 
             // Rejoin deferred shards before clearing so the next checkpoint cycle processes them.
             List<LiveGraphShard> deferred = this.deferredShards;
@@ -3022,17 +3052,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
-     * Zero-copy view over vectorStorage for a single live shard.
-     * Maps ordinal i (0-based within shard) to vectorStorage.get(startNodeId + i).
+     * Zero-copy view over a single shard's per-shard {@link VectorStorage}.
+     * Maps ordinal i (0-based within shard) directly to {@code storage.get(i)}.
      * Implements RandomAccessVectorValues for use with PQ training and OnDiskGraphIndexWriter.
      */
-    private final class VectorStorageShardView implements io.github.jbellis.jvector.graph.RandomAccessVectorValues {
-        private final int startNodeId;
+    private static final class VectorStorageShardView implements io.github.jbellis.jvector.graph.RandomAccessVectorValues {
+        private final VectorStorage storage;
         private final int size;
         private final int dimension;
 
-        VectorStorageShardView(int startNodeId, int size, int dimension) {
-            this.startNodeId = startNodeId;
+        VectorStorageShardView(VectorStorage storage, int size, int dimension) {
+            this.storage = storage;
             this.size = size;
             this.dimension = dimension;
         }
@@ -3049,7 +3079,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         @Override
         public VectorFloat<?> getVector(int i) {
-            return vectorStorage.get(startNodeId + i);
+            return storage.get(i);
         }
 
         @Override
@@ -3064,15 +3094,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
-     * Builds a ConcurrentHashMap from shard-relative ordinal (0-based) to PK.
-     * For each entry in the shard's nodeToPk, computes ordinal as (nodeId - shard.startNodeId).
+     * Returns the shard's {@code nodeToPk} map — already keyed by the
+     * shard-relative local ordinal after the issue-#256 refactor.
      */
     private ConcurrentHashMap<Integer, Bytes> buildOrdinalToPk(LiveGraphShard shard) {
-        ConcurrentHashMap<Integer, Bytes> result = new ConcurrentHashMap<>(shard.nodeToPk.size());
-        for (Map.Entry<Integer, Bytes> e : shard.nodeToPk.entrySet()) {
-            result.put(e.getKey() - shard.startNodeId, e.getValue());
-        }
-        return result;
+        return shard.nodeToPk;
     }
 
     /**
@@ -3100,9 +3126,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         writingGraphActive.incrementAndGet();
         try {
-            // Create a zero-copy view over vectorStorage for this shard's ordinals
+            // Create a zero-copy view over this shard's per-shard VectorStorage.
             VectorStorageShardView shardView = new VectorStorageShardView(
-                    shard.startNodeId, shardSize, snapshotDimension);
+                    shard.vectorStorage, shardSize, snapshotDimension);
 
             // Get the shard's already-built OnHeapGraphIndex (no rebuild!)
             OnHeapGraphIndex shardGraph = (OnHeapGraphIndex) shard.builder.getGraph();
@@ -3396,37 +3422,44 @@ public class PersistentVectorStore extends AbstractVectorStore {
             List<LiveGraphShard> currentShards = this.liveShards;
             LiveGraphShard lastSnapshot = snapshotShards.get(snapshotShards.size() - 1);
 
+            // After the issue-#256 refactor each shard owns its own per-shard
+            // VectorStorage keyed by a LOCAL ordinal, so we can preserve
+            // Phase B inserts simply by concatenating {snapshotShards,
+            // currentShards} into the new liveShards list — no cross-shard
+            // replay, no globalNodeId → local-ordinal remapping, and no risk
+            // of overflowing lastSnapshot's cap by piling vectors into it.
+            // `lastSnapshot` reference is retained only for the log below.
             for (LiveGraphShard currentShard : currentShards) {
-                for (Map.Entry<Integer, Bytes> e : currentShard.nodeToPk.entrySet()) {
-                    int nodeId = e.getKey();
-                    VectorFloat<?> vec = vectorStorage.get(nodeId);
-                    Bytes pk = e.getValue();
-                    if (vec != null) {
-                        lastSnapshot.pkToNode.put(pk, nodeId);
-                        lastSnapshot.nodeToPk.put(nodeId, pk);
-                        lastSnapshot.vectorCount.incrementAndGet();
-                        if (lastSnapshot.builder != null) {
-                            try {
-                                lastSnapshot.builder.addGraphNode(nodeId - lastSnapshot.startNodeId, vec);
-                            } catch (Exception ex) {
-                                LOGGER.log(Level.WARNING, "Failed to re-add node during recovery", ex);
-                            }
-                        }
-                    }
-                }
-                if (currentShard.builder != null) {
+                // jvector builders for currentShards remain open (initEmptyLiveShards
+                // at Phase A entry leaves the fresh shards' builders live),
+                // so nothing to close here. snapshotShards' builders are also
+                // still open — writeShardAsFusedPQSegment deliberately does
+                // not close them during Phase B (see its finally block).
+                if (currentShard.nodeToPk.isEmpty() && currentShard.builder != null) {
                     try {
                         currentShard.builder.close();
                     } catch (IOException e) {
-                        // ignore
+                        // ignore: empty-shard cleanup only
                     }
                 }
             }
+            // Tolerate an unused lastSnapshot reference when logging is disabled.
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE,
+                        "checkpoint {0}: Phase B recovery concatenating {1} snapshot + {2} current shards (last snapshot startNodeId={3})",
+                        new Object[]{indexName, snapshotShards.size(), currentShards.size(),
+                                lastSnapshot.startNodeId});
+            }
 
-            this.liveShards = new ArrayList<>(snapshotShards);
+            List<LiveGraphShard> rebuilt = new ArrayList<>(snapshotShards.size() + currentShards.size());
+            rebuilt.addAll(snapshotShards);
+            for (LiveGraphShard cur : currentShards) {
+                if (!cur.nodeToPk.isEmpty()) {
+                    rebuilt.add(cur);
+                }
+            }
+            this.liveShards = rebuilt;
             // Restore deferred shards so they rejoin the live set intact.
-            // The existing merge of Phase B new vectors into lastSnapshot is unaffected —
-            // initEmptyLiveShards put only a fresh empty shard in this.liveShards during Phase A.
             List<LiveGraphShard> deferred = this.deferredShards;
             if (deferred != null) {
                 this.liveShards.addAll(deferred);
@@ -3471,7 +3504,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
         /* boolean savedAddHierarchy = */ metaBuf.get();
         /* boolean savedFusedPQ = */ metaBuf.get();
 
-        int savedNextNodeId = metaBuf.getInt();
+        // nextNodeId is serialised as int64 after issue #256 — the in-place
+        // v3 rewrite breaks backward-compatibility on purpose.
+        long savedNextNodeId = metaBuf.getLong();
 
         this.dimension = dim;
         newPageId.set(status.newPageId);
@@ -3479,7 +3514,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         loadMultiSegmentFormat(metaBuf, dim, savedNextNodeId, savedBeamWidth, savedNeighborOverflow, savedAlpha);
     }
 
-    private void loadMultiSegmentFormat(ByteBuffer metaBuf, int dim, int savedNextNodeId,
+    private void loadMultiSegmentFormat(ByteBuffer metaBuf, int dim, long savedNextNodeId,
                                          int savedBeamWidth, float savedNeighborOverflow, float savedAlpha)
             throws IOException, DataStorageManagerException {
         java.io.DataInputStream dis = new java.io.DataInputStream(
@@ -3554,7 +3589,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 maxOrd = seg.maxOrdinal;
             }
         }
-        this.nextNodeId.set(maxOrd + 1);
+        // Prefer the persisted long nextNodeId when it is ahead of the
+        // reconstructed maxOrd — this preserves the global monotonic
+        // counter across restarts (issue #256).
+        this.nextNodeId.set(Math.max((long) maxOrd + 1L, savedNextNodeId));
 
         initEmptyLiveShards(dim, savedBeamWidth, savedNeighborOverflow, savedAlpha);
 
@@ -3597,7 +3635,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * through a {@link ReaderSupplier} backed by the storage manager's
      * multipart API — no resident copy on disk.
      */
-    private void loadFusedPQSegment(VectorSegment seg, Path mapFile, int dim, int savedNextNodeId)
+    private void loadFusedPQSegment(VectorSegment seg, Path mapFile, int dim, long savedNextNodeId)
             throws IOException, DataStorageManagerException {
         if (seg.graphFilePath == null) {
             throw new IllegalStateException(
@@ -3950,7 +3988,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
             dos.writeFloat(alpha);
             dos.writeByte(ADD_HIERARCHY ? 1 : 0);
             dos.writeByte(1); // fusedPQ
-            dos.writeInt(nextNodeId.get());
+            // nextNodeId widened to int64 after issue #256. Format version
+            // stays at v3 — the loader refuses unknown versions, so mixing
+            // old + new clients on the same checkpoint directory fails loud
+            // at load time rather than silently truncating the counter.
+            dos.writeLong(nextNodeId.get());
             dos.writeLong(newGeneration);
             dos.writeInt(totalSegments);
 
@@ -4249,19 +4291,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * Creates an empty live shard with an explicit {@code startNodeId}.
      * Use this when the global nodeId space has already been remapped (e.g., simple checkpoint rebuild).
      */
-    private LiveGraphShard createEmptyLiveShard(int dim, int bw, float no, float a, int startNodeId) {
+    private LiveGraphShard createEmptyLiveShard(int dim, int bw, float no, float a, long startNodeId) {
         int cap = computeEffectiveMaxLiveGraphSize();  // preallocate to avoid rehashing during inserts (issue #122)
         ConcurrentHashMap<Bytes, Integer> p2n = new ConcurrentHashMap<>(cap);
         ConcurrentHashMap<Integer, Bytes> n2p = new ConcurrentHashMap<>(cap);
+        // Per-shard VectorStorage — sized to the shard cap so the int-indexed
+        // backing array is bounded independent of nextNodeId (issue #256).
+        VectorStorage storage = new VectorStorage(cap);
         VectorStorageRandomAccessVectorValues ravv =
-                new VectorStorageRandomAccessVectorValues(vectorStorage, dim, -1, startNodeId);
+                new VectorStorageRandomAccessVectorValues(storage, dim);
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, similarityFunction);
         // Pass cap as initialCapacity so the jvector base-layer DenseIntMap is pre-sized
         // for the shard and concurrent addGraphNode avoids the spine-grow lock (issue #223).
         GraphIndexBuilder b = new GraphIndexBuilder(
                 bsp, dim, List.of(m), bw, no, a, ADD_HIERARCHY, REFINE_FINAL_GRAPH,
                 PhysicalCoreExecutor.pool(), ForkJoinPool.commonPool(), cap);
-        return new LiveGraphShard(p2n, n2p, ravv, b, startNodeId);
+        return new LiveGraphShard(p2n, n2p, ravv, b, storage, startNodeId);
     }
 
     /**
@@ -4451,7 +4496,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
         nextNodeId.set(0);
         nextSegmentId.set(0);
         dimension = 0;
-        vectorStorage = new VectorStorage(computeEffectiveMaxLiveGraphSize());
     }
 
     // -------------------------------------------------------------------------
@@ -4491,6 +4535,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public int getOnDiskNodeCount() {
         return (int) onDiskNodeToPkSize();
+    }
+
+    /**
+     * Returns the current value of the global monotonic node-id counter.
+     * Exposed for telemetry — dashboards can watch the burn rate and
+     * alert long before the {@code long} space is exhausted (issue #256).
+     */
+    public long getNextNodeId() {
+        return nextNodeId.get();
     }
 
     /**
@@ -4666,6 +4719,30 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public int getLiveVectorCapDuringCheckpoint() {
         return liveVectorCapDuringCheckpoint;
+    }
+
+    /**
+     * Test-only hook: fast-forward the global node-id counter past a
+     * configured threshold so unit tests can exercise the {@code long}
+     * overflow path without ingesting {@code 2^31} vectors (issue #256).
+     * Must be called before any {@code addVector} in the test so the
+     * first live shard's {@code startNodeId} adopts the seeded value.
+     */
+    public void seedNextNodeIdForTest(long value) {
+        nextNodeId.set(value);
+    }
+
+    /**
+     * Test-only hook: returns the active live shard (last in the list),
+     * so tests can assert per-shard storage bounds. {@code null} if no
+     * shard has been initialised yet.
+     */
+    public LiveGraphShard activeLiveShardForTest() {
+        List<LiveGraphShard> shards = this.liveShards;
+        if (shards == null || shards.isEmpty()) {
+            return null;
+        }
+        return shards.get(shards.size() - 1);
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -70,6 +70,21 @@ final class VectorIndexCompactor {
     private VectorIndexCompactor() {
     }
 
+    /**
+     * Test-only observer invoked once per {@code rebuildSegment} call with
+     * the synthetic {@link PersistentVectorStore.LiveGraphShard} that was
+     * constructed for the compaction output. Tests can install a
+     * {@link java.util.function.Consumer} that stashes the reference into
+     * a {@link java.lang.ref.WeakReference} to prove the shard (and its
+     * per-shard {@link VectorStorage}) is reclaimable after
+     * {@code rebuildSegment} returns (issue #256).
+     *
+     * <p>Must remain {@code null} in production. Reset by tests in a
+     * {@code @After} to avoid leaking an observer across test cases.
+     */
+    static volatile java.util.function.Consumer<PersistentVectorStore.LiveGraphShard>
+            syntheticShardObserverForTest;
+
     /** Reasons a compaction run can fail; carried through to metrics. */
     enum FailureReason {
         READ_IO,
@@ -367,15 +382,20 @@ final class VectorIndexCompactor {
             return null;
         }
 
-        // Reserve a contiguous nodeId range in the shared vectorStorage.
-        int startNodeId = store.allocateCompactionNodeIds(keptCount);
+        // Reserve a contiguous global nodeId range + force a live-shard
+        // rotation (issue #255). The synthetic shard uses its own per-shard
+        // VectorStorage keyed by a local ordinal 0..keptCount (issue #256),
+        // so no coordination with the live shards' storage is needed.
+        long startNodeId = store.allocateCompactionNodeIds(keptCount);
 
-        // Build a synthetic LiveGraphShard anchored at startNodeId.
+        // Build a synthetic LiveGraphShard anchored at startNodeId with its
+        // own isolated VectorStorage of exactly the size we need.
         ConcurrentHashMap<Bytes, Integer> pkToNode = new ConcurrentHashMap<>(keptCount);
         ConcurrentHashMap<Integer, Bytes> nodeToPk = new ConcurrentHashMap<>(keptCount);
+        VectorStorage syntheticStorage = new VectorStorage(keptCount);
         VectorStorageRandomAccessVectorValues ravv =
                 new VectorStorageRandomAccessVectorValues(
-                        store.compactionVectorStorage(), dim, keptCount, startNodeId);
+                        syntheticStorage, dim, keptCount);
         BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(
                 ravv, store.compactionSimilarity());
         GraphIndexBuilder builder = new GraphIndexBuilder(
@@ -392,13 +412,18 @@ final class VectorIndexCompactor {
 
         AtomicInteger localOrdCounter = new AtomicInteger(0);
         PersistentVectorStore.LiveGraphShard synthetic = new PersistentVectorStore.LiveGraphShard(
-                pkToNode, nodeToPk, ravv, builder, startNodeId);
+                pkToNode, nodeToPk, ravv, builder, syntheticStorage, startNodeId);
+        java.util.function.Consumer<PersistentVectorStore.LiveGraphShard> observer =
+                syntheticShardObserverForTest;
+        if (observer != null) {
+            observer.accept(synthetic);
+        }
 
         boolean success = false;
         VectorSegment mergedSegment = null;
         try {
             populateSyntheticShard(store, candidates, authority, synthetic,
-                    localOrdCounter, startNodeId);
+                    localOrdCounter);
 
             // Cleanup the builder (diversifies edges / refines).
             try {
@@ -439,7 +464,9 @@ final class VectorIndexCompactor {
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "ignoring builder close failure in compaction", e);
             }
-            store.releaseCompactionNodeIds(startNodeId, keptCount);
+            // No store-side release needed: the synthetic shard owns its own
+            // VectorStorage (issue #256), so it is reclaimed by the GC when
+            // this method returns.
             if (!success && mergedSegment != null) {
                 try {
                     mergedSegment.close();
@@ -459,8 +486,7 @@ final class VectorIndexCompactor {
             List<VectorSegment> candidates,
             Map<Bytes, Integer> authority,
             PersistentVectorStore.LiveGraphShard syntheticShard,
-            AtomicInteger localOrdCounter,
-            int startNodeId) throws CompactionException {
+            AtomicInteger localOrdCounter) throws CompactionException {
 
         for (VectorSegment seg : candidates) {
             OnDiskGraphIndex odg = seg.onDiskGraph;
@@ -506,10 +532,11 @@ final class VectorIndexCompactor {
                                 "null vector for authoritative PK in segment " + seg.segmentId);
                     }
                     int localOrd = localOrdCounter.getAndIncrement();
-                    int globalNodeId = startNodeId + localOrd;
-                    store.compactionVectorStorage().set(globalNodeId, vec);
-                    syntheticShard.pkToNode.put(pk, globalNodeId);
-                    syntheticShard.nodeToPk.put(globalNodeId, pk);
+                    // Per-shard storage keyed by local ordinal (issue #256).
+                    // No global nodeId arithmetic leaves this call site.
+                    syntheticShard.vectorStorage.set(localOrd, vec);
+                    syntheticShard.pkToNode.put(pk, localOrd);
+                    syntheticShard.nodeToPk.put(localOrd, pk);
                     syntheticShard.vectorCount.incrementAndGet();
                     try {
                         syntheticShard.builder.addGraphNode(localOrd, vec);

--- a/herddb-core/src/main/java/herddb/index/vector/VectorStorage.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorStorage.java
@@ -24,11 +24,16 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
- * Global lock-free vector storage for all live graph shards in a VectorIndexManager.
+ * Per-shard lock-free vector storage. Each {@code LiveGraphShard} owns one instance,
+ * indexed by the shard's local ordinal {@code [0, shardCap)}. The global node-id
+ * lives on {@link java.util.concurrent.atomic.AtomicLong} counters elsewhere; this
+ * class never sees it, so the {@code int}-indexed backing array is naturally bounded
+ * by the configured per-shard cap and cannot overflow as global ingest progresses
+ * (issue #256).
  *
  * <p>Replaces {@code ConcurrentHashMap<Integer, VectorFloat<?>>} (which required Integer
  * autoboxing, hash computation, and volatile segment traversal on every getVector() call)
- * with a direct array lookup indexed by the globally-sequential nodeId.
+ * with a direct array lookup.
  *
  * <p>Thread safety:
  * <ul>
@@ -43,16 +48,16 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  *       was in progress).  Growth itself is serialized by {@link #growAndSet}, which
  *       bumps {@code growSeq} to odd before the copy and back to even after the publish.
  *       Growth is rare (O(log N) over the store's lifetime), so retries are bounded.</li>
- *   <li>{@link #remove(int)} is synchronized so that its {@code array.set(nodeId, null)}
+ *   <li>{@link #remove(int)} is synchronized so that its {@code array.set(ordinal, null)}
  *       excludes a concurrent {@link #growAndSet} copy loop: without the lock, a grow
  *       running in parallel with remove could snapshot the not-yet-nulled slot into the
  *       new array, leaking the reference.</li>
  * </ul>
  *
- * <p>Write-before-read ordering guarantee: callers must call {@code set(nodeId, vec)} before
- * passing {@code nodeId} to {@code GraphIndexBuilder.addGraphNode()}.  The atomic element
- * write in {@code set} (combined with the volatile array-reference read in {@code get})
- * establishes happens-before with any subsequent read, satisfying JLS 17.4.4.
+ * <p>Write-before-read ordering guarantee: callers must call {@code set(ordinal, vec)}
+ * before passing {@code ordinal} to {@code GraphIndexBuilder.addGraphNode()}. The atomic
+ * element write in {@code set} (combined with the volatile array-reference read in
+ * {@code get}) establishes happens-before with any subsequent read, satisfying JLS 17.4.4.
  */
 @SuppressFBWarnings({"UG_SYNC_SET_UNSYNC_GET", "VO_VOLATILE_INCREMENT"})
 class VectorStorage {

--- a/herddb-core/src/main/java/herddb/index/vector/VectorStorageRandomAccessVectorValues.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorStorageRandomAccessVectorValues.java
@@ -23,10 +23,12 @@ import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 
 /**
- * {@link RandomAccessVectorValues} implementation backed by a {@link VectorStorage}.
+ * {@link RandomAccessVectorValues} implementation backed by a per-shard
+ * {@link VectorStorage}. Each {@link VectorStorage} is owned by a single
+ * {@code LiveGraphShard} and indexed by the shard's local ordinal
+ * {@code [0, shardSize)} — no offset arithmetic is needed.
  *
- * <p>{@link #getVector(int)} is a single lock-free array lookup — no Integer boxing,
- * no hash computation, no ConcurrentHashMap segment traversal.
+ * <p>{@link #getVector(int)} is a single lock-free array lookup.
  *
  * <p>{@code isValueShared()} returns {@code false}: each slot holds an independent
  * {@code VectorFloat<?>} object, so callers need not copy before storing the reference.
@@ -39,32 +41,20 @@ class VectorStorageRandomAccessVectorValues implements RandomAccessVectorValues 
     private final VectorStorage storage;
     private final int dimension;
     private final int size;
-    /**
-     * Offset added to the localNodeId before looking up in storage.
-     * For shard-local graphs this equals {@code LiveGraphShard.startNodeId},
-     * so that {@code getVector(localId)} returns the vector at global nodeId
-     * {@code localId + offset}.  Zero for any non-shard use (pool building, etc.).
-     */
-    private final int offset;
 
     VectorStorageRandomAccessVectorValues(VectorStorage storage, int dimension) {
-        this(storage, dimension, -1, 0);
+        this(storage, dimension, -1);
     }
 
     VectorStorageRandomAccessVectorValues(VectorStorage storage, int dimension, int size) {
-        this(storage, dimension, size, 0);
-    }
-
-    VectorStorageRandomAccessVectorValues(VectorStorage storage, int dimension, int size, int offset) {
         this.storage = storage;
         this.dimension = dimension;
         this.size = size;
-        this.offset = offset;
     }
 
     @Override
     public VectorFloat<?> getVector(int localNodeId) {
-        return storage.get(localNodeId + offset);
+        return storage.get(localNodeId);
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/index/vector/Issue255CompactionOrdinalGapTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue255CompactionOrdinalGapTest.java
@@ -109,27 +109,28 @@ public class Issue255CompactionOrdinalGapTest {
             // The reservation size mirrors what real compactions consume on the
             // failing benchmark workload (hundreds of thousands of nodeIds).
             int reservation = 200_000;
-            int reservedStart = store.allocateCompactionNodeIds(reservation);
-            try {
-                // After the fix, the next ingest must land on a fresh shard
-                // whose startNodeId == reservedStart + reservation. Without the
-                // fix it would land on the OLD shard with a 200K-wide gap.
-                for (int i = 0; i < 10; i++) {
-                    store.addVector(Bytes.from_int(1_000_000 + i), vec(rng, dim));
-                }
-
-                // Phase B builds a FusedPQ segment per live shard. Without the
-                // fix the active shard's local ordinal space would be
-                // {0..9, 200000..200009} but PQ would only train on 20 vectors,
-                // so writer.write → FusedPQ.writeInline → pqv.get(200000) →
-                // IndexOutOfBoundsException. With the fix, both shards are
-                // contiguous (sealed: 0..9, fresh: 0..9) so the checkpoint
-                // succeeds.
-                assertTrue("checkpoint must succeed after compaction nodeId reservation",
-                        store.checkpoint());
-            } finally {
-                store.releaseCompactionNodeIds(reservedStart, reservation);
+            long reservedStart = store.allocateCompactionNodeIds(reservation);
+            assertTrue("reservation returns a long nodeId (issue #256)",
+                    reservedStart >= 0L);
+            // After the fix, the next ingest must land on a fresh shard
+            // whose startNodeId == reservedStart + reservation. Without the
+            // fix it would land on the OLD shard with a 200K-wide gap.
+            for (int i = 0; i < 10; i++) {
+                store.addVector(Bytes.from_int(1_000_000 + i), vec(rng, dim));
             }
+
+            // Phase B builds a FusedPQ segment per live shard. Without the
+            // fix the active shard's local ordinal space would be
+            // {0..9, 200000..200009} but PQ would only train on 20 vectors,
+            // so writer.write → FusedPQ.writeInline → pqv.get(200000) →
+            // IndexOutOfBoundsException. With the fix, both shards are
+            // contiguous (sealed: 0..9, fresh: 0..9) so the checkpoint
+            // succeeds.
+            assertTrue("checkpoint must succeed after compaction nodeId reservation",
+                    store.checkpoint());
+            // After issue #256 the synthetic shard owns its own VectorStorage,
+            // so there is no store-side release step — the storage is reclaimed
+            // by the GC when VectorIndexCompactor's local reference goes away.
 
             // All inserted vectors must be searchable.
             int found = 0;

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
@@ -1,0 +1,295 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Targets the checkpoint-metadata format change from issue #256: the
+ * {@code nextNodeId} field in v3 metadata is rewritten in place from
+ * {@code int32} to {@code int64} (no back-compat per project decision).
+ *
+ * <p>Two cases:
+ * <ol>
+ *   <li>A large {@code nextNodeId} round-trips through {@code writeLong}
+ *       / {@code readLong} unscathed.</li>
+ *   <li>A checkpoint blob matching the OLD layout ({@code writeInt} for
+ *       {@code nextNodeId}, same v3 magic) must not silently migrate —
+ *       the loader's behaviour is locked in so a future refactor can't
+ *       reintroduce a half-way back-compat path.</li>
+ * </ol>
+ */
+public class Issue256CheckpointFormatTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, String uuid, MemoryDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                uuid, tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        return store;
+    }
+
+    /**
+     * Drives {@code nextNodeId} well past {@code Integer.MAX_VALUE},
+     * checkpoints, reloads, asserts the persisted counter survives.
+     * Also peeks at the raw metadata bytes to confirm the {@code long}
+     * is actually at the expected offset (not a truncated {@code int}).
+     */
+    @Test
+    public void largeNextNodeIdRoundTripsThroughCheckpointFormat() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        String uuid = "issue256-fmt-test";
+        long seeded = ((long) Integer.MAX_VALUE) + 9_000_001L;
+
+        try (PersistentVectorStore store = createStore(tmpDir, uuid, dsm)) {
+            store.start();
+            store.seedNextNodeIdForTest(seeded);
+            Random rng = new Random(17);
+            for (int i = 0; i < 25; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, 16));
+            }
+            assertTrue(store.checkpoint());
+        }
+
+        // Peek at the raw metadata blob: version (int) + dim (int) + m (int)
+        // + bw (int) + neighborOverflow (float) + alpha (float) + addHierarchy (byte)
+        // + fusedPQ (byte) + nextNodeId (long). Total header size = 4*4 + 4*2 + 2 + 8 = 34.
+        // Issue #256 moved nextNodeId from writeInt to writeLong at that offset.
+        byte[] raw = readRawIndexStatus(dsm, uuid);
+        ByteBuffer bb = ByteBuffer.wrap(raw);
+        int version = bb.getInt();
+        assertEquals("version must still be 3 (in-place rewrite per user decision)", 3, version);
+        bb.getInt(); // dim
+        bb.getInt(); // m
+        bb.getInt(); // beamWidth
+        bb.getFloat(); // neighborOverflow
+        bb.getFloat(); // alpha
+        bb.get(); // addHierarchy
+        bb.get(); // fusedPQ
+        long persistedNextNodeId = bb.getLong();
+        assertTrue("persisted nextNodeId must be widened to int64, got " + persistedNextNodeId,
+                persistedNextNodeId >= seeded + 25L);
+
+        try (PersistentVectorStore reloaded = createStore(tmpDir, uuid, dsm)) {
+            reloaded.start();
+            long reloadedCounter = reloaded.getNextNodeId();
+            assertTrue("reload must see the int64 counter (" + reloadedCounter + ")",
+                    reloadedCounter > Integer.MAX_VALUE);
+            assertTrue("reload must see at least the persisted value",
+                    reloadedCounter >= persistedNextNodeId);
+        }
+    }
+
+    /**
+     * Locks in the "no silent v3 back-compat" decision: if we hand-craft
+     * a v3 metadata blob using the OLD {@code writeInt} width for
+     * {@code nextNodeId}, the loader is NOT allowed to treat it as valid
+     * and silently promote the (now-misaligned) fields behind it. The
+     * expected outcome is either a clean "start empty" or a loud
+     * exception. The test asserts that whichever path we take, the
+     * restored {@code nextNodeId} is either zero (start empty) or a
+     * recognisably-corrupt value that would NOT compare equal to the
+     * value we would have observed under the old format.
+     */
+    @Test
+    public void oldInt32LayoutIsNotSilentlyAccepted() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        String uuid = "issue256-old-fmt";
+
+        // Write a legitimate checkpoint first so the store has a usable
+        // segments list after we corrupt the header layout.
+        long expectedOldValue = 42_000L;
+        try (PersistentVectorStore store = createStore(tmpDir, uuid, dsm)) {
+            store.start();
+            store.seedNextNodeIdForTest(expectedOldValue);
+            Random rng = new Random(19);
+            for (int i = 0; i < 10; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, 16));
+            }
+            assertTrue(store.checkpoint());
+        }
+
+        // Hand-craft a corrupted v3 blob that uses writeInt instead of
+        // writeLong at the nextNodeId offset. If the loader were to
+        // silently accept this layout it would mis-read all subsequent
+        // fields (generation, numSegments, ...) as a shifted view of
+        // the real bytes — likely throwing much later with a cryptic
+        // message. We want it to either reject cleanly OR yield
+        // nextNodeId = 0 (start empty). It must NOT yield
+        // nextNodeId == expectedOldValue, which would indicate the
+        // loader silently migrated the old format.
+        byte[] real = readRawIndexStatus(dsm, uuid);
+        // Reconstruct: header fields stay the same until the nextNodeId
+        // field, which becomes 4 bytes (writeInt of expectedOldValue).
+        // Drop the last 4 bytes of the current 8-byte long to simulate
+        // this.
+        byte[] corrupted = new byte[real.length - 4];
+        // Copy everything up to the nextNodeId offset (22 bytes):
+        // 4 (version) + 4 (dim) + 4 (m) + 4 (bw) + 4 (nbo) + 4 (alpha)
+        // wait: nbo and alpha are floats (4 bytes each), addHierarchy and
+        // fusedPQ are bytes. Recompute: 4+4+4+4+4+4+1+1 = 26.
+        System.arraycopy(real, 0, corrupted, 0, 26);
+        // Write nextNodeId as int (4 bytes): high 4 bytes of the long at
+        // offset 26 in the original, low 4 bytes at offset 30.
+        // writeInt writes big-endian; writeLong also big-endian. So the
+        // old int would occupy bytes 26..29 as the high-order bytes of
+        // what is now the long. We simulate the old layout by using the
+        // LOW 4 bytes of the long (bytes 30..33) — that's what the old
+        // code would have written for expectedOldValue (which fits in
+        // int32).
+        System.arraycopy(real, 30, corrupted, 26, 4);
+        // Copy the rest (everything after the 8-byte long, starting at
+        // offset 34 in the real buffer) into the corrupted buffer at
+        // offset 30.
+        System.arraycopy(real, 34, corrupted, 30, real.length - 34);
+
+        // Inject the corrupted blob back into the storage manager.
+        writeRawIndexStatus(dsm, uuid, corrupted);
+
+        // Reload and observe.
+        try (PersistentVectorStore reloaded = createStore(tmpDir, uuid, dsm)) {
+            long observed;
+            boolean threw = false;
+            try {
+                reloaded.start();
+                observed = reloaded.getNextNodeId();
+            } catch (RuntimeException ignored) {
+                observed = -1L;
+                threw = true;
+            } catch (Exception other) {
+                // start() throws Exception from its signature; narrow
+                // catches are impractical here without enumerating every
+                // deserialisation path.
+                observed = -1L;
+                threw = true;
+            }
+            if (!threw) {
+                // If the loader accepted the corrupted blob, it must at
+                // least NOT have silently decoded it as the old value.
+                assertTrue("loader must NOT silently decode old int32 layout as the intended value "
+                                + "(observed " + observed + ")",
+                        observed != expectedOldValue);
+            }
+            // Either path (loud throw or clean zero-out) is acceptable;
+            // what we forbid is a silent migration.
+        }
+    }
+
+    // Helper: read the raw IndexStatus blob for the given index UUID
+    // directly from the MemoryDataStorageManager.
+    private byte[] readRawIndexStatus(MemoryDataStorageManager dsm, String uuid) throws Exception {
+        herddb.storage.IndexStatus status = dsm.getIndexStatus(
+                "tstblspace", uuid, herddb.log.LogSequenceNumber.START_OF_TIME);
+        assertTrue("index status must exist for uuid=" + uuid, status != null);
+        return status.indexData;
+    }
+
+    // Helper: overwrite the raw IndexStatus blob in the
+    // MemoryDataStorageManager via the public checkpoint entry point.
+    private void writeRawIndexStatus(MemoryDataStorageManager dsm, String uuid, byte[] data) throws Exception {
+        herddb.storage.IndexStatus latest = dsm.getIndexStatus(
+                "tstblspace", uuid, herddb.log.LogSequenceNumber.START_OF_TIME);
+        herddb.storage.IndexStatus replaced = new herddb.storage.IndexStatus(
+                latest.indexName,
+                latest.sequenceNumber,
+                latest.newPageId,
+                latest.activePages,
+                data);
+        dsm.indexCheckpoint("tstblspace", uuid, replaced, true);
+    }
+
+    /**
+     * Sanity: the header-offset arithmetic used in the corruption test
+     * mirrors the actual layout written by the store. Without this
+     * check the oldInt32LayoutIsNotSilentlyAccepted test could silently
+     * drift if the header format changes.
+     */
+    @Test
+    public void headerOffsetArithmeticMatchesActualFormat() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        String uuid = "issue256-fmt-layout";
+        try (PersistentVectorStore store = createStore(tmpDir, uuid, dsm)) {
+            store.start();
+            Random rng = new Random(37);
+            for (int i = 0; i < 5; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, 16));
+            }
+            assertTrue(store.checkpoint());
+        }
+        byte[] real = readRawIndexStatus(dsm, uuid);
+        assertTrue("metadata blob must be at least 34 bytes (header), got " + real.length,
+                real.length >= 34);
+        try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(real))) {
+            assertEquals(3, dis.readInt());                 // version
+            assertEquals(16, dis.readInt());                // dim
+            assertEquals(16, dis.readInt());                // m
+            assertEquals(100, dis.readInt());               // beamWidth
+            assertEquals(1.2f, dis.readFloat(), 0.0001);    // neighborOverflow
+            assertEquals(1.4f, dis.readFloat(), 0.0001);    // alpha
+            dis.readByte();                                 // addHierarchy
+            dis.readByte();                                 // fusedPQ
+            long nextNodeId = dis.readLong();               // long after issue #256
+            assertTrue(nextNodeId >= 5L);
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256CompactionReleaseTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256CompactionReleaseTest.java
@@ -1,0 +1,309 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongConsumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Risk cover for issue #256: the compactor now owns the synthetic
+ * shard's {@link VectorStorage} (instead of reusing the store's global
+ * one). If any code path — happy or error — forgets to drop the
+ * reference, we leak heap. This test proves reclaimability on both
+ * paths and checks that concurrent ingest is isolated from the
+ * compactor's private storage.
+ */
+public class Issue256CompactionReleaseTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void tearDown() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+        VectorIndexCompactor.syntheticShardObserverForTest = null;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, MemoryDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        return store;
+    }
+
+    private void seedFiveSegments(PersistentVectorStore store) throws Exception {
+        Random rng = new Random(1);
+        int dim = 16;
+        for (int c = 0; c < 5; c++) {
+            for (int i = 0; i < 300; i++) {
+                store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+            }
+            store.checkpoint();
+        }
+        assertTrue(store.getSegmentCount() >= 4);
+    }
+
+    /**
+     * Happy path: a successful compaction must release the synthetic
+     * shard (and therefore its {@link VectorStorage}) so the GC can
+     * reclaim it.
+     */
+    @Test
+    public void syntheticShardIsReclaimedAfterSuccessfulCompaction() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        AtomicReference<WeakReference<PersistentVectorStore.LiveGraphShard>> capturedRef =
+                new AtomicReference<>();
+        AtomicReference<WeakReference<VectorStorage>> capturedStorageRef =
+                new AtomicReference<>();
+        VectorIndexCompactor.syntheticShardObserverForTest = shard -> {
+            capturedRef.set(new WeakReference<>(shard));
+            capturedStorageRef.set(new WeakReference<>(shard.vectorStorage));
+        };
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            seedFiveSegments(store);
+            store.runCompactionCycle();
+            assertEquals("compaction must have succeeded",
+                    1, store.getCompactionSuccessesTotal());
+        }
+        // Unregister before forcing GC so the observer lambda itself
+        // cannot retain a strong reference to the shard.
+        VectorIndexCompactor.syntheticShardObserverForTest = null;
+
+        assertTrue("observer must have fired", capturedRef.get() != null);
+        assertTrue("observer must have captured a storage ref",
+                capturedStorageRef.get() != null);
+        for (int gc = 0; gc < 15; gc++) {
+            System.gc();
+            Thread.sleep(30);
+            if (capturedRef.get().get() == null && capturedStorageRef.get().get() == null) {
+                break;
+            }
+        }
+        assertTrue("synthetic shard must be reclaimable after successful compaction",
+                capturedRef.get().get() == null);
+        assertTrue("synthetic VectorStorage must be reclaimable after successful compaction",
+                capturedStorageRef.get().get() == null);
+    }
+
+    /**
+     * Failure path: if the compactor throws mid-way, the synthetic
+     * shard must still be reclaimable. Before issue #256, the compactor
+     * coordinated with the store's global vectorStorage and the
+     * release path hinged on {@code releaseCompactionNodeIds}. Now the
+     * shard owns its own storage, so an exception anywhere past the
+     * {@code new LiveGraphShard(...)} call must still let GC collect it.
+     */
+    @Test
+    public void syntheticShardIsReclaimedOnWriteFailure() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        FailingDsm dsm = new FailingDsm();
+        AtomicReference<WeakReference<PersistentVectorStore.LiveGraphShard>> capturedRef =
+                new AtomicReference<>();
+        AtomicReference<WeakReference<VectorStorage>> capturedStorageRef =
+                new AtomicReference<>();
+        VectorIndexCompactor.syntheticShardObserverForTest = shard -> {
+            capturedRef.set(new WeakReference<>(shard));
+            capturedStorageRef.set(new WeakReference<>(shard.vectorStorage));
+        };
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            seedFiveSegments(store);
+            int segmentsBefore = store.getSegmentCount();
+
+            dsm.failNextMultipartWrites.set(1);
+            store.runCompactionCycle();
+
+            assertEquals("segment list must not change on write failure",
+                    segmentsBefore, store.getSegmentCount());
+            assertEquals("no compaction success on injected write failure",
+                    0, store.getCompactionSuccessesTotal());
+            assertTrue("a compaction failure must have been recorded",
+                    store.getCompactionFailuresWriteIoTotal()
+                            + store.getCompactionFailuresMetadataIoTotal() > 0);
+        }
+        VectorIndexCompactor.syntheticShardObserverForTest = null;
+
+        assertTrue("observer must have fired even on the failure path",
+                capturedRef.get() != null);
+        for (int gc = 0; gc < 15; gc++) {
+            System.gc();
+            Thread.sleep(30);
+            if (capturedRef.get().get() == null && capturedStorageRef.get().get() == null) {
+                break;
+            }
+        }
+        assertTrue("synthetic shard must be reclaimable even after write failure",
+                capturedRef.get().get() == null);
+        assertTrue("synthetic VectorStorage must be reclaimable even after write failure",
+                capturedStorageRef.get().get() == null);
+    }
+
+    /**
+     * Runs many back-to-back compactions (alternating happy + failing)
+     * and asserts each produced synthetic shard is a fresh instance.
+     * Before the refactor the compactor shared the store's global
+     * {@code vectorStorage}, so repeated compactions would accumulate
+     * entries in one growing array. Now each synthetic shard owns its
+     * own {@link VectorStorage}, and back-to-back compactions must
+     * produce DIFFERENT storage instances.
+     */
+    @Test
+    public void backToBackCompactionsUseFreshSyntheticStorage() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        FailingDsm dsm = new FailingDsm();
+        AtomicInteger observerFires = new AtomicInteger();
+        AtomicReference<VectorStorage> previousStorage = new AtomicReference<>();
+        AtomicBoolean storageReused = new AtomicBoolean(false);
+        VectorIndexCompactor.syntheticShardObserverForTest = shard -> {
+            observerFires.incrementAndGet();
+            VectorStorage prev = previousStorage.getAndSet(shard.vectorStorage);
+            if (prev != null && prev == shard.vectorStorage) {
+                storageReused.set(true);
+            }
+        };
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            seedFiveSegments(store);
+
+            // 3 cycles: fail, succeed, succeed (with fresh ingestion between).
+            dsm.failNextMultipartWrites.set(1);
+            store.runCompactionCycle();
+
+            Random rng = new Random(99);
+            for (int i = 0; i < 200; i++) {
+                store.addVector(Bytes.from_int(700_000 + i), vec(rng, 16));
+            }
+            store.checkpoint();
+
+            store.runCompactionCycle();
+            store.runCompactionCycle();
+        }
+        VectorIndexCompactor.syntheticShardObserverForTest = null;
+        assertTrue("compactor must have fired at least twice", observerFires.get() >= 2);
+        assertTrue("each compaction must get its own VectorStorage instance",
+                !storageReused.get());
+    }
+
+    /**
+     * Concurrent-ingest isolation: while a compaction is in flight the
+     * ingest path must be able to keep writing into the live shards
+     * without touching the compactor's private storage.
+     */
+    @Test(timeout = 60_000)
+    public void ingestContinuesDuringCompaction() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            seedFiveSegments(store);
+
+            AtomicBoolean stop = new AtomicBoolean(false);
+            AtomicInteger inserts = new AtomicInteger();
+            CountDownLatch started = new CountDownLatch(1);
+            ExecutorService exec = Executors.newSingleThreadExecutor();
+            try {
+                exec.submit(() -> {
+                    started.countDown();
+                    Random rng = new Random(55);
+                    while (!stop.get()) {
+                        store.addVector(Bytes.from_int(800_000 + inserts.incrementAndGet()),
+                                vec(rng, 16));
+                    }
+                });
+                started.await();
+                // Burn a compaction cycle concurrently with the ingest thread.
+                store.runCompactionCycle();
+                assertEquals(1, store.getCompactionSuccessesTotal());
+            } finally {
+                stop.set(true);
+                exec.shutdown();
+                if (!exec.awaitTermination(30, TimeUnit.SECONDS)) {
+                    fail("ingest thread did not stop in time");
+                }
+            }
+            assertTrue("ingest must have progressed during compaction, inserts=" + inserts.get(),
+                    inserts.get() > 50);
+        }
+    }
+
+    /**
+     * Failure-injection DSM modeled on
+     * {@code VectorIndexCompactorFailureTest.FailingDsm}. Only covers
+     * the hook we need for this test (failNextMultipartWrites).
+     */
+    private static final class FailingDsm extends MemoryDataStorageManager {
+        final AtomicInteger failNextMultipartWrites = new AtomicInteger(0);
+
+        @Override
+        public String writeMultipartIndexFile(
+                String tableSpace, String segmentUuid, String kind,
+                Path tempFile, LongConsumer bytesWrittenConsumer)
+                throws DataStorageManagerException, IOException {
+            if (failNextMultipartWrites.get() > 0) {
+                failNextMultipartWrites.decrementAndGet();
+                throw new DataStorageManagerException(
+                        new IOException("injected multipart write failure for " + kind));
+            }
+            return super.writeMultipartIndexFile(tableSpace, segmentUuid, kind, tempFile,
+                    bytesWrittenConsumer);
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256LongNodeIdTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256LongNodeIdTest.java
@@ -1,0 +1,323 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression suite for issue #256 — global node-id counter widened to
+ * {@code long} and per-shard {@link VectorStorage}.
+ *
+ * <p>Before the fix, {@code PersistentVectorStore.nextNodeId} was an
+ * {@link java.util.concurrent.atomic.AtomicInteger}. Crossing
+ * {@link Integer#MAX_VALUE} silently wrapped to {@link Integer#MIN_VALUE},
+ * after which {@code vectorStorage.set(nodeId,…)} and
+ * {@code (int)(nodeId - startNodeId)} produced garbage. Tests below
+ * exercise the replacement {@link java.util.concurrent.atomic.AtomicLong}
+ * counter + per-shard storage from every meaningful angle.
+ */
+public class Issue256LongNodeIdTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        return store;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Seeding {@code nextNodeId} above {@code Integer.MAX_VALUE} and then
+     * ingesting vectors must succeed — the whole point of the widening.
+     * Every inserted PK must round-trip through search.
+     */
+    @Test
+    public void ingestAcrossIntegerMaxValueBoundary() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            // Seed right below MAX_VALUE so the very first ingest crosses it.
+            store.seedNextNodeIdForTest(Integer.MAX_VALUE - 5L);
+            Random rng = new Random(7);
+            int dim = 16;
+
+            int n = 50;
+            for (int i = 0; i < n; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, dim));
+            }
+
+            assertTrue("counter must have crossed Integer.MAX_VALUE, saw "
+                            + store.getNextNodeId(),
+                    store.getNextNodeId() > Integer.MAX_VALUE);
+
+            // Every PK must be searchable.
+            int found = 0;
+            Random probe = new Random(42);
+            for (int q = 0; q < 30; q++) {
+                List<Map.Entry<Bytes, Float>> hits = store.search(vec(probe, dim), n);
+                for (Map.Entry<Bytes, Float> h : hits) {
+                    int pk = h.getKey().to_int();
+                    if (pk >= 0 && pk < n) {
+                        found++;
+                    }
+                }
+            }
+            assertTrue("inserted vectors must be searchable across the boundary, found=" + found,
+                    found > 0);
+        }
+    }
+
+    /**
+     * The compactor's {@code allocateCompactionNodeIds} reservation must be
+     * allowed to cross {@code Integer.MAX_VALUE}. Before the widening, the
+     * {@code int} return type would have truncated.
+     */
+    @Test
+    public void compactionReservationAcrossBoundary() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            // Seed just below the boundary with enough headroom for a bump.
+            store.seedNextNodeIdForTest((long) Integer.MAX_VALUE - 10L);
+            Random rng = new Random(11);
+            int dim = 16;
+
+            for (int i = 0; i < 5; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, dim));
+            }
+
+            long beforeBump = store.getNextNodeId();
+            assertTrue("counter must still be near the boundary", beforeBump >= Integer.MAX_VALUE - 10L);
+
+            long reservedStart = store.allocateCompactionNodeIds(1_000);
+            assertTrue("reservation must happen below Integer.MAX_VALUE to exercise the crossing",
+                    reservedStart <= Integer.MAX_VALUE);
+            assertTrue("post-bump counter must exceed Integer.MAX_VALUE",
+                    store.getNextNodeId() > Integer.MAX_VALUE);
+
+            // Checkpoint must still produce a valid Phase B segment.
+            assertTrue("checkpoint must succeed after a boundary-crossing reservation",
+                    store.checkpoint());
+        }
+    }
+
+    /**
+     * A checkpoint with {@code nextNodeId > Integer.MAX_VALUE} must
+     * persist the counter as a {@code long} and the value must survive
+     * close / reload. A truncated {@code int} write would round-trip as
+     * a negative value and every subsequent ingest would corrupt the
+     * local-ordinal math.
+     */
+    @Test
+    public void checkpointRoundTripAboveIntegerMaxValue() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        // Shared DataStorageManager + explicit indexUUID so the reloaded
+        // store finds the checkpoint written by the first instance. The
+        // zero-arg convenience constructor generates a nanoTime-based UUID
+        // that would change between instances and make the reload look
+        // like a fresh index.
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        String uuid = "issue256-reload-test";
+        long seeded = (long) Integer.MAX_VALUE + 1_234_567L;
+        long observedAfterCheckpoint;
+        try (PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                uuid, tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE,
+                Long.MAX_VALUE, null, 0, 0)) {
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+            store.start();
+            store.seedNextNodeIdForTest(seeded);
+
+            Random rng = new Random(101);
+            for (int i = 0; i < 20; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, 16));
+            }
+            assertTrue("checkpoint must succeed with large nextNodeId",
+                    store.checkpoint());
+            observedAfterCheckpoint = store.getNextNodeId();
+            assertTrue("checkpoint must not roll the counter back",
+                    observedAfterCheckpoint >= seeded + 20L);
+        }
+
+        // Reload: the persisted int64 nextNodeId must round-trip.
+        try (PersistentVectorStore reloaded = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                uuid, tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE,
+                Long.MAX_VALUE, null, 0, 0)) {
+            reloaded.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+            reloaded.start();
+            long reloadedCounter = reloaded.getNextNodeId();
+            assertTrue("reloaded nextNodeId must be > Integer.MAX_VALUE (saw "
+                            + reloadedCounter + ")",
+                    reloadedCounter > Integer.MAX_VALUE);
+            assertTrue("reloaded nextNodeId must be at least the pre-close value",
+                    reloadedCounter >= observedAfterCheckpoint);
+        }
+    }
+
+    /**
+     * Structural proof that each {@link LiveGraphShard}'s own
+     * {@link VectorStorage} stays bounded by the configured shard cap —
+     * {@link Integer#MAX_VALUE} positions are never approached, because
+     * the shard rotates long before its local ordinal space fills.
+     */
+    @Test
+    public void perShardStorageStaysBoundedRegardlessOfGlobalCounter() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            store.seedNextNodeIdForTest((long) Integer.MAX_VALUE - 3L);
+            Random rng = new Random(13);
+            int dim = 16;
+
+            int cap = store.getEffectiveMaxLiveGraphSize();
+            // Ingest enough to trigger at least one shard rotation.
+            int n = Math.min(cap * 2 + 10, 200);
+            for (int i = 0; i < n; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, dim));
+            }
+
+            PersistentVectorStore.LiveGraphShard active = store.activeLiveShardForTest();
+            assertNotNull(active);
+            int len = active.vectorStorage.length();
+            // Post-cap the backing array may be sized up to 2× cap because
+            // VectorStorage#growAndSet doubles. A small constant slack
+            // accounts for the initial capacity floor of 256.
+            assertTrue("active shard storage length must stay near the cap, got " + len
+                            + " with cap=" + cap,
+                    len <= Math.max(cap * 2 + 512, 1024));
+            assertTrue("active shard storage must not grow with global counter (" + len
+                            + " vs counter=" + store.getNextNodeId() + ")",
+                    (long) len < store.getNextNodeId() - (long) Integer.MAX_VALUE + cap * 4L);
+        }
+    }
+
+    /**
+     * Negative test — explicitly proves that the {@link Math#toIntExact}
+     * guard at the local-ordinal cast throws if the shard-cap invariant
+     * is violated, rather than silently wrapping. Constructs a rogue
+     * shard with a {@code startNodeId} so far in the past that the next
+     * insert would blow past {@code Integer.MAX_VALUE} locally.
+     */
+    @Test
+    public void toIntExactFiresWhenShardCapInvariantIsBypassed() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            // Seed the global counter to a huge value, then bypass the
+            // normal rotation path by pointing a shard's startNodeId
+            // at 0. The next addVector will compute
+            // (int)(huge - 0) → ArithmeticException.
+            store.seedNextNodeIdForTest((long) Integer.MAX_VALUE + 1_000L);
+            // Force-create the first shard so we can reflectively reset
+            // its startNodeId.
+            store.addVector(Bytes.from_int(0), vec(new Random(1), 16));
+            PersistentVectorStore.LiveGraphShard active = store.activeLiveShardForTest();
+            assertNotNull(active);
+            java.lang.reflect.Field f =
+                    PersistentVectorStore.LiveGraphShard.class.getDeclaredField("startNodeId");
+            f.setAccessible(true);
+            // Override the final field: valid only in a unit-test sandbox.
+            try {
+                f.set(active, 0L);
+            } catch (IllegalAccessException e) {
+                fail("reflection setup failed: " + e);
+            }
+            try {
+                // Reset rotation cap state by bumping the counter into
+                // toIntExact-overflow territory, then inserting.
+                store.seedNextNodeIdForTest((long) Integer.MAX_VALUE + 2L);
+                store.addVector(Bytes.from_int(1), vec(new Random(2), 16));
+                fail("expected ArithmeticException from Math.toIntExact at "
+                        + "addVector when the shard-cap invariant is bypassed");
+            } catch (ArithmeticException expected) {
+                // pass — the guard fires loudly instead of wrapping silently
+            }
+        }
+    }
+
+    /**
+     * Sanity-check the test-only seed hook itself: seeding zero is a
+     * no-op, seeding a negative value is accepted (the counter is
+     * {@code long}, no validation), and getters reflect the seeded value.
+     */
+    @Test
+    public void seedHookBasics() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            assertEquals(0L, store.getNextNodeId());
+            store.seedNextNodeIdForTest(42L);
+            assertEquals(42L, store.getNextNodeId());
+            store.seedNextNodeIdForTest((long) Integer.MAX_VALUE + 7L);
+            assertEquals((long) Integer.MAX_VALUE + 7L, store.getNextNodeId());
+            assertFalse("no shard is expected before first ingest",
+                    store.activeLiveShardForTest() != null && !store.activeLiveShardForTest().nodeToPk.isEmpty());
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256PhaseCShardTeardownTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256PhaseCShardTeardownTest.java
@@ -1,0 +1,231 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.lang.ref.WeakReference;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Risk cover for issue #256: after the per-shard {@code VectorStorage}
+ * refactor, Phase C drops entire shard references instead of
+ * per-slot {@code vectorStorage.remove}. If any search path holds a
+ * stale reference past the Phase C swap, the backing array leaks and
+ * eventual OOM follows. This test stresses concurrent ingest + search
+ * against a tight checkpoint loop and confirms old shards are GC'd.
+ */
+public class Issue256PhaseCShardTeardownTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        return store;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Ingest a sharp burst of vectors, checkpoint repeatedly, and track
+     * the old shards through a {@link WeakReference}. If any search
+     * path retains them past Phase C the WeakReference stays strong
+     * and GC cannot reclaim them — the test fails. Also asserts the
+     * full-test deadline to catch deadlocks in the
+     * {@code stateLock} / {@code checkpointLock} pairing.
+     */
+    @Test(timeout = 60_000)
+    public void phaseCDropsOldShardReferences() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            Random seedRng = new Random(3);
+            int dim = 16;
+
+            List<WeakReference<Object>> shardRefs = new ArrayList<>();
+            List<Bytes> insertedPks = new ArrayList<>();
+
+            int checkpoints = 20;
+            int perCheckpoint = 100;
+            for (int c = 0; c < checkpoints; c++) {
+                for (int i = 0; i < perCheckpoint; i++) {
+                    Bytes pk = Bytes.from_int(c * perCheckpoint + i);
+                    insertedPks.add(pk);
+                    store.addVector(pk, vec(seedRng, dim));
+                }
+                // Capture a weak ref to the active shard BEFORE the
+                // checkpoint starts. Phase C should make this unreachable.
+                PersistentVectorStore.LiveGraphShard active = store.activeLiveShardForTest();
+                if (active != null) {
+                    shardRefs.add(new WeakReference<>(active));
+                }
+                assertTrue("checkpoint " + c + " must succeed", store.checkpoint());
+            }
+
+            // Encourage the collector.
+            for (int gc = 0; gc < 10; gc++) {
+                System.gc();
+                Thread.sleep(30);
+            }
+
+            int stillReachable = 0;
+            for (WeakReference<Object> ref : shardRefs) {
+                if (ref.get() != null) {
+                    stillReachable++;
+                }
+            }
+            // Allow at most 1 retained ref (the very last shard may
+            // still be the active one). The rest MUST be collected.
+            assertTrue("Phase C must drop most old shard references, saw " + stillReachable
+                            + "/" + shardRefs.size(),
+                    stillReachable <= 1);
+
+            // Sanity: at least some of the previously-inserted PKs are
+            // still searchable via the on-disk segments.
+            int found = 0;
+            Random probe = new Random(42);
+            for (int q = 0; q < 40; q++) {
+                List<java.util.Map.Entry<Bytes, Float>> hits = store.search(vec(probe, dim), 40);
+                for (java.util.Map.Entry<Bytes, Float> h : hits) {
+                    if (insertedPks.contains(h.getKey())) {
+                        found++;
+                    }
+                }
+            }
+            assertTrue("some vectors must still be searchable via sealed segments, found=" + found,
+                    found > 0);
+        }
+    }
+
+    /**
+     * Pathological concurrent test: one thread ingests vectors, a
+     * second continuously searches the index, and a third fires
+     * repeated checkpoints. Confirms that the Phase C swap + per-shard
+     * storage teardown does not race the search path into an NPE or
+     * stale-array read.
+     */
+    @Test(timeout = 90_000)
+    public void concurrentIngestSearchCheckpoint() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            int dim = 16;
+            AtomicBoolean stop = new AtomicBoolean(false);
+            AtomicLong inserts = new AtomicLong();
+            AtomicLong searches = new AtomicLong();
+            AtomicLong checkpoints = new AtomicLong();
+            ExecutorService exec = Executors.newFixedThreadPool(3);
+            CountDownLatch started = new CountDownLatch(3);
+            try {
+                exec.submit(() -> {
+                    try {
+                        started.countDown();
+                        Random rng = new Random(1);
+                        while (!stop.get()) {
+                            store.addVector(Bytes.from_long(inserts.incrementAndGet()), vec(rng, dim));
+                        }
+                    } catch (RuntimeException e) {
+                        // Narrow catch kept pragmatic in a test harness: an
+                        // unchecked exception from addVector would fail the
+                        // test via the `stop=false / assertNull caught` arm
+                        // below, but we record it for diagnostics.
+                        stop.set(true);
+                        throw e;
+                    }
+                });
+                exec.submit(() -> {
+                    started.countDown();
+                    Random rng = new Random(2);
+                    while (!stop.get()) {
+                        store.search(vec(rng, dim), 10);
+                        searches.incrementAndGet();
+                    }
+                });
+                exec.submit(() -> {
+                    started.countDown();
+                    while (!stop.get()) {
+                        try {
+                            if (store.checkpoint()) {
+                                checkpoints.incrementAndGet();
+                            }
+                            Thread.sleep(50);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                    }
+                });
+                started.await();
+                // Let the workers run a realistic while.
+                Thread.sleep(5_000);
+            } finally {
+                stop.set(true);
+                exec.shutdown();
+                if (!exec.awaitTermination(30, TimeUnit.SECONDS)) {
+                    fail("workers did not stop in time — possible deadlock in stateLock / checkpointLock");
+                }
+            }
+            assertTrue("some inserts must have completed", inserts.get() > 100);
+            assertTrue("some searches must have completed", searches.get() > 100);
+            assertTrue("at least one checkpoint must have completed", checkpoints.get() > 0);
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1601,6 +1601,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.compactionNodesTotal = pvs.getCompactionNodesTotal();
             d.uploadBytesDone = pvs.getUploadBytesDone();
             d.uploadBytesTotal = pvs.getUploadBytesTotal();
+            d.nextNodeId = pvs.getNextNodeId();
             if (!"idle".equals(d.compactionPhase)) {
                 d.status = d.compactionPhase;
             }
@@ -1898,6 +1899,19 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 @Override
                 public Integer getSample() {
                     return pvs.getOnDiskNodeCount();
+                }
+            });
+            // Global monotonic node-id counter (issue #256). Exposed as a
+            // gauge so dashboards can track the burn rate and alert long
+            // before the long space is exhausted.
+            indexStats.registerGauge("next_node_id", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getNextNodeId();
                 }
             });
             indexStats.registerGauge("segment_count", new Gauge<Integer>() {
@@ -2680,5 +2694,8 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         public long compactionNodesTotal;
         public long uploadBytesDone;
         public long uploadBytesTotal;
+        // Global monotonic node-id counter (issue #256). Widened to long end-to-end;
+        // surfaced so clients and dashboards can observe the burn rate.
+        public long nextNodeId;
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -329,7 +329,8 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setCompactionNodesDone(details.compactionNodesDone)
                     .setCompactionNodesTotal(details.compactionNodesTotal)
                     .setUploadBytesDone(details.uploadBytesDone)
-                    .setUploadBytesTotal(details.uploadBytesTotal);
+                    .setUploadBytesTotal(details.uploadBytesTotal)
+                    .setNextNodeId(details.nextNodeId);
             responseObserver.onNext(builder.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -126,6 +126,10 @@ message DescribeIndexResponse {
     int64 compaction_nodes_total = 22;
     int64 upload_bytes_done = 23;
     int64 upload_bytes_total = 24;
+    // Global monotonic node-id counter (issue #256). int64 so it cannot
+    // silently wrap after 2^31 ids are burned by ingest + compaction
+    // reservations on a long-running cluster.
+    int64 next_node_id = 25;
 }
 
 message ListPrimaryKeysRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/Issue256GaugeAndProtoTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/Issue256GaugeAndProtoTest.java
@@ -1,0 +1,196 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.indexing.admin.IndexingAdminClient;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end test for the {@code next_node_id} gauge + gRPC field
+ * added in issue #256. Exercises:
+ * <ul>
+ *   <li>{@link PersistentVectorStore#getNextNodeId()} reflects ingest,</li>
+ *   <li>the engine-level {@code IndexDetails.nextNodeId} is populated,</li>
+ *   <li>{@code DescribeIndexResponse.next_node_id} round-trips over gRPC,</li>
+ *   <li>both Grafana dashboards parse and reference the new metric.</li>
+ * </ul>
+ */
+public class Issue256GaugeAndProtoTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+    private IndexingAdminClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+        client = new IndexingAdminClient(service.getAddress(), 10);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private Index vectorIndex(String indexName, String table, String tablespace) {
+        return Index.builder()
+                .name(indexName)
+                .table(table)
+                .tablespace(tablespace)
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    /**
+     * Registers a real {@link PersistentVectorStore} behind the
+     * indexing service so we can seed {@code nextNodeId} and observe
+     * it flowing through every layer.
+     */
+    private PersistentVectorStore registerPersistent(String table, String indexName,
+                                                      Path tmpDir) throws Exception {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                indexName, table, "default", "embedding",
+                indexName + "-" + System.nanoTime(), tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0, 0);
+        store.start();
+        service.getEngine().registerIndexForTest(
+                vectorIndex(indexName, table, "default"), store);
+        return store;
+    }
+
+    @Test
+    public void nextNodeIdFlowsFromStoreToGrpc() throws Exception {
+        Path tmpDir = folder.newFolder("idx").toPath();
+        PersistentVectorStore store = registerPersistent("docs", "idx_docs", tmpDir);
+
+        // Seed a recognisable >int32 value so the round-trip is unambiguous.
+        long seeded = (long) Integer.MAX_VALUE + 4_000L;
+        store.seedNextNodeIdForTest(seeded);
+
+        // Ingest a handful of vectors so the counter moves above the seed.
+        // Skip i=0 so every vector has nonzero magnitude (COSINE similarity
+        // rejects the all-zero vector with NaN).
+        for (int i = 1; i <= 10; i++) {
+            float f = i + 1.0f;
+            store.addVector(Bytes.from_int(i), new float[]{
+                    f, -f, f * 0.5f, 0.1f * f,
+                    f, -f, f * 0.5f, 0.1f * f,
+                    f, -f, f * 0.5f, 0.1f * f,
+                    f, -f, f * 0.5f, 0.1f * f
+            });
+        }
+
+        // 1. Engine-level snapshot.
+        IndexingServiceEngine.IndexDetails details =
+                service.getEngine().describeIndex("default", "docs", "idx_docs");
+        assertTrue("engine IndexDetails must reflect the seeded counter, saw "
+                        + details.nextNodeId,
+                details.nextNodeId >= seeded + 10L);
+        assertTrue("engine IndexDetails nextNodeId must be > Integer.MAX_VALUE",
+                details.nextNodeId > Integer.MAX_VALUE);
+
+        // 2. gRPC round-trip.
+        DescribeIndexResponse response = client.describeIndex("default", "docs", "idx_docs");
+        assertEquals("proto next_node_id must match engine IndexDetails",
+                details.nextNodeId, response.getNextNodeId());
+        assertTrue("proto next_node_id must be > Integer.MAX_VALUE",
+                response.getNextNodeId() > Integer.MAX_VALUE);
+
+        // 3. After more ingest the counter must strictly increase across a
+        //    second describeIndex round-trip.
+        for (int i = 11; i < 30; i++) {
+            float f = i + 1.0f;
+            store.addVector(Bytes.from_int(i), new float[]{
+                    f, -f, f * 0.5f, 0.1f * f,
+                    f, -f, f * 0.5f, 0.1f * f,
+                    f, -f, f * 0.5f, 0.1f * f,
+                    f, -f, f * 0.5f, 0.1f * f
+            });
+        }
+        DescribeIndexResponse response2 = client.describeIndex("default", "docs", "idx_docs");
+        assertTrue("next_node_id must strictly increase with ingest",
+                response2.getNextNodeId() > response.getNextNodeId());
+    }
+
+    /**
+     * Reads both Grafana dashboard files and asserts each references
+     * the new {@code next_node_id} metric. Jackson is not on the
+     * classpath of this module so we fall back to a string scan —
+     * sufficient to catch the panel being accidentally dropped.
+     */
+    @Test
+    public void grafanaDashboardsReferenceNewMetric() throws Exception {
+        File repoRoot = new File(System.getProperty("user.dir"), "..").getCanonicalFile();
+        File[] dashboards = {
+                new File(repoRoot,
+                        "herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/"
+                                + "indexing-service-dashboard.json"),
+                new File(repoRoot,
+                        "herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/"
+                                + "herddb-dashboard.json"),
+        };
+        for (File d : dashboards) {
+            assertTrue("dashboard file must exist: " + d, d.exists());
+            StringBuilder contents = new StringBuilder();
+            try (FileReader reader = new FileReader(d)) {
+                char[] buf = new char[8192];
+                int n;
+                while ((n = reader.read(buf)) > 0) {
+                    contents.append(buf, 0, n);
+                }
+            }
+            String serialised = contents.toString();
+            assertTrue("dashboard " + d.getName() + " must reference next_node_id",
+                    serialised.contains("next_node_id"));
+        }
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/herddb-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/herddb-dashboard.json
@@ -1714,9 +1714,16 @@
               "intervalFactor": 2,
               "legendFormat": "ondisk {{__name__}}",
               "refId": "B"
+            },
+            {
+              "expr": "{__name__=~\".*vidx_.*_next_node_id\", instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "next_node_id {{__name__}}",
+              "refId": "C"
             }
           ],
-          "title": "Live vs On-Disk Nodes",
+          "title": "Live vs On-Disk Nodes (+ global next_node_id)",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -997,6 +997,62 @@
               "show": true
             }
           ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Global monotonic node-id counter (issue #256). Watch the derivative to see burn rate; with int64 the absolute value cannot silently overflow.",
+          "fill": 1,
+          "id": 256,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 6,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_next_node_id\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "title": "Global next_node_id counter",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "decimals": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
         }
       ],
       "showTitle": false,


### PR DESCRIPTION
## Summary
- `PersistentVectorStore.nextNodeId` is promoted from `AtomicInteger` to `AtomicLong` and each `LiveGraphShard` now owns its own `VectorStorage` keyed by a LOCAL ordinal bounded by the shard cap. Closes #256.
- Checkpoint v3 metadata is rewritten in place: `writeInt(nextNodeId)` → `writeLong(nextNodeId)` (no back-compat per project decision).
- Synthetic compaction storage is owned by `VectorIndexCompactor` — `releaseCompactionNodeIds` / `compactionVectorStorage()` are gone.
- `allocateCompactionNodeIds` now rotates on ANY stale `startNodeId`, closing a pre-existing gap in PR #257 where an empty active shard would leak a bump-wide local-ordinal gap into the next ingest batch.
- New `next_node_id` gauge on `IndexingServiceEngine`, new `int64 next_node_id = 25` on `DescribeIndexResponse`, panels added to `herddb-dashboard.json` and `indexing-service-dashboard.json`.
- `Math.toIntExact(globalNodeId - startNodeId)` at every cast site turns silent wrap into a loud `ArithmeticException` if the shard-cap invariant is ever bypassed.

## Test plan
- [x] `Issue256LongNodeIdTest` — 6 scenarios: ingest across `Integer.MAX_VALUE`, compaction reservation across the boundary, checkpoint round-trip above MAX_VALUE, per-shard storage bound invariant, `toIntExact` guard fires, seed-hook sanity.
- [x] `Issue256CheckpointFormatTest` — large `nextNodeId` round-trips through the new `writeLong` format; old int32 layout is NOT silently migrated; header-offset arithmetic locked in against format drift.
- [x] `Issue256PhaseCShardTeardownTest` — `WeakReference` leak check on dropped shards + concurrent ingest/search/checkpoint stress (`@Test(timeout = 60_000)` guards for deadlocks).
- [x] `Issue256CompactionReleaseTest` — synthetic shard + its `VectorStorage` reclaimable on happy AND write-failure paths; back-to-back compactions use fresh storage instances; ingest stays isolated from compactor's private storage during a run.
- [x] `Issue256GaugeAndProtoTest` — `next_node_id` flows from store → `IndexDetails` → gRPC response; both Grafana dashboards reference the metric.
- [x] `Issue255CompactionOrdinalGapTest` updated for the new `long` return type and removed `releaseCompactionNodeIds` call — still green.
- [x] `VectorStorageTest` (15 tests) still green after the RAVV `offset` field was removed and the javadoc was updated to per-shard semantics.
- [x] Full vector test suite green: 78 tests across `Issue256*`, `Issue255*`, `VectorStorageTest`, `PersistentVectorStoreDeleteTest`, `PersistentVectorStoreMergePolicyTest`, `PersistentVectorStoreBackoffTest`, `VectorIndexCompactor{Metrics,Failure,ConcurrentDelete}Test`, `VectorIndexShadowReloadTest`, `PersistentVectorStoreCapComputationTest`.
- [x] Hammer suite (`DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test`) run **twice**, both 12/12 green (per CLAUDE.md).
- [x] `mvn checkstyle:check spotbugs:check install -DskipTests -Pci` green (rat:check skipped locally due to a stray `~/dev/repo2` shell-expansion artifact in the working tree unrelated to this PR — CI runs against a fresh checkout so it will validate there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)