### PR TITLE
issue #285: add count-based compaction trigger to prevent unbounded segment accumulation

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -414,7 +414,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private volatile long vectorIndexCompactionMinBytes = 256L * 1024 * 1024;
     private volatile long vectorIndexCompactionMaxBytes = 1024L * 1024 * 1024;
     private volatile int vectorIndexCompactionMinCount = 4;
+    /**
+     * Count-based compaction trigger (issue #285): fire compaction when the
+     * segment count reaches this ceiling, even if the total-byte threshold
+     * has not been met.  Prevents unbounded segment accumulation during
+     * tailing catch-up when each checkpoint produces many small segments.
+     */
+    private volatile int vectorIndexCompactionMaxCount = 200;
     private volatile long vectorIndexCompactionRetentionMs = 10L * 60_000L;
+
+    /**
+     * Log a WARNING during Phase A when the total on-disk segment count
+     * exceeds this threshold, making runaway accumulation visible without
+     * having to parse checkpoint log lines.
+     */
+    static final int COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD = 50;
 
     // Compaction metrics
     final AtomicLong compactionRunsTotal = new AtomicLong();
@@ -1289,11 +1303,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * re-tune a running store.
      */
     public void configureCompaction(long intervalMs, long minBytes, long maxBytes,
-                                    int minCount, long retentionMs) {
+                                    int minCount, int maxCount, long retentionMs) {
         this.vectorIndexCompactionIntervalMs = intervalMs;
         this.vectorIndexCompactionMinBytes = minBytes;
         this.vectorIndexCompactionMaxBytes = maxBytes;
         this.vectorIndexCompactionMinCount = minCount;
+        this.vectorIndexCompactionMaxCount = maxCount;
         this.vectorIndexCompactionRetentionMs = retentionMs;
     }
 
@@ -1513,8 +1528,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     snapshot,
                     vectorIndexCompactionMinCount,
                     vectorIndexCompactionMinBytes,
-                    vectorIndexCompactionMaxBytes);
+                    vectorIndexCompactionMaxBytes,
+                    vectorIndexCompactionMaxCount);
             if (candidates.isEmpty()) {
+                if (snapshot.size() >= COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD) {
+                    LOGGER.log(Level.WARNING,
+                            "vector store {0}: {1} segments accumulated but neither byte "
+                                    + "threshold ({2} bytes) nor count trigger ({3} segments) "
+                                    + "fired; consider lowering vector.index.compaction.minBytes "
+                                    + "or vector.index.compaction.maxCount",
+                            new Object[]{indexName, snapshot.size(),
+                                    vectorIndexCompactionMinBytes,
+                                    vectorIndexCompactionMaxCount});
+                }
                 return;
             }
 
@@ -2752,6 +2778,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // demote the smallest sealed segments back to the mergeable pool so
             // the upcoming Phase B compacts them into larger segments.
             demoteSmallestSealedSegments(sealedSegments, mergeableSegments);
