### PR TITLE
issue #263: expose ingest-threads and query-threads as runtime-tunable admin endpoints

### DIFF
--- a/vector-testings/src/main/java/herddb/vectortesting/AdminApiServer.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/AdminApiServer.java
@@ -42,8 +42,12 @@ import org.eclipse.jetty.servlet.ServletHolder;
  * <ul>
  *   <li>{@code GET /ingestion/config}</li>
  *   <li>{@code POST /ingestion/config/ingest-max-ops}</li>
+ *   <li>{@code GET /ingestion/config/ingest-threads}</li>
+ *   <li>{@code POST /ingestion/config/ingest-threads}</li>
  *   <li>{@code GET /query/config}</li>
  *   <li>{@code POST /query/config/query-max-ops}</li>
+ *   <li>{@code GET /query/config/query-threads}</li>
+ *   <li>{@code POST /query/config/query-threads}</li>
  *   <li>{@code GET /status}</li>
  * </ul>
  */
@@ -128,7 +132,13 @@ public class AdminApiServer {
             String path = pathOf(req);
             switch (path) {
                 case "/ingestion/config" -> writeJson(resp, HttpServletResponse.SC_OK, ingestionConfig());
+                case "/ingestion/config/ingest-threads" ->
+                        writeJson(resp, HttpServletResponse.SC_OK,
+                                Map.of("ingest-threads", runtime.config().ingestThreads));
                 case "/query/config" -> writeJson(resp, HttpServletResponse.SC_OK, queryConfig());
+                case "/query/config/query-threads" ->
+                        writeJson(resp, HttpServletResponse.SC_OK,
+                                Map.of("query-threads", runtime.config().queryThreads));
                 case "/status" -> writeJson(resp, HttpServletResponse.SC_OK, runtime.getStatusSupplier().get());
                 default -> writeError(resp, HttpServletResponse.SC_NOT_FOUND, "no such endpoint: GET " + path);
             }
@@ -145,9 +155,19 @@ public class AdminApiServer {
                         runtime.setIngestMaxOps(value);
                         writeJson(resp, HttpServletResponse.SC_OK, ingestionConfig());
                     }
+                    case "/ingestion/config/ingest-threads" -> {
+                        int value = readIntValue(req);
+                        runtime.setIngestThreads(value);
+                        writeJson(resp, HttpServletResponse.SC_OK, ingestionConfig());
+                    }
                     case "/query/config/query-max-ops" -> {
                         int value = readIntValue(req);
                         runtime.setQueryMaxOps(value);
+                        writeJson(resp, HttpServletResponse.SC_OK, queryConfig());
+                    }
+                    case "/query/config/query-threads" -> {
+                        int value = readIntValue(req);
+                        runtime.setQueryThreads(value);
                         writeJson(resp, HttpServletResponse.SC_OK, queryConfig());
                     }
                     case "/query/config/top-k" -> {
@@ -162,6 +182,10 @@ public class AdminApiServer {
                 }
             } catch (IllegalArgumentException e) {
                 writeError(resp, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                writeError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        "request interrupted: " + e.getMessage());
             }
         }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/BenchRuntime.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/BenchRuntime.java
