### PR TITLE
Size direct-memory ByteBuf caches from Netty maxDirectMemory; new thread-pool knobs

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -217,16 +217,35 @@ public class PersistentVectorStore extends AbstractVectorStore {
             Math.max(2, Integer.getInteger(
                     "herddb.vectorindex.segmentMergeBatch", 4));
 
+    /**
+     * Parallelism for the JVM-wide checkpoint pool. Configurable via the
+     * {@code herddb.vectorindex.checkpointThreads} system property. Default
+     * is {@code max(1, availableProcessors() / 2)}.
+     */
+    private static final int CHECKPOINT_POOL_SIZE = Math.max(1,
+            Integer.getInteger("herddb.vectorindex.checkpointThreads",
+                    Math.max(1, Runtime.getRuntime().availableProcessors() / 2)));
+
     /** Dedicated ForkJoinPool for checkpoint graph building. */
-    private static final ForkJoinPool CHECKPOINT_POOL = new ForkJoinPool(
-            Math.max(1, Runtime.getRuntime().availableProcessors() / 2),
-            pool -> {
-                ForkJoinWorkerThread t = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-                t.setDaemon(true);
-                t.setName("persistent-vector-store-checkpoint-" + t.getPoolIndex());
-                return t;
-            },
-            null, false);
+    private static final ForkJoinPool CHECKPOINT_POOL = createCheckpointPool();
+
+    private static ForkJoinPool createCheckpointPool() {
+        int defaultSize = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+        LOGGER.log(Level.INFO,
+                "PersistentVectorStore checkpoint pool: parallelism={0} "
+                        + "(system property herddb.vectorindex.checkpointThreads, "
+                        + "default max(1, availableProcessors()/2)={1})",
+                new Object[]{CHECKPOINT_POOL_SIZE, defaultSize});
+        return new ForkJoinPool(
+                CHECKPOINT_POOL_SIZE,
+                pool -> {
+                    ForkJoinWorkerThread t = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+                    t.setDaemon(true);
+                    t.setName("persistent-vector-store-checkpoint-" + t.getPoolIndex());
+                    return t;
+                },
+                null, false);
+    }
 
     /** Buffer size for in-memory / on-disk staging of index artefacts (1 MB). */
     static final int CHUNK_SIZE = 1_048_576;

--- a/herddb-core/src/test/java/herddb/index/vector/PersistentVectorStoreCheckpointPoolTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PersistentVectorStoreCheckpointPoolTest.java
@@ -1,0 +1,46 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import java.lang.reflect.Field;
+import java.util.concurrent.ForkJoinPool;
+import org.junit.Test;
+
+/**
+ * Verifies that the JVM-wide checkpoint {@link ForkJoinPool} parallelism is
+ * driven by the {@code herddb.vectorindex.checkpointThreads} system property
+ * (with a default of {@code max(1, availableProcessors() / 2)}).
+ */
+public class PersistentVectorStoreCheckpointPoolTest {
+
+    @Test
+    public void checkpointPoolParallelismMatchesSystemProperty() throws Exception {
+        int defaultSize = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+        int expected = Math.max(1,
+                Integer.getInteger("herddb.vectorindex.checkpointThreads", defaultSize));
+
+        Field f = PersistentVectorStore.class.getDeclaredField("CHECKPOINT_POOL");
+        f.setAccessible(true);
+        ForkJoinPool pool = (ForkJoinPool) f.get(null);
+
+        assertEquals(expected, pool.getParallelism());
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -119,7 +119,8 @@ public final class IndexingServerConfiguration {
 
     public static final String PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES =
             "indexing.vector.segmentPageCacheMaxBytes";
-    public static final long PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES_DEFAULT = 0; // 0 = compute as 1/4 of heap
+    // 0 = auto-size as 1/4 of Netty maxDirectMemory (heap fallback when unavailable)
+    public static final long PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES_DEFAULT = 0;
 
     // Compaction (checkpoint driver — existing)
     public static final String PROPERTY_COMPACTION_INTERVAL = "indexing.compaction.interval";

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -48,6 +48,7 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.IndexStatus;
 import herddb.utils.Bytes;
 import herddb.utils.XXHash64Utils;
+import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -413,10 +414,23 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES,
                     IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES_DEFAULT);
             // A value of 0 (default) means "auto-size": budget the cache at 1/4 of
-            // the JVM max heap. This matches the documented behaviour of the config
-            // property and the historical SharedSegmentPageCache default.
+            // Netty's max direct memory because the cache stores pooled direct
+            // ByteBufs (see SegmentBlockCache). Falls back to JVM max heap when
+            // PlatformDependent.maxDirectMemory() is unavailable (returns -1).
             if (segmentPageCacheMaxBytes == 0) {
-                segmentPageCacheMaxBytes = Runtime.getRuntime().maxMemory() / 4;
+                long maxDirect = PlatformDependent.maxDirectMemory();
+                long source = maxDirect > 0 ? maxDirect : Runtime.getRuntime().maxMemory();
+                String sourceLabel = maxDirect > 0 ? "Netty maxDirectMemory" : "JVM maxMemory (fallback)";
+                segmentPageCacheMaxBytes = source / 4;
+                LOGGER.log(Level.INFO,
+                        "vector index segmentPageCacheMaxBytes auto-sized to {0} bytes "
+                                + "({1} MB) = 1/4 of {2} ({3} bytes)",
+                        new Object[]{
+                                segmentPageCacheMaxBytes,
+                                segmentPageCacheMaxBytes / (1024 * 1024),
+                                sourceLabel,
+                                source
+                        });
             }
             this.segmentBlockCache = segmentPageCacheMaxBytes > 0
                     ? new SegmentBlockCache(segmentPageCacheMaxBytes)

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -33,6 +33,7 @@ import io.grpc.Server;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
 import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -90,6 +91,13 @@ public class RemoteFileServer implements AutoCloseable {
     public static final String CONFIG_READ_EXECUTOR_THREADS = "fileserver.read.executor.threads";
     /** Config key: thread count for the dedicated write-lane executor (issue #100). */
     public static final String CONFIG_WRITE_EXECUTOR_THREADS = "fileserver.write.executor.threads";
+    /** Config key: thread count for the Netty gRPC worker event loop. Defaults to {@code ioThreads}. */
+    public static final String CONFIG_NETTY_WORKER_THREADS = "fileserver.netty.worker.threads";
+    /**
+     * Config key: thread count for the metadata executor (directory ops on local
+     * storage, disk-cache index writer). Defaults to {@code ioThreads}.
+     */
+    public static final String CONFIG_METADATA_EXECUTOR_THREADS = "fileserver.metadata.executor.threads";
 
     private final String host;
     private final int port;
@@ -136,7 +144,9 @@ public class RemoteFileServer implements AutoCloseable {
             t.setDaemon(true);
             return t;
         };
-        metadataExecutor = Executors.newFixedThreadPool(ioThreads, threadFactory);
+        int metadataExecutorThreads = Integer.parseInt(
+                config.getProperty(CONFIG_METADATA_EXECUTOR_THREADS, String.valueOf(ioThreads)));
+        metadataExecutor = Executors.newFixedThreadPool(metadataExecutorThreads, threadFactory);
 
         int readExecutorThreads = Integer.parseInt(
                 config.getProperty(CONFIG_READ_EXECUTOR_THREADS, String.valueOf(ioThreads)));
@@ -164,8 +174,9 @@ public class RemoteFileServer implements AutoCloseable {
             objectStorage = new LocalObjectStorage(dataDirectory, metadataExecutor, statsLogger);
         }
 
-        // Wrap with in-heap block cache if enabled. Sits in front of the inner storage
-        // (local or S3+disk-cache) so hot graph blocks never re-touch disk/S3.
+        // Wrap with the direct-memory block cache if enabled. Sits in front of the
+        // inner storage (local or S3+disk-cache) so hot graph blocks never re-touch
+        // disk/S3. Values are pooled direct ByteBufs — only keys live on heap.
         boolean blockCacheEnabled = Boolean.parseBoolean(
                 config.getProperty(CONFIG_BLOCK_CACHE_ENABLED, "true"));
         InMemoryBlockCacheObjectStorage blockCache = null;
@@ -176,10 +187,10 @@ public class RemoteFileServer implements AutoCloseable {
             blockCache = new InMemoryBlockCacheObjectStorage(objectStorage, blockCacheMaxBytes);
             objectStorage = blockCache;
             LOGGER.log(Level.INFO,
-                    "In-heap block cache enabled: maxBytes={0} ({1} MB)",
+                    "block cache enabled: maxBytes={0} ({1} MB)",
                     new Object[]{blockCacheMaxBytes, blockCacheMaxBytes / (1024 * 1024)});
         } else {
-            LOGGER.log(Level.INFO, "In-heap block cache disabled");
+            LOGGER.log(Level.INFO, "block cache disabled");
         }
         if (blockCache != null) {
             registerBlockCacheGauges(statsLogger, blockCache);
@@ -188,9 +199,16 @@ public class RemoteFileServer implements AutoCloseable {
         int ioRatio = Integer.getInteger("herddb.fileserver.netty.ioRatio", DEFAULT_IO_RATIO);
         this.blockSize = Integer.parseInt(config.getProperty("block.size",
                 String.valueOf(DEFAULT_BLOCK_SIZE)));
+        int nettyWorkerThreads = Integer.parseInt(
+                config.getProperty(CONFIG_NETTY_WORKER_THREADS, String.valueOf(ioThreads)));
         bossGroup = new NioEventLoopGroup(1);
-        workerGroup = new NioEventLoopGroup(ioThreads);
+        workerGroup = new NioEventLoopGroup(nettyWorkerThreads);
         workerGroup.setIoRatio(ioRatio);
+        LOGGER.log(Level.INFO,
+                "RemoteFileServer thread pools: ioThreads(default)={0}, "
+                        + "nettyWorker={1}, metadataExecutor={2}, readExecutor={3}, writeExecutor={4}",
+                new Object[]{ioThreads, nettyWorkerThreads, metadataExecutorThreads,
+                        readExecutorThreads, writeExecutorThreads});
 
         RemoteFileServiceImpl serviceImpl = new RemoteFileServiceImpl(
                 objectStorage, statsLogger, readExecutor, writeExecutor);
@@ -408,14 +426,33 @@ public class RemoteFileServer implements AutoCloseable {
         }
     }
 
-    /** Default in-heap block-cache budget: 1/4 of the JVM max heap. */
+    /**
+     * Default block-cache budget: 1/4 of Netty's max direct memory because the
+     * cache stores pooled direct ByteBufs (see InMemoryBlockCacheObjectStorage).
+     * Falls back to JVM max heap when {@link PlatformDependent#maxDirectMemory()}
+     * is unavailable (returns -1).
+     */
     static long defaultBlockCacheMaxBytes() {
-        long max = Runtime.getRuntime().maxMemory();
-        if (max == Long.MAX_VALUE) {
-            // -Xmx unset: fall back to total memory so we don't allocate everything in sight.
-            max = Runtime.getRuntime().totalMemory();
+        long maxDirect = PlatformDependent.maxDirectMemory();
+        long source;
+        String sourceLabel;
+        if (maxDirect > 0) {
+            source = maxDirect;
+            sourceLabel = "Netty maxDirectMemory";
+        } else {
+            long heap = Runtime.getRuntime().maxMemory();
+            if (heap == Long.MAX_VALUE) {
+                // -Xmx unset: fall back to total memory so we don't allocate everything in sight.
+                heap = Runtime.getRuntime().totalMemory();
+            }
+            source = heap;
+            sourceLabel = "JVM maxMemory (fallback)";
         }
-        return Math.max(1, max / 4);
+        long budget = Math.max(1, source / 4);
+        LOGGER.log(Level.INFO,
+                "block-cache auto-size: {0} bytes ({1} MB) = 1/4 of {2} ({3} bytes)",
+                new Object[]{budget, budget / (1024 * 1024), sourceLabel, source});
+        return budget;
     }
 
     private static void registerBlockCacheGauges(StatsLogger root, InMemoryBlockCacheObjectStorage cache) {

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServerThreadPoolConfigTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServerThreadPoolConfigTest.java
@@ -1,0 +1,113 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.internal.PlatformDependent;
+import java.lang.reflect.Field;
+import java.util.Properties;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that the auto-sized block-cache budget is derived from Netty's
+ * direct-memory ceiling and that the Netty worker / metadata executor pool
+ * sizes can be configured independently of {@code ioThreads}.
+ */
+public class RemoteFileServerThreadPoolConfigTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void defaultBlockCacheBudgetIsQuarterOfDirectMemoryOrHeap() {
+        long actual = RemoteFileServer.defaultBlockCacheMaxBytes();
+        long maxDirect = PlatformDependent.maxDirectMemory();
+        long expected;
+        if (maxDirect > 0) {
+            expected = Math.max(1, maxDirect / 4);
+        } else {
+            long heap = Runtime.getRuntime().maxMemory();
+            if (heap == Long.MAX_VALUE) {
+                heap = Runtime.getRuntime().totalMemory();
+            }
+            expected = Math.max(1, heap / 4);
+        }
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void splitsNettyWorkerAndMetadataExecutorPools() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(RemoteFileServer.CONFIG_NETTY_WORKER_THREADS, "3");
+        props.setProperty(RemoteFileServer.CONFIG_METADATA_EXECUTOR_THREADS, "2");
+        // ioThreads passed in is intentionally a different value to prove the
+        // new keys override it.
+        server = new RemoteFileServer("localhost", 0,
+                folder.newFolder("data").toPath(), 7, props);
+        server.start();
+
+        NioEventLoopGroup workerGroup = readField(server, "workerGroup", NioEventLoopGroup.class);
+        ThreadPoolExecutor metadataExecutor =
+                readField(server, "metadataExecutor", ThreadPoolExecutor.class);
+
+        assertEquals("Netty worker group must honour fileserver.netty.worker.threads",
+                3, workerGroup.executorCount());
+        assertEquals("metadataExecutor must honour fileserver.metadata.executor.threads",
+                2, metadataExecutor.getCorePoolSize());
+    }
+
+    @Test
+    public void omittingNewKeysFallsBackToIoThreads() throws Exception {
+        server = new RemoteFileServer("localhost", 0,
+                folder.newFolder("data").toPath(), 5, new Properties());
+        server.start();
+
+        NioEventLoopGroup workerGroup = readField(server, "workerGroup", NioEventLoopGroup.class);
+        ThreadPoolExecutor metadataExecutor =
+                readField(server, "metadataExecutor", ThreadPoolExecutor.class);
+
+        assertEquals("Netty worker group should default to ioThreads",
+                5, workerGroup.executorCount());
+        assertEquals("metadataExecutor should default to ioThreads",
+                5, metadataExecutor.getCorePoolSize());
+    }
+
+    private static <T> T readField(Object target, String name, Class<T> type) throws Exception {
+        Field f = target.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        Object value = f.get(target);
+        return type.cast(value);
+    }
+}

--- a/herddb-services/src/main/java/herddb/server/RemoteFileServerMain.java
+++ b/herddb-services/src/main/java/herddb/server/RemoteFileServerMain.java
@@ -113,8 +113,13 @@ public class RemoteFileServerMain {
         int port = Integer.parseInt(configuration.getProperty("port", "9846"));
         String bindHost = configuration.getProperty("bind.host", "0.0.0.0");
         String dataDir = configuration.getProperty("data.dir", "fileserver_" + port);
+        int defaultIoThreads = Runtime.getRuntime().availableProcessors();
         int ioThreads = Integer.parseInt(configuration.getProperty("io.threads",
-                String.valueOf(Runtime.getRuntime().availableProcessors())));
+                String.valueOf(defaultIoThreads)));
+        LOG.info("io.threads=" + ioThreads + " (default availableProcessors()=" + defaultIoThreads
+                + "); fallback for fileserver.netty.worker.threads, "
+                + "fileserver.metadata.executor.threads, fileserver.read.executor.threads, "
+                + "fileserver.write.executor.threads when those are unset");
 
         // Per-port PID file so multiple instances can coexist on the same host
         System.setProperty("pidfile", "file-server-" + port + ".java.pid");

--- a/herddb-services/src/main/resources/conf/fileserver.properties
+++ b/herddb-services/src/main/resources/conf/fileserver.properties
@@ -38,12 +38,19 @@ bind.host=0.0.0.0
 # s3.prefix=
 # cache.max.bytes=1073741824
 
-# In-heap block cache (fronts the object storage for readRange requests).
-# Holds whole multipart blocks in memory so repeated random reads from
-# ANN/HNSW traversal are served without touching disk or S3.
+# Block cache (fronts the object storage for readRange requests).
+# Holds whole multipart blocks as pooled direct ByteBufs so repeated random reads
+# from ANN/HNSW traversal are served without touching disk or S3.
 # block.cache.enabled=true
-# Default: 1/4 of the JVM max heap (-Xmx). Override in bytes.
+# Default: 1/4 of Netty's max direct memory (heap fallback). Override in bytes.
 # block.cache.max.bytes=
+
+# Thread pools. All keys below default to io.threads when unset.
+# io.threads=
+# fileserver.netty.worker.threads=
+# fileserver.metadata.executor.threads=
+# fileserver.read.executor.threads=
+# fileserver.write.executor.threads=
 
 # HTTP server for Prometheus metrics and Web UI
 http.enable=true


### PR DESCRIPTION
## Summary
- Two Caffeine caches that store pooled Netty `ByteBuf` values were auto-sizing their byte budget from `Runtime.getRuntime().maxMemory()` (heap). On JVMs where heap and `MaxDirectMemorySize` are tuned independently the budget was unrelated to the resource the cache actually consumes — under-utilising direct memory or risking `OutOfDirectMemoryError` before Caffeine ever evicts.
- Both caches (vector-index `SegmentBlockCache` budget computed in `IndexingServiceEngine`, and `RemoteFileServer.defaultBlockCacheMaxBytes`) now derive their auto-size from `PlatformDependent.maxDirectMemory() / 4`, falling back to `Runtime.maxMemory()` when Netty cannot report a ceiling. An INFO log explains the chosen value and source at startup.
- Three thread-pool knobs were refined while in the area, all preserving current defaults:
  - `PersistentVectorStore` checkpoint `ForkJoinPool` parallelism is now configurable via `-Dherddb.vectorindex.checkpointThreads` (was hardcoded; default `max(1, availableProcessors()/2)`).
  - `RemoteFileServer` previously fanned `ioThreads` to both the Netty worker `EventLoopGroup` and the metadata executor. Two new keys split them: `fileserver.netty.worker.threads`, `fileserver.metadata.executor.threads` (read/write lane keys already existed for issue #100). All default to `ioThreads`.
  - `RemoteFileServerMain` now logs the resolved `io.threads` default and the fallback role for the new keys.

## Test plan
- [x] `mvn -B -pl herddb-core,herddb-remote-file-service,herddb-indexing-service,herddb-services -am checkstyle:check spotbugs:check install -DskipTests -Pci` passes.
- [x] New test `RemoteFileServerThreadPoolConfigTest` boots a `RemoteFileServer` and asserts via reflection that `workerGroup.executorCount()` and `metadataExecutor.getCorePoolSize()` honour the new keys, and fall back to `ioThreads` when unset; also asserts `defaultBlockCacheMaxBytes()` matches the documented formula.
- [x] New test `PersistentVectorStoreCheckpointPoolTest` asserts the checkpoint pool's `getParallelism()` matches the system property formula.
- [ ] Hammer suite (`DirectMultipleConcurrentUpdatesSuite*Test`) — recommended before merge since Step E touches the static checkpoint pool used during Phase B graph building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)