### PR TITLE
issue #290: BLink-paged compaction authority map and pending-delete sets

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/CompactionAuthorityMap.java
+++ b/herddb-core/src/main/java/herddb/index/vector/CompactionAuthorityMap.java
@@ -1,0 +1,166 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import herddb.index.blink.BLink;
+import herddb.utils.Bytes;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Authority map used by {@link VectorIndexCompactor} to track, for each PK
+ * present in the candidate segments of a compaction cycle, the highest-generation
+ * segment that owns it (or {@link VectorIndexCompactor#LIVE_SHARD_SEGMENT_ID}
+ * when a live shard supersedes the candidate).
+ *
+ * <p>Backed by a {@link BLink} of {@code (Bytes -> Long)}; the {@link Long} value
+ * packs both the winning segment id and the winning generation:
+ * <ul>
+ *   <li>high 32 bits: generation (unsigned, capped at {@code 0xFFFFFFFFL})</li>
+ *   <li>low 32 bits: signed {@code int} segment id (negative values
+ *       — including {@link VectorIndexCompactor#LIVE_SHARD_SEGMENT_ID} —
+ *       round-trip through a sign-extending narrowing cast)</li>
+ * </ul>
+ *
+ * <p>Memory usage of the BLink is bounded by the index page replacement policy
+ * configured on the per-store {@link herddb.core.MemoryManager}: cold pages are
+ * paged out to the {@link herddb.storage.DataStorageManager} backing the
+ * {@code BLink}'s {@link herddb.index.blink.BLinkIndexDataStorage}. This keeps
+ * compaction heap usage bounded by the index-memory budget rather than by the
+ * number of PKs in the index, which is what causes
+ * <a href="https://github.com/eolivelli/herddb/issues/290">issue #290</a> when
+ * the unbounded {@code HashMap} variant is used over hundreds of millions of
+ * PKs.
+ *
+ * <p>Lifecycle: instances are created per compaction cycle by
+ * {@link PersistentVectorStore} and closed in a {@code finally} block — closing
+ * unloads the BLink's resident pages and drops the temporary backing index from
+ * the storage manager so no leftover state survives across cycles. The class
+ * implements {@link Closeable} (rather than {@link AutoCloseable}) so callers
+ * can rethrow {@link IOException} from {@code close()}.
+ */
+final class CompactionAuthorityMap implements Closeable {
+
+    private static final Logger LOGGER = Logger.getLogger(CompactionAuthorityMap.class.getName());
+
+    /**
+     * Maximum representable generation when packed into the high 32 bits.
+     * Beyond this, the encoder asserts to surface a misuse early — at one
+     * checkpoint per second this corresponds to ~136 years of uptime.
+     */
+    static final long MAX_PACKABLE_GENERATION = 0xFFFFFFFFL;
+
+    /**
+     * Marker generation written for live-shard wins. Equal to
+     * {@link #MAX_PACKABLE_GENERATION} so a live-shard entry always beats any
+     * real on-disk segment generation under the {@code newGen > existingGen}
+     * comparison performed by {@link #updateIfHigherGeneration(Bytes, long, int)}.
+     */
+    static final long LIVE_SHARD_GENERATION_MARKER = MAX_PACKABLE_GENERATION;
+
+    private final BLink<Bytes, Long> blink;
+    private final Runnable onDrop;
+
+    /**
+     * @param blink  the BLink storing PK -> packed (generation, segmentId)
+     * @param onDrop callback invoked after the BLink is closed, used by the
+     *               production constructor to drop the temp storage; tests
+     *               typically pass a no-op
+     */
+    CompactionAuthorityMap(BLink<Bytes, Long> blink, Runnable onDrop) {
+        this.blink = blink;
+        this.onDrop = onDrop;
+    }
+
+    /**
+     * Inserts the given PK with the supplied (generation, segmentId) tuple if no
+     * entry exists yet, or replaces the existing entry when {@code newGeneration}
+     * is strictly greater than the recorded generation. No-op when the existing
+     * generation is greater or equal.
+     */
+    void updateIfHigherGeneration(Bytes pk, long newGeneration, int segmentId) {
+        long encoded = encode(newGeneration, segmentId);
+        Long existing = blink.search(pk);
+        if (existing == null || newGeneration > decodeGeneration(existing)) {
+            blink.insert(pk, encoded);
+        }
+    }
+
+    /**
+     * Returns the winning segment id for {@code pk}, or {@code null} if the
+     * PK is not in the authority map. {@link VectorIndexCompactor#LIVE_SHARD_SEGMENT_ID}
+     * indicates a live-shard win.
+     */
+    Integer getSegmentId(Bytes pk) {
+        Long encoded = blink.search(pk);
+        if (encoded == null) {
+            return null;
+        }
+        return decodeSegmentId(encoded);
+    }
+
+    /** Returns the number of stored PKs (live + paged-out). Test-only. */
+    long size() {
+        return blink.size();
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Close the BLink first so its resident pages stop being tracked by
+        // the page replacement policy; then drop the underlying storage so
+        // we don't leak temp pages across compaction cycles. Both steps are
+        // best-effort: a failure on close should never prevent the temp
+        // storage from being dropped.
+        try {
+            blink.close();
+        } catch (RuntimeException e) {
+            // BLink.close() may surface unchecked IO failures from the
+            // page replacement policy unloading paged-out nodes. We log
+            // and continue so the storage drop still runs.
+            LOGGER.log(Level.WARNING,
+                    "compaction authority map: blink close failed (continuing)", e);
+        }
+        onDrop.run();
+    }
+
+    /**
+     * Packs {@code generation} (unsigned 32 bits) and {@code segmentId}
+     * (signed int) into a single {@code long}.
+     */
+    static long encode(long generation, int segmentId) {
+        if (generation < 0L || generation > MAX_PACKABLE_GENERATION) {
+            throw new IllegalArgumentException(
+                    "generation out of range for 32-bit packing: " + generation);
+        }
+        return (generation << 32) | (((long) segmentId) & 0xFFFFFFFFL);
+    }
+
+    /** Recovers the segment id from a packed value. Sign-extending narrowing cast. */
+    static int decodeSegmentId(long encoded) {
+        return (int) encoded;
+    }
+
+    /** Recovers the generation from a packed value. Unsigned shift. */
+    static long decodeGeneration(long encoded) {
+        return encoded >>> 32;
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/vector/PagedPkSet.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PagedPkSet.java
@@ -1,0 +1,121 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import herddb.index.blink.BLink;
+import herddb.utils.Bytes;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Append-only PK set used by {@link PersistentVectorStore} to track
+ * primary keys deleted during a long-running checkpoint or compaction
+ * cycle so the new on-disk artefact can be purged of those PKs before
+ * it becomes visible.
+ *
+ * <p>Backed by a {@link BLink} of {@code (Bytes -> Long)}; the {@code Long}
+ * value is unused (always {@code 0L}) — this is a set, not a map. We reuse
+ * the existing {@code BLink} infrastructure (rather than introducing a
+ * dedicated set type) because:
+ *
+ * <ul>
+ *   <li>memory is bounded by the index page replacement policy on the
+ *       per-store {@link herddb.core.MemoryManager}: cold pages spill to
+ *       the {@link herddb.storage.DataStorageManager} backing the set's
+ *       {@link herddb.index.blink.BLinkIndexDataStorage};</li>
+ *   <li>concurrent {@code add} operations are safe — {@code BLink.insert}
+ *       handles its own locking; the previous {@code ConcurrentHashMap.newKeySet()}
+ *       behaviour relied on the same property.</li>
+ * </ul>
+ *
+ * <p>This addresses the same heap-pressure pattern as
+ * <a href="https://github.com/eolivelli/herddb/issues/290">issue #290</a>:
+ * with sustained delete traffic during a multi-minute checkpoint or
+ * compaction, the previous unbounded {@code Set<Bytes>} grew without
+ * limit and consumed an arbitrary amount of heap on top of the already
+ * large baseline of resident segment metadata.
+ *
+ * <p>Lifecycle: instances are created at the start of a checkpoint or
+ * compaction cycle by {@link PersistentVectorStore} and closed in a
+ * {@code finally} block. Closing unloads resident pages and drops the
+ * temporary backing index so no leftover state survives across cycles.
+ */
+final class PagedPkSet implements Closeable {
+
+    private static final Logger LOGGER = Logger.getLogger(PagedPkSet.class.getName());
+
+    /** Sentinel value stored in the underlying BLink. The set semantics ignore it. */
+    private static final Long PRESENT = 0L;
+
+    private final BLink<Bytes, Long> blink;
+    private final Runnable onDrop;
+
+    /**
+     * @param blink  the BLink used as the underlying paged storage
+     * @param onDrop callback invoked after the BLink is closed, used by the
+     *               production constructor to drop the temp storage; tests
+     *               typically pass a no-op
+     */
+    PagedPkSet(BLink<Bytes, Long> blink, Runnable onDrop) {
+        this.blink = blink;
+        this.onDrop = onDrop;
+    }
+
+    /** Adds {@code pk} to the set. Idempotent. Safe to call concurrently. */
+    void add(Bytes pk) {
+        blink.insert(pk, PRESENT);
+    }
+
+    /** Returns {@code true} if {@code pk} has been added to the set. */
+    boolean contains(Bytes pk) {
+        return blink.search(pk) != null;
+    }
+
+    /** Number of PKs currently stored (live + paged-out). */
+    long size() {
+        return blink.size();
+    }
+
+    /**
+     * Iterates over every stored PK, applying {@code action} to each. The
+     * iteration order is the BLink's natural key order. The set must not be
+     * mutated during iteration.
+     */
+    void forEach(Consumer<Bytes> action) {
+        blink.scan(null, null).forEach(entry -> action.accept(entry.getKey()));
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            blink.close();
+        } catch (RuntimeException e) {
+            // BLink.close() may surface unchecked IO failures from the
+            // page replacement policy unloading paged-out nodes. We log
+            // and continue so the storage drop still runs.
+            LOGGER.log(Level.WARNING,
+                    "paged PK set: blink close failed (continuing)", e);
+        }
+        onDrop.run();
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -338,8 +338,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     private volatile List<LiveGraphShard> deferredShards;
 
-    /** PKs deleted during Phase B. */
-    private volatile Set<Bytes> pendingCheckpointDeletes;
+    /**
+     * PKs deleted during Phase B.
+     *
+     * <p>Backed by a {@link PagedPkSet} (BLink-paged storage with the existing
+     * {@link MemoryManager} page replacement policy) so memory stays bounded
+     * even when sustained delete traffic arrives during a multi-minute
+     * checkpoint cycle (issue #290).
+     */
+    private volatile PagedPkSet pendingCheckpointDeletes;
 
     /** Max live vectors allowed during Phase B before back-pressure kicks in. */
     private volatile int liveVectorCapDuringCheckpoint = Integer.MAX_VALUE;
@@ -382,8 +389,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * {@link #removeVector} call appends to this set so the swap step
      * can replay the deletes against the freshly-built merged output
      * before it becomes visible.
+     *
+     * <p>Backed by a {@link PagedPkSet} (BLink-paged storage with the
+     * existing {@link MemoryManager} page replacement policy) so memory
+     * stays bounded even when sustained delete traffic arrives during a
+     * multi-minute compaction cycle (issue #290).
      */
-    private volatile Set<Bytes> pendingCompactionDeletes;
+    private volatile PagedPkSet pendingCompactionDeletes;
 
     // -------------------------------------------------------------------------
     // Compaction state
@@ -1494,7 +1506,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
         try {
             long cycleStart = System.currentTimeMillis();
-            compactionRunsTotal.incrementAndGet();
+            long cycleId = compactionRunsTotal.incrementAndGet();
 
             List<VectorSegment> snapshot = new ArrayList<>(segments);
             List<VectorSegment> candidates = VectorIndexCompactor.chooseSegmentsToMerge(
@@ -1511,106 +1523,149 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     new Object[]{indexName, candidates.size()});
 
             compactionActive.set(1);
-            this.pendingCompactionDeletes =
-                    java.util.concurrent.ConcurrentHashMap.newKeySet();
-            Set<Bytes> liveShardPkSnapshot = new java.util.HashSet<>();
-            for (LiveGraphShard shard : liveShards) {
-                liveShardPkSnapshot.addAll(shard.pkToNode.keySet());
-            }
-            Map<Bytes, Integer> authority = VectorIndexCompactor.buildAuthorityMap(
-                    candidates, snapshot, liveShardPkSnapshot);
 
-            long bytesRead = 0;
-            long vectorsWritten = 0;
-            long vectorsFiltered = 0;
-            VectorIndexCompactor.RebuildResult rebuild = null;
+            // Allocate the BLink-backed pendingCompactionDeletes set + the
+            // BLink-backed authority map (issue #290): both replace the prior
+            // unbounded HashMap/HashSet structures so memory stays bounded by
+            // the index page replacement policy.
+            PagedPkSet pendingDeletes = createTempPagedPkSet("cmpdel_" + cycleId);
+            this.pendingCompactionDeletes = pendingDeletes;
+            CompactionAuthorityMap authority = createTempCompactionAuthorityMap(cycleId);
+
             try {
-                rebuild = VectorIndexCompactor.rebuildSegment(this, candidates, authority);
-                if (rebuild == null) {
-                    // Nothing survived the filter — everything in these inputs
-                    // is tombstoned or superseded. Skip the rebuild; just
-                    // swap the inputs out and queue them for retention.
-                    atomicSwapCompactionResult(candidates, null, 0L);
+                // Stream live-shard PKs into the authority map (only updates
+                // entries already in it — see VectorIndexCompactor). We pass
+                // a flat Iterable<Bytes> view rather than materialising a
+                // HashSet of every live PK, keeping live-shard memory bounded
+                // for catch-up workloads with very large live shards.
+                Iterable<Bytes> liveShardPks = collectLiveShardPksLazy();
+                VectorIndexCompactor.buildAuthorityMap(
+                        authority, candidates, snapshot, liveShardPks);
+
+                long bytesRead = 0;
+                long vectorsWritten = 0;
+                long vectorsFiltered = 0;
+                VectorIndexCompactor.RebuildResult rebuild = null;
+                try {
+                    rebuild = VectorIndexCompactor.rebuildSegment(this, candidates, authority);
+                    if (rebuild == null) {
+                        // Nothing survived the filter — everything in these inputs
+                        // is tombstoned or superseded. Skip the rebuild; just
+                        // swap the inputs out and queue them for retention.
+                        atomicSwapCompactionResult(candidates, null, 0L);
+                        compactionSuccessesTotal.incrementAndGet();
+                        compactionConsecutiveFailures.set(0);
+                        long emptyCycleMs = System.currentTimeMillis() - cycleStart;
+                        compactionLastDurationMs.set(emptyCycleMs);
+                        compactionLastBytesRead.set(candidates.stream()
+                                .mapToLong(s -> s.estimatedSizeBytes).sum());
+                        compactionLastBytesWritten.set(0);
+                        compactionLastInputSegments.set(candidates.size());
+                        compactionLastOutputSegments.set(0);
+                        compactionLivePkFilteredTotal.addAndGet(countDeadPks(candidates, authority));
+                        LOGGER.log(Level.INFO,
+                                "vector store {0}: empty-result compaction in {1} ms — "
+                                        + "swapped out {2} fully-obsolete segments",
+                                new Object[]{indexName, emptyCycleMs, candidates.size()});
+                        return;
+                    }
+
+                    bytesRead = candidates.stream().mapToLong(s -> s.estimatedSizeBytes).sum();
+                    vectorsWritten = rebuild.vectorCount;
+                    vectorsFiltered = rebuild.filteredCount;
+
+                    // Apply deletes that arrived during the rebuild. We capture
+                    // the local reference defensively — the field could be
+                    // cleared by a concurrent shutdown.
+                    PagedPkSet lateDeletes = this.pendingCompactionDeletes;
+                    if (lateDeletes != null) {
+                        VectorSegment merged = rebuild.mergedSegment;
+                        lateDeletes.forEach(merged::deletePk);
+                    }
+
+                    atomicSwapCompactionResult(candidates, rebuild.mergedSegment,
+                            rebuild.bytesWritten);
+
                     compactionSuccessesTotal.incrementAndGet();
                     compactionConsecutiveFailures.set(0);
-                    long emptyCycleMs = System.currentTimeMillis() - cycleStart;
-                    compactionLastDurationMs.set(emptyCycleMs);
-                    compactionLastBytesRead.set(candidates.stream()
-                            .mapToLong(s -> s.estimatedSizeBytes).sum());
-                    compactionLastBytesWritten.set(0);
+                    long durationMs = System.currentTimeMillis() - cycleStart;
+                    compactionLastDurationMs.set(durationMs);
+                    compactionLastBytesRead.set(bytesRead);
+                    compactionLastBytesWritten.set(rebuild.bytesWritten);
                     compactionLastInputSegments.set(candidates.size());
-                    compactionLastOutputSegments.set(0);
-                    compactionLivePkFilteredTotal.addAndGet(countDeadPks(candidates, authority));
+                    compactionLastOutputSegments.set(1);
+                    compactionLivePkFilteredTotal.addAndGet(vectorsFiltered);
+
                     LOGGER.log(Level.INFO,
-                            "vector store {0}: empty-result compaction in {1} ms — "
-                                    + "swapped out {2} fully-obsolete segments",
-                            new Object[]{indexName, emptyCycleMs, candidates.size()});
-                    return;
-                }
-
-                bytesRead = candidates.stream().mapToLong(s -> s.estimatedSizeBytes).sum();
-                vectorsWritten = rebuild.vectorCount;
-                vectorsFiltered = rebuild.filteredCount;
-
-                // Apply deletes that arrived during the rebuild.
-                Set<Bytes> lateDeletes = this.pendingCompactionDeletes;
-                if (lateDeletes != null) {
-                    for (Bytes pk : lateDeletes) {
-                        rebuild.mergedSegment.deletePk(pk);
+                            "vector store {0}: compaction complete in {1} ms — "
+                                    + "{2} inputs ({3} bytes) -> 1 output ({4} bytes, "
+                                    + "{5} vectors kept, {6} filtered)",
+                            new Object[]{indexName, durationMs, candidates.size(), bytesRead,
+                                    rebuild.bytesWritten, vectorsWritten, vectorsFiltered});
+                } catch (VectorIndexCompactor.CompactionException e) {
+                    recordCompactionFailure(e.reason);
+                    LOGGER.log(Level.WARNING,
+                            "vector store " + indexName + ": compaction failed ("
+                                    + e.reason + ")", e);
+                    // Clean up orphaned output files if any were written.
+                    if (rebuild != null && rebuild.orphanPaths != null) {
+                        long now = System.currentTimeMillis();
+                        long sinceGen = currentIndexStatusGeneration.get();
+                        for (String[] orphan : rebuild.orphanPaths) {
+                            this.pendingDeletes.add(new PendingDelete(
+                                    encodeMultipartPath(orphan[0], orphan[1]),
+                                    now, sinceGen));
+                        }
                     }
+                } catch (IOException e) {
+                    recordCompactionFailure(VectorIndexCompactor.FailureReason.WRITE_IO);
+                    LOGGER.log(Level.WARNING,
+                            "vector store " + indexName + ": compaction I/O failure", e);
+                } catch (DataStorageManagerException e) {
+                    recordCompactionFailure(VectorIndexCompactor.FailureReason.METADATA_IO);
+                    LOGGER.log(Level.WARNING,
+                            "vector store " + indexName + ": compaction metadata failure", e);
                 }
-
-                atomicSwapCompactionResult(candidates, rebuild.mergedSegment,
-                        rebuild.bytesWritten);
-
-                compactionSuccessesTotal.incrementAndGet();
-                compactionConsecutiveFailures.set(0);
-                long durationMs = System.currentTimeMillis() - cycleStart;
-                compactionLastDurationMs.set(durationMs);
-                compactionLastBytesRead.set(bytesRead);
-                compactionLastBytesWritten.set(rebuild.bytesWritten);
-                compactionLastInputSegments.set(candidates.size());
-                compactionLastOutputSegments.set(1);
-                compactionLivePkFilteredTotal.addAndGet(vectorsFiltered);
-
-                LOGGER.log(Level.INFO,
-                        "vector store {0}: compaction complete in {1} ms — "
-                                + "{2} inputs ({3} bytes) -> 1 output ({4} bytes, "
-                                + "{5} vectors kept, {6} filtered)",
-                        new Object[]{indexName, durationMs, candidates.size(), bytesRead,
-                                rebuild.bytesWritten, vectorsWritten, vectorsFiltered});
-            } catch (VectorIndexCompactor.CompactionException e) {
-                recordCompactionFailure(e.reason);
-                LOGGER.log(Level.WARNING,
-                        "vector store " + indexName + ": compaction failed ("
-                                + e.reason + ")", e);
-                // Clean up orphaned output files if any were written.
-                if (rebuild != null && rebuild.orphanPaths != null) {
-                    long now = System.currentTimeMillis();
-                    long sinceGen = currentIndexStatusGeneration.get();
-                    for (String[] orphan : rebuild.orphanPaths) {
-                        pendingDeletes.add(new PendingDelete(
-                                encodeMultipartPath(orphan[0], orphan[1]),
-                                now, sinceGen));
-                    }
+            } finally {
+                // Drop the temporary BLink storages regardless of outcome so
+                // we don't leak pages across cycles.
+                this.pendingCompactionDeletes = null;
+                try {
+                    pendingDeletes.close();
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING,
+                            "vector store " + indexName
+                                    + ": failed to close pendingCompactionDeletes set", e);
                 }
-            } catch (IOException e) {
-                recordCompactionFailure(VectorIndexCompactor.FailureReason.WRITE_IO);
-                LOGGER.log(Level.WARNING,
-                        "vector store " + indexName + ": compaction I/O failure", e);
-            } catch (DataStorageManagerException e) {
-                recordCompactionFailure(VectorIndexCompactor.FailureReason.METADATA_IO);
-                LOGGER.log(Level.WARNING,
-                        "vector store " + indexName + ": compaction metadata failure", e);
+                try {
+                    authority.close();
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING,
+                            "vector store " + indexName
+                                    + ": failed to close compaction authority map", e);
+                }
             }
         } finally {
             compactionActive.set(0);
-            this.pendingCompactionDeletes = null;
             compactionLock.unlock();
         }
     }
 
-    private static long countDeadPks(List<VectorSegment> candidates, Map<Bytes, Integer> authority) {
+    /**
+     * Returns an {@link Iterable} that streams primary keys from every live
+     * shard at iteration time. Unlike materialising a {@code HashSet} of all
+     * live-shard PKs up-front, this lets the caller (the compaction authority
+     * map population step) probe them one-by-one without holding all of them
+     * in heap simultaneously, which matters for catch-up workloads where the
+     * combined live shards can hold millions of PKs (issue #290).
+     */
+    private Iterable<Bytes> collectLiveShardPksLazy() {
+        return () -> liveShards.stream()
+                .flatMap(shard -> shard.pkToNode.keySet().stream())
+                .iterator();
+    }
+
+    private static long countDeadPks(List<VectorSegment> candidates, CompactionAuthorityMap authority) {
         long total = 0;
         for (VectorSegment seg : candidates) {
             int[] offsets = seg.pkOffsets;
@@ -1625,7 +1680,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     continue;
                 }
                 Bytes pk = Bytes.from_array(data, offsets[ord], lengths[ord]);
-                Integer owner = authority.get(pk);
+                Integer owner = authority.getSegmentId(pk);
                 if (owner == null || owner != seg.segmentId) {
                     total++;
                 }
@@ -1993,7 +2048,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.deferredShards = null;
             currentDeferredVectors.set(0);
         }
-        this.pendingCheckpointDeletes = null;
+        closePendingCheckpointDeletesQuietly();
         this.liveVectorCapDuringCheckpoint = Integer.MAX_VALUE;
         CountDownLatch latch = this.checkpointPhaseComplete;
         if (latch != null) {
@@ -2182,14 +2237,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 }
             }
             // Track delete for Phase B awareness
-            Set<Bytes> pending = pendingCheckpointDeletes;
+            PagedPkSet pending = pendingCheckpointDeletes;
             if (pending != null) {
                 pending.add(pk);
             }
             // Track delete for in-flight compaction: if we are rebuilding
             // segments right now, the merged output must see this delete
             // before it is published.
-            Set<Bytes> pendingCompact = pendingCompactionDeletes;
+            PagedPkSet pendingCompact = pendingCompactionDeletes;
             if (pendingCompact != null) {
                 pendingCompact.add(pk);
             }
@@ -2281,7 +2336,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // allows multiple concurrent read holders.
         stateLock.readLock().lock();
         try {
-            final Set<Bytes> pending = pendingCheckpointDeletes;
+            final PagedPkSet pending = pendingCheckpointDeletes;
             List<LiveGraphShard> frozen = frozenShards;
             if (frozen != null) {
                 for (final LiveGraphShard shard : frozen) {
@@ -2324,7 +2379,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * frozen/deferred shards during a checkpoint.
      */
     private List<Map.Entry<Bytes, Float>> searchLiveShard(LiveGraphShard shard, VectorFloat<?> qv,
-                                                          int perSourceK, Set<Bytes> pendingDeletes) {
+                                                          int perSourceK, PagedPkSet pendingDeletes) {
         int k = Math.min(perSourceK, shard.nodeToPk.size());
         ImmutableGraphIndex graph = shard.builder.getGraph();
         SearchResult result = GraphSearcher.search(
@@ -2699,7 +2754,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
             demoteSmallestSealedSegments(sealedSegments, mergeableSegments);
 
             this.frozenShards = snapshotShards;
-            this.pendingCheckpointDeletes = ConcurrentHashMap.newKeySet();
+            // Use a BLink-paged PK set so memory stays bounded even when
+            // sustained delete traffic arrives during a multi-minute Phase B
+            // (issue #290). The total-checkpoint counter is monotonic across
+            // the store's lifetime, so the temp store name never collides
+            // with a leftover from a crashed cycle.
+            this.pendingCheckpointDeletes = createTempPagedPkSet(
+                    "ckpdel_" + totalCheckpointCount.get());
             this.checkpointPhaseComplete = new CountDownLatch(1);
             int totalSnapshotSize = 0;
             for (LiveGraphShard shard : snapshotShards) {
@@ -2846,15 +2907,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // Add newly written segments from this checkpoint
             newSegments.addAll(preloadedSegments);
 
-            Set<Bytes> pending = this.pendingCheckpointDeletes;
+            PagedPkSet pending = this.pendingCheckpointDeletes;
             if (pending != null) {
-                for (Bytes pk : pending) {
+                pending.forEach(pk -> {
                     for (VectorSegment seg : newSegments) {
                         if (seg.deletePk(pk)) {
-                            break;
+                            return;
                         }
                     }
-                }
+                });
             }
 
             this.segments = newSegments;
@@ -2889,7 +2950,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.frozenShards = null;
             this.deferredShards = null;
             currentDeferredVectors.set(0);  // Deferred shards have been restored to live set
-            this.pendingCheckpointDeletes = null;
+            closePendingCheckpointDeletesQuietly();
             this.liveVectorCapDuringCheckpoint = Integer.MAX_VALUE;
             dirty.set(totalLiveSize() > 0);
 
@@ -3648,7 +3709,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.frozenShards = null;
             this.deferredShards = null;
             currentDeferredVectors.set(0);  // Deferred shards have been restored to live set
-            this.pendingCheckpointDeletes = null;
+            closePendingCheckpointDeletesQuietly();
             this.liveVectorCapDuringCheckpoint = Integer.MAX_VALUE;
             dirty.set(true);
         } finally {
@@ -4271,6 +4332,105 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     // -------------------------------------------------------------------------
+    // Temporary BLink factories for compaction & checkpoint memory bounding
+    // (issue #290).
+    //
+    // The compaction authority map and the pendingCompactionDeletes /
+    // pendingCheckpointDeletes sets all share the same problem: they may
+    // accumulate hundreds of millions of PKs during a long-running cycle and
+    // exhaust the JVM heap if held in unbounded HashMaps. Backing them with
+    // BLink<Bytes, Long> reuses the same paged-storage / page-replacement
+    // policy we already use for seg.onDiskPkToNode, so memory stays bounded
+    // by the index page budget.
+    //
+    // Each temporary index is created with a unique name (cycle-id qualified
+    // by the caller) and dropped via TempBlinkHandle.drop() in a finally
+    // block. The provisional name uses the {@code _tmp_} infix so that
+    // operator-side cleanup tooling can identify orphans left behind by
+    // ungraceful JVM exits.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a fresh BLink-backed compaction authority map for the supplied
+     * cycle id. The returned wrapper owns the BLink and its temp storage; it
+     * <strong>must</strong> be closed in a {@code finally} block so the temp
+     * pages are dropped.
+     */
+    CompactionAuthorityMap createTempCompactionAuthorityMap(long cycleId) {
+        String storeName = indexUUID + "_tmp_cmpaut_" + cycleId;
+        try {
+            dataStorageManager.initIndex(tableSpaceUUID, storeName);
+        } catch (DataStorageManagerException e) {
+            throw new RuntimeException("Failed to init compaction authority BLink storage "
+                    + storeName + " for vector store " + indexName, e);
+        }
+        BLink<Bytes, Long> blink = new BLink<>(
+                memoryManager.getMaxLogicalPageSize(),
+                BytesLongSizeEvaluator.INSTANCE,
+                memoryManager.getIndexPageReplacementPolicy(),
+                new BytesLongStorage(storeName));
+        return new CompactionAuthorityMap(blink, () -> dropTempIndexQuietly(storeName));
+    }
+
+    /**
+     * Closes and clears the {@link #pendingCheckpointDeletes} field, swallowing
+     * any close failures (best-effort cleanup so a checkpoint never fails just
+     * because the temp PK set could not be released).
+     */
+    private void closePendingCheckpointDeletesQuietly() {
+        PagedPkSet set = this.pendingCheckpointDeletes;
+        this.pendingCheckpointDeletes = null;
+        if (set != null) {
+            try {
+                set.close();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING,
+                        "vector store " + indexName
+                                + ": failed to close pendingCheckpointDeletes set", e);
+            }
+        }
+    }
+
+    /**
+     * Creates a fresh BLink-backed PK set with the given purpose tag (used to
+     * build a unique temp store name). The returned wrapper owns the BLink
+     * and its temp storage; it <strong>must</strong> be closed in a
+     * {@code finally} block so the temp pages are dropped. Callers
+     * disambiguate concurrent or back-to-back instances by adding a
+     * monotonically increasing token to the {@code purposeTag}.
+     */
+    PagedPkSet createTempPagedPkSet(String purposeTag) {
+        String storeName = indexUUID + "_tmp_pkset_" + purposeTag;
+        try {
+            dataStorageManager.initIndex(tableSpaceUUID, storeName);
+        } catch (DataStorageManagerException e) {
+            throw new RuntimeException("Failed to init paged PK set BLink storage "
+                    + storeName + " for vector store " + indexName, e);
+        }
+        BLink<Bytes, Long> blink = new BLink<>(
+                memoryManager.getMaxLogicalPageSize(),
+                BytesLongSizeEvaluator.INSTANCE,
+                memoryManager.getIndexPageReplacementPolicy(),
+                new BytesLongStorage(storeName));
+        return new PagedPkSet(blink, () -> dropTempIndexQuietly(storeName));
+    }
+
+    /**
+     * Best-effort drop of a temporary index. Failures are logged but never
+     * propagated — the temp index leaking pages is preferable to letting a
+     * cleanup failure abort the surrounding operation.
+     */
+    private void dropTempIndexQuietly(String storeName) {
+        try {
+            dataStorageManager.dropIndex(tableSpaceUUID, storeName);
+        } catch (DataStorageManagerException e) {
+            LOGGER.log(Level.WARNING,
+                    "vector store " + indexName
+                            + ": failed to drop temp BLink storage " + storeName, e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // BLink data storage implementations
     // -------------------------------------------------------------------------
 
@@ -4672,7 +4832,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
         frozenShards = null;
-        pendingCheckpointDeletes = null;
+        closePendingCheckpointDeletesQuietly();
         liveVectorCapDuringCheckpoint = Integer.MAX_VALUE;
         CountDownLatch latch = this.checkpointPhaseComplete;
         if (latch != null) {

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -29,9 +29,9 @@ import io.github.jbellis.jvector.vector.types.VectorFloat;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -181,76 +181,110 @@ final class VectorIndexCompactor {
     }
 
     /**
-     * Builds the PK authority map used by the live-PK filter. For every
-     * primary key observed across the input candidates, all later
-     * segments (segments with a strictly greater {@code generation}
-     * than the max candidate generation), and any live-shard index, the
-     * map records the highest-generation source.
+     * Populates the supplied {@link CompactionAuthorityMap} with the per-PK
+     * authority decisions used by the live-PK filter during a compaction
+     * cycle.
      *
-     * <p>During the rebuild the caller re-inserts a (PK, vector) pair
-     * iff the authority map's value for that PK resolves back to the
-     * same input candidate. Tombstoned or superseded vectors are
-     * silently dropped, reclaiming their storage.
+     * <p>The authority map is intentionally <em>candidate-only</em>: it stores
+     * one entry per primary key that appears in any of the {@code candidates},
+     * recording the highest-generation source of that PK across:
      *
-     * <p>{@code liveShardPks} is the set of PKs currently resident in
-     * any live shard; live shards are always the newest source, so
-     * their PKs dominate every segment.
+     * <ul>
+     *   <li>the candidates themselves (initial seed),</li>
+     *   <li>any non-candidate segment with strictly greater generation than
+     *       the max candidate generation that has the PK in its
+     *       {@code onDiskPkToNode} BLink,</li>
+     *   <li>the live in-memory shards, which always dominate (recorded with
+     *       {@link #LIVE_SHARD_SEGMENT_ID}).</li>
+     * </ul>
      *
-     * @return map {@code PK -> authoritative segment id}; a synthetic
-     *     segment id of {@link #LIVE_SHARD_SEGMENT_ID} marks PKs owned
-     *     by a live shard.
+     * <p>PKs that exist in newer segments or live shards but are <strong>not</strong>
+     * present in any candidate are deliberately omitted — they are irrelevant
+     * to the rebuild ({@link #populateSyntheticShard} only consults the map
+     * for candidate PKs). This is the key memory optimisation behind issue #290:
+     * the authority map is bounded by the candidate PK count (≈ tens of
+     * thousands per cycle) instead of the total PK count across all segments
+     * (which can reach hundreds of millions). Combined with the BLink-backed
+     * paged storage of {@code CompactionAuthorityMap}, total compaction
+     * heap pressure stops growing with the size of the index.
+     *
+     * <p>Older non-candidate segments are not consulted: candidates cover their
+     * own generation by construction and the merged output replaces them.
+     *
+     * <p>During the rebuild the caller re-inserts a (PK, vector) pair iff
+     * {@link CompactionAuthorityMap#getSegmentId} returns the candidate's own
+     * segment id. Tombstoned or superseded vectors are silently dropped,
+     * reclaiming their storage.
      */
-    static Map<Bytes, Integer> buildAuthorityMap(
+    static void buildAuthorityMap(
+            CompactionAuthorityMap authority,
             List<VectorSegment> candidates,
             List<VectorSegment> allSegments,
             Iterable<Bytes> liveShardPks) {
 
-        Map<Bytes, Long> winnerGeneration = new HashMap<>();
-        Map<Bytes, Integer> winnerSegment = new HashMap<>();
-
-        // Scan candidates first — their generation is the baseline.
+        // Step 1: seed the authority map with candidate PKs. This is the only
+        // bulk insertion we perform; its size is bounded by sum(candidate.size).
         for (VectorSegment seg : candidates) {
-            visitSegmentPks(seg, winnerGeneration, winnerSegment);
+            insertSegmentPks(seg, authority);
         }
 
-        // Scan segments that are newer than any candidate. Older or
-        // equal-generation segments are irrelevant for the authority
-        // decision — candidates already cover their own generation and
-        // the merged output will replace them.
+        // Step 2: walk newer non-candidate segments and update the authority
+        // entries for any PK that ALSO appears in a candidate. We avoid
+        // materialising newer-segment PKs into the BLink: each candidate PK
+        // is looked up against each newer segment's onDiskPkToNode BLink (the
+        // same paged structure already used by deletePk), and only on a hit
+        // do we update the authority map. This is O(|candidate PKs| × |newer
+        // segments|) BLink searches in the worst case, which is far cheaper
+        // than the previous O(|all PKs|) HashMap inserts and — crucially —
+        // does not materialise any per-PK Bytes object outside the inner
+        // BLink lookups.
         long maxCandidateGeneration = 0L;
+        Set<Integer> candidateIds = new HashSet<>(candidates.size() * 2);
         for (VectorSegment seg : candidates) {
             if (seg.generation > maxCandidateGeneration) {
                 maxCandidateGeneration = seg.generation;
             }
+            candidateIds.add(seg.segmentId);
         }
+        List<VectorSegment> newerSegments = new ArrayList<>();
         for (VectorSegment seg : allSegments) {
-            if (seg.generation > maxCandidateGeneration && !candidates.contains(seg)) {
-                visitSegmentPks(seg, winnerGeneration, winnerSegment);
+            if (seg.generation > maxCandidateGeneration && !candidateIds.contains(seg.segmentId)) {
+                newerSegments.add(seg);
+            }
+        }
+        // Sort newer segments by generation descending: the first hit during
+        // the lookup loop is the authoritative one, and we can short-circuit.
+        newerSegments.sort(Comparator.comparingLong((VectorSegment s) -> s.generation).reversed());
+
+        if (!newerSegments.isEmpty()) {
+            for (VectorSegment cand : candidates) {
+                checkSupersessionForCandidate(cand, newerSegments, authority);
             }
         }
 
-        // Live shards always dominate — they hold the newest state.
+        // Step 3: live shards always dominate any PK they hold. Walk the
+        // live-shard PK iterator once and update only entries that are
+        // already in the authority map.
         if (liveShardPks != null) {
             for (Bytes pk : liveShardPks) {
-                winnerGeneration.put(pk, Long.MAX_VALUE);
-                winnerSegment.put(pk, LIVE_SHARD_SEGMENT_ID);
+                if (authority.getSegmentId(pk) != null) {
+                    authority.updateIfHigherGeneration(pk,
+                            CompactionAuthorityMap.LIVE_SHARD_GENERATION_MARKER,
+                            LIVE_SHARD_SEGMENT_ID);
+                }
             }
         }
-
-        return winnerSegment;
     }
 
     /**
-     * Synthetic segment id returned by {@link #buildAuthorityMap} when
-     * the authoritative source for a PK is a live in-memory shard.
+     * Synthetic segment id returned by {@link CompactionAuthorityMap#getSegmentId}
+     * when the authoritative source for a PK is a live in-memory shard.
      * Any real {@link VectorSegment} id is non-negative; this sentinel
      * is {@code -1} so callers can check with {@code ownerId < 0}.
      */
     static final int LIVE_SHARD_SEGMENT_ID = -1;
 
-    private static void visitSegmentPks(VectorSegment seg,
-                                        Map<Bytes, Long> winnerGeneration,
-                                        Map<Bytes, Integer> winnerSegment) {
+    private static void insertSegmentPks(VectorSegment seg, CompactionAuthorityMap authority) {
         int[] offsets = seg.pkOffsets;
         int[] lengths = seg.pkLengths;
         byte[] data = seg.pkData;
@@ -258,16 +292,52 @@ final class VectorIndexCompactor {
             return;
         }
         long gen = seg.generation;
+        int segmentId = seg.segmentId;
         for (int ord = 0; ord < offsets.length; ord++) {
             int off = offsets[ord];
             if (off < 0) {
                 continue; // tombstoned — not a candidate for re-insert.
             }
             Bytes pk = Bytes.from_array(data, off, lengths[ord]);
-            Long existing = winnerGeneration.get(pk);
-            if (existing == null || gen > existing) {
-                winnerGeneration.put(pk, gen);
-                winnerSegment.put(pk, seg.segmentId);
+            authority.updateIfHigherGeneration(pk, gen, segmentId);
+        }
+    }
+
+    /**
+     * For each authoritative candidate PK in {@code cand}, looks the PK up
+     * in every newer segment's {@code onDiskPkToNode} BLink and, on the first
+     * hit (newer segments are sorted highest-generation-first), updates the
+     * authority map to record that newer segment as the winner.
+     *
+     * <p>This is the BLink-driven supersession check that replaces the
+     * previous bulk PK iteration over non-candidate segments.
+     */
+    private static void checkSupersessionForCandidate(VectorSegment cand,
+                                                      List<VectorSegment> newerSegmentsDesc,
+                                                      CompactionAuthorityMap authority) {
+        int[] offsets = cand.pkOffsets;
+        int[] lengths = cand.pkLengths;
+        byte[] data = cand.pkData;
+        if (offsets == null || data == null || lengths == null) {
+            return;
+        }
+        for (int ord = 0; ord < offsets.length; ord++) {
+            int off = offsets[ord];
+            if (off < 0) {
+                continue;
+            }
+            Bytes pk = Bytes.from_array(data, off, lengths[ord]);
+            for (VectorSegment newerSeg : newerSegmentsDesc) {
+                herddb.index.blink.BLink<Bytes, Long> p2n = newerSeg.onDiskPkToNode;
+                if (p2n == null) {
+                    continue;
+                }
+                if (p2n.search(pk) != null) {
+                    // Found the authoritative newer segment — update and
+                    // short-circuit since later segments have lower generation.
+                    authority.updateIfHigherGeneration(pk, newerSeg.generation, newerSeg.segmentId);
+                    break;
+                }
             }
         }
     }
@@ -340,7 +410,7 @@ final class VectorIndexCompactor {
     static RebuildResult rebuildSegment(
             PersistentVectorStore store,
             List<VectorSegment> candidates,
-            Map<Bytes, Integer> authority)
+            CompactionAuthorityMap authority)
             throws CompactionException, IOException, DataStorageManagerException {
 
         int dim = store.compactionDimension();
@@ -368,7 +438,7 @@ final class VectorIndexCompactor {
                     continue;
                 }
                 Bytes pk = Bytes.from_array(data, off, lengths[ord]);
-                Integer owner = authority.get(pk);
+                Integer owner = authority.getSegmentId(pk);
                 if (owner == null || owner != seg.segmentId) {
                     filteredCount++;
                 } else {
@@ -484,7 +554,7 @@ final class VectorIndexCompactor {
     private static void populateSyntheticShard(
             PersistentVectorStore store,
             List<VectorSegment> candidates,
-            Map<Bytes, Integer> authority,
+            CompactionAuthorityMap authority,
             PersistentVectorStore.LiveGraphShard syntheticShard,
             AtomicInteger localOrdCounter) throws CompactionException {
 
@@ -515,7 +585,7 @@ final class VectorIndexCompactor {
                         continue;
                     }
                     Bytes pk = Bytes.from_array(data, off, lengths[ord]);
-                    Integer owner = authority.get(pk);
+                    Integer owner = authority.getSegmentId(pk);
                     if (owner == null || owner != seg.segmentId) {
                         continue;
                     }

--- a/herddb-core/src/test/java/herddb/index/vector/CompactionAuthorityMapBLinkTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/CompactionAuthorityMapBLinkTest.java
@@ -1,0 +1,237 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.utils.Bytes;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Stress test for the BLink-backed {@link CompactionAuthorityMap} introduced
+ * for issue #290. Builds an authority map across hundreds of segments and
+ * thousands of PKs with a tiny page-replacement budget so the BLink
+ * <em>must</em> spill cold pages to disk; verifies that:
+ *
+ * <ul>
+ *   <li>every candidate PK with no newer source resolves to its own
+ *       candidate segment id;</li>
+ *   <li>every candidate PK that is also present in a higher-generation
+ *       non-candidate segment resolves to the highest-generation winner;</li>
+ *   <li>every candidate PK present in a live shard resolves to
+ *       {@link VectorIndexCompactor#LIVE_SHARD_SEGMENT_ID};</li>
+ *   <li>candidate-PK count materialised in the BLink is bounded by the
+ *       sum of candidate sizes (NOT by the total PK count across all
+ *       segments) — this is the core memory-bound invariant of the fix.</li>
+ * </ul>
+ */
+public class CompactionAuthorityMapBLinkTest {
+
+    private static Bytes pk(int index) {
+        // PKs as small UTF-8 strings so the BLink's variable-key path is exercised.
+        return Bytes.from_array(("pk_" + index).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Build a {@link VectorSegment} with sequential PKs, a generation, and
+     * an in-memory BLink-backed {@code onDiskPkToNode} so the
+     * supersession-check path can find the PKs.
+     */
+    private static VectorSegment makeSegment(int segmentId, long generation,
+                                             int pkOffset, int pkCount) {
+        VectorSegment s = new VectorSegment(segmentId);
+        s.generation = generation;
+        java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        int[] offsets = new int[pkCount];
+        int[] lengths = new int[pkCount];
+        s.onDiskPkToNode = TestBLinks.inMemoryPkToNode();
+        for (int i = 0; i < pkCount; i++) {
+            byte[] raw = ("pk_" + (pkOffset + i)).getBytes(StandardCharsets.UTF_8);
+            offsets[i] = bos.size();
+            lengths[i] = raw.length;
+            bos.write(raw, 0, raw.length);
+            s.onDiskPkToNode.insert(Bytes.from_array(raw), (long) i);
+        }
+        s.pkData = bos.toByteArray();
+        s.pkOffsets = offsets;
+        s.pkLengths = lengths;
+        return s;
+    }
+
+    @Test
+    public void candidateOnlyPksAreAllAuthoritative() throws IOException {
+        // 5 candidate segments × 1k PKs = 5000 candidate PKs, plus 50 newer
+        // non-candidate segments × 5k PKs = 250 000 non-candidate PKs.
+        // The fix must keep the authority map bounded to ~5000 entries.
+        List<VectorSegment> candidates = new ArrayList<>();
+        int pkCounter = 0;
+        for (int s = 0; s < 5; s++) {
+            candidates.add(makeSegment(/*id*/ 100 + s, /*gen*/ 1L + s,
+                    pkCounter, 1000));
+            pkCounter += 1000;
+        }
+        List<VectorSegment> newer = new ArrayList<>();
+        for (int s = 0; s < 50; s++) {
+            // Disjoint PK ranges so no candidate is superseded by a non-candidate.
+            newer.add(makeSegment(/*id*/ 1000 + s, /*gen*/ 100L + s,
+                    pkCounter, 5000));
+            pkCounter += 5000;
+        }
+        List<VectorSegment> all = new ArrayList<>(candidates);
+        all.addAll(newer);
+
+        // Tiny page-replacement budget so the BLink must spill.
+        try (CompactionAuthorityMap authority =
+                     TestBLinks.inMemoryCompactionAuthorityMap(/*pageSize*/ 1024L,
+                             /*policyCapacity*/ 4)) {
+            VectorIndexCompactor.buildAuthorityMap(authority, candidates, all,
+                    Collections.emptyList());
+            assertEquals("authority map size must equal sum(candidate PKs)",
+                    5000L, authority.size());
+            // Every candidate PK resolves to its own candidate segment id.
+            int verified = 0;
+            for (int s = 0; s < 5; s++) {
+                int expectedId = 100 + s;
+                int base = s * 1000;
+                for (int i = 0; i < 1000; i += 17) {
+                    Integer owner = authority.getSegmentId(pk(base + i));
+                    assertEquals("PK pk_" + (base + i),
+                            Integer.valueOf(expectedId), owner);
+                    verified++;
+                }
+            }
+            assertTrue("verified at least 250 PKs", verified > 250);
+            // PKs from non-candidate segments are NOT recorded.
+            assertNull(authority.getSegmentId(pk(pkCounter - 1)));
+        }
+    }
+
+    @Test
+    public void newerSegmentsSupersedeCandidatePks() throws IOException {
+        // 4 candidate segments at generations 1..4, all sharing the same
+        // PK range [0, 500). 3 newer non-candidate segments at generations
+        // 10, 20, 30 also share the PK range. The highest-generation
+        // newer segment must win for every shared PK.
+        List<VectorSegment> candidates = new ArrayList<>();
+        for (int s = 0; s < 4; s++) {
+            candidates.add(makeSegment(/*id*/ 10 + s, /*gen*/ 1L + s, 0, 500));
+        }
+        List<VectorSegment> newer = new ArrayList<>();
+        newer.add(makeSegment(/*id*/ 100, /*gen*/ 10L, 0, 500));
+        newer.add(makeSegment(/*id*/ 200, /*gen*/ 20L, 0, 500));
+        newer.add(makeSegment(/*id*/ 300, /*gen*/ 30L, 0, 500));
+        List<VectorSegment> all = new ArrayList<>(candidates);
+        all.addAll(newer);
+
+        try (CompactionAuthorityMap authority =
+                     TestBLinks.inMemoryCompactionAuthorityMap(/*pageSize*/ 1024L,
+                             /*policyCapacity*/ 4)) {
+            VectorIndexCompactor.buildAuthorityMap(authority, candidates, all,
+                    Collections.emptyList());
+            // Every PK in [0, 500) is owned by segment 300 (highest gen).
+            for (int i = 0; i < 500; i += 13) {
+                assertEquals("PK pk_" + i, Integer.valueOf(300),
+                        authority.getSegmentId(pk(i)));
+            }
+        }
+    }
+
+    @Test
+    public void liveShardOverridesEverything() throws IOException {
+        // 3 candidate segments × 200 PKs in disjoint ranges. Half the PKs
+        // of each candidate are also in the live shards (which always win).
+        List<VectorSegment> candidates = new ArrayList<>();
+        candidates.add(makeSegment(/*id*/ 1, /*gen*/ 1L, /*pkOffset*/ 0, 200));
+        candidates.add(makeSegment(/*id*/ 2, /*gen*/ 2L, /*pkOffset*/ 200, 200));
+        candidates.add(makeSegment(/*id*/ 3, /*gen*/ 3L, /*pkOffset*/ 400, 200));
+        List<VectorSegment> all = new ArrayList<>(candidates);
+        Set<Bytes> liveShard = new HashSet<>();
+        for (int i = 0; i < 600; i += 2) {
+            liveShard.add(pk(i));
+        }
+
+        try (CompactionAuthorityMap authority =
+                     TestBLinks.inMemoryCompactionAuthorityMap(/*pageSize*/ 1024L,
+                             /*policyCapacity*/ 4)) {
+            VectorIndexCompactor.buildAuthorityMap(authority, candidates, all, liveShard);
+            for (int i = 0; i < 600; i++) {
+                Integer owner = authority.getSegmentId(pk(i));
+                if (i % 2 == 0) {
+                    assertEquals("even PKs go to live shard, pk_" + i,
+                            Integer.valueOf(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID),
+                            owner);
+                } else {
+                    int expectedId = 1 + i / 200;
+                    assertEquals("odd PKs stay with their candidate, pk_" + i,
+                            Integer.valueOf(expectedId), owner);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void closedAuthorityMapDropsTempStorage() throws IOException {
+        // The cleanup callback must run exactly once on close, even when
+        // the BLink has spilled to disk. We verify by counting the number
+        // of times the on-drop runnable fires.
+        int[] onDropCount = new int[1];
+        herddb.index.blink.BLink<Bytes, Long> blink =
+                TestBLinks.inMemoryPkToNode();
+        try (CompactionAuthorityMap authority =
+                     new CompactionAuthorityMap(blink, () -> onDropCount[0]++)) {
+            for (int i = 0; i < 100; i++) {
+                authority.updateIfHigherGeneration(pk(i), i + 1L, 42);
+            }
+            assertEquals(100L, authority.size());
+        }
+        assertEquals("on-drop callback fired exactly once", 1, onDropCount[0]);
+    }
+
+    @Test
+    public void supersessionWithMissingOnDiskPkToNodeIsSafe() throws IOException {
+        // Defensive: a newer segment whose onDiskPkToNode field is null
+        // (e.g. mid-load on startup) must not blow up the authority build.
+        VectorSegment cand = makeSegment(/*id*/ 1, /*gen*/ 1L, 0, 10);
+        VectorSegment newerWithoutBlink = makeSegment(/*id*/ 2, /*gen*/ 5L, 0, 10);
+        newerWithoutBlink.onDiskPkToNode = null;
+
+        try (CompactionAuthorityMap authority =
+                     TestBLinks.inMemoryCompactionAuthorityMap()) {
+            VectorIndexCompactor.buildAuthorityMap(authority,
+                    Arrays.asList(cand),
+                    Arrays.asList(cand, newerWithoutBlink),
+                    Collections.emptyList());
+            // The newer segment is skipped silently — every candidate PK
+            // remains attributed to its own segment.
+            for (int i = 0; i < 10; i++) {
+                assertEquals(Integer.valueOf(1), authority.getSegmentId(pk(i)));
+            }
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/CompactionAuthorityMapCleanupTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/CompactionAuthorityMapCleanupTest.java
@@ -1,0 +1,235 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that {@link PersistentVectorStore#runCompactionCycle()} drops every
+ * temporary BLink storage it creates for the {@link CompactionAuthorityMap}
+ * and the {@code pendingCompactionDeletes} {@link PagedPkSet} — both on the
+ * happy path and when the cycle finishes without doing useful work.
+ *
+ * <p>This is the regression test for the cleanup contract introduced for
+ * issue #290: every {@code _tmp_cmpaut_*} and {@code _tmp_pkset_cmpdel_*}
+ * index name initialised by the cycle must have a matching {@code dropIndex}
+ * by the time the cycle returns.
+ */
+public class CompactionAuthorityMapCleanupTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    /** A {@link MemoryDataStorageManager} that records every {@code initIndex} /
+     * {@code dropIndex} call so the test can assert proper cleanup. */
+    static final class TrackingDsm extends MemoryDataStorageManager {
+        final Set<String> openIndexes = ConcurrentHashMap.newKeySet();
+        final AtomicInteger initCallsCmpaut = new AtomicInteger();
+        final AtomicInteger dropCallsCmpaut = new AtomicInteger();
+        final AtomicInteger initCallsPkset = new AtomicInteger();
+        final AtomicInteger dropCallsPkset = new AtomicInteger();
+
+        @Override
+        public void initIndex(String tableSpace, String name) throws DataStorageManagerException {
+            super.initIndex(tableSpace, name);
+            openIndexes.add(name);
+            if (name.contains("_tmp_cmpaut_")) {
+                initCallsCmpaut.incrementAndGet();
+            } else if (name.contains("_tmp_pkset_")) {
+                initCallsPkset.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void dropIndex(String tableSpace, String name) throws DataStorageManagerException {
+            super.dropIndex(tableSpace, name);
+            openIndexes.remove(name);
+            if (name.contains("_tmp_cmpaut_")) {
+                dropCallsCmpaut.incrementAndGet();
+            } else if (name.contains("_tmp_pkset_")) {
+                dropCallsPkset.incrementAndGet();
+            }
+        }
+
+        Set<String> orphanTempIndexes() {
+            Set<String> out = new HashSet<>();
+            for (String name : openIndexes) {
+                if (name.contains("_tmp_cmpaut_") || name.contains("_tmp_pkset_")) {
+                    out.add(name);
+                }
+            }
+            return out;
+        }
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, TrackingDsm dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        // Aggressive compaction policy: any segment count >= 4 with any size triggers a cycle.
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        return store;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void successfulCompactionCycleDropsTempStorages() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        TrackingDsm dsm = new TrackingDsm();
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            Random rng = new Random(11);
+            int dim = 16;
+            // Build 5 small segments via 5 checkpoints.
+            for (int c = 0; c < 5; c++) {
+                for (int i = 0; i < 300; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            assertTrue("expected >= 4 segments before compaction",
+                    store.getSegmentCount() >= 4);
+
+            int initBefore = dsm.initCallsCmpaut.get();
+            int dropBefore = dsm.dropCallsCmpaut.get();
+            int psInitBefore = dsm.initCallsPkset.get();
+            int psDropBefore = dsm.dropCallsPkset.get();
+
+            store.runCompactionCycle();
+
+            assertEquals("authority map init/drop pair on success",
+                    1, dsm.initCallsCmpaut.get() - initBefore);
+            assertEquals("authority map dropped on success",
+                    1, dsm.dropCallsCmpaut.get() - dropBefore);
+            // The cycle creates ONE pkset (pendingCompactionDeletes); checkpoint
+            // ones initialised earlier should have been dropped already.
+            assertEquals("compaction-deletes pkset init",
+                    1, dsm.initCallsPkset.get() - psInitBefore);
+            assertEquals("compaction-deletes pkset dropped",
+                    1, dsm.dropCallsPkset.get() - psDropBefore);
+            assertEquals("no orphan _tmp_* index after cycle",
+                    java.util.Collections.emptySet(), dsm.orphanTempIndexes());
+        }
+    }
+
+    @Test
+    public void backToBackCyclesNeverLeak() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        TrackingDsm dsm = new TrackingDsm();
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            Random rng = new Random(11);
+            int dim = 16;
+            for (int c = 0; c < 12; c++) {
+                for (int i = 0; i < 300; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int totalCycles = 0;
+            for (int i = 0; i < 4; i++) {
+                int beforeRuns = (int) store.getCompactionRunsTotal();
+                store.runCompactionCycle();
+                if (store.getCompactionRunsTotal() > beforeRuns) {
+                    totalCycles++;
+                }
+            }
+            assertTrue("at least one compaction cycle ran across the loop",
+                    totalCycles > 0);
+            assertEquals("no orphan _tmp_* index after multiple cycles",
+                    java.util.Collections.emptySet(), dsm.orphanTempIndexes());
+            assertEquals("authority map init count == drop count",
+                    dsm.initCallsCmpaut.get(), dsm.dropCallsCmpaut.get());
+            // pkset init count must equal drop count too. We track both
+            // checkpoint and compaction sets, so the counter aggregates them.
+            assertEquals("pkset init count == drop count",
+                    dsm.initCallsPkset.get(), dsm.dropCallsPkset.get());
+        }
+    }
+
+    @Test
+    public void emptyResultCycleStillDrops() throws Exception {
+        // If chooseSegmentsToMerge returns nothing the cycle exits early —
+        // it must NOT have allocated any temp storage in that path.
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        TrackingDsm dsm = new TrackingDsm();
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            // Raise the min-segment-count threshold above any segment count
+            // we'll reach so the cycle returns early.
+            store.start();
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 1000, 0);
+
+            // No segments at all => candidates.isEmpty() => early return.
+            int initBefore = dsm.initCallsCmpaut.get();
+            int dropBefore = dsm.dropCallsCmpaut.get();
+            int psInitBefore = dsm.initCallsPkset.get();
+            int psDropBefore = dsm.dropCallsPkset.get();
+
+            store.runCompactionCycle();
+
+            assertEquals("no authority map allocated on early return",
+                    0, dsm.initCallsCmpaut.get() - initBefore);
+            assertEquals("no authority map dropped on early return",
+                    0, dsm.dropCallsCmpaut.get() - dropBefore);
+            assertEquals("no pkset allocated on early return",
+                    0, dsm.initCallsPkset.get() - psInitBefore);
+            assertEquals("no pkset dropped on early return",
+                    0, dsm.dropCallsPkset.get() - psDropBefore);
+            assertEquals("no orphan _tmp_* index after early-return cycle",
+                    java.util.Collections.emptySet(), dsm.orphanTempIndexes());
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/PagedPkSetTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PagedPkSetTest.java
@@ -1,0 +1,174 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.utils.Bytes;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PagedPkSet} — the BLink-backed PK set used by
+ * {@link PersistentVectorStore} for {@code pendingCheckpointDeletes} and
+ * {@code pendingCompactionDeletes} (issue #290).
+ */
+public class PagedPkSetTest {
+
+    private static Bytes pk(int i) {
+        return Bytes.from_array(("pk_" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void addAndContainsAreConsistent() throws IOException {
+        try (PagedPkSet set = TestBLinks.inMemoryPagedPkSet()) {
+            assertFalse(set.contains(pk(1)));
+            set.add(pk(1));
+            assertTrue(set.contains(pk(1)));
+            assertFalse(set.contains(pk(2)));
+            set.add(pk(2));
+            assertTrue(set.contains(pk(2)));
+            assertEquals(2L, set.size());
+        }
+    }
+
+    @Test
+    public void addIsIdempotent() throws IOException {
+        try (PagedPkSet set = TestBLinks.inMemoryPagedPkSet()) {
+            set.add(pk(7));
+            set.add(pk(7));
+            set.add(pk(7));
+            assertTrue(set.contains(pk(7)));
+            assertEquals("duplicate adds produce a single entry",
+                    1L, set.size());
+        }
+    }
+
+    @Test
+    public void forEachVisitsEveryPk() throws IOException {
+        try (PagedPkSet set = TestBLinks.inMemoryPagedPkSet()) {
+            for (int i = 0; i < 100; i++) {
+                set.add(pk(i));
+            }
+            Set<Bytes> visited = new HashSet<>();
+            set.forEach(visited::add);
+            assertEquals(100, visited.size());
+            for (int i = 0; i < 100; i++) {
+                assertTrue("PK pk_" + i + " visited", visited.contains(pk(i)));
+            }
+        }
+    }
+
+    @Test
+    public void closeFiresOnDropExactlyOnce() throws IOException {
+        int[] count = new int[1];
+        herddb.index.blink.BLink<Bytes, Long> blink = TestBLinks.inMemoryPkToNode();
+        try (PagedPkSet set = new PagedPkSet(blink, () -> count[0]++)) {
+            set.add(pk(1));
+        }
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void largeSetWithSpillStillCorrect() throws IOException {
+        // Force the BLink to spill: small page size + tiny resident-page
+        // capacity. Adding 5 000 PKs ensures multiple page evictions.
+        try (PagedPkSet set = new PagedPkSet(
+                newSpillyBLink(), () -> { })) {
+            for (int i = 0; i < 5000; i++) {
+                set.add(pk(i));
+            }
+            assertEquals(5000L, set.size());
+            for (int i = 0; i < 5000; i += 53) {
+                assertTrue("pk_" + i, set.contains(pk(i)));
+            }
+            assertFalse(set.contains(pk(99999)));
+        }
+    }
+
+    private static herddb.index.blink.BLink<Bytes, Long> newSpillyBLink() {
+        // Tiny page-replacement budget — 4 resident pages × 1 KiB each.
+        return new herddb.index.blink.BLink<>(
+                /*pageSize*/ 1024L,
+                herddb.index.blink.BytesLongSizeEvaluator.INSTANCE,
+                new herddb.core.RandomPageReplacementPolicy(4),
+                new TestInMemoryBytesLongStorage());
+    }
+
+    /**
+     * Minimal in-memory BLinkIndexDataStorage implementation copy for the
+     * spill test — kept here to avoid making
+     * {@link TestBLinks}'s private impl visible.
+     */
+    private static final class TestInMemoryBytesLongStorage implements
+            herddb.index.blink.BLinkIndexDataStorage<Bytes, Long> {
+
+        private final java.util.concurrent.atomic.AtomicLong nextId =
+                new java.util.concurrent.atomic.AtomicLong();
+        private final java.util.concurrent.ConcurrentHashMap<Long, Object> data =
+                new java.util.concurrent.ConcurrentHashMap<>();
+
+        @Override
+        public void loadNodePage(long pageId, java.util.Map<Bytes, Long> dst) {
+            @SuppressWarnings("unchecked")
+            java.util.Map<Bytes, Long> p = (java.util.Map<Bytes, Long>) data.get(pageId);
+            if (p != null) {
+                dst.putAll(p);
+            }
+        }
+
+        @Override
+        public void loadLeafPage(long pageId, java.util.Map<Bytes, Long> dst) {
+            @SuppressWarnings("unchecked")
+            java.util.Map<Bytes, Long> p = (java.util.Map<Bytes, Long>) data.get(pageId);
+            if (p != null) {
+                dst.putAll(p);
+            }
+        }
+
+        @Override
+        public long createNodePage(java.util.Map<Bytes, Long> page) {
+            long id = nextId.incrementAndGet();
+            data.put(id, new java.util.HashMap<>(page));
+            return id;
+        }
+
+        @Override
+        public long createLeafPage(java.util.Map<Bytes, Long> page) {
+            long id = nextId.incrementAndGet();
+            data.put(id, new java.util.HashMap<>(page));
+            return id;
+        }
+
+        @Override
+        public void overwriteNodePage(long pageId, java.util.Map<Bytes, Long> page) {
+            data.put(pageId, new java.util.HashMap<>(page));
+        }
+
+        @Override
+        public void overwriteLeafPage(long pageId, java.util.Map<Bytes, Long> page) {
+            data.put(pageId, new java.util.HashMap<>(page));
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/TestBLinks.java
+++ b/herddb-core/src/test/java/herddb/index/vector/TestBLinks.java
@@ -1,0 +1,150 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import herddb.core.PageReplacementPolicy;
+import herddb.core.RandomPageReplacementPolicy;
+import herddb.index.blink.BLink;
+import herddb.index.blink.BLinkIndexDataStorage;
+import herddb.index.blink.BytesLongSizeEvaluator;
+import herddb.utils.Bytes;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Test-only factory for {@link BLink}-backed structures used by the vector
+ * index — replaces the dependency on {@link PersistentVectorStore}'s factory
+ * methods so tests can exercise {@link CompactionAuthorityMap} and
+ * {@link PagedPkSet} without spinning up a full store.
+ *
+ * <p>Each helper returns a wrapper backed by an in-memory
+ * {@link BLinkIndexDataStorage}; the cleanup callback is a no-op since
+ * there is no underlying disk storage to drop.
+ */
+final class TestBLinks {
+
+    /** Default page size for test BLinks. Small enough to exercise paging. */
+    static final long DEFAULT_PAGE_SIZE = 4 * 1024L;
+
+    /** Default page replacement policy capacity (pages held resident). */
+    static final int DEFAULT_POLICY_CAPACITY = 4;
+
+    private TestBLinks() {
+    }
+
+    /**
+     * Returns a new {@link CompactionAuthorityMap} backed by a small
+     * in-memory BLink. The cleanup hook is a no-op.
+     */
+    static CompactionAuthorityMap inMemoryCompactionAuthorityMap() {
+        BLink<Bytes, Long> blink = newInMemoryBytesLongBLink(
+                DEFAULT_PAGE_SIZE, DEFAULT_POLICY_CAPACITY);
+        return new CompactionAuthorityMap(blink, () -> { });
+    }
+
+    /**
+     * Returns a new {@link CompactionAuthorityMap} backed by an in-memory
+     * BLink configured with the supplied page size and resident-page
+     * capacity. Useful for spill-coverage tests.
+     */
+    static CompactionAuthorityMap inMemoryCompactionAuthorityMap(long pageSize, int policyCapacity) {
+        BLink<Bytes, Long> blink = newInMemoryBytesLongBLink(pageSize, policyCapacity);
+        return new CompactionAuthorityMap(blink, () -> { });
+    }
+
+    /**
+     * Returns a new {@link PagedPkSet} backed by a small in-memory BLink.
+     * The cleanup hook is a no-op.
+     */
+    static PagedPkSet inMemoryPagedPkSet() {
+        BLink<Bytes, Long> blink = newInMemoryBytesLongBLink(
+                DEFAULT_PAGE_SIZE, DEFAULT_POLICY_CAPACITY);
+        return new PagedPkSet(blink, () -> { });
+    }
+
+    /**
+     * Returns an in-memory {@code BLink<Bytes, Long>} suitable for use as a
+     * test stand-in for {@link VectorSegment#onDiskPkToNode}.
+     */
+    static BLink<Bytes, Long> inMemoryPkToNode() {
+        return newInMemoryBytesLongBLink(DEFAULT_PAGE_SIZE, DEFAULT_POLICY_CAPACITY);
+    }
+
+    private static BLink<Bytes, Long> newInMemoryBytesLongBLink(long pageSize, int policyCapacity) {
+        PageReplacementPolicy policy = new RandomPageReplacementPolicy(policyCapacity);
+        return new BLink<>(pageSize, BytesLongSizeEvaluator.INSTANCE,
+                policy, new InMemoryBytesLongStorage());
+    }
+
+    /**
+     * In-memory {@link BLinkIndexDataStorage} for {@code (Bytes, Long)} BLinks.
+     * Pages are stored in a {@link ConcurrentHashMap}; the same instance is
+     * never shared across BLinks (each test factory call creates a fresh one).
+     */
+    private static final class InMemoryBytesLongStorage implements BLinkIndexDataStorage<Bytes, Long> {
+        private final AtomicLong newPageId = new AtomicLong();
+        private final ConcurrentHashMap<Long, Object> datas = new ConcurrentHashMap<>();
+
+        @Override
+        public void loadNodePage(long pageId, Map<Bytes, Long> data) throws IOException {
+            @SuppressWarnings("unchecked")
+            Map<Bytes, Long> res = (Map<Bytes, Long>) datas.get(pageId);
+            if (res != null) {
+                data.putAll(res);
+            }
+        }
+
+        @Override
+        public void loadLeafPage(long pageId, Map<Bytes, Long> data) throws IOException {
+            @SuppressWarnings("unchecked")
+            Map<Bytes, Long> res = (Map<Bytes, Long>) datas.get(pageId);
+            if (res != null) {
+                data.putAll(res);
+            }
+        }
+
+        @Override
+        public long createNodePage(Map<Bytes, Long> data) throws IOException {
+            long id = newPageId.incrementAndGet();
+            datas.put(id, new HashMap<>(data));
+            return id;
+        }
+
+        @Override
+        public long createLeafPage(Map<Bytes, Long> data) throws IOException {
+            long id = newPageId.incrementAndGet();
+            datas.put(id, new HashMap<>(data));
+            return id;
+        }
+
+        @Override
+        public void overwriteNodePage(long pageId, Map<Bytes, Long> data) throws IOException {
+            datas.put(pageId, new HashMap<>(data));
+        }
+
+        @Override
+        public void overwriteLeafPage(long pageId, Map<Bytes, Long> data) throws IOException {
+            datas.put(pageId, new HashMap<>(data));
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorLivePkFilterTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorLivePkFilterTest.java
@@ -24,17 +24,24 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import herddb.utils.Bytes;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import org.junit.Test;
 
 /**
  * Tests for {@link VectorIndexCompactor#buildAuthorityMap} — the
  * live-PK filter that drops tombstoned PKs and PKs superseded by
  * later segments or live shards during compaction.
+ *
+ * <p>After issue #290 the authority map is intentionally
+ * <em>candidate-only</em>: only PKs that appear in at least one
+ * candidate are recorded. PKs that exist exclusively in newer
+ * non-candidate segments or in live shards are not tracked because
+ * they are never queried during the rebuild (the rebuild only
+ * consults the map for candidate PKs).
  */
 public class VectorIndexCompactorLivePkFilterTest {
 
@@ -60,6 +67,15 @@ public class VectorIndexCompactorLivePkFilterTest {
         s.pkData = bos.toByteArray();
         s.pkOffsets = offsets;
         s.pkLengths = lengths;
+        // Wire an in-memory BLink as the pkToNode lookup so the
+        // BLink-driven supersession check (issue #290) finds non-tombstoned
+        // PKs. Tests that omit this rely on supersession via candidates only.
+        s.onDiskPkToNode = TestBLinks.inMemoryPkToNode();
+        for (int i = 0; i < pks.length; i++) {
+            if (pks[i] != null) {
+                s.onDiskPkToNode.insert(pk(pks[i]), (long) i);
+            }
+        }
         return s;
     }
 
@@ -67,86 +83,191 @@ public class VectorIndexCompactorLivePkFilterTest {
         return Bytes.from_array(s.getBytes(StandardCharsets.UTF_8));
     }
 
+    private static CompactionAuthorityMap newAuthority() {
+        return TestBLinks.inMemoryCompactionAuthorityMap();
+    }
+
     @Test
-    public void tombstonedPksAreExcluded() {
+    public void tombstonedPksAreExcluded() throws IOException {
         // ord 1 is tombstoned; it should NOT appear in the authority map
         // for segment A.
         VectorSegment a = seg(10, 5L, "alpha", null, "gamma");
-        Map<Bytes, Integer> owners = VectorIndexCompactor.buildAuthorityMap(
-                Arrays.asList(a), Arrays.asList(a), new ArrayList<>());
-        assertEquals(Integer.valueOf(10), owners.get(pk("alpha")));
-        assertNull(owners.get(pk("beta")));
-        assertEquals(Integer.valueOf(10), owners.get(pk("gamma")));
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(a), Arrays.asList(a), new ArrayList<>());
+            assertEquals(Integer.valueOf(10), owners.getSegmentId(pk("alpha")));
+            assertNull(owners.getSegmentId(pk("beta")));
+            assertEquals(Integer.valueOf(10), owners.getSegmentId(pk("gamma")));
+        }
     }
 
     @Test
-    public void laterSegmentSupersedesCandidate() {
+    public void laterSegmentSupersedesCandidate() throws IOException {
         VectorSegment oldA = seg(10, 3L, "shared", "onlyA");
         VectorSegment newB = seg(20, 7L, "shared", "onlyB");
 
-        Map<Bytes, Integer> owners = VectorIndexCompactor.buildAuthorityMap(
-                Arrays.asList(oldA),
-                Arrays.asList(oldA, newB),
-                new ArrayList<>());
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(oldA),
+                    Arrays.asList(oldA, newB),
+                    new ArrayList<>());
 
-        // shared: newer generation (7) beats candidate (3) — B wins.
-        assertEquals(Integer.valueOf(20), owners.get(pk("shared")));
-        // onlyA is only in the candidate, no newer source exists.
-        assertEquals(Integer.valueOf(10), owners.get(pk("onlyA")));
-        // onlyB is in a non-candidate segment, so it's still recorded.
-        assertEquals(Integer.valueOf(20), owners.get(pk("onlyB")));
+            // shared: newer generation (7) beats candidate (3) — B wins.
+            assertEquals(Integer.valueOf(20), owners.getSegmentId(pk("shared")));
+            // onlyA is only in the candidate, no newer source exists.
+            assertEquals(Integer.valueOf(10), owners.getSegmentId(pk("onlyA")));
+            // onlyB is in a non-candidate segment — after issue #290 the
+            // authority map is candidate-only, so it is NOT recorded.
+            assertNull(owners.getSegmentId(pk("onlyB")));
+        }
     }
 
     @Test
-    public void liveShardAlwaysDominates() {
+    public void liveShardAlwaysDominates() throws IOException {
         VectorSegment a = seg(10, 3L, "x", "y");
         List<Bytes> liveShardPks = Arrays.asList(pk("x"));
 
-        Map<Bytes, Integer> owners = VectorIndexCompactor.buildAuthorityMap(
-                Arrays.asList(a), Arrays.asList(a), liveShardPks);
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(a), Arrays.asList(a), liveShardPks);
 
-        assertEquals(Integer.valueOf(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID),
-                owners.get(pk("x")));
-        assertEquals(Integer.valueOf(10), owners.get(pk("y")));
+            assertEquals(Integer.valueOf(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID),
+                    owners.getSegmentId(pk("x")));
+            assertEquals(Integer.valueOf(10), owners.getSegmentId(pk("y")));
+        }
     }
 
     @Test
-    public void olderNonCandidateSegmentIsIgnored() {
+    public void liveShardPkNotInCandidatesIsIgnored() throws IOException {
+        // Live-shard PK that is NOT in any candidate is ignored — the
+        // authority map only tracks PKs that are candidates for re-insert
+        // by the rebuild.
+        VectorSegment a = seg(10, 3L, "x");
+        List<Bytes> liveShardPks = Arrays.asList(pk("foreign"));
+
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(a), Arrays.asList(a), liveShardPks);
+
+            assertEquals(Integer.valueOf(10), owners.getSegmentId(pk("x")));
+            assertNull(owners.getSegmentId(pk("foreign")));
+        }
+    }
+
+    @Test
+    public void olderNonCandidateSegmentIsIgnored() throws IOException {
         // A candidate at gen 5; an older non-candidate at gen 2 has no
         // say over anything.
         VectorSegment cand = seg(10, 5L, "k");
         VectorSegment older = seg(20, 2L, "k", "other");
 
-        Map<Bytes, Integer> owners = VectorIndexCompactor.buildAuthorityMap(
-                Arrays.asList(cand),
-                Arrays.asList(cand, older),
-                new ArrayList<>());
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(cand),
+                    Arrays.asList(cand, older),
+                    new ArrayList<>());
 
-        // 'k' belongs to the candidate; 'other' from the older
-        // non-candidate is NOT added because the older segment is not
-        // inspected (candidates cover their own generation and the
-        // merged output will replace them).
-        assertEquals(Integer.valueOf(10), owners.get(pk("k")));
-        assertNull(owners.get(pk("other")));
+            // 'k' belongs to the candidate; 'other' from the older
+            // non-candidate is NOT added because the older segment is not
+            // inspected (candidates cover their own generation and the
+            // merged output will replace them).
+            assertEquals(Integer.valueOf(10), owners.getSegmentId(pk("k")));
+            assertNull(owners.getSegmentId(pk("other")));
+        }
     }
 
     @Test
-    public void nullPkArraysAreIgnored() {
+    public void nullPkArraysAreIgnored() throws IOException {
         // A segment that has never been populated (fresh / pre-load).
         VectorSegment empty = new VectorSegment(99);
         empty.generation = 7L;
         // pkData/offsets/lengths are null.
-        Map<Bytes, Integer> owners = VectorIndexCompactor.buildAuthorityMap(
-                Arrays.asList(empty), Arrays.asList(empty), new ArrayList<>());
-        assertTrue(owners.isEmpty());
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(empty), Arrays.asList(empty), new ArrayList<>());
+            assertEquals(0L, owners.size());
+        }
     }
 
     @Test
-    public void simpleCandidateHappyPath() {
+    public void simpleCandidateHappyPath() throws IOException {
         VectorSegment only = seg(1, 1L, "a", "b", "c");
-        Map<Bytes, Integer> owners = VectorIndexCompactor.buildAuthorityMap(
-                Arrays.asList(only), Arrays.asList(only), new ArrayList<>());
-        assertEquals(3, owners.size());
-        assertFalse(owners.containsValue(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID));
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(only), Arrays.asList(only), new ArrayList<>());
+            assertEquals(3L, owners.size());
+            assertEquals(Integer.valueOf(1), owners.getSegmentId(pk("a")));
+            assertEquals(Integer.valueOf(1), owners.getSegmentId(pk("b")));
+            assertEquals(Integer.valueOf(1), owners.getSegmentId(pk("c")));
+            assertFalse(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID
+                    == owners.getSegmentId(pk("a")));
+        }
+    }
+
+    @Test
+    public void supersessionFindsHighestGenerationWinner() throws IOException {
+        // Three sources hold the same PK. The candidate is the lowest-gen
+        // source; among the newer non-candidates, the highest-gen wins.
+        VectorSegment cand = seg(10, 1L, "shared");
+        VectorSegment mid = seg(20, 3L, "shared");
+        VectorSegment top = seg(30, 5L, "shared");
+
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(cand),
+                    Arrays.asList(cand, mid, top),
+                    new ArrayList<>());
+
+            assertEquals(Integer.valueOf(30), owners.getSegmentId(pk("shared")));
+        }
+    }
+
+    @Test
+    public void liveShardBeatsNewerSegment() throws IOException {
+        // Live shard always wins, even over a newer non-candidate segment
+        // that also has the PK.
+        VectorSegment cand = seg(10, 1L, "shared");
+        VectorSegment newer = seg(20, 5L, "shared");
+
+        try (CompactionAuthorityMap owners = newAuthority()) {
+            VectorIndexCompactor.buildAuthorityMap(owners,
+                    Arrays.asList(cand),
+                    Arrays.asList(cand, newer),
+                    Arrays.asList(pk("shared")));
+
+            assertEquals(Integer.valueOf(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID),
+                    owners.getSegmentId(pk("shared")));
+        }
+    }
+
+    @Test
+    public void encoderRoundTripsLiveShardSegmentId() {
+        // Defensive: the (gen, segId) -> Long packing must round-trip
+        // negative segment ids (LIVE_SHARD_SEGMENT_ID = -1).
+        long encoded = CompactionAuthorityMap.encode(42L, VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID);
+        assertEquals(VectorIndexCompactor.LIVE_SHARD_SEGMENT_ID,
+                CompactionAuthorityMap.decodeSegmentId(encoded));
+        assertEquals(42L, CompactionAuthorityMap.decodeGeneration(encoded));
+        // And ordinary positive ids.
+        encoded = CompactionAuthorityMap.encode(7L, 12345);
+        assertEquals(12345, CompactionAuthorityMap.decodeSegmentId(encoded));
+        assertEquals(7L, CompactionAuthorityMap.decodeGeneration(encoded));
+    }
+
+    @Test
+    public void encoderRejectsOutOfRangeGeneration() {
+        // Defensive: generation must fit in the high 32 bits (0..2^32-1).
+        try {
+            CompactionAuthorityMap.encode(-1L, 0);
+            org.junit.Assert.fail("expected IllegalArgumentException for negative generation");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("generation"));
+        }
+        try {
+            CompactionAuthorityMap.encode(0x1_0000_0000L, 0);
+            org.junit.Assert.fail("expected IllegalArgumentException for over-range generation");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("generation"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #290.

## Root cause

`VectorIndexCompactor.buildAuthorityMap` materialised a `HashMap<Bytes, Long>` plus a `HashMap<Bytes, Integer>` over **every** PK in **every** non-candidate newer segment. With 3,867 segments × 50k PKs ≈ 200M `Bytes` allocations (10–20 GB of temporary heap) on top of the already-resident segment state, the IS hit `java.lang.OutOfMemoryError: Java heap space` mid-compaction (40 GB heap, ~68% baseline). The same unbounded heap pattern applied to the two `Set<Bytes>` fields used during long-running checkpoints / compactions:

- `pendingCompactionDeletes` (delete traffic during a multi-minute compaction)
- `pendingCheckpointDeletes` (delete traffic during a multi-minute Phase B)

## Changes

- **`CompactionAuthorityMap`** (new): wraps a `BLink<Bytes, Long>` whose value packs `(generation, segmentId)` into a single `Long` — high 32 bits hold the unsigned generation, low 32 bits the signed segment id (so `LIVE_SHARD_SEGMENT_ID = -1` round-trips cleanly through a sign-extending narrowing cast). `Closeable`; `close()` unloads the BLink and runs an `onDrop` callback (drops the temp index in production, no-op in tests).
- **`PagedPkSet`** (new): tiny BLink-backed PK set used as the new backing for `pendingCompactionDeletes` and `pendingCheckpointDeletes`. Same lifecycle pattern as the authority map.
- **`VectorIndexCompactor.buildAuthorityMap`** rewritten to be candidate-only:
  - seed the map with PKs from the candidates;
  - for each newer non-candidate segment (sorted highest-generation-first) probe each candidate PK against `seg.onDiskPkToNode.search(pk)` — already a paged BLink — and update on the first hit (short-circuit);
  - for live-shard PKs, only update entries that are already in the map.
  
  The map size is now bounded by ∑ candidate sizes (tens of thousands per cycle) rather than by the global PK count, regardless of how many segments accumulate.
- **`PersistentVectorStore`** gains two factory methods (`createTempCompactionAuthorityMap(cycleId)`, `createTempPagedPkSet(purposeTag)`) that build a temp BLink under a unique `_tmp_cmpaut_*` / `_tmp_pkset_*` index name and return wrappers whose `close()` drops the index. `runCompactionCycle` and the Phase B checkpoint code use `try-finally` to release them. The `liveShardPkSnapshot` `HashSet` is replaced with a lazy stream so live-shard PKs are probed one by one.

All temporary BLinks share the existing `MemoryManager` page replacement policy (ClockPro by default), so cold pages spill to disk through the same `BytesLongStorage` infrastructure already used for `seg.onDiskPkToNode`.

## Tests

- **`CompactionAuthorityMapBLinkTest`** (new): builds an authority map across 5 candidates × 1k PKs + 50 newer non-candidates × 5k PKs with a 1 KiB page size and a 4-page resident budget so the BLink **must** spill — asserts the resulting map is exactly the candidate count, that newer-segment supersession picks the highest generation, and that live-shard PKs override candidates with disjoint ranges.
- **`CompactionAuthorityMapCleanupTest`** (new): wraps `MemoryDataStorageManager` with a recording subclass and verifies that one full + many back-to-back `runCompactionCycle()` invocations each leave **zero** orphan `_tmp_cmpaut_*` or `_tmp_pkset_*` indexes; also verifies the early-return path (no candidates) allocates no temp storage.
- **`PagedPkSetTest`** (new): unit tests `add`/`contains`/`forEach`/idempotent-add/`close`-fires-once and a 5 000-PK spill scenario.
- **`VectorIndexCompactorLivePkFilterTest`** updated for the candidate-only contract: PKs that exist exclusively in newer non-candidate segments or in live shards are no longer recorded; added two new cases that exercise multi-segment supersession ordering and live-shard-over-newer-segment dominance, plus encoder round-trip / range-check defensive tests.
- Full vector-package suite (200 tests) and the compaction hammer suite (`DirectMultipleConcurrentUpdatesSuiteNoIndexes/WithNonUniqueIndexes/WithUniqueIndexes` — 12 tests, run twice) green.
- Pre-PR validation (`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`) green across all 22 modules.

🤖 Implemented by the `pr-worker` agent.