### PR TITLE
issue #266: reset stale BK ledger handle and add backoff on BKClientClosedException

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -1252,7 +1252,22 @@ public class BookkeeperCommitLog extends CommitLog {
             }
 
         } catch (BKClientClosedException err) {
+            // The BK client connection was lost (e.g. a transient ZK session
+            // interruption).  Reset the stale ledger handle so ensureOpenReader
+            // re-opens it from fresh ZooKeeper metadata on the next iteration.
+            // Without the reset, the same stale handle is reused on every
+            // iteration: ensureOpenReader calls tryReadLastAddConfirmed() on it,
+            // that immediately throws BKClientClosedException again, and the
+            // FollowerThread spins in a tight busy-loop that never applies any
+            // log entries.  The 100 ms sleep prevents hammering the BK client
+            // before it has a chance to reconnect.
             LOGGER.log(Level.FINE, "stop following " + tableSpaceDescription(), err);
+            fContext.resetCurrentLedger();
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
         } catch (org.apache.bookkeeper.client.api.BKException err) {
             LOGGER.log(Level.SEVERE, tableSpaceDescription() + " internal BK error", err);
             fContext.resetCurrentLedger();


### PR DESCRIPTION
Fixes #266.

## Root cause

When `BKClientClosedException` is caught in `BookkeeperCommitLog.followTheLeader()`, the stale `ReadHandle` stored in `BKFollowerContext.currentLedger` was **not** being reset. On the next `FollowerThread` iteration `ensureOpenReader` finds `currentLedger != null`, calls `tryReadLastAddConfirmed()` on the same broken handle, and immediately gets another `BKClientClosedException`. The result is a tight busy-loop that spins without applying any log entries — causing `SimpleFollowerTest.followerMustNoRollbackAbandonedTransactions` to time out after 100 s waiting for the transaction to become visible on the follower.

## Changes

- `herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java`: in the `BKClientClosedException` handler of `followTheLeader()`, call `fContext.resetCurrentLedger()` so `ensureOpenReader` re-opens the ledger from fresh ZooKeeper metadata on the next iteration. Added a 100 ms `Thread.sleep` to prevent hammering a reconnecting BK client before it has a chance to recover.

## Tests

- `SimpleFollowerTest#followerMustNoRollbackAbandonedTransactions` was run **20 consecutive times locally** — all 20 passed (was previously flaky in CI: runs 24842206250, 24794947130 documented in the issue).
- Full `SimpleFollowerTest` (all 5 tests) run 3 consecutive times — all passed.

🤖 Implemented by the `pr-worker` agent.