+
+            // Warn when the total on-disk segment count is unusually high.
+            // This makes runaway accumulation (issue #285) visible in the logs
+            // without needing to inspect checkpoint detail lines.
+            int totalOnDiskSegments = sealedSegments.size() + mergeableSegments.size();
+            if (totalOnDiskSegments > COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD) {
+                LOGGER.log(Level.WARNING,
+                        "checkpoint {0} Phase A: high on-disk segment count: {1} segments "
+                                + "({2} sealed + {3} mergeable); graph-merge compaction "
+                                + "may not be keeping up",
+                        new Object[]{indexName, totalOnDiskSegments,
+                                sealedSegments.size(), mergeableSegments.size()});
+            }
 
             this.frozenShards = snapshotShards;
             // Use a BLink-paged PK set so memory stays bounded even when

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -143,12 +143,17 @@ final class VectorIndexCompactor {
      *   <li>a minimum total-size threshold ({@code minTotalBytes});</li>
      *   <li>a hard per-run byte cap ({@code maxTotalBytes}) to bound
      *       temporary write amplification;</li>
+     *   <li>a count-based secondary trigger ({@code maxCount}): if the
+     *       picked set reaches {@code maxCount} segments the byte
+     *       threshold is waived and compaction fires regardless — this
+     *       prevents unbounded segment accumulation when many small shards
+     *       are produced during tailing catch-up (issue #285);</li>
      *   <li>smallest-first ordering to maximise the contraction ratio
      *       and avoid rewriting already-large segments.</li>
      * </ul>
      *
-     * <p>Returns an empty list when either the count or size thresholds
-     * are not met, signalling that compaction should not fire yet.
+     * <p>Returns an empty list when neither the byte threshold nor the
+     * count trigger is satisfied.
      *
      * <p>Package-private for unit tests.
      */
@@ -156,7 +161,8 @@ final class VectorIndexCompactor {
             List<VectorSegment> candidates,
             int minCount,
             long minTotalBytes,
-            long maxTotalBytes) {
+            long maxTotalBytes,
+            int maxCount) {
         if (candidates == null || candidates.size() < minCount) {
             return new ArrayList<>();
         }
@@ -174,10 +180,19 @@ final class VectorIndexCompactor {
             total += seg.estimatedSizeBytes;
         }
 
-        if (picked.size() < minCount || total < minTotalBytes) {
-            return new ArrayList<>();
+        // Standard byte-threshold trigger.
+        if (picked.size() >= minCount && total >= minTotalBytes) {
+            return picked;
         }
-        return picked;
+        // Count-based trigger (issue #285): fire even if the byte threshold
+        // is not met when too many segments have accumulated.  This guards
+        // against the scenario where every segment is individually small
+        // (e.g. catch-up with tiny shards) and the sum never reaches
+        // minTotalBytes despite hundreds of segments building up.
+        if (picked.size() >= maxCount) {
+            return picked;
+        }
+        return new ArrayList<>();
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/index/vector/CompactionAuthorityMapCleanupTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/CompactionAuthorityMapCleanupTest.java
@@ -113,7 +113,7 @@ public class CompactionAuthorityMapCleanupTest {
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
         // Aggressive compaction policy: any segment count >= 4 with any size triggers a cycle.
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 
@@ -210,7 +210,7 @@ public class CompactionAuthorityMapCleanupTest {
             // Raise the min-segment-count threshold above any segment count
             // we'll reach so the cycle returns early.
             store.start();
-            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 1000, 0);
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 1000, Integer.MAX_VALUE, 0);
 
             // No segments at all => candidates.isEmpty() => early return.
             int initBefore = dsm.initCallsCmpaut.get();

--- a/herddb-core/src/test/java/herddb/index/vector/Issue255CompactionOrdinalGapTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue255CompactionOrdinalGapTest.java
@@ -73,7 +73,7 @@ public class Issue255CompactionOrdinalGapTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
@@ -82,7 +82,7 @@ public class Issue256CheckpointFormatTest {
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE,
                 VectorSimilarityFunction.COSINE, Long.MAX_VALUE, null, 0, 0);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256CompactionReleaseTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256CompactionReleaseTest.java
@@ -83,7 +83,7 @@ public class Issue256CompactionReleaseTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256LongNodeIdTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256LongNodeIdTest.java
@@ -72,7 +72,7 @@ public class Issue256LongNodeIdTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 
@@ -186,7 +186,7 @@ public class Issue256LongNodeIdTest {
                 Long.MAX_VALUE,
                 io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE,
                 Long.MAX_VALUE, null, 0, 0)) {
-            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
             store.start();
             store.seedNextNodeIdForTest(seeded);
 
@@ -209,7 +209,7 @@ public class Issue256LongNodeIdTest {
                 Long.MAX_VALUE,
                 io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE,
                 Long.MAX_VALUE, null, 0, 0)) {
-            reloaded.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+            reloaded.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
             reloaded.start();
             long reloadedCounter = reloaded.getNextNodeId();
             assertTrue("reloaded nextNodeId must be > Integer.MAX_VALUE (saw "

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256PhaseCShardTeardownTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256PhaseCShardTeardownTest.java
@@ -72,7 +72,7 @@ public class Issue256PhaseCShardTeardownTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue282ConcurrentRotationTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue282ConcurrentRotationTest.java
@@ -95,7 +95,7 @@ public class Issue282ConcurrentRotationTest {
                 /*fusedPQ=*/true, /*maxSegmentSize=*/2_000_000_000L,
                 /*maxLiveGraphSize=*/shardCap,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue285SegmentCountCompactionTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue285SegmentCountCompactionTest.java
@@ -1,0 +1,181 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #285: count-based compaction trigger.
+ *
+ * <p>In a catch-up scenario the Indexing Service creates many small segments
+ * whose individual byte sizes never reach the {@code minBytes} threshold, so
+ * the standard byte trigger never fires and segments accumulate indefinitely.
+ * The fix adds a {@code maxCount} knob: when the number of non-sealed segments
+ * reaches or exceeds {@code maxCount} the compaction cycle fires regardless of
+ * the byte total.
+ *
+ * <p>This test uses a very high {@code minBytes} (effectively unreachable with
+ * tiny vectors) and a low {@code maxCount} to verify that compaction fires
+ * purely on segment count.
+ */
+public class Issue285SegmentCountCompactionTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    /**
+     * Builds a store whose byte threshold is unreachably high (Long.MAX_VALUE)
+     * but whose maxCount is set to a small number, then inserts enough vectors
+     * across multiple checkpoints to exceed maxCount and verifies that
+     * {@link PersistentVectorStore#runCompactionCycle()} fires.
+     */
+    @Test
+    public void countTriggerFiresWhenBytesNeverReachThreshold() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        // maxCount = 6: compaction fires once we have >= 6 non-sealed segments.
+        // minBytes = Long.MAX_VALUE / 2: never reachable with tiny test vectors.
+        int maxCount = 6;
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx285", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ Long.MAX_VALUE / 2,   // unreachably high
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ 2,
+                /*maxCount*/ maxCount,
+                /*retentionMs*/ 0);
+
+        try (store) {
+            store.start();
+            Random rng = new Random(285);
+            int dim = 8;
+
+            // Create 8 checkpoints of 200 vectors each = 8 on-disk segments.
+            // Byte total is tiny — the byte trigger cannot fire.
+            int numCheckpoints = 8;
+            for (int c = 0; c < numCheckpoints; c++) {
+                for (int i = 0; i < 200; i++) {
+                    float[] vec = new float[dim];
+                    for (int d = 0; d < dim; d++) {
+                        vec[d] = rng.nextFloat();
+                    }
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec);
+                }
+                store.checkpoint();
+            }
+
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("need >= maxCount segments to exercise count trigger, got "
+                    + segmentsBefore, segmentsBefore >= maxCount);
+
+            long runsBefore = store.getCompactionRunsTotal();
+            long successesBefore = store.getCompactionSuccessesTotal();
+
+            store.runCompactionCycle();
+
+            assertEquals("compaction run counter must advance",
+                    runsBefore + 1, store.getCompactionRunsTotal());
+            assertEquals("count trigger must produce at least one successful compaction",
+                    successesBefore + 1, store.getCompactionSuccessesTotal());
+            assertTrue("segment count must decrease after count-triggered compaction",
+                    store.getSegmentCount() < segmentsBefore);
+            assertEquals("no consecutive failures expected",
+                    0, store.getCompactionConsecutiveFailures());
+        }
+    }
+
+    /**
+     * Verifies the opposite: when the segment count stays below {@code maxCount}
+     * and the byte threshold is also not met, the cycle does NOT fire.
+     */
+    @Test
+    public void neitherTriggerFiresWhenBelowBothThresholds() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        // maxCount = 100: we will only create 3 segments.
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx285b", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ Long.MAX_VALUE / 2,   // unreachably high
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ 2,
+                /*maxCount*/ 100,                  // way above 3 segments
+                /*retentionMs*/ 0);
+
+        try (store) {
+            store.start();
+            Random rng = new Random(286);
+            int dim = 8;
+            for (int c = 0; c < 3; c++) {
+                for (int i = 0; i < 200; i++) {
+                    float[] vec = new float[dim];
+                    for (int d = 0; d < dim; d++) {
+                        vec[d] = rng.nextFloat();
+                    }
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec);
+                }
+                store.checkpoint();
+            }
+
+            int segmentsBefore = store.getSegmentCount();
+            long successesBefore = store.getCompactionSuccessesTotal();
+            store.runCompactionCycle();
+            // The run counter increments unconditionally; what must NOT change
+            // is the segment count and the success counter.
+            assertEquals("no successful compaction when below both thresholds",
+                    successesBefore, store.getCompactionSuccessesTotal());
+            assertEquals("segment count must be unchanged when no trigger fires",
+                    segmentsBefore, store.getSegmentCount());
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorChooseTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorChooseTest.java
@@ -42,7 +42,8 @@ public class VectorIndexCompactorChooseTest {
         cand.add(seg(1, 200L * 1024 * 1024));
         cand.add(seg(2, 200L * 1024 * 1024));
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
-                cand, /*minCount*/ 4, /*minBytes*/ 10, /*maxBytes*/ Long.MAX_VALUE);
+                cand, /*minCount*/ 4, /*minBytes*/ 10, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE);
         assertTrue(picked.isEmpty());
     }
 
