### PR TITLE
JDK 25 + Netty 4.1.121: enable Unsafe memory access for no-cleaner direct buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ herddb-core/nbproject/
 # Benchmark datasets
 vector-testings/datasets/
 
+# local-bench fallback workspace (when neither HERDDB_TESTS_HOME nor
+# HERDDB_SERVER_HOME is set, the local-bench scripts default to this dir).
+herddb-services/examples/local-bench/workspace/
+
 # Mac
 **/.DS_Store
 

--- a/herddb-services/examples/local-bench/install.sh
+++ b/herddb-services/examples/local-bench/install.sh
@@ -29,7 +29,7 @@
 #   --zip <path>                 Path to the herddb-services-*.zip to install.
 #                                Default: auto-discover from herddb-services/target.
 #   --server-heap <size>         -Xms/-Xmx for the server JVM (default: 15g).
-#   --indexing-heap <size>       -Xms/-Xmx for the indexing-service JVM (default: 40g).
+#   --indexing-heap <size>       -Xms/-Xmx for the indexing-service JVM (default: 30g).
 #   --indexing-rebuild-threads N Threads for vector index rebuild (default: 8).
 #   --reuse                      Do not wipe $CLUSTER_DIR if it already exists;
 #                                just (re-)start the services.
@@ -52,7 +52,7 @@ source "$SCRIPT_DIR/scripts/common.sh"
 
 ZIP=""
 SERVER_HEAP="15g"
-INDEXING_HEAP="40g"
+INDEXING_HEAP="30g"
 INDEXING_REBUILD_THREADS="8"
 REUSE=false
 
@@ -151,11 +151,13 @@ fi
 # ── Start the server ─────────────────────────────────────────────────────────
 section "Starting HerdDB server (heap=${SERVER_HEAP})"
 export JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx${SERVER_HEAP} -Xms${SERVER_HEAP} \
--Dio.netty.maxDirectMemory=0 -Djava.net.preferIPv4Stack=true \
--XX:MaxDirectMemorySize=1g -XX:+DisableExplicitGC -Djava.awt.headless=true \
+-Djava.net.preferIPv4Stack=true \
+-XX:MaxDirectMemorySize=4g -Dio.netty.maxDirectMemory=4294967296 \
+-XX:+DisableExplicitGC -Djava.awt.headless=true \
 -Djava.util.logging.config.file=conf/logging.properties \
 --add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError \
 -XX:HeapDumpPath=$CLUSTER_DIR/server-heapdump.hprof \
+-Dherddb.file.requirefsync=false \
 -Djava.io.tmpdir=$CLUSTER_DIR/tmp"
 bin/service server start
 
@@ -166,10 +168,12 @@ section "Starting indexing service (heap=${INDEXING_HEAP}, rebuild-threads=${IND
 export JAVA_OPTS="-XX:+UseG1GC -Duser.language=en \
 -Dherddb.vectorindex.rebuild.threads=${INDEXING_REBUILD_THREADS} \
 -Djava.net.preferIPv4Stack=true -Xmx${INDEXING_HEAP} -Xms${INDEXING_HEAP} \
+-XX:MaxDirectMemorySize=2g -Dio.netty.maxDirectMemory=4294967296 \
 -Djava.awt.headless=true \
 -Djava.util.logging.config.file=conf/logging.properties \
 -XX:+HeapDumpOnOutOfMemoryError \
 -XX:HeapDumpPath=$CLUSTER_DIR/indexingservice-heapdump.hprof \
+-Dherddb.file.requirefsync=false \
 --add-modules jdk.incubator.vector -Djava.io.tmpdir=$CLUSTER_DIR/tmp"
 bin/service indexing-service start
 

--- a/herddb-services/src/main/resources/bin/setenv.sh
+++ b/herddb-services/src/main/resources/bin/setenv.sh
@@ -31,7 +31,24 @@ JVECTOR_JAVA_OPTS="--add-modules jdk.incubator.vector -XX:CompileCommandFile=con
 # JAVA_OPTS_EXTRA / JDK_JAVA_OPTIONS_EXTRA: appended to the final value, so
 # deployments (e.g. the Helm chart's server.javaOptsExtra) can ADD flags
 # on top of the defaults without having to re-specify the baseline.
-JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS:---add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --enable-native-access=ALL-UNNAMED} ${JDK_JAVA_OPTIONS_EXTRA:-}"
+#
+# --add-opens=java.base/java.nio=ALL-UNNAMED + -Dio.netty.tryReflectionSetAccessible=true
+# are required so that Netty's PlatformDependent can reflectively install its own
+# off-heap memory accounting and avoid the JVM's Bits.reserveMemory direct-buffer
+# limit on JDK 9+. Without these flags Netty falls back to ByteBuffer.allocateDirect
+# and every direct allocation (pooled and unpooled) is bounded by -XX:MaxDirectMemorySize,
+# which causes OutOfMemoryError under heavy ingestion.
+#
+# --sun-misc-unsafe-memory-access=allow re-enables sun.misc.Unsafe memory-access
+# methods on JDK 24+ (where the default is "warn" and may become "deny" on
+# JDK 26+). Netty 4.1.120 and 4.1.121 disabled their internal Unsafe usage by
+# default to silence the JEP 498 warnings, which made
+# PlatformDependent.useDirectBufferNoCleaner() return false and forced every
+# direct allocation back through Bits.reserveMemory — defeating
+# -Dio.netty.maxDirectMemory.  This flag restores the no-cleaner pooled path
+# until we upgrade to Netty 4.1.122+ (where the default was reverted) or 4.2.x
+# (FFM-based and Unsafe-free).
+JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS:---add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dio.netty.tryReflectionSetAccessible=true} ${JDK_JAVA_OPTIONS_EXTRA:-}"
 JAVA_OPTS="${JAVA_OPTS:--XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=1g -Dio.netty.maxDirectMemory=0 -XX:+DisableExplicitGC -Djava.awt.headless=true -Djava.util.logging.config.file=conf/logging.properties} $JVECTOR_JAVA_OPTS ${JAVA_OPTS_EXTRA:-}"
 # Export so the settings reach child java processes started by launcher
 # scripts that rely on the JDK picking JDK_JAVA_OPTIONS up automatically

