### PR TITLE
issue #265: refuse ledger rotation when previous writer had a non-BK write error

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -237,6 +237,37 @@ public class BookkeeperCommitLog extends CommitLog {
             return ledgerId;
         }
 
+        // Visible for testing
+        public boolean isErrorOccurredDuringWrite() {
+            return errorOccurredDuringWrite;
+        }
+
+        // Visible for testing
+        public long getPendingAdds() {
+            return pendingAdds.get();
+        }
+
+        /**
+         * Visible for testing: directly marks this writer as errored with the given
+         * {@code error} without routing through the BK async callback.  This simulates
+         * the scenario where a transport-level {@link RuntimeException} (e.g.
+         * "Bookie is not running any more" from the JVM-local transport) sets
+         * {@code errorOccurredDuringWrite=true} and {@code writeError} to a
+         * <em>non-BKException</em> while leaving the BK {@link WriteHandle}
+         * in the OPEN state.
+         *
+         * <p>This method intentionally bypasses {@link #handleBookKeeperFailure} so
+         * that {@code failed} is NOT set — reproducing the exact race that the fix in
+         * {@code openNewLedger()} guards against: the guard inspects the previous
+         * writer's {@code writeError} and, if it is a non-{@link BKException},
+         * calls {@link #signalLogFailed()} and throws instead of creating a new ledger.
+         */
+        // Visible for testing
+        public void forceWriteError(Throwable error) {
+            writeError.set(error);
+            errorOccurredDuringWrite = true;
+        }
+
         public CompletableFuture<LogSequenceNumber> writeEntry(LogEntry edit) {
             // BK will release the buffer after handling the entry
             ByteBuf serialize = edit.serializeAsByteBuf();
@@ -511,6 +542,14 @@ public class BookkeeperCommitLog extends CommitLog {
         } else if (cause instanceof org.apache.bookkeeper.client.api.BKException) {
             LOGGER.log(Level.SEVERE, "bookkeeper failure for tablespace " + tableSpaceDescription(), cause);
             signalLogFailed();
+        } else {
+            // Non-BK exception (e.g. RuntimeException from JVM-local transport or any
+            // unexpected callback error).  We cannot determine whether the ledger is in
+            // a consistent state, so treat this as fatal: signal failure so that
+            // openNewLedger() will refuse to create a new ledger and the tablespace
+            // activator can perform a clean recovery.
+            LOGGER.log(Level.SEVERE, "unexpected non-BKException failure for tablespace " + tableSpaceDescription(), cause);
+            signalLogFailed();
         }
     }
 