@@ -53,7 +54,8 @@ public class VectorIndexCompactorChooseTest {
             cand.add(seg(i, 1024L)); // 10 KB total
         }
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
-                cand, /*minCount*/ 2, /*minBytes*/ 1L * 1024 * 1024, /*maxBytes*/ Long.MAX_VALUE);
+                cand, /*minCount*/ 2, /*minBytes*/ 1L * 1024 * 1024, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE);
         assertTrue(picked.isEmpty());
     }
 
@@ -66,7 +68,8 @@ public class VectorIndexCompactorChooseTest {
         cand.add(seg(4, 2000L * 1024 * 1024));
         // Cap = 250 MB: we should pick 3 (50) + 2 (100) = 150 MB; 1 (500) would overflow.
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
-                cand, /*minCount*/ 2, /*minBytes*/ 1L, /*maxBytes*/ 250L * 1024 * 1024);
+                cand, /*minCount*/ 2, /*minBytes*/ 1L, /*maxBytes*/ 250L * 1024 * 1024,
+                /*maxCount*/ Integer.MAX_VALUE);
         assertEquals(2, picked.size());
         assertEquals(3, picked.get(0).segmentId);
         assertEquals(2, picked.get(1).segmentId);
@@ -79,21 +82,102 @@ public class VectorIndexCompactorChooseTest {
         cand.add(seg(2, 100L));
         cand.add(seg(3, 100L));
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
-                cand, 2, 1L, Long.MAX_VALUE);
+                cand, 2, 1L, Long.MAX_VALUE, Integer.MAX_VALUE);
         assertEquals(3, picked.size());
     }
 
     @Test
     public void emptyInputReturnsEmpty() {
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
-                new ArrayList<>(), 1, 1L, Long.MAX_VALUE);
+                new ArrayList<>(), 1, 1L, Long.MAX_VALUE, Integer.MAX_VALUE);
         assertTrue(picked.isEmpty());
     }
 
     @Test
     public void nullInputReturnsEmpty() {
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
-                null, 1, 1L, Long.MAX_VALUE);
+                null, 1, 1L, Long.MAX_VALUE, Integer.MAX_VALUE);
         assertTrue(picked.isEmpty());
