### PR TITLE
issue #274: downgrade BookKeeper 4.17.3→4.17.2, Netty 4.1.130→4.1.121

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <libs.netty4>4.1.130.Final</libs.netty4>
+        <libs.netty4>4.1.121.Final</libs.netty4>
         <libs.netty4ssl>2.0.70.Final</libs.netty4ssl>
         <!-- needed in tests for TLS certificate autogeneration on jdk-15+ -->
         <libs.bouncycastle>1.70</libs.bouncycastle>
@@ -100,7 +100,7 @@
         <libs.slf4j>2.0.4</libs.slf4j>
         <libs.commonscollections>3.2.2</libs.commonscollections>
         <libs.lz4>1.3.0</libs.lz4>
-        <libs.bookkeeper>4.17.3</libs.bookkeeper>
+        <libs.bookkeeper>4.17.2</libs.bookkeeper>
         <libs.jersey>2.26</libs.jersey>
         <libs.jcipi-annotations>1.0</libs.jcipi-annotations>
         <libs.spotbugsannotations>4.9.8</libs.spotbugsannotations>


### PR DESCRIPTION
Fixes #274.

## Root cause

`BookKeeper 4.17.3` upgraded its bundled Netty from **4.1.121.Final** to
**4.1.130.Final** (upstream PR apache/bookkeeper#4699). The changed
thread-scheduling behaviour in Netty 4.1.130 exposes a pre-existing race in
`LedgerHandle.monitorPendingAddOps`: a `ConcurrentLinkedQueue` iterator on
the scheduler thread can see a `PendingAddOp` *after* the same op has been
removed from the queue and recycled by the application thread
(`recyclePendAddOpObject()` clears `clientCtx = null`). The timeout-monitor
task then calls `op.maybeTimeout()` → `clientCtx.getConf()` → NPE.

## Changes

- **`pom.xml`** — `libs.bookkeeper` 4.17.3 → **4.17.2**; `libs.netty4`
  4.1.130.Final → **4.1.121.Final**.
  - `ZooKeeper` (3.9.3) and `netty-tcnative-boringssl-static` (2.0.70.Final)
    are unchanged — BK 4.17.2 uses the same versions.
  - No Java source changes needed: BK 4.17.2 still uses
    `commons-configuration2` for `PrometheusMetricsProvider.start()`.

## Tests

- `BookKeeperCommitLogTest` (13 tests): ✅ green against BK 4.17.2.
- Pre-PR validation (`checkstyle` + Apache RAT + SpotBugs + full build
  `-DskipTests -Pci`): ✅ `BUILD SUCCESS`.

## Follow-up

An upstream issue has been opened against `apache/bookkeeper` requesting a
null-guard in `PendingAddOp.maybeTimeout` so the NPE cannot occur regardless
of Netty version.

🤖 Implemented by the `pr-worker` agent.