### PR TITLE
issue #321: show BLink layout and loaded blocks in primary-index UI

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -331,19 +331,60 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     }
 
     /**
+     * Maximum number of {@link BLink.NodeInfo per-node entries} that
+     * {@link #snapshotInfo()} will include in its response. Larger trees are
+     * truncated; the {@link PrimaryIndexSnapshot#isTruncated() truncated} flag
+     * is set so the UI can warn the operator. Tests may override this via
+     * {@link #setSnapshotNodeLimit(int)}.
+     */
+    public static final int DEFAULT_SNAPSHOT_NODE_LIMIT = 10_000;
+
+    private static volatile int snapshotNodeLimit = DEFAULT_SNAPSHOT_NODE_LIMIT;
+
+    /**
+     * Test hook: override the per-snapshot node cap. Returns the previous
+     * value so callers can restore it.
+     */
+    public static int setSnapshotNodeLimit(int newLimit) {
+        int prev = snapshotNodeLimit;
+        snapshotNodeLimit = newLimit;
+        return prev;
+    }
+
+    /**
      * Read-only snapshot of the primary key index tree, used by the Web UI
-     * v2 backend to render a "primary index" summary panel.
+     * v2 backend to render a "primary index" summary panel and a per-node
+     * layout heatmap.
      *
      * <p>The snapshot does not force a checkpoint: it only reports the
      * counters already maintained by the in-memory tree (number of keys,
-     * number of nodes currently in memory and total memory occupancy).
+     * number of nodes currently in memory, total memory occupancy) plus a
+     * weakly-consistent per-node view (id, on-disk page, loaded/dirty flags,
+     * keys and size). Concurrent mutations may produce slightly inconsistent
+     * per-node reads — the snapshot is for visualisation only.
      */
     public PrimaryIndexSnapshot snapshotInfo() {
         BLink<Bytes, Long> tree = getTree();
+        int totalNodes = tree.nodes();
+        int limit = snapshotNodeLimit;
+        java.util.List<BLink.NodeInfo> sample = tree.snapshotNodes(limit);
+        boolean truncated = limit > 0 && totalNodes > sample.size();
+        // Count nodes currently resident in memory from the per-node sample.
+        // When truncated, this is a lower bound — same convention as the
+        // visualisation use case that requested this metric.
+        int loadedNodes = 0;
+        for (BLink.NodeInfo info : sample) {
+            if (info.isLoaded()) {
+                loadedNodes++;
+            }
+        }
         return new PrimaryIndexSnapshot(
                 tree.size(),
-                tree.nodes(),
-                tree.getUsedMemory());
+                loadedNodes,
+                tree.getUsedMemory(),
+                sample,
+                truncated,
+                totalNodes);
     }
 
     /**
@@ -354,11 +395,33 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
         private final long entries;
         private final int loadedNodes;
         private final long usedMemoryBytes;
+        private final java.util.List<BLink.NodeInfo> nodes;
+        private final boolean truncated;
+        private final int totalNodes;
 
+        /**
+         * Legacy 3-argument constructor retained for backwards compatibility
+         * with non-BLink callers (fallback branch in the UI backend, plus
+         * any external consumer that does not need per-node details). The
+         * new fields default to an empty node list, {@code truncated=false}
+         * and {@code totalNodes=loadedNodes}.
+         */
         public PrimaryIndexSnapshot(long entries, int loadedNodes, long usedMemoryBytes) {
+            this(entries, loadedNodes, usedMemoryBytes, Collections.emptyList(),
+                    false, loadedNodes);
+        }
+
+        public PrimaryIndexSnapshot(long entries, int loadedNodes, long usedMemoryBytes,
+                                    java.util.List<BLink.NodeInfo> nodes, boolean truncated,
+                                    int totalNodes) {
             this.entries = entries;
             this.loadedNodes = loadedNodes;
             this.usedMemoryBytes = usedMemoryBytes;
+            this.nodes = nodes == null
+                    ? Collections.emptyList()
+                    : Collections.unmodifiableList(new java.util.ArrayList<>(nodes));
+            this.truncated = truncated;
+            this.totalNodes = totalNodes;
         }
 
         public long getEntries() {
@@ -371,6 +434,18 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
         public long getUsedMemoryBytes() {
             return usedMemoryBytes;
+        }
+
+        public java.util.List<BLink.NodeInfo> getNodes() {
+            return nodes;
+        }
+
+        public boolean isTruncated() {
+            return truncated;
+        }
+
+        public int getTotalNodes() {
+            return totalNodes;
         }
     }
 

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -358,14 +358,28 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
     /**
      * Read-only snapshot of the underlying B-Link tree, used by the Web
      * UI v2 backend. Same wire shape as
-     * {@link BLinkKeyToPageIndex#snapshotInfo()}.
+     * {@link BLinkKeyToPageIndex#snapshotInfo()}, including the
+     * weakly-consistent per-node layout list.
      */
     public BLinkKeyToPageIndex.PrimaryIndexSnapshot snapshotInfo() {
         BLink<Bytes, Long> t = getTree();
+        int totalNodes = t.nodes();
+        int limit = BLinkKeyToPageIndex.DEFAULT_SNAPSHOT_NODE_LIMIT;
+        java.util.List<BLink.NodeInfo> sample = t.snapshotNodes(limit);
+        boolean truncated = limit > 0 && totalNodes > sample.size();
+        int loadedNodes = 0;
+        for (BLink.NodeInfo info : sample) {
+            if (info.isLoaded()) {
+                loadedNodes++;
+            }
+        }
         return new BLinkKeyToPageIndex.PrimaryIndexSnapshot(
                 t.size(),
-                t.nodes(),
-                t.getUsedMemory());
+                loadedNodes,
+                t.getUsedMemory(),
+                sample,
+                truncated,
+                totalNodes);
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
@@ -20,9 +20,14 @@
 
 package herddb.index;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import herddb.core.AbstractIndexManager;
 import herddb.core.MemoryManager;
 import herddb.core.PostCheckpointAction;