+    }
+
+    // ---- Tests for the count-based trigger (issue #285) ----
+
+    /**
+     * When byte threshold is NOT met but segment count >= maxCount,
+     * compaction must fire.
+     */
+    @Test
+    public void countTriggerFiresWhenBytesNotMet() {
+        List<VectorSegment> cand = new ArrayList<>();
+        // 10 tiny segments (100 bytes each) — total = 1000 bytes.
+        // minBytes = 1 MB, so byte threshold is never reached.
+        // maxCount = 10 → count-based trigger must fire.
+        for (int i = 0; i < 10; i++) {
+            cand.add(seg(i, 100L));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1L * 1024 * 1024,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 10);
+        assertEquals("count trigger must return all 10 candidates", 10, picked.size());
+    }
+
+    /**
+     * When count is just below maxCount, neither byte nor count trigger fires.
+     */
+    @Test
+    public void countTriggerDoesNotFireBelowMaxCount() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            cand.add(seg(i, 100L));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1L * 1024 * 1024,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 10);
+        assertTrue("should not fire when count < maxCount", picked.isEmpty());
+    }
+
+    /**
+     * Byte trigger takes priority: when byte threshold IS met at lower count,
+     * the result must be that subset even if maxCount has not been reached.
+     */
+    @Test
+    public void byteThresholdTakesPriorityOverCountTrigger() {
+        List<VectorSegment> cand = new ArrayList<>();
+        // 5 segments each 50 MB — total = 250 MB >= minBytes = 200 MB.
+        // maxCount = 100 (unreachable here), minCount = 2.
+        for (int i = 0; i < 5; i++) {
+            cand.add(seg(i, 50L * 1024 * 1024));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 200L * 1024 * 1024,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 100);
+        assertEquals("byte trigger fires normally with 5 segments", 5, picked.size());
+    }
+
+    /**
+     * Segments that individually exceed maxBytes are excluded from the picked
+     * list even under the count trigger.  The count trigger operates only on
+     * the segments that already passed the maxBytes filter.
+     */
+    @Test
+    public void countTriggerRespectsMaxBytesPerSegmentCap() {
+        List<VectorSegment> cand = new ArrayList<>();
+        // 5 small segments (10 B each) + 5 huge segments (3 GB each).
+        // maxBytes cap = 1 GB, so huge segments are cut from picked.
+        // Only 5 small fit → count = 5 = maxCount = 5 → trigger fires.
+        for (int i = 0; i < 5; i++) {
+            cand.add(seg(i, 10L));
+        }
+        for (int i = 5; i < 10; i++) {
+            cand.add(seg(i, 3L * 1024 * 1024 * 1024));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1L * 1024 * 1024 * 1024,
+                /*maxBytes*/ 1L * 1024 * 1024 * 1024, /*maxCount*/ 5);
+        assertEquals("only the 5 small segments should be picked", 5, picked.size());
+        for (VectorSegment s : picked) {
+            assertTrue("no huge segment should be in the result",
+                    s.estimatedSizeBytes <= 10L);
+        }
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorConcurrentDeleteTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorConcurrentDeleteTest.java
@@ -63,7 +63,7 @@ public class VectorIndexCompactorConcurrentDeleteTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorEndToEndTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorEndToEndTest.java
@@ -79,6 +79,7 @@ public class VectorIndexCompactorEndToEndTest {
                 /*minBytes*/ 1L,
                 /*maxBytes*/ Long.MAX_VALUE,
                 /*minCount*/ 4,
+                /*maxCount*/ Integer.MAX_VALUE,
                 /*retentionMs*/ 0);
         return store;
     }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorFailureTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorFailureTest.java