--- a/pom.xml
+++ b/pom.xml
@@ -725,7 +725,7 @@
                         <configuration>
                             <reuseForks>false</reuseForks>
                             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-                            <argLine>-Dzookeeper.forceSync=no -Dio.netty.tryReflectionSetAccessible=true -Xmx2G -XX:+UseG1GC -Djava.io.tmpdir=${project.build.directory} --add-opens=java.base/java.nio=ALL-UNNAMED  --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
+                            <argLine>-Dzookeeper.forceSync=no -Dio.netty.tryReflectionSetAccessible=true -Xmx2G -XX:+UseG1GC -Djava.io.tmpdir=${project.build.directory} --add-opens=java.base/java.nio=ALL-UNNAMED  --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow</argLine>
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>
                     </plugin>
@@ -968,7 +968,7 @@
                         <version>3.0.0-M5</version>
                         <configuration>
                             <reuseForks>false</reuseForks>
-                            <argLine> --add-opens=java.base/java.nio=ALL-UNNAMED  --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Xmx2G -XX:+UseG1GC  @{argLine}</argLine>
+                            <argLine> --add-opens=java.base/java.nio=ALL-UNNAMED  --add-opens=java.base/java.io=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xmx2G -XX:+UseG1GC  @{argLine}</argLine>
                             <trimStackTrace>false</trimStackTrace>
                             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                             <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>


### PR DESCRIPTION
## Summary

Netty 4.1.120 and 4.1.121 disabled their internal `sun.misc.Unsafe` usage by default ([netty/netty#14975](https://github.com/netty/netty/pull/14975)) to silence JEP 498 warnings on JDK 24+. With Unsafe disabled, `PlatformDependent.useDirectBufferNoCleaner()` returns `false`: every Netty direct buffer (pooled **and** unpooled) falls back to `ByteBuffer.allocateDirect` → `java.nio.Bits.reserveMemory`, which is bounded by `-XX:MaxDirectMemorySize`. The result is `OutOfMemoryError` under heavy ingestion even though `-Dio.netty.maxDirectMemory` was set generously.

Netty 4.1.122 ([netty/netty#15296](https://github.com/netty/netty/pull/15296)) reverts the default. Until HerdDB upgrades (commit c0cf458e downgraded us 4.1.130 → 4.1.121 for issue #274), add `--sun-misc-unsafe-memory-access=allow` to:

- `herddb-services/src/main/resources/bin/setenv.sh` — applies to every JVM launched via `bin/service` (server, indexing-service, file-server, bookkeeper) and to the CLI tools that inherit `JDK_JAVA_OPTIONS` (`herddb-cli.sh`, `vector-bench.sh`, `indexing-admin.sh`).
- `pom.xml` — both Surefire `argLine`s (default and `ci` profile) so unit tests on JDK 25 don't take the slow `Bits.reserveMemory` path either.

## Verification

Reproduced locally on Eclipse Temurin **JDK 25.0.2** with the in-tree Netty **4.1.121**.

**Before** (no flag): server saturates `-XX:MaxDirectMemorySize=1g`, OOMs at 160k/1M rows even with `-Dio.netty.maxDirectMemory=4g`. `netty_used_direct_memory_bytes` Prometheus gauge stuck at `-1` (counter inactive).

**After** (with flag): server peak direct memory ~300 MiB, **0 OutOfMemoryErrors** through the full gist1m bench (1M vectors × 960-dim, 8 ingest threads, 5000 batch, post-ingest checkpoint, recall queries). `netty_used_direct_memory_bytes` reports actual usage (counter active).

| Metric | Before | After |
|---|---|---|
| `netty_used_direct_memory_bytes` | `-1` | active (~134 MiB at end) |
| Server direct mem peak | hits 1024/1024 MiB cap | ~300 MiB / 4 GiB |
| OOMs in 1M-row ingest | 30–66 | **0** |
| Ingest throughput | bench fails | 20,332 rows/s |
| Recall@10 | bench fails | 0.91 |

## Also included

`herddb-services/examples/local-bench/install.sh` got a small batch of bench-tuning changes that emerged from this investigation:

- `-Dherddb.file.requirefsync=false` for both server and indexing-service (benchmark-only — never use this in production).
- Explicit `-XX:MaxDirectMemorySize` and `-Dio.netty.maxDirectMemory` for both services (was leaving Netty at `=0`/JVM-bound; now explicit and consistent).
- Indexing-service heap reduced from 40g → 30g so the `(server) + (IS)` budget fits in a 61 GiB host with headroom for the OS.
- Documentation comments explaining the layout.

These are isolated to the `examples/local-bench` directory and don't affect production defaults.

## Test plan

- [ ] CI runs all unit tests with the new Surefire `argLine` on JDK 25
- [ ] Smoke-test the `local-bench` example: `./teardown.sh && ./install.sh && ./scripts/run-bench.sh --dataset gist1m -n 1000000 --ingest-threads 8 --batch-size 5000 --checkpoint --wait-for-indexes`

## Long-term follow-up

When HerdDB is upgraded back to **Netty 4.1.122+** (or **4.2.x**, which is FFM-based and Unsafe-free), the `--sun-misc-unsafe-memory-access=allow` flag in `setenv.sh` becomes redundant and the comment block can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)