### PR TITLE
issue #315: avoid re-downloading Node on every CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,21 +39,23 @@ jobs:
         with:
           java-version: '25'
           distribution: 'oracle'
-      - name: 'Set up Node.js 20'
-        # The herddb-ui module's frontend-maven-plugin will still download
-        # its own pinned Node toolchain into target/node-toolchain (so the
-        # local dev experience matches CI), but having a system Node on
-        # PATH speeds up first-time runs and gives us a fallback if the
-        # pinned download is flaky.
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
         with:
           path: ~/.m2
           key: 'cache'
           restore-keys: 'cache'
+      - name: 'Cache Node toolchain'
+        # frontend-maven-plugin installs Node/npm to ~/.cache/frontend-maven-plugin
+        # (outside target/ so it is not wiped by mvn clean). Caching that
+        # directory avoids re-downloading the Node tarball on every CI run.
+        # The key includes the pom.xml hash so bumping nodeVersion or npmVersion
+        # automatically busts the cache.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/frontend-maven-plugin
+          key: node-toolchain-${{ runner.os }}-${{ hashFiles('herddb-ui/pom.xml') }}
+          restore-keys: node-toolchain-${{ runner.os }}-
       - name: 'Checkout jvector'
         uses: actions/checkout@v4
         with:
@@ -156,18 +158,23 @@ jobs:
         with:
           java-version: '25'
           distribution: 'oracle'
-      - name: 'Set up Node.js 20'
-        # Required by the herddb-ui module — the test phase runs
-        # `vitest run` via frontend-maven-plugin.
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
         with:
           path: ~/.m2
           key: 'cache'
           restore-keys: 'cache'
+      - name: 'Cache Node toolchain'
+        # frontend-maven-plugin installs Node/npm to ~/.cache/frontend-maven-plugin
+        # (outside target/ so it is not wiped by mvn clean). Caching that
+        # directory avoids re-downloading the Node tarball on every CI run.
+        # The key includes the pom.xml hash so bumping nodeVersion or npmVersion
+        # automatically busts the cache.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/frontend-maven-plugin
+          key: node-toolchain-${{ runner.os }}-${{ hashFiles('herddb-ui/pom.xml') }}
+          restore-keys: node-toolchain-${{ runner.os }}-
       - name: 'Download build artifacts'
         uses: actions/download-artifact@v4
         with:
@@ -267,16 +274,6 @@ jobs:
         with:
           java-version: '25'
           distribution: 'oracle'
-      - name: 'Set up Node.js 20'
-        # herddb-services depends on the herddb-ui WAR; even though
-        # frontend-maven-plugin only runs in the herddb-ui module, the
-        # full reactor build executed here picks up the pre-built
-        # artifact via download-artifact and never invokes Node directly.
-        # We still install Node defensively so that `mvn verify` will not
-        # block if any future test reaches into the SPA tooling.
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
         with:

--- a/herddb-ui/pom.xml
+++ b/herddb-ui/pom.xml
@@ -159,7 +159,15 @@
                 <configuration>
                     <nodeVersion>${frontend.node.version}</nodeVersion>
                     <npmVersion>${frontend.npm.version}</npmVersion>
-                    <installDirectory>${project.build.directory}/node-toolchain</installDirectory>
+                    <!--
+                        Install the Node/npm toolchain outside target/ so it
+                        survives `mvn clean` and can be cached by CI.
+                        In GitHub Actions the cache key is based on the
+                        herddb-ui/pom.xml hash (see .github/workflows/ci.yml),
+                        so bumping nodeVersion or npmVersion automatically
+                        busts the cache and triggers a fresh download.
+                    -->
+                    <installDirectory>${user.home}/.cache/frontend-maven-plugin</installDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixes #315.

## Changes
- **`herddb-ui/pom.xml`**: Change `frontend-maven-plugin`'s `installDirectory` from `${project.build.directory}/node-toolchain` (inside `target/`, wiped on every CI run) to `${user.home}/.cache/frontend-maven-plugin` (outside `target/`, persists across Maven invocations). On the second and subsequent builds the plugin detects the existing binary and skips the install entirely — no download, no extraction.
- **`.github/workflows/ci.yml`**:
  - Add a `Cache Node toolchain` step in the **`build`** and **`test-other`** jobs (the two jobs that actually run the `herddb-ui` module). The cache key is `node-toolchain-${{ runner.os }}-${{ hashFiles('herddb-ui/pom.xml') }}` so bumping `nodeVersion` or `npmVersion` in the pom automatically busts the cache and triggers a fresh download.
  - Remove the redundant `actions/setup-node` steps from **`build`**, **`test-other`**, and **`test-services`**. `frontend-maven-plugin` manages its own Node binary from `installDirectory`; the system-installed Node is never used by the Maven build.

## Tests
- Verified locally that the first Maven run downloads Node once and extracts it to `~/.cache/frontend-maven-plugin/node/node`.
- Verified that a second `mvn install` run prints `Skipping execution.` for the `install-node-and-npm` goal — no re-download, no re-extraction.
- All 35 `herddb-ui` Java tests pass (`mvn -pl herddb-ui test`).
- Full pre-PR validation (`checkstyle`, `apache-rat`, `spotbugs`, `install -DskipTests -Pci`) passes cleanly.

🤖 Implemented by the `pr-worker` agent.