+import herddb.index.blink.BLink;
 import herddb.index.blink.BLinkKeyToPageIndex;
 import herddb.log.LogSequenceNumber;
 import herddb.mem.MemoryDataStorageManager;
@@ -34,6 +39,7 @@ import herddb.utils.Bytes;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
+import org.junit.Test;
 
 /**
  * Base test suite for {@link  BLinkKeyToPageIndex}
@@ -170,6 +176,104 @@ public class BLinkKeyToPageIndexTest extends KeyToPageIndexTest {
             return delegate.isSortedAscending(pkTypes);
         }
 
+    }
+
+    /**
+     * Issue #321: {@link BLinkKeyToPageIndex#snapshotInfo()} must return a
+     * per-node layout list (not just summary counters), so the Web UI can
+     * render the BLink layout on disk and the loaded blocks.
+     */
+    @Test
+    public void snapshotInfoReportsNodesList() throws Exception {
+        // Tiny page size so the tree splits into multiple nodes after a few
+        // hundred inserts.
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * 4096L, 4096L);
+        try (MemoryDataStorageManager ds = new MemoryDataStorageManager()) {
+            BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+            try {
+                idx.init();
+                idx.start(LogSequenceNumber.START_OF_TIME, true);
+
+                final int rows = 1000;
+                for (int i = 0; i < rows; i++) {
+                    idx.put(Bytes.from_int(i), (long) i);
+                }
+
+                BLinkKeyToPageIndex.PrimaryIndexSnapshot snapshot = idx.snapshotInfo();
+                assertNotNull(snapshot);
+                assertEquals(rows, snapshot.getEntries());
+                assertNotNull("nodes list must not be null", snapshot.getNodes());
+                assertFalse("nodes list must not be empty", snapshot.getNodes().isEmpty());
+                assertFalse("truncated flag must be false for a small tree",
+                        snapshot.isTruncated());
+
+                int loadedFromList = 0;
+                long sumLeafKeys = 0;
+                for (BLink.NodeInfo info : snapshot.getNodes()) {
+                    assertTrue("sizeBytes must be positive, got " + info.getSizeBytes(),
+                            info.getSizeBytes() > 0);
+                    assertTrue("keys must be non-negative, got " + info.getKeys(),
+                            info.getKeys() >= 0);
+                    if (info.isLoaded()) {
+                        loadedFromList++;
+                    }
+                    if (info.isLeaf()) {
+                        sumLeafKeys += info.getKeys();
+                    }
+                }
+                assertEquals(
+                        "loaded count from per-node list must match summary",
+                        snapshot.getLoadedNodes(),
+                        loadedFromList);
+                assertEquals(
+                        "totalNodes must match the per-node list size when not truncated",
+                        snapshot.getNodes().size(),
+                        snapshot.getTotalNodes());
+                assertTrue(
+                        "totalNodes must be >= loadedNodes",
+                        snapshot.getTotalNodes() >= snapshot.getLoadedNodes());
+                assertEquals(
+                        "sum of leaf keys must equal entries",
+                        snapshot.getEntries(),
+                        sumLeafKeys);
+            } finally {
+                idx.close();
+            }
+        }
+    }
+
+    /**
+     * Issue #321: when the tree has more nodes than the per-snapshot cap,
+     * {@code snapshotInfo()} must return a truncated list and set the
+     * {@code truncated} flag.
+     */
+    @Test
+    public void snapshotInfoSetsTruncatedFlagWhenLimitExceeded() throws Exception {
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * 4096L, 4096L);
+        try (MemoryDataStorageManager ds = new MemoryDataStorageManager()) {
+            BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+            int previousLimit = BLinkKeyToPageIndex.setSnapshotNodeLimit(2);
+            try {
+                idx.init();
+                idx.start(LogSequenceNumber.START_OF_TIME, true);
+
+                for (int i = 0; i < 500; i++) {
+                    idx.put(Bytes.from_int(i), (long) i);
+                }
+
+                BLinkKeyToPageIndex.PrimaryIndexSnapshot snapshot = idx.snapshotInfo();
+                assertNotNull(snapshot);
+                assertEquals(2, snapshot.getNodes().size());
+                assertTrue("truncated flag must be set when nodes > limit",
+                        snapshot.isTruncated());
+                assertTrue(
+                        "totalNodes must reflect the full tree, not the truncated sample",
+                        snapshot.getTotalNodes() > snapshot.getNodes().size());
+            } finally {
+                BLinkKeyToPageIndex.setSnapshotNodeLimit(previousLimit);
+                idx.close();
+            }
+        }
     }
 
 }

--- a/herddb-ui/src/frontend/api/client.ts
+++ b/herddb-ui/src/frontend/api/client.ts
@@ -111,11 +111,40 @@ export interface PageLayoutDTO {
     pages: DataPageInfoDTO[];
 }
 