@@ -520,6 +559,32 @@ public class BookkeeperCommitLog extends CommitLog {
         try {
             if (!startWritingCalled) {
                 throw new LogNotAvailableException("this log has is not allowed to write");
+            }
+            // Guard: if the current writer's write error is a non-BKException (e.g. a
+            // RuntimeException from the JVM-local transport), we cannot safely rotate to
+            // a new ledger.  The bookie's state is unknown and an external agent may have
+            // fenced us in the meantime.  Creating a new ledger here would silently clear
+            // the `failed` flag and allow writes to proceed on a potentially split-brained
+            // log.  Abort instead so the tablespace activator can perform a clean recovery.
+            // Note: unwrap one layer of CompletionException / LogNotAvailableException
+            // (same as handleBookKeeperFailure) before checking the exception type.
+            if (writer != null && writer.errorOccurredDuringWrite) {
+                Throwable prevError = writer.writeError.get();
+                if (prevError != null) {
+                    Throwable unwrapped = prevError;
+                    if (unwrapped instanceof CompletionException && unwrapped.getCause() != null) {
+                        unwrapped = unwrapped.getCause();
+                    }
+                    if (unwrapped instanceof LogNotAvailableException && unwrapped.getCause() != null) {
+                        unwrapped = unwrapped.getCause();
+                    }
+                    if (!(unwrapped instanceof BKException)) {
+                        signalLogFailed();
+                        throw new LogNotAvailableException(tableSpaceDescription()
+                                + ": aborting ledger rotation — previous ledger had a non-BK"
+                                + " write error, ledger state is unknown: " + prevError);
+                    }
+                }
             }
             // wait for all previous writes to succeed and then close the ledger
             // closing a ledger invalidates all pending writes and seals metadata
@@ -932,19 +997,30 @@ public class BookkeeperCommitLog extends CommitLog {
                 }
                 writer.close();
             } catch (LogNotAvailableException err) {
-                if (hadWriteError && !wasFenced) {
-                    // The ledger had transient write errors (e.g. addEntryTimeoutSec fired
-                    // while the bookie was paused).  The BK client may have internally
-                    // sealed/closed the write handle as part of its timeout handling, making
-                    // out.closeAsync() fail immediately.  This is harmless: the ledger is
-                    // effectively sealed and no new entries can reach it
-                    // (errorOccurredDuringWrite=true keeps isWritable()==false).  Log the
+                if (hadWriteError && !wasFenced && !containsFencingError(err)) {
+                    // The ledger had a transient BK write error (e.g. BKLedgerClosedException
+                    // when addEntryTimeoutSec fired while the bookie was paused).  The BK
+                    // client may have internally sealed the write handle as part of its
+                    // timeout handling, making out.closeAsync() fail immediately.  This is
+                    // harmless: the ledger is effectively sealed and no new entries can reach
+                    // it (errorOccurredDuringWrite=true keeps isWritable()==false).  Log the
                     // error and let openNewLedger() proceed to create a fresh, healthy ledger.
+                    //
+                    // Safety: we also check !containsFencingError(err) here.  In some BK
+                    // versions / configurations closeAsync() itself can throw
+                    // BKLedgerFencedException (e.g. when the ledger was explicitly recovered
+                    // by another node).  That would mean another leader has taken over and we
+                    // must stop immediately to prevent split-brain — do not swallow it.
+                    //
+                    // Non-BK write errors (RuntimeException etc.) are blocked upstream in
+                    // openNewLedger() and never reach this branch, so we only ever get here
+                    // for recoverable BKLedgerClosedException writes.
                     LOGGER.log(Level.INFO,
                             "{0} ignoring error closing an already-errored ledger (will open a new one): {1}",
                             new Object[]{tableSpaceDescription(), err.toString()});
                 } else {
-                    // Fatal condition (fencing) or error on a healthy ledger: propagate.
+                    // Fatal condition: fencing (from prior write or from close() itself),
+                    // or an error on a ledger that had no prior write errors.  Propagate.
                     signalLogFailed();
                     throw err;
                 }

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/FencingTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/FencingTest.java
@@ -250,4 +250,171 @@ public class FencingTest extends BookkeeperFailuresBase {
             }
         }
     }
+
+    /**
+     * Regression test for the race between a transient, non-BK write error and a
+     * subsequent external ledger-fencing event (issue #265).
+     *
+     * <p>The flaky scenario in {@link #testFencingDuringTransaction} is caused by a
+     * JVM-local transport stale-reference bug: the first test leaves behind a
+     * {@code LocalBookiesRegistry} entry for a bookie that is no longer running.  The
+     * second test allocates a new bookie on a recycled port, but some write callbacks
+     * still fire with {@code RuntimeException("Bookie is not running any more")} from
+     * the old entry.  That {@code RuntimeException} is <em>not</em> a
+     * {@code BKException}, so before the fix {@code handleBookKeeperFailure} did not
+     * call {@code signalLogFailed()}, and the BK
+     * {@link org.apache.bookkeeper.client.api.WriteHandle} stayed in the OPEN state.
+     *
+     * <p>When an external agent later fences the ledger and the next write triggers
+     * {@code openNewLedger()}, the old code called {@code closeCurrentWriter()} and
+     * — because {@code closeAsync()} in BookKeeper 4.17.x is a pure ZK-metadata
+     * operation that succeeds even on a bookie-side fenced ledger when
+     * {@code openLedgerNoRecovery} was used — the close succeeded.  The old
+     * {@code openNewLedger()} then created a fresh ledger and reset {@code failed=false},
+     * allowing the commit to succeed despite the ledger having been fenced.
+     *
+     * <p>The fix adds a guard at the top of {@code openNewLedger()}: if the previous
+     * writer's {@code writeError} is a non-{@link org.apache.bookkeeper.client.api.BKException}
+     * (i.e. a {@code RuntimeException} from the local transport layer), the ledger
+     * state is unknown and we must not silently create a new one.  Instead,
+     * {@code signalLogFailed()} is called and a {@code LogNotAvailableException} is
+     * thrown, which propagates back to the caller as a
+     * {@link herddb.model.StatementExecutionException}.
+     * Additionally, {@code handleBookKeeperFailure} now calls {@code signalLogFailed()}
+     * for any non-BK exception encountered in the write callback, providing a
+     * second line of defence for the real-runtime path (where the error goes through
+     * the callback rather than {@link BookkeeperCommitLog.CommitFileWriter#forceWriteError}).
+     *
+     * <p>This test reproduces the race deterministically:
+     * <ol>
+     *   <li>Write a sync entry so the BK write handle is in the OPEN state with all
+     *       pending adds completed.</li>
+     *   <li>Start a transaction and wait for its async BK writes to be ACKed
+     *       ({@code pendingAdds == 0}), leaving the handle OPEN.</li>
+     *   <li>Inject a non-BK write error via
+     *       {@link BookkeeperCommitLog.CommitFileWriter#forceWriteError} to set
+     *       {@code errorOccurredDuringWrite=true} and {@code writeError=RuntimeException}
+     *       without touching the BK write handle and without going through
+     *       {@code handleBookKeeperFailure} (so {@code failed} stays {@code false}).</li>
+     *   <li>Fence the ledger via {@code openLedgerNoRecovery} (bookie-side fence only,
+     *       ZK metadata unchanged).</li>
+     *   <li>Attempt to commit: {@code openNewLedger()} detects the non-BK write error,
+     *       calls {@code signalLogFailed()}, and throws {@code LogNotAvailableException}
+     *       instead of creating a new ledger.</li>
+     * </ol>
+     *
+     * <p>Without the fix, step 5 creates a new ledger and resets {@code failed=false},
+     * letting the commit succeed.  With the fix the commit correctly throws
+     * {@link herddb.model.StatementExecutionException}.
+     */
+    @Test
+    public void testFencingAfterTransientWriteError() throws Exception {
+        ServerConfiguration serverconfig = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
+        serverconfig.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        serverconfig.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
+
+        try (Server server = new Server(serverconfig)) {
+            server.start();
+            server.waitForStandaloneBoot();
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+            server.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+
+            // Sync NO_TRANSACTION write: establishes the ledger and ensures all
+            // pending adds complete, leaving the BK write handle in OPEN state.
+            server.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1",
+                            RecordSerializer.makeRecord(table, "c", 1)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+
+            TableSpaceManager tableSpaceManager = server.getManager().getTableSpaceManager(TableSpace.DEFAULT);
+            BookkeeperCommitLog log = (BookkeeperCommitLog) tableSpaceManager.getLog();
+            long ledgerId = log.getLastSequenceNumber().ledgerId;
+            assertTrue(ledgerId >= 0);
+
+            // Start a transaction and insert a row (async BK write, sync=false).
+            StatementExecutionResult txResult = server.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1",
+                            RecordSerializer.makeRecord(table, "c", 2)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            long transactionId = txResult.transactionId;
+
+            // Wait for all in-flight BK writes (BEGIN_TX + INSERT) to be ACKed so that
+            // pendingAdds == 0.  The BK write handle is then fully OPEN with no
+            // outstanding requests — exactly the state produced by the stale-transport
+            // scenario (where the RuntimeException fires immediately).
+            long ackedDeadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < ackedDeadline) {
+                BookkeeperCommitLog.CommitFileWriter w = log.getWriter();
+                if (w != null && w.getPendingAdds() == 0) {
+                    break;
+                }
+                Thread.sleep(100);
+            }
+            BookkeeperCommitLog.CommitFileWriter writer = log.getWriter();
+            Assert.assertNotNull("writer must be non-null", writer);
+            assertTrue("all BK writes must have been ACKed (pendingAdds == 0)",
+                    writer.getPendingAdds() == 0);
+
+            // Inject a non-fencing write error.  This mimics the stale-transport
+            // RuntimeException that sets errorOccurredDuringWrite=true / wasFenced=false
+            // WITHOUT going through handleBookKeeperFailure (so failed stays false) and
+            // WITHOUT closing the BK write handle (so writer.close() can still interact
+            // with the bookie and detect fencing later).
+            writer.forceWriteError(new RuntimeException("simulated stale-transport error"));
+            assertTrue("errorOccurredDuringWrite must be true after forceWriteError",
+                    writer.isErrorOccurredDuringWrite());
+
+            // Prevent the tablespace activator from automatically recovering the
+            // tablespace so we can verify the commit-path fencing detection.
+            server.getManager().setActivatorPauseStatus(true);
+
+            // Fence ledger X using openLedgerNoRecovery: this sends a fence request to
+            // all bookies (they mark the ledger as FENCED) without completing the full
+            // ZK-metadata update (ledger stays OPEN in ZK).  Keep the handle open so the
+            // bookie stays in FENCED state during the commit attempt.
+            try (BookKeeper bk = createBookKeeper();
+                 LedgerHandle fenced = bk.openLedgerNoRecovery(
+                         ledgerId, BookKeeper.DigestType.CRC32C,
+                         "herddb".getBytes(StandardCharsets.UTF_8))) {
+
+                // The commit must fail.  Without the fix, openNewLedger() silently creates
+                // a new ledger and resets failed=false, so the commit wrongly succeeds.
+                // With the fix, openNewLedger() detects the non-BK writeError, calls
+                // signalLogFailed(), and throws LogNotAvailableException, which surfaces
+                // here as StatementExecutionException.
+                try {
+                    server.getManager().executeStatement(
+                            new CommitTransactionStatement(TableSpace.DEFAULT, transactionId),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                            TransactionContext.NO_TRANSACTION);
+                    fail("commit must fail when the ledger has been externally fenced");
+                } catch (StatementExecutionException expected) {
+                    // correct: the commit detected the fencing and refused to proceed
+                }
+            }
+
+            // Verify the tablespace reaches the FAILED state
+            long failDeadline = System.currentTimeMillis() + 20_000;
+            while (System.currentTimeMillis() < failDeadline) {
+                if (tableSpaceManager.isFailed()) {
+                    break;
+                }
+                Thread.sleep(200);
+            }
+            assertTrue("tablespace must be marked failed after ledger fencing",
+                    tableSpaceManager.isFailed());
+        }
+    }
 }