@@ -80,7 +80,7 @@ public class VectorIndexCompactorFailureTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorMetricsTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorMetricsTest.java
@@ -67,7 +67,7 @@ public class VectorIndexCompactorMetricsTest {
                 tmpDir, dsm, mm,
                 16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
                 Long.MAX_VALUE);
-        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         return store;
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexShadowReloadTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexShadowReloadTest.java
@@ -81,7 +81,7 @@ public class VectorIndexShadowReloadTest {
                 Long.MAX_VALUE,
                 io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE,
                 Long.MAX_VALUE);
-        leader.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        leader.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         leader.start();
 
         try {
@@ -139,7 +139,7 @@ public class VectorIndexShadowReloadTest {
                 Long.MAX_VALUE,
                 io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE,
                 Long.MAX_VALUE);
-        leader.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, 0);
+        leader.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
         leader.start();
 
         PersistentVectorStore shadow = new PersistentVectorStore(

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -151,6 +151,18 @@ public final class IndexingServerConfiguration {
             1024L * 1024 * 1024; // 1 GB
 
     /**
+     * Count-based compaction trigger (issue #285): fire compaction when the
+     * on-disk segment count reaches this ceiling, even if the total byte
+     * threshold ({@link #PROPERTY_VECTOR_INDEX_COMPACTION_MIN_BYTES}) has not
+     * been met. Prevents unbounded segment accumulation during tailing
+     * catch-up when each checkpoint produces many small segments.
+     * Set to {@code Integer.MAX_VALUE} to disable the count trigger entirely.
+     */
+    public static final String PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT =
+            "vector.index.compaction.maxCount";
+    public static final int PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT_DEFAULT = 200;
+
+    /**
      * How long old segment files remain on-disk after a compaction swap
      * before the reaper may physically delete them. Also gated by
      * {@code shadowAckedGeneration}: reclaim waits for the later of the

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -405,6 +405,9 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             final long vectorCompactionRetentionMs = config.getLong(
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_RETENTION_MS,
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_RETENTION_MS_DEFAULT);
+            final int vectorCompactionMaxCount = config.getInt(
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT,
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT_DEFAULT);
             final long maxLiveBytesPerCheckpoint = config.getLong(
                     IndexingServerConfiguration.PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT,
                     IndexingServerConfiguration.PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT_DEFAULT);
@@ -483,6 +486,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         vectorCompactionMinBytes,
                         vectorCompactionMaxBytes,
                         /*minCount*/ 4,
+                        vectorCompactionMaxCount,
                         vectorCompactionRetentionMs);
                 try {
                     store.start();
@@ -1571,7 +1575,10 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             AbstractVectorStore store = vectorStores.get(storeKey(idx.table, idx.name));
             long vectorCount = store != null ? store.size() : 0;
             String status = store != null ? "tailing" : "missing";
-            out.add(new IndexDescriptor(idx.tablespace, idx.table, idx.name, vectorCount, status));
+            int segmentCount = (store instanceof PersistentVectorStore)
+                    ? ((PersistentVectorStore) store).getSegmentCount()
+                    : (store != null ? 1 : 0);
+            out.add(new IndexDescriptor(idx.tablespace, idx.table, idx.name, vectorCount, status, segmentCount));
         }
         return out;
     }