+export interface BLinkNodeDTO {
+    /** Stable in-memory identifier of the node within the BLink tree. */
+    nodeId: number;
+    /** Page id used by the underlying storage, or {@code -1} for never-flushed nodes. */
+    storeId: number;
+    /** {@code true} for leaf nodes (key → value), false for inner separator nodes. */
+    leaf: boolean;
+    /** Number of entries currently stored in the node. */
+    keys: number;
+    /** Estimated in-memory size of the node, in bytes. */
+    sizeBytes: number;
+    /** {@code true} if the node's data is currently resident in memory. */
+    loaded: boolean;
+    /** {@code true} if the node has uncheckpointed changes. */
+    dirty: boolean;
+}
+
 export interface PrimaryIndexDTO {
     type: string;
     entries: number;
     loadedNodes: number;
+    /** Total number of BLink nodes (loaded + on-disk only). */
+    totalNodes: number;
     usedMemoryBytes: number;
+    /**
+     * Per-node layout (one entry per BLink node, both on-disk and
+     * in-memory). Empty for non-BLink primary indexes.
+     */
+    nodes: BLinkNodeDTO[];
+    /**
+     * {@code true} when the tree has more nodes than the per-snapshot cap
+     * and {@code nodes} was clipped.
+     */
+    truncated: boolean;
 }
 
 export interface BrinBlockDTO {

--- a/herddb-ui/src/frontend/pages/PrimaryIndexPage.test.tsx
+++ b/herddb-ui/src/frontend/pages/PrimaryIndexPage.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import type { PrimaryIndexDTO } from '../api/client';
+import { PrimaryIndexPage } from './PrimaryIndexPage';
+
+const snapshot: PrimaryIndexDTO = {
+    type: 'blink',
+    entries: 1234,
+    loadedNodes: 2,
+    totalNodes: 3,
+    usedMemoryBytes: 65_536,
+    truncated: false,
+    nodes: [
+        {
+            nodeId: 1,
+            storeId: 10,
+            leaf: false,
+            keys: 3,
+            sizeBytes: 4096,
+            loaded: true,
+            dirty: false,
+        },
+        {
+            nodeId: 2,
+            storeId: 11,
+            leaf: true,
+            keys: 600,
+            sizeBytes: 16_384,
+            loaded: true,
+            dirty: true,
+        },
+        {
+            nodeId: 3,
+            storeId: 12,
+            leaf: true,
+            keys: 634,
+            sizeBytes: 16_500,
+            loaded: false,
+            dirty: false,
+        },
+    ],
+};
+
+describe('PrimaryIndexPage', () => {
+    it('renders summary counters and a heatmap cell per BLink node', async () => {
+        render(
+            <MemoryRouter
+                initialEntries={['/tablespaces/herd/tables/t/primary-index']}
+            >
+                <Routes>
+                    <Route
+                        path="/tablespaces/:tablespace/tables/:name/primary-index"
+                        element={
+                            <PrimaryIndexPage loader={async () => snapshot} />
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(
+            await screen.findByRole('heading', {
+                name: /Primary index — herd\.t/i,
+            }),
+        ).toBeInTheDocument();
+
+        // Implementation row
+        expect(screen.getByText('blink')).toBeInTheDocument();
+        // Entries
+        expect(screen.getByText('1,234')).toBeInTheDocument();
+        // Total nodes (3)
+        const cells = await screen.findAllByText('3');
+        expect(cells.length).toBeGreaterThan(0);
+
+        // Heatmap rendered with one rect per node
+        const svg = await screen.findByTestId('primary-index-heatmap');
+        expect(svg.querySelectorAll('rect').length).toBe(snapshot.nodes.length);
+    });
+
+    it('shows the truncation hint when the snapshot was clipped', async () => {
+        const truncated: PrimaryIndexDTO = {
+            ...snapshot,
+            truncated: true,
+        };
+        render(
+            <MemoryRouter
+                initialEntries={['/tablespaces/herd/tables/t/primary-index']}
+            >
+                <Routes>
+                    <Route
+                        path="/tablespaces/:tablespace/tables/:name/primary-index"
+                        element={
+                            <PrimaryIndexPage loader={async () => truncated} />
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(
+            await screen.findByRole('status'),
+        ).toHaveTextContent(/Tree is too large/i);
+    });
+
+    it('falls back gracefully for non-BLink primary indexes (no nodes)', async () => {
+        const nonBlink: PrimaryIndexDTO = {
+            type: 'ConcurrentMapKeyToPageIndex',
+            entries: 42,
+            loadedNodes: 0,
+            totalNodes: 0,
+            usedMemoryBytes: 0,
+            truncated: false,
+            nodes: [],
+        };
+        render(
+            <MemoryRouter
+                initialEntries={['/tablespaces/herd/tables/t/primary-index']}
+            >
+                <Routes>
+                    <Route
+                        path="/tablespaces/:tablespace/tables/:name/primary-index"
+                        element={
+                            <PrimaryIndexPage loader={async () => nonBlink} />
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        expect(
+            await screen.findByText(/No BLink nodes to display/i),
+        ).toBeInTheDocument();
+    });
+});

--- a/herddb-ui/src/frontend/pages/PrimaryIndexPage.tsx
+++ b/herddb-ui/src/frontend/pages/PrimaryIndexPage.tsx
@@ -19,6 +19,7 @@
 import { Link, useParams } from 'react-router-dom';
 import { HerdDbApi, type PrimaryIndexDTO } from '../api/client';
 import { useAsync } from '../components/AsyncResource';
+import { PrimaryIndexView } from '../visualizations/PrimaryIndexView';
 
 const formatter = new Intl.NumberFormat('en-US');
 const fmt = (v: number | undefined | null): string =>
@@ -58,29 +59,76 @@ export function PrimaryIndexPage({
                 </p>
             )}
             {!loading && !error && data && (
-                <table className="herd-table">
-                    <tbody>
-                        <tr>
-                            <th scope="row">Implementation</th>
-                            <td>
-                                <code>{data.type}</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Entries</th>
-                            <td>{fmt(data.entries)}</td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Loaded nodes</th>
-                            <td>{fmt(data.loadedNodes)}</td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Memory used</th>
-                            <td>{fmt(data.usedMemoryBytes)} bytes</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <PrimaryIndexBody data={data} />
             )}
         </section>
+    );
+}
+
+interface PrimaryIndexBodyProps {
+    data: PrimaryIndexDTO;
+}
+
+function PrimaryIndexBody({ data }: PrimaryIndexBodyProps) {
+    const nodes = data.nodes ?? [];
+    // Server-side authoritative total (covers the case where the per-node
+    // list was truncated). Falls back to the array length for older
+    // backends that didn't ship the field.
+    const totalNodes = data.totalNodes || nodes.length;
+    const onDiskNodes = nodes.filter((n) => !n.loaded).length;
+    const dirtyNodes = nodes.filter((n) => n.dirty).length;
+    const leafNodes = nodes.filter((n) => n.leaf).length;
+
+    return (
+        <>
+            <table className="herd-table">
+                <tbody>
+                    <tr>
+                        <th scope="row">Implementation</th>
+                        <td>
+                            <code>{data.type}</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Entries</th>
+                        <td>{fmt(data.entries)}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Total nodes</th>
+                        <td>{fmt(totalNodes)}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Loaded nodes</th>
+                        <td>{fmt(data.loadedNodes)}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">On-disk only</th>
+                        <td>{fmt(onDiskNodes)}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Dirty nodes</th>
+                        <td>{fmt(dirtyNodes)}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Leaf nodes</th>
+                        <td>{fmt(leafNodes)}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Memory used</th>
+                        <td>{fmt(data.usedMemoryBytes)} bytes</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            {data.truncated && (
+                <p className="herd-page__hint" role="status">
+                    Tree is too large — only the first {fmt(nodes.length)} of{' '}
+                    {fmt(totalNodes)} nodes are shown.
+                </p>
+            )}
+
+            <h2>Layout</h2>
+            <PrimaryIndexView nodes={nodes} />
+        </>
     );
 }

--- a/herddb-ui/src/frontend/visualizations/PrimaryIndexView.tsx
+++ b/herddb-ui/src/frontend/visualizations/PrimaryIndexView.tsx
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Group } from '@visx/group';
+import { ParentSize } from '@visx/responsive';
+import { scaleLinear } from '@visx/scale';
+import type { BLinkNodeDTO } from '../api/client';
+
+interface PrimaryIndexViewProps {
+    nodes: BLinkNodeDTO[];
+}
+
+const CELL_PER_ROW = 16;
+const CELL_GAP = 2;
+const MIN_HEIGHT = 200;
+
+/**
+ * Heatmap-style visualisation of the BLink primary-key index. Each cell is
+ * one node; cell brightness encodes the byte size, a yellow border
+ * distinguishes nodes currently resident in memory, a red overlay flags
+ * dirty (uncheckpointed) nodes, and inner (non-leaf) nodes are drawn with
+ * a dashed outline so the operator can spot the routing layer.
+ */
+export function PrimaryIndexView({ nodes }: PrimaryIndexViewProps) {
+    if (nodes.length === 0) {
+        return (
+            <p className="herd-page__hint">
+                No BLink nodes to display (the primary index may not be a
+                B-Link implementation, e.g. the in-memory map used in local
+                mode).
+            </p>
+        );
+    }
+
+    const maxSize = nodes.reduce((acc, n) => Math.max(acc, n.sizeBytes), 0);
+    const fill = scaleLinear<string>({
+        domain: [0, Math.max(maxSize, 1)],
+        range: ['#0f172a', '#38bdf8'],
+    });
+
+    return (
+        <div className="herd-viz">
+            <ParentSize>
+                {({ width }) => {
+                    const cellWidth =
+                        Math.max(20, (width - CELL_GAP * (CELL_PER_ROW - 1)) / CELL_PER_ROW);
+                    const cellHeight = cellWidth * 0.6;
+                    const rows = Math.ceil(nodes.length / CELL_PER_ROW);
+                    const height = Math.max(
+                        MIN_HEIGHT,
+                        rows * (cellHeight + CELL_GAP),
+                    );
+                    return (
+                        <svg
+                            width={width}
+                            height={height}
+                            data-testid="primary-index-heatmap"
+                        >
+                            <Group>
+                                {nodes.map((node, idx) => {
+                                    const row = Math.floor(idx / CELL_PER_ROW);
+                                    const col = idx % CELL_PER_ROW;
+                                    return (
+                                        <rect
+                                            key={node.nodeId}
+                                            x={col * (cellWidth + CELL_GAP)}
+                                            y={row * (cellHeight + CELL_GAP)}
+                                            width={cellWidth}
+                                            height={cellHeight}
+                                            fill={
+                                                node.dirty
+                                                    ? '#ef4444'
+                                                    : fill(node.sizeBytes)
+                                            }
+                                            stroke={
+                                                node.loaded
+                                                    ? '#facc15'
+                                                    : '#334155'
+                                            }
+                                            strokeWidth={node.loaded ? 2 : 1}
+                                            strokeDasharray={
+                                                node.leaf ? undefined : '3 2'
+                                            }
+                                        >
+                                            <title>
+                                                {`node #${node.nodeId}\n` +
+                                                    `storeId: ${node.storeId}\n` +
+                                                    `leaf: ${node.leaf}\n` +
+                                                    `keys: ${node.keys}\n` +
+                                                    `size: ${node.sizeBytes} bytes\n` +
+                                                    `loaded: ${node.loaded}\n` +
+                                                    `dirty: ${node.dirty}`}
+                                            </title>
+                                        </rect>
+                                    );
+                                })}
+                            </Group>
+                        </svg>
+                    );
+                }}
+            </ParentSize>
+            <p className="herd-page__hint">
+                Each cell is one BLink node. Brighter cells hold more bytes;
+                cells with a yellow border are resident in memory; red cells
+                are dirty (uncheckpointed); inner nodes have a dashed border.
+                Hover over a cell for details.
+            </p>
+        </div>
+    );
+}

--- a/herddb-ui/src/main/java/org/herddb/ui/api/v2/TableResource.java
+++ b/herddb-ui/src/main/java/org/herddb/ui/api/v2/TableResource.java
@@ -174,11 +174,25 @@ public class TableResource {
             snapshot = ((IncrementalBLinkKeyToPageIndex) pkIndex).snapshotInfo();
         }
         if (snapshot != null) {
+            List<PrimaryIndexDTO.BLinkNodeDTO> nodes = new ArrayList<>(snapshot.getNodes().size());
+            for (herddb.index.blink.BLink.NodeInfo info : snapshot.getNodes()) {
+                nodes.add(new PrimaryIndexDTO.BLinkNodeDTO(
+                        info.getNodeId(),
+                        info.getStoreId(),
+                        info.isLeaf(),
+                        info.getKeys(),
+                        info.getSizeBytes(),
+                        info.isLoaded(),
+                        info.isDirty()));
+            }
             return new PrimaryIndexDTO(
                     "blink",
                     snapshot.getEntries(),
                     snapshot.getLoadedNodes(),
-                    snapshot.getUsedMemoryBytes());
+                    snapshot.getTotalNodes(),
+                    snapshot.getUsedMemoryBytes(),
+                    nodes,
+                    snapshot.isTruncated());
         }
         // Fall-back: report the implementing class so the UI can show
         // *something*, even for index types we do not know how to drill

--- a/herddb-ui/src/main/java/org/herddb/ui/dto/PrimaryIndexDTO.java
+++ b/herddb-ui/src/main/java/org/herddb/ui/dto/PrimaryIndexDTO.java
@@ -20,29 +20,63 @@
 
 package org.herddb.ui.dto;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Summary of a primary-key index, returned by
  * {@code GET /api/v2/tablespaces/{ts}/tables/{t}/primary-index}.
  *
- * <p>Currently scoped to high-level B-Link counters (entries, in-memory
- * nodes, used memory). Detailed per-node enumeration is intentionally
- * deferred to a follow-up because it requires forcing a checkpoint.
+ * <p>For B-Link indexes the response carries:
+ * <ul>
+ *   <li>top-level counters ({@code entries}, {@code loadedNodes},
+ *       {@code usedMemoryBytes}) for the summary panel;</li>
+ *   <li>a {@code nodes} list (one entry per BLink node, both on-disk and
+ *       in-memory) for the layout heatmap;</li>
+ *   <li>a {@code truncated} flag set when the tree is larger than the
+ *       per-snapshot node cap and the node list was clipped.</li>
+ * </ul>
+ *
+ * <p>For non-BLink primary indexes (e.g. the in-memory
+ * {@code ConcurrentMapKeyToPageIndex} used in local mode) the {@code nodes}
+ * list is empty and {@code truncated} is {@code false}.
  */
 public final class PrimaryIndexDTO {
 
     private String type;
     private long entries;
     private int loadedNodes;
+    private int totalNodes;
     private long usedMemoryBytes;
+    private List<BLinkNodeDTO> nodes = Collections.emptyList();
+    private boolean truncated;
 
     public PrimaryIndexDTO() {
     }
 
+    /**
+     * Legacy 4-argument constructor retained for callers that don't ship
+     * per-node details (non-BLink fallback). The {@code nodes} list defaults
+     * to empty, {@code truncated} to {@code false} and {@code totalNodes} to
+     * the supplied {@code loadedNodes}.
+     */
     public PrimaryIndexDTO(String type, long entries, int loadedNodes, long usedMemoryBytes) {
+        this(type, entries, loadedNodes, loadedNodes, usedMemoryBytes,
+                Collections.emptyList(), false);
+    }
+
+    public PrimaryIndexDTO(String type, long entries, int loadedNodes, int totalNodes,
+                           long usedMemoryBytes, List<BLinkNodeDTO> nodes, boolean truncated) {
         this.type = type;
         this.entries = entries;
         this.loadedNodes = loadedNodes;
+        this.totalNodes = totalNodes;
         this.usedMemoryBytes = usedMemoryBytes;
+        this.nodes = nodes == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(nodes));
+        this.truncated = truncated;
     }
 
     public String getType() {
@@ -69,11 +103,123 @@ public final class PrimaryIndexDTO {
         this.loadedNodes = loadedNodes;
     }
 
+    public int getTotalNodes() {
+        return totalNodes;
+    }
+
+    public void setTotalNodes(int totalNodes) {
+        this.totalNodes = totalNodes;
+    }
+
     public long getUsedMemoryBytes() {
         return usedMemoryBytes;
     }
 
     public void setUsedMemoryBytes(long usedMemoryBytes) {
         this.usedMemoryBytes = usedMemoryBytes;
+    }
+
+    public List<BLinkNodeDTO> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<BLinkNodeDTO> nodes) {
+        this.nodes = nodes == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(nodes));
+    }
+
+    public boolean isTruncated() {
+        return truncated;
+    }
+
+    public void setTruncated(boolean truncated) {
+        this.truncated = truncated;
+    }
+
+    /**
+     * Wire-shape for a single BLink node: stable in-memory id, on-disk page
+     * id (or {@code -1} when the node has never been flushed), leaf flag,
+     * key count, byte size, loaded and dirty flags.
+     */
+    public static final class BLinkNodeDTO {
+
+        private long nodeId;
+        private long storeId;
+        private boolean leaf;
+        private int keys;
+        private long sizeBytes;
+        private boolean loaded;
+        private boolean dirty;
+
+        public BLinkNodeDTO() {
+        }
+
+        public BLinkNodeDTO(long nodeId, long storeId, boolean leaf, int keys,
+                            long sizeBytes, boolean loaded, boolean dirty) {
+            this.nodeId = nodeId;
+            this.storeId = storeId;
+            this.leaf = leaf;
+            this.keys = keys;
+            this.sizeBytes = sizeBytes;
+            this.loaded = loaded;
+            this.dirty = dirty;
+        }
+
+        public long getNodeId() {
+            return nodeId;
+        }
+
+        public void setNodeId(long nodeId) {
+            this.nodeId = nodeId;
+        }
+
+        public long getStoreId() {
+            return storeId;
+        }
+
+        public void setStoreId(long storeId) {
+            this.storeId = storeId;
+        }
+
+        public boolean isLeaf() {
+            return leaf;
+        }
+
+        public void setLeaf(boolean leaf) {
+            this.leaf = leaf;
+        }
+
+        public int getKeys() {
+            return keys;
+        }
+
+        public void setKeys(int keys) {
+            this.keys = keys;
+        }
+
+        public long getSizeBytes() {
+            return sizeBytes;
+        }
+
+        public void setSizeBytes(long sizeBytes) {
+            this.sizeBytes = sizeBytes;
+        }
+
+        public boolean isLoaded() {
+            return loaded;
+        }
+
+        public void setLoaded(boolean loaded) {
+            this.loaded = loaded;
+        }
+
+        public boolean isDirty() {
+            return dirty;
+        }
+
+        public void setDirty(boolean dirty) {
+            this.dirty = dirty;
+        }
     }
 }

--- a/herddb-ui/src/test/java/org/herddb/ui/api/v2/TableResourceTest.java
+++ b/herddb-ui/src/test/java/org/herddb/ui/api/v2/TableResourceTest.java
@@ -205,8 +205,43 @@ public class TableResourceTest {
                 "loadedNodes must be > 0, got " + snapshot.getLoadedNodes(),
                 snapshot.getLoadedNodes() > 0);
         assertTrue(
+                "totalNodes must be >= loadedNodes",
+                snapshot.getTotalNodes() >= snapshot.getLoadedNodes());
+        assertTrue(
                 "usedMemoryBytes must be > 0, got " + snapshot.getUsedMemoryBytes(),
                 snapshot.getUsedMemoryBytes() > 0);
+        // Per-node layout: must be populated (issue #321).
+        assertNotNull("nodes list must be non-null", snapshot.getNodes());
+        assertFalse("nodes list must not be empty for a populated BLink index",
+                snapshot.getNodes().isEmpty());
+        int loadedFromList = 0;
+        long sumKeys = 0;
+        for (PrimaryIndexDTO.BLinkNodeDTO node : snapshot.getNodes()) {
+            assertTrue("sizeBytes must be > 0, got " + node.getSizeBytes(),
+                    node.getSizeBytes() > 0);
+            assertTrue("keys must be >= 0, got " + node.getKeys(),
+                    node.getKeys() >= 0);
+            if (node.isLoaded()) {
+                loadedFromList++;
+            }
+            if (node.isLeaf()) {
+                sumKeys += node.getKeys();
+            }
+        }
+        assertEquals(
+                "count of loaded nodes in the per-node list must match the summary",
+                snapshot.getLoadedNodes(),
+                loadedFromList);
+        assertEquals(
+                "totalNodes must equal the size of the per-node list when not truncated",
+                snapshot.getNodes().size(),
+                snapshot.getTotalNodes());
+        assertEquals(
+                "sum of leaf keys must equal the entries counter",
+                snapshot.getEntries(),
+                sumKeys);
+        assertFalse("truncated flag should be false for a small tree",
+                snapshot.isTruncated());
     }
 
     @Test

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -465,6 +465,121 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         return nodes.size();
     }
 