@@ -22,6 +22,9 @@ package herddb.vectortesting;
 import com.google.common.util.concurrent.RateLimiter;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -54,14 +57,43 @@ public class BenchRuntime {
      */
     public static final double UNLIMITED_RATE = 1_000_000_000.0;
 
+    /**
+     * Maximum number of ingest threads that may be set via the admin API.
+     * Prevents runaway thread creation from misconfigured POST requests.
+     */
+    public static final int MAX_INGEST_THREADS = 1024;
+
     private final Config config;
     private final AtomicReference<RateLimiter> ingestRateLimiterRef;
     private final AtomicReference<RateLimiter> queryRateLimiterRef;
     private final AtomicReference<Supplier<Map<String, Object>>> statusSupplier =
             new AtomicReference<>(() -> Collections.singletonMap("phase", "idle"));
 
+    /**
+     * Number of ingest workers currently alive (incremented at the start of
+     * each worker's {@code run()}, decremented in its {@code finally} block).
+     * Used by {@link #setIngestThreads} to compute how many poison pills to
+     * inject (reduction) or how many new workers to spawn (increase).
+     */
+    public final AtomicInteger activeIngestWorkers = new AtomicInteger(0);
+
+    /**
+     * The target ingest thread count as last requested via {@link #setIngestThreads}.
+     * Initialised from {@link Config#ingestThreads}; may diverge if updated
+     * before the ingest phase starts.
+     */
+    private volatile int targetIngestThreads;
+
+    // Ingest context — set by VectorBench at the start of the ingest phase so
+    // setIngestThreads can inject pills or spawn workers live. Cleared after
+    // the ingest phase completes so stale references are not held.
+    private volatile BlockingQueue<float[]> ingestQueue;
+    private volatile ExecutorService ingestPool;
+    private volatile Supplier<Runnable> ingestWorkerFactory;
+
     public BenchRuntime(Config config) {
         this.config = config;
+        this.targetIngestThreads = config.ingestThreads;
         this.ingestRateLimiterRef = new AtomicReference<>(RateLimiter.create(
                 config.ingestMaxOpsPerSecond > 0 ? config.ingestMaxOpsPerSecond : UNLIMITED_RATE));
         this.queryRateLimiterRef = new AtomicReference<>(RateLimiter.create(
@@ -121,5 +153,113 @@ public class BenchRuntime {
 
     public void setStatusSupplier(Supplier<Map<String, Object>> supplier) {
         statusSupplier.set(supplier);
+    }
+
+    /**
+     * Registers the live ingest context so that {@link #setIngestThreads} can
+     * inject poison pills or spawn new workers during the ingest phase.
+     * Must be called by {@code VectorBench} immediately before submitting the
+     * initial ingest workers and after all three parameters are ready.
+     *
+     * @param queue   the shared queue that ingest workers drain
+     * @param pool    the executor service running the ingest workers
+     * @param factory supplier that creates a new {@link IngestionWorker} runnable
+     *                with all shared state already captured
+     */
+    public void setIngestContext(BlockingQueue<float[]> queue, ExecutorService pool,
+                                 Supplier<Runnable> factory) {
+        this.ingestQueue = queue;
+        this.ingestPool = pool;
+        this.ingestWorkerFactory = factory;
+    }
+
+    /**
+     * Clears the ingest context after the ingest phase completes so that stale
+     * references to the queue and pool are not retained beyond their useful life.
+     */
+    public void clearIngestContext() {
+        this.ingestQueue = null;
+        this.ingestPool = null;
+        this.ingestWorkerFactory = null;
+    }
+
+    /**
+     * Changes the number of live ingest threads.
+     *
+     * <p><b>Reducing</b> (newThreads &lt; activeIngestWorkers): injects
+     * {@code (active - newThreads)} poison pills into the ingest queue. Each
+     * pill causes one worker to exit after its current commit completes — no
+     * batch is interrupted mid-flight. If the ingest context is not yet set
+     * (called before the ingest phase), the pill injection is skipped and only
+     * the config is updated.
+     *
+     * <p><b>Increasing</b> (newThreads &gt; activeIngestWorkers): submits
+     * {@code (newThreads - active)} new worker tasks via the registered pool
+     * and factory. New workers share the same queue and accumulators as the
+     * initial workers. If the ingest context is not yet set, the spawn is
+     * skipped and only the config is updated.
+     *
+     * @param newThreads target thread count; must be between 1 and
+     *                   {@value #MAX_INGEST_THREADS} inclusive
+     * @throws IllegalArgumentException if the value is out of range
+     * @throws InterruptedException if a poison-pill {@code put} is interrupted
+     */
+    public void setIngestThreads(int newThreads) throws InterruptedException {
+        if (newThreads <= 0) {
+            throw new IllegalArgumentException("ingest-threads must be >= 1, got " + newThreads);
+        }
+        if (newThreads > MAX_INGEST_THREADS) {
+            throw new IllegalArgumentException(
+                    "ingest-threads must be <= " + MAX_INGEST_THREADS + ", got " + newThreads);
+        }
+
+        int active = activeIngestWorkers.get();
+        BlockingQueue<float[]> queue = this.ingestQueue;
+        ExecutorService pool = this.ingestPool;
+        Supplier<Runnable> factory = this.ingestWorkerFactory;
+
+        if (newThreads < active && queue != null) {
+            // Inject poison pills to retire excess workers gracefully.
+            int toRetire = active - newThreads;
+            for (int i = 0; i < toRetire; i++) {
+                queue.put(new float[0]);
+            }
+        } else if (newThreads > active && pool != null && factory != null) {
+            // Spawn additional workers up to the target.
+            int toSpawn = newThreads - active;
+            for (int i = 0; i < toSpawn; i++) {
+                pool.submit(factory.get());
+            }
+        }
+
+        config.ingestThreads = newThreads;
+        targetIngestThreads = newThreads;
+    }
+
+    /**
+     * Returns the current target ingest thread count (as last set via
+     * {@link #setIngestThreads} or initialised from {@link Config}).
+     */
+    public int getTargetIngestThreads() {
+        return targetIngestThreads;
+    }
+
+    /**
+     * Changes the number of query threads stored in {@link Config}.
+     *
+     * <p>Note: the query phase pre-partitions work by thread index at startup,
+     * so a live change during an ongoing query phase will not repartition
+     * in-flight work. The new value is reflected immediately in
+     * {@code GET /query/config} and takes full effect when the next benchmark
+     * run starts.
+     *
+     * @param newThreads target thread count; must be >= 1
+     * @throws IllegalArgumentException if the value is &lt; 1
+     */
+    public void setQueryThreads(int newThreads) {
+        if (newThreads <= 0) {
+            throw new IllegalArgumentException("query-threads must be >= 1, got " + newThreads);
+        }
+        config.queryThreads = newThreads;
     }
 }

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -65,6 +65,14 @@ public class IngestionWorker implements Runnable {
      * limiting" (test-only path).
      */
     private final Supplier<RateLimiter> ingestRateLimiter;
+    /**
+     * Optional runtime reference for tracking the live worker count.
+     * When non-null, {@link BenchRuntime#activeIngestWorkers} is incremented
+     * at worker start and decremented at worker exit (in a {@code finally}
+     * block). May be {@code null} in unit tests that construct the worker
+     * directly without a full {@link BenchRuntime}.
+     */
+    private final BenchRuntime runtime;
 
     /**
      * Base of the exponential back-off between commit retries, in milliseconds.
@@ -73,10 +81,27 @@ public class IngestionWorker implements Runnable {
      */
     long backoffBaseMillis = 10_000L;
 
+    /**
+     * Constructs an {@code IngestionWorker} without a {@link BenchRuntime} reference.
+     * Used in unit tests that do not need live thread-count tracking.
+     */
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
                            AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted,
                            Supplier<RateLimiter> ingestRateLimiter) {
+        this(config, queue, done, rowId, metrics, statusLine, ingestStartNanos,
+                commitsTotal, commitsRecovered, rowsCommitted, ingestRateLimiter, null);
+    }
+
+    /**
+     * Constructs an {@code IngestionWorker} with an optional {@link BenchRuntime}
+     * for live thread-count tracking. Pass {@code null} for {@code runtime} when
+     * constructing workers in unit tests that do not need this feature.
+     */
+    public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
+                           MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
+                           AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted,
+                           Supplier<RateLimiter> ingestRateLimiter, BenchRuntime runtime) {
         this.config = config;
         this.queue = queue;
         this.done = done;
@@ -88,6 +113,7 @@ public class IngestionWorker implements Runnable {
         this.commitsRecovered = commitsRecovered;
         this.rowsCommitted = rowsCommitted;
         this.ingestRateLimiter = ingestRateLimiter;
+        this.runtime = runtime;
     }
 
     private static String formatEta(double seconds) {
@@ -264,6 +290,9 @@ public class IngestionWorker implements Runnable {
 
     @Override
     public void run() {
+        if (runtime != null) {
+            runtime.activeIngestWorkers.incrementAndGet();
+        }
         String sql = "INSERT INTO " + config.tableName + "(id, vec) VALUES(?, ?)";
         try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password)) {
             conn.setAutoCommit(false);
@@ -352,6 +381,10 @@ public class IngestionWorker implements Runnable {
             // Propagate: awaitTermination ignores task exceptions, so swallowing here
             // would silently drop the uncommitted pendingBatch.
             throw new RuntimeException("Ingestion worker failed", e);
+        } finally {
+            if (runtime != null) {
+                runtime.activeIngestWorkers.decrementAndGet();
+            }
         }
     }
 }

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -34,10 +34,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class VectorBench {
 
@@ -250,12 +253,27 @@ public class VectorBench {
             // swaps the limiter inside BenchRuntime; workers re-read the
             // supplier per batch so the swap takes effect on the next acquire.
 
-            ExecutorService ingestPool = Executors.newFixedThreadPool(config.ingestThreads);
+            // Use a growable pool so POST /ingestion/config/ingest-threads can
+            // spawn additional workers at runtime. SynchronousQueue ensures each
+            // submitted task gets its own thread immediately (no hidden queuing
+            // that would delay new workers). The upper bound of MAX_INGEST_THREADS
+            // prevents runaway thread creation from a misconfigured admin call.
+            ExecutorService ingestPool = new ThreadPoolExecutor(
+                    config.ingestThreads, BenchRuntime.MAX_INGEST_THREADS,
+                    60L, TimeUnit.SECONDS, new SynchronousQueue<>());
+
+            // Factory captures all shared state so setIngestThreads can spawn
+            // additional workers with the same queue and accumulators.
+            Supplier<Runnable> ingestWorkerFactory = () -> new IngestionWorker(
+                    config, ingestQueue, producerDone, rowId,
+                    ingestMetrics, ingestStatus, ingestStart, commitsTotal, commitsRecovered, rowsCommitted,
+                    runtime::ingestRateLimiter, runtime);
+
+            runtime.setIngestContext(ingestQueue, ingestPool, ingestWorkerFactory);
+
             List<Future<?>> ingestFutures = new ArrayList<>(config.ingestThreads);
             for (int t = 0; t < config.ingestThreads; t++) {
-                ingestFutures.add(ingestPool.submit(new IngestionWorker(config, ingestQueue, producerDone, rowId,
-                        ingestMetrics, ingestStatus, ingestStart, commitsTotal, commitsRecovered, rowsCommitted,
-                        runtime::ingestRateLimiter)));
+                ingestFutures.add(ingestPool.submit(ingestWorkerFactory.get()));
             }
 
             // Feed the admin /status endpoint with a live snapshot of ingestion progress.
@@ -372,11 +390,16 @@ public class VectorBench {
                 }
             }
             producerDone.set(true);
-            for (int t = 0; t < config.ingestThreads; t++) {
+            // Inject one poison pill per live worker. Reading activeIngestWorkers
+            // here (rather than config.ingestThreads) accounts for any thread-count
+            // change made via POST /ingestion/config/ingest-threads during the run.
+            int liveWorkers = runtime.activeIngestWorkers.get();
+            for (int t = 0; t < liveWorkers; t++) {
                 ingestQueue.put(new float[0]); // poison pills
             }
             ingestPool.shutdown();
             ingestPool.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            runtime.clearIngestContext();
 
             // awaitTermination ignores task-level exceptions, so a worker that died
             // mid-flush leaves its partial batch silently uncommitted unless we

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestThreadsAdminApiTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestThreadsAdminApiTest.java
@@ -1,0 +1,419 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for the ingest-threads and query-threads admin API endpoints.
+ *
+ * <p>Each test starts an {@link AdminApiServer} on an ephemeral port, exercises
+ * the four new endpoints ({@code GET} and {@code POST} for both
+ * {@code /ingestion/config/ingest-threads} and {@code /query/config/query-threads}),
+ * then stops the server. No shared state, no fixed ports, no sleeps.
+ */
+class IngestThreadsAdminApiTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private BenchRuntime runtime;
+    private AdminApiServer server;
+    private HttpClient client;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() throws Exception {
+        Config cfg = new Config();
+        cfg.ingestThreads = 4;
+        cfg.queryThreads = 4;
+        cfg.ingestMaxOpsPerSecond = 100_000;
+        cfg.queryMaxOpsPerSecond = 10;
+        runtime = new BenchRuntime(cfg);
+        server = new AdminApiServer(runtime, 0); // port 0 = ephemeral
+        int port = server.start();
+        baseUrl = "http://127.0.0.1:" + port;
+        client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void stop() {
+        server.stop();
+    }
+
+    // ---- GET /ingestion/config/ingest-threads ----
+
+    @Test
+    void getIngestThreadsReturnsCurrentValue() throws Exception {
+        HttpResponse<String> resp = get("/ingestion/config/ingest-threads");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(4, json.get("ingest-threads").asInt());
+    }
+
+    @Test
+    void getIngestThreadsReflectsConfigUpdate() throws Exception {
+        runtime.config().ingestThreads = 8;
+        HttpResponse<String> resp = get("/ingestion/config/ingest-threads");
+        assertEquals(200, resp.statusCode());
+        assertEquals(8, MAPPER.readTree(resp.body()).get("ingest-threads").asInt());
+    }
+
+    // ---- POST /ingestion/config/ingest-threads ----
+
+    @Test
+    void postIngestThreadsUpdatesConfig() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-threads", "{\"value\": 8}");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        // Response body is the full ingestion config (same shape as GET /ingestion/config).
+        assertEquals(8, json.get("ingest-threads").asInt());
+        assertEquals(8, runtime.config().ingestThreads);
+    }
+
+    @Test
+    void postIngestThreadsRejectsZero() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-threads", "{\"value\": 0}");
+        assertEquals(400, resp.statusCode());
+        // Config must be unchanged.
+        assertEquals(4, runtime.config().ingestThreads);
+    }
+
+    @Test
+    void postIngestThreadsRejectsNegative() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-threads", "{\"value\": -2}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(4, runtime.config().ingestThreads);
+    }
+
+    @Test
+    void postIngestThreadsRejectsAboveMax() throws Exception {
+        HttpResponse<String> resp = postJson(
+                "/ingestion/config/ingest-threads",
+                "{\"value\": " + (BenchRuntime.MAX_INGEST_THREADS + 1) + "}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(4, runtime.config().ingestThreads);
+    }
+
+    @Test
+    void postIngestThreadsAcceptsMaxBoundary() throws Exception {
+        HttpResponse<String> resp = postJson(
+                "/ingestion/config/ingest-threads",
+                "{\"value\": " + BenchRuntime.MAX_INGEST_THREADS + "}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(BenchRuntime.MAX_INGEST_THREADS, runtime.config().ingestThreads);
+    }
+
+    @Test
+    void postIngestThreadsAcceptsOne() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-threads", "{\"value\": 1}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(1, runtime.config().ingestThreads);
+    }
+
+    @Test
+    void postIngestThreadsAcceptsPlainNumericBody() throws Exception {
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-threads", "6");
+        assertEquals(200, resp.statusCode());
+        assertEquals(6, runtime.config().ingestThreads);
+    }
+
+    // ---- GET /query/config/query-threads ----
+
+    @Test
+    void getQueryThreadsReturnsCurrentValue() throws Exception {
+        HttpResponse<String> resp = get("/query/config/query-threads");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(4, json.get("query-threads").asInt());
+    }
+
+    // ---- POST /query/config/query-threads ----
+
+    @Test
+    void postQueryThreadsUpdatesConfig() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/query-threads", "{\"value\": 6}");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(6, json.get("query-threads").asInt());
+        assertEquals(6, runtime.config().queryThreads);
+    }
+
+    @Test
+    void postQueryThreadsRejectsZero() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/query-threads", "{\"value\": 0}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(4, runtime.config().queryThreads);
+    }
+
+    @Test
+    void postQueryThreadsRejectsNegative() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/query-threads", "{\"value\": -1}");
+        assertEquals(400, resp.statusCode());
+        assertEquals(4, runtime.config().queryThreads);
+    }
+
+    @Test
+    void postQueryThreadsAcceptsOne() throws Exception {
+        HttpResponse<String> resp = postJson("/query/config/query-threads", "{\"value\": 1}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(1, runtime.config().queryThreads);
+    }
+
+    // ---- GET /ingestion/config reflects the thread count ----
+
+    @Test
+    void getIngestionConfigIncludesIngestThreads() throws Exception {
+        HttpResponse<String> resp = get("/ingestion/config");
+        assertEquals(200, resp.statusCode());
+        JsonNode json = MAPPER.readTree(resp.body());
+        assertEquals(4, json.get("ingest-threads").asInt());
+    }
+
+    @Test
+    void postIngestThreadsReflectedInGetIngestionConfig() throws Exception {
+        postJson("/ingestion/config/ingest-threads", "{\"value\": 7}");
+        HttpResponse<String> resp = get("/ingestion/config");
+        assertEquals(200, resp.statusCode());
+        assertEquals(7, MAPPER.readTree(resp.body()).get("ingest-threads").asInt());
+    }
+
+    // ---- Live ingest-context: reduction via poison pills ----
+
+    /**
+     * Sets up a minimal live ingest context (a real blocking queue + growable pool +
+     * worker factory) and verifies that reducing the thread count via the admin API
+     * causes the excess workers to exit promptly via poison pills.
+     *
+     * <p>Workers are lightweight stubs that block on the queue and exit on a poison
+     * pill, mimicking the real {@link IngestionWorker} pattern without needing a
+     * real database connection.
+     */
+    @Test
+    void liveReductionSendsEnoughPoisonPillsForExcessWorkers() throws Exception {
+        int initialThreads = 4;
+        int targetThreads = 2;
+        int excess = initialThreads - targetThreads;
+
+        BlockingQueue<float[]> queue = new ArrayBlockingQueue<>(128);
+        // Latch released when a worker exits (one per excess worker expected).
+        CountDownLatch exitLatch = new CountDownLatch(excess);
+
+        ExecutorService pool = Executors.newFixedThreadPool(initialThreads);
+        // Stub workers: block on queue, exit on poison pill, count-down latch.
+        Supplier<Runnable> factory = () -> () -> {
+            runtime.activeIngestWorkers.incrementAndGet();
+            try {
+                while (true) {
+                    float[] item = queue.poll(200, TimeUnit.MILLISECONDS);
+                    if (item != null && item.length == 0) {
+                        // poison pill — retire
+                        break;
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                runtime.activeIngestWorkers.decrementAndGet();
+                exitLatch.countDown();
+            }
+        };
+
+        runtime.setIngestContext(queue, pool, factory);
+        // Start all workers.
+        for (int i = 0; i < initialThreads; i++) {
+            pool.submit(factory.get());
+        }
+
+        // Wait until all workers are live.
+        long deadline = System.currentTimeMillis() + 5000;
+        while (runtime.activeIngestWorkers.get() < initialThreads
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20);
+        }
+        assertEquals(initialThreads, runtime.activeIngestWorkers.get(),
+                "all " + initialThreads + " workers should be live before reduction");
+
+        // Reduce via admin API.
+        HttpResponse<String> resp = postJson(
+                "/ingestion/config/ingest-threads", "{\"value\": " + targetThreads + "}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(targetThreads, runtime.config().ingestThreads);
+
+        // Excess workers should exit after receiving their poison pills.
+        boolean exited = exitLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(exited, "excess workers should have exited within 5s after poison pill injection");
+
+        pool.shutdownNow();
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Verifies that increasing the thread count via the admin API causes new
+     * workers to be submitted to the pool by checking {@code activeIngestWorkers}
+     * grows to the new target.
+     */
+    @Test
+    void liveIncreaseSpawnsNewWorkers() throws Exception {
+        int initialThreads = 2;
+        int targetThreads = 4;
+        int extra = targetThreads - initialThreads;
+
+        BlockingQueue<float[]> queue = new ArrayBlockingQueue<>(128);
+        // A latch to know when newly spawned workers are live.
+        CountDownLatch spawnLatch = new CountDownLatch(extra);
+
+        ExecutorService pool = new ThreadPoolExecutor(
+                initialThreads, BenchRuntime.MAX_INGEST_THREADS,
+                60L, TimeUnit.SECONDS, new SynchronousQueue<>());
+
+        AtomicBoolean stopAll = new AtomicBoolean(false);
+        Supplier<Runnable> factory = () -> () -> {
+            runtime.activeIngestWorkers.incrementAndGet();
+            spawnLatch.countDown();
+            try {
+                while (!stopAll.get()) {
+                    queue.poll(100, TimeUnit.MILLISECONDS);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                runtime.activeIngestWorkers.decrementAndGet();
+            }
+        };
+
+        runtime.setIngestContext(queue, pool, factory);
+        // Start initial workers.
+        for (int i = 0; i < initialThreads; i++) {
+            pool.submit(factory.get());
+        }
+
+        // Wait for initial workers.
+        long deadline = System.currentTimeMillis() + 5000;
+        while (runtime.activeIngestWorkers.get() < initialThreads
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20);
+        }
+        assertEquals(initialThreads, runtime.activeIngestWorkers.get());
+
+        // Increase via admin API.
+        HttpResponse<String> resp = postJson(
+                "/ingestion/config/ingest-threads", "{\"value\": " + targetThreads + "}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(targetThreads, runtime.config().ingestThreads);
+
+        // New workers should appear.
+        boolean spawned = spawnLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(spawned, "new workers should have been spawned within 5s");
+
+        assertEquals(targetThreads, runtime.activeIngestWorkers.get(),
+                "activeIngestWorkers should equal target after increase");
+
+        stopAll.set(true);
+        pool.shutdownNow();
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+    }
+
+    // ---- setIngestThreads without live context (no-op for pills/spawn) ----
+
+    @Test
+    void setIngestThreadsWithoutContextStillUpdatesConfig() throws Exception {
+        // No setIngestContext — queue/pool/factory are null.
+        HttpResponse<String> resp = postJson("/ingestion/config/ingest-threads", "{\"value\": 3}");
+        assertEquals(200, resp.statusCode());
+        assertEquals(3, runtime.config().ingestThreads);
+    }
+
+    // ---- BenchRuntime unit-level validation ----
+
+    @Test
+    void benchRuntimeSetIngestThreadsRejectsZero() {
+        try {
+            runtime.setIngestThreads(0);
+        } catch (IllegalArgumentException e) {
+            assertEquals(4, runtime.config().ingestThreads); // unchanged
+            return;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new AssertionError("expected IllegalArgumentException");
+    }
+
+    @Test
+    void benchRuntimeSetQueryThreadsRejectsZero() {
+        try {
+            runtime.setQueryThreads(0);
+        } catch (IllegalArgumentException e) {
+            assertEquals(4, runtime.config().queryThreads); // unchanged
+            return;
+        }
+        throw new AssertionError("expected IllegalArgumentException");
+    }
+
+    @Test
+    void benchRuntimeSetIngestThreadsUpdatesTargetField() throws Exception {
+        runtime.setIngestThreads(7);
+        assertEquals(7, runtime.getTargetIngestThreads());
+        assertEquals(7, runtime.config().ingestThreads);
+    }
+
+    // ---- helpers ----
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build(), BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> postJson(String path, String body) throws Exception {
+        return client.send(HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(5))
+                .header("Content-Type", "application/json")
+                .POST(BodyPublishers.ofString(body))
+                .build(), BodyHandlers.ofString());
+    }
+}


### PR DESCRIPTION
Fixes #263.

## Changes

- **`BenchRuntime`**: added `activeIngestWorkers` (`AtomicInteger` incremented/decremented by each worker), `targetIngestThreads`, and `setIngestContext(queue, pool, factory)` / `clearIngestContext()` lifecycle hooks. `setIngestThreads(n)` validates the value (1–1024), injects poison pills to retire excess workers (reduction), or submits new workers from the registered factory (increase). `setQueryThreads(n)` validates and updates `config.queryThreads`.

- **`IngestionWorker`**: accepts an optional `BenchRuntime` parameter (second constructor overload for backward-compat with tests); increments `activeIngestWorkers` at `run()` start and decrements in `finally`.

- **`VectorBench`**: switched ingest pool from `newFixedThreadPool` to a growable `ThreadPoolExecutor` (`SynchronousQueue`, max=1024 threads) so new workers can be dispatched immediately on increase. Registers the pool + worker factory with `runtime.setIngestContext(...)` before submitting initial workers; uses `runtime.activeIngestWorkers.get()` for the end-of-producer poison-pill count (accounts for any live thread-count change during the run); clears the context after ingest.

- **`AdminApiServer`**: wired four new endpoints:
  - `GET /ingestion/config/ingest-threads` → `{"ingest-threads": N}`
  - `POST /ingestion/config/ingest-threads` → calls `runtime.setIngestThreads(value)`, returns full ingestion config
  - `GET /query/config/query-threads` → `{"query-threads": N}`
  - `POST /query/config/query-threads` → calls `runtime.setQueryThreads(value)`, returns full query config

## Tests

- **`IngestThreadsAdminApiTest`** (22 new tests): covers all four new endpoints, input validation (zero, negative, above max), plain numeric body, GET reflects POST update, and two live-context integration tests: `liveReductionSendsEnoughPoisonPillsForExcessWorkers` (start 4 stub workers, POST thread count to 2, verify 2 excess workers exit within 5 s) and `liveIncreaseSpawnsNewWorkers` (start 2 stub workers, POST thread count to 4, verify `activeIngestWorkers` reaches 4).

- **`AdminApiServerTest`**: all 24 existing tests continue to pass unmodified.

🤖 Implemented by the `pr-worker` agent.