### PR TITLE
issue #97: skip commitlog PVC and volumeMount when storageMode=remote

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
@@ -114,8 +114,10 @@ spec:
             {{- end }}
             - name: data
               mountPath: /opt/herddb/data
+            {{- if eq .Values.server.storageMode "local" }}
             - name: commitlog
               mountPath: /opt/herddb/commitlog
+            {{- end }}
       volumes:
         - name: server-config
           configMap:
@@ -131,6 +133,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.server.storage.data.size }}
+    {{- if eq .Values.server.storageMode "local" }}
     - metadata:
         name: commitlog
       spec:
@@ -141,3 +144,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.server.storage.commitlog.size }}
+    {{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
@@ -44,12 +44,24 @@ tests:
             containerPort: 9845
             protocol: TCP
 
-  - it: should have two volumeClaimTemplates (data and commitlog)
+  - it: should have two volumeClaimTemplates (data and commitlog) when storageMode is local
     template: templates/server-statefulset.yaml
+    set:
+      server.storageMode: local
     asserts:
       - lengthEqual:
           path: spec.volumeClaimTemplates
           count: 2
+
+  - it: should have one volumeClaimTemplate (data only) when storageMode is remote
+    template: templates/server-statefulset.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.volumeClaimTemplates
+          count: 1
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
 
   - it: should mount the server config file
     template: templates/server-statefulset.yaml
@@ -70,10 +82,21 @@ tests:
             name: data
             mountPath: /opt/herddb/data
 
-  - it: should mount commitlog PVC at /opt/herddb/commitlog
+  - it: should mount commitlog PVC at /opt/herddb/commitlog when storageMode is local
     template: templates/server-statefulset.yaml
+    set:
+      server.storageMode: local
     asserts:
       - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: commitlog
+            mountPath: /opt/herddb/commitlog
+
+  - it: should not mount commitlog volumeMount when storageMode is remote
+    template: templates/server-statefulset.yaml
+    asserts:
+      - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: commitlog

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -46,6 +46,10 @@ server:
     data:
       size: 10Gi
       storageClass: ""
+    # commitlog PVC is only provisioned when storageMode: local.
+    # When storageMode: remote (the default), HerdDB uses BookKeeper as its
+    # write-ahead log and the local commitlog directory is not written to,
+    # so no PVC is created.
     commitlog:
       size: 5Gi
       storageClass: ""


### PR DESCRIPTION
Fixes #97.

## Changes

- **`herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml`**: wrapped the `commitlog` `volumeMount` and `volumeClaimTemplate` in `{{- if eq .Values.server.storageMode "local" }}` guards. When `storageMode: remote` (the default for cluster/GKE deployments), BookKeeper is the write-ahead log and the local commitlog directory is never written to, so no PVC is provisioned.
- **`herddb-kubernetes/src/main/helm/herddb/values.yaml`**: added a comment to the `storage.commitlog` block documenting that it is only used when `storageMode: local`.

## Tests

- Updated "should have two volumeClaimTemplates (data and commitlog)" test to explicitly set `server.storageMode: local` so the two-PVC assertion remains valid.
- Updated "should mount commitlog PVC at /opt/herddb/commitlog" test to set `server.storageMode: local`.
- Added **"should have one volumeClaimTemplate (data only) when storageMode is remote"**: asserts `spec.volumeClaimTemplates` has length 1 with default values (`storageMode: remote`).
- Added **"should not mount commitlog volumeMount when storageMode is remote"**: asserts the commitlog `volumeMount` is absent with default values.

All 127 helm-unittest cases pass. `helm lint` is clean.

## Notes for operators upgrading existing clusters

If you are upgrading a Helm release that was previously deployed with `storageMode: remote`, Helm will **not** automatically delete the now-orphaned `commitlog-herddb-server-N` PVCs (Kubernetes does not remove StatefulSet PVCs on upgrade). You can delete them manually once the server pod has been restarted and is running cleanly:

```bash
kubectl delete pvc commitlog-herddb-server-0
```

🤖 Implemented by the `pr-worker` agent.