+    /**
+     * Returns a weakly-consistent, read-only snapshot of every node currently
+     * tracked by this tree (both nodes resident in memory and nodes that only
+     * exist on disk).
+     *
+     * <p>This is intended for visualisation / monitoring use cases (e.g. the
+     * Web UI v2 backend). It does <em>not</em> acquire any lock, so concurrent
+     * mutations may produce slightly inconsistent reads of {@code keys},
+     * {@code sizeBytes}, {@code storeId}, {@code loaded} or {@code dirty}; the
+     * iteration itself is safe because {@link #nodes} is a
+     * {@link ConcurrentHashMap}, which provides weakly-consistent iterators.
+     * Callers must <strong>not</strong> use the returned values for anything
+     * correctness-sensitive.
+     *
+     * <p>If {@code limit} is positive and the tree contains more nodes than
+     * that, the result is truncated to the first {@code limit} nodes (ordered
+     * by {@code nodeId}). Use {@link Integer#MAX_VALUE} or a non-positive value
+     * for "no limit".
+     *
+     * @param limit maximum number of nodes to include, or {@code <= 0} for no
+     *              limit
+     * @return immutable list of node info, ordered by ascending {@code nodeId}
+     */
+    public List<NodeInfo> snapshotNodes(int limit) {
+        List<NodeInfo> out = new ArrayList<>(nodes.size());
+        for (Node<K, V> node : nodes.values()) {
+            out.add(new NodeInfo(
+                    node.pageId,
+                    node.storeId,
+                    node.leaf,
+                    node.keys,
+                    node.size,
+                    node.loaded,
+                    node.dirty));
+        }
+        out.sort((a, b) -> Long.compare(a.nodeId, b.nodeId));
+        if (limit > 0 && out.size() > limit) {
+            out = new ArrayList<>(out.subList(0, limit));
+        }
+        return Collections.unmodifiableList(out);
+    }
+
+    /**
+     * Immutable per-node snapshot returned by {@link #snapshotNodes(int)}.
+     *
+     * <p>Field semantics:
+     * <ul>
+     *   <li>{@code nodeId} — stable in-memory identifier of the node within
+     *       the tree (the key in the internal nodes map).</li>
+     *   <li>{@code storeId} — page id used by the underlying
+     *       {@link BLinkIndexDataStorage}, or
+     *       {@link BLinkIndexDataStorage#NEW_PAGE} for nodes that have never
+     *       been flushed.</li>
+     *   <li>{@code leaf} — {@code true} for leaf nodes (key → value), false
+     *       for inner separator nodes.</li>
+     *   <li>{@code keys} — number of entries currently stored in the node
+     *       (separators for inner nodes, key/value pairs for leaves).</li>
+     *   <li>{@code sizeBytes} — estimated memory occupancy of the node
+     *       (matches what is accounted in {@link #getUsedMemory()}).</li>
+     *   <li>{@code loaded} — {@code true} if the node's data is currently
+     *       resident in memory; {@code false} if it lives only on disk.</li>
+     *   <li>{@code dirty} — {@code true} if the node has uncheckpointed
+     *       changes.</li>
+     * </ul>
+     */
+    public static final class NodeInfo {
+
+        private final long nodeId;
+        private final long storeId;
+        private final boolean leaf;
+        private final int keys;
+        private final long sizeBytes;
+        private final boolean loaded;
+        private final boolean dirty;
+
+        public NodeInfo(long nodeId, long storeId, boolean leaf, int keys,
+                        long sizeBytes, boolean loaded, boolean dirty) {
+            this.nodeId = nodeId;
+            this.storeId = storeId;
+            this.leaf = leaf;
+            this.keys = keys;
+            this.sizeBytes = sizeBytes;
+            this.loaded = loaded;
+            this.dirty = dirty;
+        }
+
+        public long getNodeId() {
+            return nodeId;
+        }
+
+        public long getStoreId() {
+            return storeId;
+        }
+
+        public boolean isLeaf() {
+            return leaf;
+        }
+
+        public int getKeys() {
+            return keys;
+        }
+
+        public long getSizeBytes() {
+            return sizeBytes;
+        }
+
+        public boolean isLoaded() {
+            return loaded;
+        }
+
+        public boolean isDirty() {
+            return dirty;
+        }
+    }
+
     /* ******************** */
     /* *** PAGE LOADING *** */
     /* ******************** */

