### PR TITLE
issue #262: wire VECTORBENCH_ADMIN_PORT through Helm chart and launch script

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
@@ -56,6 +56,8 @@ spec:
               value: {{ .Values.tools.javaOpts | default "-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true" | quote }}
             - name: VECTORBENCH_DATASET_DIR
               value: /opt/herddb/vector-datasets
+            - name: VECTORBENCH_ADMIN_PORT
+              value: {{ .Values.tools.adminPort | default "8080" | quote }}
             {{- if .Values.tools.gcs.datasetsBucket }}
             - name: VECTORBENCH_DATASETS_BUCKET
               value: "gs://{{ .Values.tools.gcs.datasetsBucket }}"

--- a/herddb-kubernetes/src/main/helm/herddb/tests/tools-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/tools-statefulset_test.yaml
@@ -59,6 +59,26 @@ tests:
             name: VECTORBENCH_DATASET_DIR
             value: /opt/herddb/vector-datasets
 
+  - it: should set VECTORBENCH_ADMIN_PORT to 8080 by default
+    template: templates/tools-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VECTORBENCH_ADMIN_PORT
+            value: "8080"
+
+  - it: should honour a custom tools.adminPort value
+    template: templates/tools-statefulset.yaml
+    set:
+      tools.adminPort: "9090"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VECTORBENCH_ADMIN_PORT
+            value: "9090"
+
   - it: should mount the tools scripts configmap
     template: templates/tools-statefulset.yaml
     asserts:

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -232,6 +232,11 @@ tools:
   enabled: true
   # JVM options for the CLI (defaults to lightweight settings)
   javaOpts: ""
+  # Port for the embedded VectorBench admin HTTP API (GET /status,
+  # POST /ingestion/config/ingest-max-ops, etc.).  Passed to the JVM
+  # as -Dvectorbench.admin.port=<N> via VECTORBENCH_ADMIN_PORT env var.
+  # Set to "0" or a negative value to disable the admin API.
+  adminPort: "8080"
   # PodDisruptionBudget — prevents voluntary node evictions (e.g. GKE Autopilot
   # scale-down) from killing the tools pod mid-benchmark. Enabled by default
   # when tools is enabled. Set to false only for short-lived / disposable runs.

--- a/herddb-services/src/main/resources/bin/vector-bench.sh
+++ b/herddb-services/src/main/resources/bin/vector-bench.sh
@@ -54,4 +54,13 @@ if [ -n "$HERDDB_JDBC_URL" ]; then
     fi
 fi
 
-exec $JAVA $JAVA_HEAP -jar "$JAR" "${EXTRA_ARGS[@]}" "$@"
+# Honor VECTORBENCH_ADMIN_PORT env var (set by the Helm chart via tools.adminPort).
+# Passes the port as the vectorbench.admin.port system property so the embedded
+# Jetty admin API binds on the configured port.  Leave unset to use the Java-side
+# default (8080).
+ADMIN_PORT_PROP=""
+if [ -n "$VECTORBENCH_ADMIN_PORT" ]; then
+    ADMIN_PORT_PROP="-Dvectorbench.admin.port=${VECTORBENCH_ADMIN_PORT}"
+fi
+
+exec $JAVA $JAVA_HEAP $ADMIN_PORT_PROP -jar "$JAR" "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
Fixes #262.

## Changes

- **`values.yaml`** — add `tools.adminPort` (default `"8080"`): a Helm-level knob for the embedded VectorBench admin HTTP API port. Set `"0"` or a negative string to disable.
- **`tools-statefulset.yaml`** — inject `VECTORBENCH_ADMIN_PORT` env var from `tools.adminPort` so every `kubectl exec … vector-bench.sh` invocation picks up the correct port automatically.
- **`vector-bench.sh`** — honour `VECTORBENCH_ADMIN_PORT` env var by passing it as `-Dvectorbench.admin.port=<N>` to the JVM; when unset the Java-side default (`8080`) takes effect unchanged.
- **`tests/tools-statefulset_test.yaml`** — two new Helm unit-test assertions: `VECTORBENCH_ADMIN_PORT` is `"8080"` with the default values, and a custom `tools.adminPort` value is propagated correctly.

## Tests

- Helm chart unit tests: `should set VECTORBENCH_ADMIN_PORT to 8080 by default` and `should honour a custom tools.adminPort value` verify the env-var is rendered with the right value in both the default and override cases.

🤖 Implemented by the `pr-worker` agent.