### PR TITLE
issue #268: release inflight-read permits before completing the future

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -660,24 +660,24 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
                             @Override
                             public void onError(Throwable t) {
-                                try {
-                                    if (result != null) {
-                                        result.release();
-                                        result = null;
-                                    }
-                                    future.completeExceptionally(t);
-                                } finally {
-                                    releaseOnce.run();
+                                if (result != null) {
+                                    result.release();
+                                    result = null;
                                 }
+                                // Release permits before completing the future so that any thread
+                                // unblocked by future.completeExceptionally() observes the
+                                // restored budget immediately (issue #268).
+                                releaseOnce.run();
+                                future.completeExceptionally(t);
                             }
 
                             @Override
                             public void onCompleted() {
-                                try {
-                                    future.complete(result);
-                                } finally {
-                                    releaseOnce.run();
-                                }
+                                // Release permits before completing the future so that any thread
+                                // unblocked by future.complete() observes the restored budget
+                                // immediately (issue #268).
+                                releaseOnce.run();
+                                future.complete(result);
                             }
                         });
             } catch (RuntimeException e) {
@@ -1031,30 +1031,33 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
                             @Override
                             public void onError(Throwable t) {
-                                try {
-                                    if (result != null) {
-                                        ReferenceCountUtil.safeRelease(result);
-                                        result = null;
-                                    }
-                                    future.completeExceptionally(t);
-                                } finally {
-                                    releaseOnce.run();
+                                if (result != null) {
+                                    ReferenceCountUtil.safeRelease(result);
+                                    result = null;
                                 }
+                                // Release permits before completing the future so that any thread
+                                // unblocked by future.completeExceptionally() observes the
+                                // restored budget immediately (issue #268).
+                                releaseOnce.run();
+                                future.completeExceptionally(t);
                             }
 
                             @Override
                             public void onCompleted() {
-                                try {
-                                    if (!future.isDone()) {
-                                        future.complete(result);
-                                    } else if (result != null) {
-                                        // Future already failed in onNext — release the buffer we
-                                        // would have returned so it does not leak.
+                                if (future.isDone()) {
+                                    // Future already failed in onNext — release the buffer we
+                                    // would have returned so it does not leak.
+                                    if (result != null) {
                                         ReferenceCountUtil.safeRelease(result);
                                         result = null;
                                     }
-                                } finally {
-                                    releaseOnce.run();
+                                }
+                                // Release permits before completing the future so that any thread
+                                // unblocked by future.complete() observes the restored budget
+                                // immediately (issue #268).
+                                releaseOnce.run();
+                                if (!future.isDone()) {
+                                    future.complete(result);
                                 }
                             }
                         });


### PR DESCRIPTION
Fixes #268.

## Changes

- **`RemoteFileServiceClient.java`**: In both `doReadFileAsByteBufAsync` and
  `doReadFileRangeAsByteBufAsync`, moved `releaseOnce.run()` to execute *before*
  `future.complete()` / `future.completeExceptionally()` in every terminal gRPC
  callback (`onError` and `onCompleted`).

  **Root cause**: `CompletableFuture.complete()` synchronously cascades through all
  chained `whenComplete` callbacks in the same thread, ultimately unparking any thread
  blocked in `.get()`. On a multi-core machine that thread can be scheduled on another
  core and call `availableInflightReadBytes()` before the gRPC callback thread reaches
  the `finally { releaseOnce.run(); }` block — observing `0` instead of the full
  configured budget. The fix makes the budget visible as restored *before* any
  observer of the future can run.

  The existing `AtomicBoolean` guard inside `releaseOnce` still prevents accidental
  double-release from the synchronous-failure `catch` path.

## Tests

- `RemoteFileServiceClientByteBufTest#testInflightReadBytes_smallBudgetRoundTrip` —
  already existed; verifies the full budget is restored after a successful read against
  a budget sized to exactly one block (the tightest possible scenario for the race).
- `RemoteFileServiceClientByteBufTest#testInflightReadBytes_smallBudgetSurvivesRepeatedNotFound` —
  already existed; verifies the budget is restored after each not-found response using
  the same tight budget; a deadlock would occur after the first call if permits leaked.
- All 24 tests in `RemoteFileServiceClientByteBufTest` pass (run 3× locally).

🤖 Implemented by the `pr-worker` agent.