@@ -2642,13 +2649,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         private final String index;
         private final long vectorCount;
         private final String status;
+        private final int segmentCount;
 
-        public IndexDescriptor(String tablespace, String table, String index, long vectorCount, String status) {
+        public IndexDescriptor(String tablespace, String table, String index,
+                               long vectorCount, String status, int segmentCount) {
             this.tablespace = tablespace;
             this.table = table;
             this.index = index;
             this.vectorCount = vectorCount;
             this.status = status;
+            this.segmentCount = segmentCount;
         }
 
         public String getTablespace() {
@@ -2669,6 +2679,10 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
 
         public String getStatus() {
             return status;
+        }
+
+        public int getSegmentCount() {
+            return segmentCount;
         }
     }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -269,6 +269,7 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                         .setIndex(nullToEmpty(d.getIndex()))
                         .setVectorCount(d.getVectorCount())
                         .setStatus(nullToEmpty(d.getStatus()))
+                        .setSegmentCount(d.getSegmentCount())
                         .build());
             }
             responseObserver.onNext(builder.build());

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -242,12 +242,12 @@ public final class IndexingAdminCli {
                 if (response.getIndexesCount() == 0) {
                     out.println("(no indexes loaded on this instance)");
                 } else {
-                    out.printf(Locale.ROOT, "%-20s %-20s %-20s %12s %-10s%n",
-                            "TABLESPACE", "TABLE", "INDEX", "VECTORS", "STATUS");
+                    out.printf(Locale.ROOT, "%-20s %-20s %-20s %12s %8s %-10s%n",
+                            "TABLESPACE", "TABLE", "INDEX", "VECTORS", "SEGMENTS", "STATUS");
                     for (IndexDescriptor d : response.getIndexesList()) {
-                        out.printf(Locale.ROOT, "%-20s %-20s %-20s %12d %-10s%n",
+                        out.printf(Locale.ROOT, "%-20s %-20s %-20s %12d %8d %-10s%n",
                                 d.getTablespace(), d.getTable(), d.getIndex(),
-                                d.getVectorCount(), d.getStatus());
+                                d.getVectorCount(), d.getSegmentCount(), d.getStatus());
                     }
                 }
             }