### PR DESCRIPTION
Fixes #265.

## Root cause

When a write callback fires with a `RuntimeException` (e.g. `"Bookie is not running any more"` from the JVM-local transport), `handleBookKeeperFailure` left `failed=false` because it only handled `BKException` subtypes.  A subsequent call to `openNewLedger()` would then create a fresh ledger and reset `failed=false`, allowing commits to succeed even after the old ledger had been externally fenced — a split-brain risk.

In BookKeeper 4.17.x `WriteHandle.closeAsync()` is a pure ZK-metadata operation, so bookie-side fencing does **not** cause it to throw.  The stale path was therefore completely silent: `closeCurrentWriter()` succeeded, a new ledger was created, and the tablespace continued writing on a potentially fenced log.

## Changes

- **`BookkeeperCommitLog.java`**
  - `openNewLedger()`: new guard at the top — if the previous writer's `writeError` is a non-`BKException` (unwrapped past `CompletionException`/`LogNotAvailableException`), call `signalLogFailed()` and throw instead of creating a new ledger.  This is the primary fix.
  - `handleBookKeeperFailure()`: added `else` branch that calls `signalLogFailed()` for any non-`BKException` error from the write callback — defense-in-depth for the real-runtime path.
  - `closeCurrentWriter()`: tightened the swallow guard from `hadWriteError && !wasFenced` to `hadWriteError && !wasFenced && !containsFencingError(err)` so a fencing exception from `closeAsync()` itself is never silently swallowed.
  - `CommitFileWriter.forceWriteError()` / `isErrorOccurredDuringWrite()` / `getPendingAdds()`: three test-visible helpers added to allow the deterministic reproducer to inject error state and inspect internal counters.

- **`FencingTest.java`**
  - New `testFencingAfterTransientWriteError()`: deterministic reproducer that injects a `RuntimeException` write error via `forceWriteError`, fences the ledger with `openLedgerNoRecovery` (bookie-side only, ZK unchanged), then asserts that `CommitTransaction` throws `StatementExecutionException` and the tablespace reaches `FAILED` state.

## Tests

- `FencingTest` — all 3 methods (new + existing) pass ✅
- `BookKeeperCommitLogTest` — all 13 methods pass ✅
- Pre-PR validation (`checkstyle`, Apache RAT, SpotBugs, `install -DskipTests -Pci`) — green ✅

🤖 Implemented by the `pr-worker` agent.