### PR TITLE
issue #329: propagate runWithProgress worker failures so VectorBench exits non-zero

### DIFF
--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -91,20 +91,31 @@ public class VectorBench {
         }
     }
 
-    /** Runs a task with a progress spinner and returns elapsed wall-clock seconds. */
-    private static double runWithProgress(BenchOutput out, String phase, String label, SqlTask task) throws Exception {
+    /**
+     * Runs a task with a progress spinner and returns elapsed wall-clock seconds.
+     * Any exception (or error) thrown by the task is captured and re-thrown on the
+     * calling thread so that the JVM exits with a non-zero code instead of swallowing
+     * the failure silently.
+     */
+    static double runWithProgress(BenchOutput out, String phase, String label, SqlTask task) throws Exception {
         if (!out.suppressesText()) {
             out.header(label);
         }
         out.phaseStart(phase);
         long startNs = System.nanoTime();
-        Exception[] err = {null};
+        // AtomicReference provides volatile read/write semantics so the error written
+        // by the worker thread is always visible to the calling thread after join().
+        AtomicReference<Throwable> workerError = new AtomicReference<>();
 
         Thread worker = new Thread(() -> {
             try {
                 task.run();
-            } catch (Exception e) {
-                err[0] = e;
+            } catch (Throwable t) {
+                // Catch Throwable — not just Exception — so that Errors such as
+                // OutOfMemoryError are also propagated to the caller rather than
+                // silently swallowed by the thread's default UncaughtExceptionHandler,
+                // which would leave the main thread unaware of the failure.
+                workerError.set(t);
             }
         });
         worker.start();
@@ -115,12 +126,19 @@ public class VectorBench {
             out.progress(phase, elapsed, null, fields);
             worker.join(500);
         }
+        // Unconditional join() after the loop establishes a happens-before relationship
+        // between the worker's last write (workerError.set) and our read below, even when
+        // the final worker.join(500) inside the loop timed out before the worker died.
+        worker.join();
 
         double totalSecs = (System.nanoTime() - startNs) / 1e9;
         out.phaseDone(phase, totalSecs);
 
-        if (err[0] != null) {
-            throw err[0];
+        Throwable t = workerError.get();
+        if (t instanceof Exception) {
+            throw (Exception) t;
+        } else if (t != null) {
+            throw new RuntimeException("Benchmark phase failed: " + t.getMessage(), t);
         }
         return totalSecs;
     }

--- a/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
@@ -22,11 +22,16 @@ package herddb.vectortesting;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -414,6 +419,79 @@ class VectorBenchTest {
         org.junit.jupiter.api.Assertions.assertTrue(
                 sql.contains("table_name=?"),
                 "SQL must use a positional parameter (?) for table_name; got: " + sql);
+    }
+
+    // -----------------------------------------------------------------------
+    // runWithProgress tests (issue #329)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Issue #329: an exception thrown by the task inside runWithProgress must be
+     * re-thrown on the calling thread so that the JVM exits with a non-zero code.
+     * Previously, a visibility race between the worker thread and the main thread
+     * (no happens-before when the last join(500) timed out) could leave the caller
+     * unaware of the failure and allow execution to continue normally to System.exit(0).
+     */
+    @Test
+    void runWithProgressPropagatesCheckedExceptionFromWorkerThread() throws Exception {
+        BenchOutput out = BenchOutput.create(
+                Config.parse(new String[]{"--no-progress"}),
+                new PrintStream(OutputStream.nullOutputStream()));
+
+        SQLException cause = new SQLException("WAITFORINDEXES timed out after 1800000 ms");
+
+        Exception thrown = assertThrows(SQLException.class, () ->
+                VectorBench.runWithProgress(out, "test_phase", "=== TEST ===", () -> {
+                    throw cause;
+                }));
+
+        assertSame(cause, thrown,
+                "runWithProgress must re-throw the exact exception from the worker thread");
+    }
+
+    /**
+     * Issue #329: an Error (e.g. OutOfMemoryError) thrown by the task must also be
+     * surfaced to the caller. Previously, only Exception was caught; an Error would be
+     * silently swallowed by the thread's UncaughtExceptionHandler and the caller would
+     * see a successful return.
+     */
+    @Test
+    void runWithProgressPropagatesErrorFromWorkerThread() {
+        BenchOutput out;
+        try {
+            out = BenchOutput.create(
+                    Config.parse(new String[]{"--no-progress"}),
+                    new PrintStream(OutputStream.nullOutputStream()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Error cause = new OutOfMemoryError("simulated OOM");
+
+        RuntimeException wrapped = assertThrows(RuntimeException.class, () ->
+                VectorBench.runWithProgress(out, "test_phase", "=== TEST ===", () -> {
+                    throw cause;
+                }));
+
+        assertSame(cause, wrapped.getCause(),
+                "runWithProgress must wrap Error in RuntimeException and preserve the cause");
+    }
+
+    /**
+     * Sanity check: runWithProgress must return a positive elapsed time when the
+     * task completes successfully.
+     */
+    @Test
+    void runWithProgressReturnsTotalElapsedSecondsOnSuccess() throws Exception {
+        BenchOutput out = BenchOutput.create(
+                Config.parse(new String[]{"--no-progress"}),
+                new PrintStream(OutputStream.nullOutputStream()));
+
+        double elapsed = VectorBench.runWithProgress(out, "test_phase", "=== TEST ===", () -> {
+            // no-op task — completes immediately
+        });
+
+        assertTrue(elapsed >= 0.0, "elapsed time must be non-negative");
     }
 
     private static void writeLittleEndianInt(DataOutputStream dos, int value) throws Exception {


### PR DESCRIPTION
Fixes #329.

## Root cause

`runWithProgress` captured the worker thread's exception into a plain
`Exception[] err = {null}` array.  When the last `worker.join(500)` in
the progress loop timed out before the worker died, and the worker died
between that timeout and the next `worker.isAlive()` check, no subsequent
`join()` providing a JMM happens-before relationship was called.  The main
thread could therefore read `err[0]` as `null` even though the worker had
already stored the exception — execution would fall through to
`System.exit(0)` as if the phase had succeeded.

A second, orthogonal gap: only `Exception` was caught in the lambda, so
any `Error` (e.g. `OutOfMemoryError`) thrown by the task would be silently
swallowed by the thread's `UncaughtExceptionHandler` and the caller would
see a successful return.

## Changes

- `VectorBench.java`: replace `Exception[] err` with
  `AtomicReference<Throwable>` (volatile read/write semantics eliminate the
  visibility race); widen `catch (Exception)` → `catch (Throwable)` with an
  explanatory comment (worker-thread isolation boundary — exactly the case
  CLAUDE.md carves out); add `worker.join()` after the progress loop as
  defence-in-depth for the happens-before edge; relax `runWithProgress` from
  `private static` to package-private so unit tests can reach it directly.
- `VectorBenchTest.java`: three new tests covering (1) checked
  `SQLException` propagated as-is, (2) `OutOfMemoryError` wrapped in
  `RuntimeException` with original cause, (3) successful task returns
  non-negative elapsed time.

## Tests

- `runWithProgressPropagatesCheckedExceptionFromWorkerThread` — passes a
  task that throws `SQLException`; asserts the exact exception is re-thrown
  on the caller.
- `runWithProgressPropagatesErrorFromWorkerThread` — passes a task that
  throws `OutOfMemoryError`; asserts it is wrapped in `RuntimeException`
  with the original error as cause.
- `runWithProgressReturnsTotalElapsedSecondsOnSuccess` — no-op task;
  asserts elapsed time ≥ 0.

All 33 tests in `VectorBenchTest` pass.  Pre-PR validation (checkstyle,
Apache RAT, SpotBugs, install -DskipTests -Pci) is green.

🤖 Implemented by the `pr-worker` agent.