### PR TITLE
issue #317: fix SPA 404 on browser refresh; add Refresh button

### DIFF
--- a/herddb-ui/src/frontend/components/Header.tsx
+++ b/herddb-ui/src/frontend/components/Header.tsx
@@ -70,6 +70,14 @@ export function Header({ serverInfoLoader = HerdDbApi.serverInfo }: HeaderProps)
                           ? `Node ${serverInfo.nodeId} · ${serverInfo.mode}`
                           : 'Server: loading…'}
                 </span>
+                <button
+                    className="herd-header__refresh-btn"
+                    title="Reload current page"
+                    aria-label="Refresh"
+                    onClick={() => window.location.reload()}
+                >
+                    ⟳ Refresh
+                </button>
             </div>
         </header>
     );

--- a/herddb-ui/src/frontend/theme/theme.css
+++ b/herddb-ui/src/frontend/theme/theme.css
@@ -111,6 +111,21 @@ body {
     font-family: var(--herd-mono);
 }
 
+.herd-header__refresh-btn {
+    background: transparent;
+    border: 1px solid var(--herd-border);
+    border-radius: 0.25rem;
+    color: var(--herd-muted);
+    cursor: pointer;
+    font-size: 0.85rem;
+    padding: 0.2rem 0.6rem;
+}
+
+.herd-header__refresh-btn:hover {
+    border-color: var(--herd-accent);
+    color: var(--herd-accent);
+}
+
 .herd-selector {
     display: inline-flex;
     align-items: center;

--- a/herddb-ui/src/main/java/org/herddb/ui/filter/SpaFallbackFilter.java
+++ b/herddb-ui/src/main/java/org/herddb/ui/filter/SpaFallbackFilter.java
@@ -1,0 +1,100 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package org.herddb.ui.filter;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * SPA (Single-Page Application) fallback filter.
+ *
+ * <p>When the React front-end uses the HTML5 History API ({@code BrowserRouter})
+ * the URL in the browser's address bar changes without any round-trip to the
+ * server.  On a hard refresh (Ctrl-R) or a direct deep-link access the browser
+ * issues a real HTTP GET for the current path — for example
+ * {@code /tablespaces/herd/tables/vector_bench/data-pages}.  Jetty's default
+ * servlet cannot find a static file at that path and returns 404.
+ *
+ * <p>This filter intercepts those requests and forwards them to
+ * {@code /index.html} so that React Router can take over and render the
+ * correct page client-side.  Three types of request are <em>not</em> forwarded
+ * and instead fall through the filter chain unchanged:
+ * <ol>
+ *   <li>Requests whose path starts with {@code /api/} — handled by the
+ *       Jersey JAX-RS servlet.</li>
+ *   <li>Requests whose last path segment contains a {@code '.'} — these are
+ *       static assets (JavaScript bundles, CSS, images, …) that the default
+ *       servlet must serve directly.</li>
+ *   <li>Non-GET requests on any path — only GET is used for SPA navigation;
+ *       POST/PUT/DELETE on an unmapped path should not be silently rewritten.</li>
+ * </ol>
+ */
+public class SpaFallbackFilter implements Filter {
+
+    private static final String INDEX_HTML = "/index.html";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // no initialisation required
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String path = httpRequest.getRequestURI()
+                .substring(httpRequest.getContextPath().length());
+
+        // 1. REST API — let Jersey handle it
+        if (path.startsWith("/api/")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 2. Static assets — any path segment that contains a '.' is assumed
+        //    to be a real file (e.g. main.js, theme.css, favicon.ico).
+        String lastSegment = path.substring(path.lastIndexOf('/') + 1);
+        if (lastSegment.contains(".")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 3. Non-GET methods on unmapped paths — pass through without rewriting.
+        if (!"GET".equalsIgnoreCase(httpRequest.getMethod())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // SPA route — forward to the React entry point.
+        httpRequest.getRequestDispatcher(INDEX_HTML).forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        // no resources to release
+    }
+}

--- a/herddb-ui/src/main/java/org/herddb/ui/filter/package-info.java
+++ b/herddb-ui/src/main/java/org/herddb/ui/filter/package-info.java
@@ -1,0 +1,28 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+/**
+ * Servlet filters for the HerdDB Web UI v2.
+ *
+ * <p>Currently contains only {@link org.herddb.ui.filter.SpaFallbackFilter},
+ * which rewrites deep SPA routes to {@code /index.html} so that React Router
+ * can handle them on a browser refresh or direct URL access.
+ */
+package org.herddb.ui.filter;

--- a/herddb-ui/src/main/webapp/WEB-INF/web.xml
+++ b/herddb-ui/src/main/webapp/WEB-INF/web.xml
@@ -25,6 +25,23 @@
     <display-name>HerdDB Web UI v2</display-name>
 
     <!--
+        SPA fallback filter: forwards deep React Router URLs (e.g.
+        /tablespaces/herd/tables/foo/data-pages) to /index.html on a browser
+        refresh or direct link, so that React Router can handle them
+        client-side.  API paths (/api/*) and static assets (paths with a
+        file extension) are passed straight through the filter chain.
+        See org.herddb.ui.filter.SpaFallbackFilter for details.
+    -->
+    <filter>
+        <filter-name>SpaFallbackFilter</filter-name>
+        <filter-class>org.herddb.ui.filter.SpaFallbackFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>SpaFallbackFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <!--
         JAX-RS application registering all v2 REST resources under /api/v2.
         See org.herddb.ui.api.v2.ApplicationConfigV2 for the resource list.
     -->

--- a/herddb-ui/src/test/java/org/herddb/ui/filter/SpaFallbackFilterTest.java
+++ b/herddb-ui/src/test/java/org/herddb/ui/filter/SpaFallbackFilterTest.java
@@ -1,0 +1,337 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package org.herddb.ui.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.servlet.FilterChain;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SpaFallbackFilter}.
+ *
+ * <p>Each test builds a minimal stub {@link HttpServletRequest} via
+ * {@link java.lang.reflect.Proxy} — only the three methods the filter
+ * actually invokes ({@code getRequestURI}, {@code getContextPath},
+ * {@code getMethod}, and {@code getRequestDispatcher}) are implemented.
+ * All other interface methods throw {@link UnsupportedOperationException}
+ * so that any accidental call surfaces immediately.
+ */
+public class SpaFallbackFilterTest {
+
+    private SpaFallbackFilter filter;
+
+    @Before
+    public void setUp() throws ServletException {
+        filter = new SpaFallbackFilter();
+        filter.init(null);
+    }
+
+    // ------------------------------------------------------------------
+    // Helper: build a stub HttpServletRequest via a dynamic proxy
+    // ------------------------------------------------------------------
+
+    /**
+     * Returns a proxy {@link HttpServletRequest} that answers the four
+     * methods used by the filter.  All other method calls throw
+     * {@link UnsupportedOperationException}.
+     *
+     * @param requestUri   value returned by {@code getRequestURI()}
+     * @param contextPath  value returned by {@code getContextPath()}
+     * @param method       value returned by {@code getMethod()}
+     * @param dispatcher   value returned by {@code getRequestDispatcher(…)}
+     *                     (may be {@code null} if the filter is not expected
+     *                     to call that method in the tested scenario)
+     */
+    private static HttpServletRequest stubRequest(
+            String requestUri,
+            String contextPath,
+            String method,
+            RequestDispatcher dispatcher) {
+
+        return (HttpServletRequest) java.lang.reflect.Proxy.newProxyInstance(
+                SpaFallbackFilterTest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                (proxy, m, args) -> {
+                    switch (m.getName()) {
+                        case "getRequestURI":
+                            return requestUri;
+                        case "getContextPath":
+                            return contextPath;
+                        case "getMethod":
+                            return method;
+                        case "getRequestDispatcher":
+                            return dispatcher;
+                        default:
+                            throw new UnsupportedOperationException(
+                                    "Unexpected call in test: " + m.getName());
+                    }
+                });
+    }
+
+    /** Records whether {@link FilterChain#doFilter} was invoked. */
+    private static FilterChain recordingChain(AtomicBoolean called) {
+        return (req, res) -> called.set(true);
+    }
+
+    /** Records the path passed to {@link RequestDispatcher#forward}. */
+    private static RequestDispatcher recordingDispatcher(
+            AtomicBoolean forwardCalled,
+            AtomicReference<String> capturedPath,
+            String path) {
+
+        return new RequestDispatcher() {
+            @Override
+            public void forward(ServletRequest req, ServletResponse res)
+                    throws ServletException, IOException {
+                forwardCalled.set(true);
+                capturedPath.set(path);
+            }
+
+            @Override
+            public void include(ServletRequest req, ServletResponse res) {
+                throw new UnsupportedOperationException("include not expected");
+            }
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    /**
+     * Requests whose path starts with {@code /api/} must be forwarded
+     * through the filter chain without touching the request dispatcher.
+     */
+    @Test
+    public void apiRequestPassesThroughChain() throws Exception {
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+
+        HttpServletRequest request = stubRequest(
+                "/api/v2/health", "", "GET",
+                recordingDispatcher(forwardCalled, new AtomicReference<>(), "/index.html"));
+
+        filter.doFilter(request, null, recordingChain(chainCalled));
+
+        assertTrue("chain must be called for /api/v2/health", chainCalled.get());
+        assertFalse("dispatcher must NOT be called for API paths", forwardCalled.get());
+    }
+
+    /**
+     * Requests for static assets (last path segment contains {@code '.'})
+     * must pass through the chain without a forward to {@code /index.html}.
+     */
+    @Test
+    public void staticAssetRequestPassesThroughChain() throws Exception {
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+
+        for (String assetPath : new String[]{
+                "/assets/main.abc123.js",
+                "/assets/theme.css",
+                "/favicon.ico",
+                "/logo.png"}) {
+
+            chainCalled.set(false);
+            forwardCalled.set(false);
+
+            HttpServletRequest request = stubRequest(
+                    assetPath, "", "GET",
+                    recordingDispatcher(forwardCalled, new AtomicReference<>(), "/index.html"));
+
+            filter.doFilter(request, null, recordingChain(chainCalled));
+
+            assertTrue("chain must be called for " + assetPath, chainCalled.get());
+            assertFalse("dispatcher must NOT be called for " + assetPath, forwardCalled.get());
+        }
+    }
+
+    /**
+     * Deep SPA routes (GET requests without a file extension) must be
+     * forwarded to {@code /index.html} so React Router can render them.
+     */
+    @Test
+    public void spaRouteIsForwardedToIndexHtml() throws Exception {
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+        AtomicReference<String> capturedPath = new AtomicReference<>();
+
+        for (String spaPath : new String[]{
+                "/tablespaces",
+                "/tablespaces/herd/tables",
+                "/tablespaces/herd/tables/vector_bench/data-pages",
+                "/tablespaces/herd/tables/vector_bench/primary-index",
+                "/indexing-services"}) {
+
+            chainCalled.set(false);
+            forwardCalled.set(false);
+            capturedPath.set(null);
+
+            HttpServletRequest request = stubRequest(
+                    spaPath, "", "GET",
+                    recordingDispatcher(forwardCalled, capturedPath, spaPath));
+
+            filter.doFilter(request, null, recordingChain(chainCalled));
+
+            assertFalse("chain must NOT be called for SPA route " + spaPath, chainCalled.get());
+            assertTrue("dispatcher forward must be called for SPA route " + spaPath, forwardCalled.get());
+        }
+    }
+
+    /**
+     * The root path {@code /} is also a SPA route and must be forwarded
+     * to {@code /index.html}.
+     */
+    @Test
+    public void rootPathIsForwardedToIndexHtml() throws Exception {
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+        HttpServletRequest request = stubRequest(
+                "/", "", "GET",
+                recordingDispatcher(forwardCalled, new AtomicReference<>(), "/"));
+
+        filter.doFilter(request, null, recordingChain(chainCalled));
+
+        assertFalse("chain must NOT be called for /", chainCalled.get());
+        assertTrue("dispatcher forward must be called for /", forwardCalled.get());
+    }
+
+    /**
+     * Non-GET requests on SPA-style paths must pass through the chain
+     * unchanged.  Only GET is used for SPA page navigation; rewriting
+     * POST/PUT/DELETE would silently corrupt REST calls to unmapped paths.
+     */
+    @Test
+    public void nonGetSpaPathPassesThroughChain() throws Exception {
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+
+        for (String httpMethod : new String[]{"POST", "PUT", "DELETE", "PATCH"}) {
+            chainCalled.set(false);
+            forwardCalled.set(false);
+
+            HttpServletRequest request = stubRequest(
+                    "/tablespaces/herd/tables", "", httpMethod,
+                    recordingDispatcher(forwardCalled, new AtomicReference<>(), "/index.html"));
+
+            filter.doFilter(request, null, recordingChain(chainCalled));
+
+            assertTrue("chain must be called for " + httpMethod, chainCalled.get());
+            assertFalse("dispatcher must NOT be called for " + httpMethod, forwardCalled.get());
+        }
+    }
+
+    /**
+     * The filter should strip the context path before inspecting the path.
+     * A request with URI {@code /ui/tablespaces} and context path {@code /ui}
+     * must be treated as the SPA route {@code /tablespaces}.
+     */
+    @Test
+    public void contextPathIsStrippedBeforeMatching() throws Exception {
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+        HttpServletRequest request = stubRequest(
+                "/ui/tablespaces/herd/tables/foo/data-pages", "/ui", "GET",
+                recordingDispatcher(forwardCalled, new AtomicReference<>(),
+                        "/tablespaces/herd/tables/foo/data-pages"));
+
+        filter.doFilter(request, null, recordingChain(chainCalled));
+
+        assertFalse("chain must NOT be called for SPA route under /ui context", chainCalled.get());
+        assertTrue("dispatcher forward must be called for SPA route under /ui context", forwardCalled.get());
+    }
+
+    /**
+     * An API request under the context path must still pass through the chain.
+     */
+    @Test
+    public void apiRequestUnderContextPathPassesThroughChain() throws Exception {
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        AtomicBoolean forwardCalled = new AtomicBoolean(false);
+
+        HttpServletRequest request = stubRequest(
+                "/ui/api/v2/health", "/ui", "GET",
+                recordingDispatcher(forwardCalled, new AtomicReference<>(), "/index.html"));
+
+        filter.doFilter(request, null, recordingChain(chainCalled));
+
+        assertTrue("chain must be called for API path under /ui context", chainCalled.get());
+        assertFalse("dispatcher must NOT be called for API path", forwardCalled.get());
+    }
+
+    /**
+     * Verify the path used when forwarding to the SPA entry point is
+     * exactly {@code /index.html}.
+     */
+    @Test
+    public void forwardTargetIsIndexHtml() throws Exception {
+        AtomicReference<String> capturedDispatcherPath = new AtomicReference<>();
+
+        // Intercept the getRequestDispatcher call to capture the path argument
+        HttpServletRequest request = (HttpServletRequest) java.lang.reflect.Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                (proxy, m, args) -> {
+                    switch (m.getName()) {
+                        case "getRequestURI":
+                            return "/tablespaces/herd/tables/foo";
+                        case "getContextPath":
+                            return "";
+                        case "getMethod":
+                            return "GET";
+                        case "getRequestDispatcher":
+                            String path = (String) args[0];
+                            capturedDispatcherPath.set(path);
+                            return new RequestDispatcher() {
+                                @Override
+                                public void forward(ServletRequest req, ServletResponse res) {
+                                    // no-op for this test
+                                }
+                                @Override
+                                public void include(ServletRequest req, ServletResponse res) {
+                                    throw new UnsupportedOperationException();
+                                }
+                            };
+                        default:
+                            throw new UnsupportedOperationException(m.getName());
+                    }
+                });
+
+        filter.doFilter(request, null, (req, res) -> {
+            throw new AssertionError("chain must not be called for SPA route");
+        });
+
+        assertEquals("forward must target /index.html", "/index.html", capturedDispatcherPath.get());
+    }
+}


### PR DESCRIPTION
Fixes #317.

## Changes

- **`herddb-ui/src/main/java/org/herddb/ui/filter/SpaFallbackFilter.java`** (new) — servlet `Filter` that forwards deep React Router URLs (e.g. `/tablespaces/herd/tables/foo/data-pages`) to `/index.html` on a browser refresh or direct-URL access. Three request types pass straight through the chain: paths starting with `/api/` (Jersey JAX-RS), paths with a file extension (Vite-bundled static assets), and non-GET methods.
- **`herddb-ui/src/main/java/org/herddb/ui/filter/package-info.java`** (new) — package javadoc with Apache RAT license header.
- **`herddb-ui/src/main/webapp/WEB-INF/web.xml`** — register `SpaFallbackFilter` on `/*`.
- **`herddb-ui/src/frontend/components/Header.tsx`** — add a `⟳ Refresh` button (top-right) that calls `window.location.reload()`.
- **`herddb-ui/src/frontend/theme/theme.css`** — add `.herd-header__refresh-btn` styles matching the header palette.

## Tests

- **`SpaFallbackFilterTest`** (8 tests) — unit tests for the three filter branches: API path → chain pass-through; static asset → chain pass-through; SPA route (including root, deep paths, paths under a context prefix) → forward to `/index.html`; non-GET methods → chain pass-through; verifies the exact forward target is `/index.html`.

## Root cause

The React SPA uses `BrowserRouter` (HTML5 History API). Navigation within the app updates the URL client-side without touching the server. On `Ctrl-R` or a direct deep link the browser issues a real GET for the current URL; Jetty's default servlet finds no static file at that path and returns 404. The `SpaFallbackFilter` intercepts these requests and forwards them to `/index.html` so React Router renders the correct page.

🤖 Implemented by the `pr-worker` agent.