### PR TITLE
issue #267: fix flaky MultipleConcurrentUpdatesTest client timeout

### DIFF
--- a/herddb-core/src/test/java/herddb/server/hammer/MultipleConcurrentUpdatesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/MultipleConcurrentUpdatesTest.java
@@ -127,6 +127,17 @@ public class MultipleConcurrentUpdatesTest {
             server.start();
             server.waitForStandaloneBoot();
             ClientConfiguration clientConfiguration = new ClientConfiguration(folder.newFolder().toPath());
+            /*
+             * Set the client request timeout to 600 s — twice the server-side
+             * CHECKPOINT_LOCK_READ_TIMEOUT (300 s). Phase C of a checkpoint holds the
+             * checkpoint write lock while doing disk I/O (keyToPage.checkpoint +
+             * tableCheckpoint). On a loaded CI runner this can approach 300 s, causing
+             * the default 300 s client timeout to fire before the server's own tryLock
+             * expires, producing a spurious TimeoutException. Setting the client timeout
+             * to CHECKPOINT_LOCK_WRITE_TIMEOUT (600 s) ensures the client never gives up
+             * before the server's read-lock side does. See issue #267.
+             */
+            clientConfiguration.set(ClientConfiguration.PROPERTY_TIMEOUT, 600_000);
             try (HDBClient client = new HDBClient(clientConfiguration);
                  HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
@@ -216,7 +227,10 @@ public class MultipleConcurrentUpdatesTest {
                         ));
                     }
                     for (Future f : futures) {
-                        f.get();
+                        // 600 s matches the client timeout set above; prevents an infinite
+                        // hang in case a future becomes truly stuck (e.g. thread pool
+                        // exhaustion or undetected deadlock). Mirrors DirectMultipleConcurrentUpdatesSuite.
+                        f.get(600, TimeUnit.SECONDS);
                     }
 
                     System.out.println("stats::updates:" + updates);


### PR DESCRIPTION
Fixes #267.

## Root cause

`MultipleConcurrentUpdatesTest.testWithTransactionsWithCheckpoints` fails because the HDB **client request timeout (300 s, `ClientConfiguration.PROPERTY_TIMEOUT_DEFAULT`)** equals the server-side **`CHECKPOINT_LOCK_READ_TIMEOUT` (300 s)**. Phase C of a checkpoint holds the checkpoint write lock while doing disk I/O (`keyToPage.checkpoint()` + `dataStorageManager.tableCheckpoint()`). On a loaded CI runner this can approach 300 s. Commit requests queued on `callbacksExecutor` threads waiting for the read lock add their queue-wait time on top of the lock-wait time; when the total reaches the 300 s client timeout the client fires a `TimeoutException` before the server's own `tryLock` expires. The `DirectMultipleConcurrentUpdatesSuite` variants are immune because they call `DBManager` directly (no client timeout) and use 20 threads instead of 100.

## Changes

- **`herddb-core/src/test/java/herddb/server/hammer/MultipleConcurrentUpdatesTest.java`**
  - Set `ClientConfiguration.PROPERTY_TIMEOUT` to `600_000` (600 s = `CHECKPOINT_LOCK_WRITE_TIMEOUT`) in `performTest()`, so the client can never time out before the server's read-lock `tryLock` expires.
  - Changed `f.get()` → `f.get(600, TimeUnit.SECONDS)` to match `DirectMultipleConcurrentUpdatesSuite`'s defensive pattern and surface truly stuck futures quickly instead of hanging indefinitely.

## Tests

- `MultipleConcurrentUpdatesTest#testWithTransactionsWithCheckpoints` — run 3× locally, passes each time.
- `MultipleConcurrentUpdatesTest` — all 8 methods green (16 s).
- Hammer suite (`DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`, `WithNonUniqueIndexesTest`, `WithUniqueIndexesTest`) — 12/12 tests, run 2× to reduce flake risk.
- Pre-PR validation (`checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`) — BUILD SUCCESS.

🤖 Implemented by the `pr-worker` agent.