@@ -482,6 +482,7 @@ public final class IndexingAdminCli {
         m.put("table", d.getTable());
         m.put("index", d.getIndex());
         m.put("vector_count", d.getVectorCount());
+        m.put("segment_count", d.getSegmentCount());
         m.put("status", d.getStatus());
         return m;
     }

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -83,6 +83,9 @@ message IndexDescriptor {
     string index = 3;
     int64 vector_count = 4;
     string status = 5;
+    // Number of on-disk segments held by the vector index.
+    // Populated from PersistentVectorStore.getSegmentCount() (issue #285).
+    int32 segment_count = 6;
 }
 
 message ListIndexesRequest {


### PR DESCRIPTION
Fixes #285.

## Root cause

During IS tailing catch-up (or any workload that produces many tiny checkpoints) each on-disk segment is individually small. The existing byte-threshold trigger (`minTotalBytes`) never fires because the sum of segment sizes stays below it, so segments accumulate indefinitely — 2,000+ were observed in the GKE benchmark.

## Changes

- **`VectorIndexCompactor.chooseSegmentsToMerge()`** — adds a `maxCount` parameter (5th arg). When the number of non-sealed candidate segments reaches or exceeds `maxCount`, the cycle fires regardless of the byte total. Standard byte-threshold trigger is unchanged; count trigger is a secondary fallback.
- **`PersistentVectorStore.configureCompaction()`** — exposes the new `maxCount` knob (default 200). Adds:
  - `COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD = 50` constant.
  - WARNING log in `runCompactionCycle()` when segments exceed the threshold but neither trigger fires.
  - WARNING log in checkpoint Phase A when total on-disk segment count is high.
- **`IndexingServerConfiguration`** — adds `PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT` (default 200) so the IS can be tuned via config without code changes.
- **`IndexingServiceEngine`** — reads the new config key and passes it to `configureCompaction()`; `listIndexes()` now populates `segmentCount` in the returned descriptor.
- **`indexing_service.proto`** — adds `int32 segment_count = 6` to `IndexDescriptor` so operators can monitor segment accumulation in list-indexes output.
- **`IndexingServiceImpl`** — populates `segment_count` in the `listIndexes` gRPC response.
- **`IndexingAdminCli`** — adds SEGMENTS column to `list-indexes` tabular output and includes `segment_count` in the JSON map.
- All 15 existing `configureCompaction()` call sites in tests updated to the new 5-arg signature (with `Integer.MAX_VALUE` as `maxCount` to preserve test semantics).

## Tests

- **`Issue285SegmentCountCompactionTest`** — new end-to-end test that builds 8 segments with an unreachably high byte threshold and verifies that the count trigger fires compaction; also verifies no trigger fires when segment count is below both thresholds.
- **`VectorIndexCompactorChooseTest`** — 4 new unit policy cases: count trigger fires at exactly `maxCount`, does not fire below `maxCount`, byte threshold takes priority, and `maxBytes` cap is respected under the count trigger.

🤖 Implemented by the `pr-worker` agent.