### PR TITLE
issue #326: skip CREATE VECTOR INDEX when index already exists

### DIFF
--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -62,6 +62,35 @@ public class VectorBench {
         return sb.toString();
     }
 
+    /**
+     * Returns the SQL used to check whether the vector index {@code vidx} already exists
+     * for a given table in the {@code herd} tablespace.
+     * The query uses a positional parameter ({@code ?}) for the table name.
+     */
+    static String buildVectorIndexExistsSql() {
+        return "SELECT index_name FROM herd.sysindexes"
+                + " WHERE table_name=? AND index_name='vidx' AND index_type='vector'";
+    }
+
+    /**
+     * Returns {@code true} if the vector index {@code vidx} already exists for
+     * {@link Config#tableName} in the {@code herd} tablespace.
+     * <p>
+     * Called before each {@code CREATE VECTOR INDEX} attempt so the benchmark skips
+     * creation and logs a notice rather than crashing with
+     * {@code IndexAlreadyExistsException} when a previous run already built the index.
+     * </p>
+     */
+    static boolean vectorIndexExists(Config config) throws java.sql.SQLException {
+        try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
+             java.sql.PreparedStatement ps = conn.prepareStatement(buildVectorIndexExistsSql())) {
+            ps.setString(1, config.tableName);
+            try (java.sql.ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
     /** Runs a task with a progress spinner and returns elapsed wall-clock seconds. */
     private static double runWithProgress(BenchOutput out, String phase, String label, SqlTask task) throws Exception {
         if (!out.suppressesText()) {
@@ -131,6 +160,10 @@ public class VectorBench {
         double ingestionWallSecs = -1, indexWallSecs = -1, queryWallSecs = -1;
         double checkpointPostIngestSecs = -1, checkpointPostIndexSecs = -1;
         double waitForIndexesSecs = -1;
+        // True only when a post-ingest CREATE VECTOR INDEX was actually executed this run
+        // (not skipped via --skip-index, not created pre-ingest, and not already present).
+        // Used to gate the Phase 5b checkpoint so we don't checkpoint when nothing changed.
+        boolean indexCreatedPostIngest = false;
         long ingestionRows = 0;
         double ingestionThroughput = 0;
         MetricsCollector.Stats ingestionLatency = null;
@@ -205,14 +238,21 @@ public class VectorBench {
 
         // Phase 4a: Index creation before ingestion (if requested)
         if (config.indexBeforeIngest && !config.skipIndex) {
-            String indexSql = buildCreateVectorIndexSql(config);
-            out.info("Executing (pre-ingest): " + indexSql);
-            indexWallSecs = runWithProgress(out, "index_creation", "=== INDEX CREATION (pre-ingest) ===", () -> {
-                try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
-                     Statement stmt = conn.createStatement()) {
-                    stmt.execute(indexSql);
-                }
-            });
+            if (vectorIndexExists(config)) {
+                out.info("Vector index 'vidx' already exists — skipping CREATE VECTOR INDEX.");
+                out.info("  Note: index parameters (m, beamWidth, similarity, numShards) cannot be"
+                        + " verified automatically. If they changed since the index was built,"
+                        + " drop and recreate the index manually.");
+            } else {
+                String indexSql = buildCreateVectorIndexSql(config);
+                out.info("Executing (pre-ingest): " + indexSql);
+                indexWallSecs = runWithProgress(out, "index_creation", "=== INDEX CREATION (pre-ingest) ===", () -> {
+                    try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
+                         Statement stmt = conn.createStatement()) {
+                        stmt.execute(indexSql);
+                    }
+                });
+            }
         }
 
         // Phase 4: Ingestion
@@ -528,20 +568,29 @@ public class VectorBench {
 
         // Phase 5: Index creation (post-ingest, unless already created before ingestion)
         if (!config.skipIndex && !config.indexBeforeIngest) {
-            String indexSql = buildCreateVectorIndexSql(config);
-            out.info("Executing: " + indexSql);
-            indexWallSecs = runWithProgress(out, "index_creation", "=== INDEX CREATION ===", () -> {
-                try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
-                     Statement stmt = conn.createStatement()) {
-                    stmt.execute(indexSql);
-                }
-            });
+            if (vectorIndexExists(config)) {
+                out.info("Vector index 'vidx' already exists — skipping CREATE VECTOR INDEX.");
+                out.info("  Note: index parameters (m, beamWidth, similarity, numShards) cannot be"
+                        + " verified automatically. If they changed since the index was built,"
+                        + " drop and recreate the index manually.");
+            } else {
+                String indexSql = buildCreateVectorIndexSql(config);
+                out.info("Executing: " + indexSql);
+                indexWallSecs = runWithProgress(out, "index_creation", "=== INDEX CREATION ===", () -> {
+                    try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);
+                         Statement stmt = conn.createStatement()) {
+                        stmt.execute(indexSql);
+                    }
+                });
+                indexCreatedPostIngest = true;
+            }
         } else if (config.skipIndex) {
             out.info("Skipping index creation.");
         }
 
-        // Phase 5b: Checkpoint after index creation
-        if (config.checkpoint && !config.skipIndex && !config.indexBeforeIngest) {
+        // Phase 5b: Checkpoint after index creation — only when a post-ingest index was
+        // actually created this run (not skipped because it already existed or via --skip-index).
+        if (config.checkpoint && indexCreatedPostIngest) {
             out.info("Executing checkpoint with timeout " + config.checkpointTimeoutSeconds + "s ...");
             checkpointPostIndexSecs = runWithProgress(out, "checkpoint_post_index", "=== CHECKPOINT (post-index) ===", () -> {
                 try (Connection conn = DriverManager.getConnection(config.effectiveJdbcUrl(), config.username, config.password);

--- a/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
@@ -380,6 +380,42 @@ class VectorBenchTest {
         assertEquals(Config.OutputFormat.JSON, cfg.outputFormat);
     }
 
+    // -----------------------------------------------------------------------
+    // buildVectorIndexExistsSql tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    void buildVectorIndexExistsSqlQueriesSysindexes() {
+        String sql = VectorBench.buildVectorIndexExistsSql();
+        org.junit.jupiter.api.Assertions.assertTrue(
+                sql.contains("sysindexes"),
+                "SQL must query sysindexes; got: " + sql);
+    }
+
+    @Test
+    void buildVectorIndexExistsSqlFiltersOnIndexName() {
+        String sql = VectorBench.buildVectorIndexExistsSql();
+        org.junit.jupiter.api.Assertions.assertTrue(
+                sql.contains("index_name='vidx'"),
+                "SQL must filter by index_name='vidx'; got: " + sql);
+    }
+
+    @Test
+    void buildVectorIndexExistsSqlFiltersOnVectorType() {
+        String sql = VectorBench.buildVectorIndexExistsSql();
+        org.junit.jupiter.api.Assertions.assertTrue(
+                sql.contains("index_type='vector'"),
+                "SQL must filter by index_type='vector'; got: " + sql);
+    }
+
+    @Test
+    void buildVectorIndexExistsSqlUsesPositionalParameterForTableName() {
+        String sql = VectorBench.buildVectorIndexExistsSql();
+        org.junit.jupiter.api.Assertions.assertTrue(
+                sql.contains("table_name=?"),
+                "SQL must use a positional parameter (?) for table_name; got: " + sql);
+    }
+
     private static void writeLittleEndianInt(DataOutputStream dos, int value) throws Exception {
         byte[] buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array();
         dos.write(buf);


### PR DESCRIPTION
Fixes #326.

## Changes

- **`VectorBench.java`**: Before executing `CREATE VECTOR INDEX`, call the new
  `vectorIndexExists(config)` helper which queries `herd.sysindexes` (filtering by
  `index_name='vidx'` and `index_type='vector'`). If the index is found, log a clear
  notice and skip creation — making the benchmark idempotent with respect to index
  creation, regardless of whether `--resume-from` is set. The notice also reminds the
  operator to verify parameter consistency (`m`, `beamWidth`, `similarity`, `numShards`)
  manually, since those are not exposed by `sysindexes`.

- **`VectorBench.java`**: Add `indexCreatedPostIngest` boolean flag so the Phase-5b
  checkpoint only fires when a post-ingest `CREATE VECTOR INDEX` was actually executed
  this run (not when creation was skipped because the index existed, or via `--skip-index`).

- **`VectorBenchTest.java`**: Four new unit tests verify that `buildVectorIndexExistsSql()`
  produces a query that targets `sysindexes`, filters on `index_name='vidx'` and
  `index_type='vector'`, and uses a positional parameter for the table name.

## Tests

- `VectorBenchTest` (34 tests total, all passing): four new tests for `buildVectorIndexExistsSql`;
  all pre-existing tests remain green.
- Pre-PR validation (checkstyle + Apache RAT + SpotBugs + `install -DskipTests -Pci`) passed locally.

🤖 Implemented by the `pr-worker` agent.