--- a/herddb-utils/src/test/java/herddb/index/blink/BLinkTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/BLinkTest.java
@@ -701,4 +701,69 @@ public class BLinkTest {
 
     }
 
+    @Test
+    public void testSnapshotNodesReturnsPerNodeMetadata() throws Exception {
+        try (BLink<Sized<Long>, Long> blink = new BLink<>(1024L, new LongSizeEvaluator(),
+                new RandomPageReplacementPolicy(10), new DummyBLinkIndexDataStorage<>())) {
+
+            // Insert until the tree splits so we get at least 2 nodes.
+            long l = 0;
+            while (blink.nodes() < 2) {
+                blink.insert(Sized.valueOf(l), l);
+                l++;
+            }
+
+            List<BLink.NodeInfo> snapshot = blink.snapshotNodes(Integer.MAX_VALUE);
+
+            assertNotNull(snapshot);
+            assertEquals(blink.nodes(), snapshot.size());
+
+            // Sorted by ascending nodeId.
+            long previousId = Long.MIN_VALUE;
+            int leafCount = 0;
+            int loadedCount = 0;
+            long totalKeys = 0;
+            for (BLink.NodeInfo info : snapshot) {
+                assertTrue("nodeId must be ascending", info.getNodeId() > previousId);
+                previousId = info.getNodeId();
+                assertTrue("sizeBytes must be positive, got " + info.getSizeBytes(),
+                        info.getSizeBytes() > 0);
+                assertTrue("keys must be >= 0, got " + info.getKeys(),
+                        info.getKeys() >= 0);
+                if (info.isLeaf()) {
+                    leafCount++;
+                    totalKeys += info.getKeys();
+                }
+                if (info.isLoaded()) {
+                    loadedCount++;
+                }
+            }
+            assertTrue("at least one leaf node must be present", leafCount >= 1);
+            assertTrue("at least one node must be loaded after inserts", loadedCount >= 1);
+            assertEquals("sum of leaf keys must equal tree size",
+                    blink.size(), totalKeys);
+        }
+    }
+
+    @Test
+    public void testSnapshotNodesIsTruncatedWhenLimitIsLower() throws Exception {
+        try (BLink<Sized<Long>, Long> blink = new BLink<>(1024L, new LongSizeEvaluator(),
+                new RandomPageReplacementPolicy(10), new DummyBLinkIndexDataStorage<>())) {
+
+            long l = 0;
+            while (blink.nodes() < 3) {
+                blink.insert(Sized.valueOf(l), l);
+                l++;
+            }
+
+            int total = blink.nodes();
+            List<BLink.NodeInfo> truncated = blink.snapshotNodes(2);
+            assertEquals(2, truncated.size());
+            assertTrue("truncated list must be a strict prefix", truncated.size() < total);
+
+            List<BLink.NodeInfo> unlimited = blink.snapshotNodes(0);
+            assertEquals(total, unlimited.size());
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #321.

## Changes

### Backend
- **`herddb-utils/.../BLink.java`** — new public `NodeInfo` immutable record + `snapshotNodes(limit)` returning a weakly-consistent, ordered, read-only list of every node (id, on-disk page, leaf, keys, size, loaded, dirty). No locks taken: the snapshot is best-effort, intended for visualisation only.
- **`herddb-core/.../BLinkKeyToPageIndex.java`** + **`IncrementalBLinkKeyToPageIndex.java`** — extended `PrimaryIndexSnapshot` with the per-node list, a `totalNodes` counter and a `truncated` flag. Default cap of 10 000 nodes per snapshot, configurable via `setSnapshotNodeLimit`. The historical `loadedNodes` field is now populated correctly (count of in-memory residents) instead of carrying the total node count — that was a latent bug masked by the lack of visualisation.
- **`herddb-ui/.../PrimaryIndexDTO.java`** + **`TableResource.java`** — REST response `GET .../primary-index` now ships the per-node list, the new `totalNodes` counter and the `truncated` flag. The legacy 4-arg DTO constructor is preserved for the non-BLink fallback branch (in-memory `ConcurrentMapKeyToPageIndex`).

### Frontend
- **`herddb-ui/src/frontend/api/client.ts`** — `PrimaryIndexDTO` interface extended with `BLinkNodeDTO[] nodes`, `totalNodes` and `truncated`.
- **`herddb-ui/src/frontend/pages/PrimaryIndexPage.tsx`** — summary table now shows total / loaded / on-disk / dirty / leaf counters; renders a `<PrimaryIndexView>` heatmap and a truncation hint when the response was clipped; falls back gracefully for non-BLink primary indexes.
- **`herddb-ui/src/frontend/visualizations/PrimaryIndexView.tsx`** *(new)* — heatmap-style visualisation: one cell per BLink node, brightness encodes byte size, yellow border for in-memory residents, red fill for dirty (uncheckpointed) nodes, dashed outline for inner (non-leaf) nodes.

## Tests
- `BLinkTest#testSnapshotNodesReturnsPerNodeMetadata` — split a tree to ≥ 2 nodes, assert per-node fields, ordering, leaf coverage and that the sum of leaf keys equals `tree.size()`.
- `BLinkTest#testSnapshotNodesIsTruncatedWhenLimitIsLower` — exercises the limit clip and the unlimited path.
- `BLinkKeyToPageIndexTest#snapshotInfoReportsNodesList` — populates a real `BLinkKeyToPageIndex`, verifies `loadedNodes` matches the per-node list, `totalNodes` matches the list size when not truncated, and the leaf-keys invariant holds.
- `BLinkKeyToPageIndexTest#snapshotInfoSetsTruncatedFlagWhenLimitExceeded` — uses `setSnapshotNodeLimit(2)` to confirm the truncation flag and that `totalNodes` reflects the full tree.
- `TableResourceTest#primaryIndexReturnsBlinkSnapshot` — extended end-to-end assertions against the live REST resource (loaded count match, totalNodes==list size, leaf-keys invariant).
- `PrimaryIndexPage.test.tsx` *(new, 3 cases)* — verifies summary cells + heatmap rect count, the truncation banner, and the non-BLink fallback message.

## Local validation

| Suite | Result |
|---|---|
| `mvn -pl herddb-utils -Dtest='BLinkTest' test` | 16 pass (2 new) |
| `mvn -pl herddb-core -Dtest='BLinkKeyToPageIndexTest,IncrementalBLinkKeyToPageIndexTest,BLinkParallelWriteCheckpointTest' test` | 7 + 5 + 2 pass |
| `mvn -pl herddb-ui -Dtest='TableResourceTest' test` | Java 11 pass + vitest 27 pass (3 new) |
| `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` | green across all modules |
| Hammer suite (`DirectMultipleConcurrentUpdatesSuite{NoIndexes,NonUniqueIndexes,UniqueIndexes}Test`) | 12 pass × 2 runs |

🤖 Implemented by the `pr-worker` agent.