### PR TITLE
issue #332: add PodDisruptionBudgets for all StatefulSets and Deployments

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -29,6 +29,13 @@
 #   bookkeeper      :   2 g heap +  1 g direct + 1 g =  4 g  (< 8 GiB)
 #   zookeeper       : 512 m heap + 512 m direct       = ~1 g  (< 4 GiB)
 
+#
+# PodDisruptionBudgets are enabled below for every workload that runs in this
+# example. The original motivation for this knob was a GKE cluster-autoscaler
+# scale-down event that evicted herddb-zookeeper-0 mid-benchmark, expired all
+# client sessions, and permanently lost a tablespace (see issue #332). On a
+# long-running benchmark, blocking voluntary evictions is the desired default.
+
 image:
   # Always re-pull so that re-pushed tags (common during active
   # benchmark iteration) are picked up on every pod restart.
@@ -40,6 +47,8 @@ server:
   mode: cluster
   storageMode: remote
   replicaCount: 1
+  pdb:
+    enabled: true
   # Pin to europe-west4-a to keep all traffic within a single zone
   # (cross-zone egress in GKE is billed; same-zone traffic is free).
   nodeSelector:
@@ -123,6 +132,8 @@ server:
 
 fileServer:
   replicaCount: 2
+  pdb:
+    enabled: true
   # Pin to europe-west4-a (same-zone traffic is free).
   nodeSelector:
     topology.kubernetes.io/zone: "europe-west4-a"
@@ -171,6 +182,8 @@ minio:
 
 zookeeper:
   enabled: true
+  pdb:
+    enabled: true
   # Pin to europe-west4-a (same-zone traffic is free).
   nodeSelector:
     topology.kubernetes.io/zone: "europe-west4-a"
@@ -188,6 +201,8 @@ zookeeper:
 bookkeeper:
   enabled: true
   replicaCount: 2
+  pdb:
+    enabled: true
   # Pin to europe-west4-a (same-zone traffic is free).
   nodeSelector:
     topology.kubernetes.io/zone: "europe-west4-a"
@@ -264,6 +279,8 @@ indexingService:
   enabled: true
   storageMode: remote
   replicaCount: 2
+  pdb:
+    enabled: true
   # Request AVX-512 capable nodes for jvector acceleration.
   # europe-west4 (Netherlands) has both C3 (Intel Sapphire Rapids, AVX-512F/BW/VL/DQ/VNNI/FP16)
   # and C3D (AMD EPYC Genoa, AVX-512F/BW/VL/DQ/VNNI).  Either is a significant upgrade
@@ -351,6 +368,9 @@ indexingService:
 
 tools:
   enabled: true
+  # PDB is on by default for tools (see values.yaml); pinned here for clarity.
+  pdb:
+    enabled: true
   # Pin to europe-west4-a (same-zone traffic is free).
   nodeSelector:
     topology.kubernetes.io/zone: "europe-west4-a"

--- a/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.bookkeeper.enabled .Values.bookkeeper.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-bookkeeper
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bookkeeper
+spec:
+  minAvailable: {{ .Values.bookkeeper.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bookkeeper
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/file-server-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/file-server-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and (eq .Values.server.storageMode "remote") .Values.fileServer.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-file-server
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: file-server
+spec:
+  minAvailable: {{ .Values.fileServer.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: file-server
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/grafana-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/grafana-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.grafana.enabled .Values.grafana.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-grafana
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
+spec:
+  minAvailable: {{ .Values.grafana.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: grafana
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/indexing-service-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/indexing-service-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.indexingService.enabled .Values.indexingService.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-indexing-service
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: indexing-service
+spec:
+  minAvailable: {{ .Values.indexingService.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: indexing-service
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/minio-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/minio-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.minio.enabled .Values.minio.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-minio
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  minAvailable: {{ .Values.minio.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/prometheus-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/prometheus-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-prometheus
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: prometheus
+spec:
+  minAvailable: {{ .Values.prometheus.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: prometheus
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/server-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/server-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.server.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-server
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  minAvailable: {{ .Values.server.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "herddb.labels" . | nindent 4 }}
     app.kubernetes.io/component: tools
 spec:
-  minAvailable: 1
+  minAvailable: {{ .Values.tools.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
       {{- include "herddb.selectorLabels" . | nindent 6 }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/zookeeper-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/zookeeper-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.zookeeper.enabled .Values.zookeeper.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "herddb.fullname" . }}-zookeeper
+  labels:
+    {{- include "herddb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zookeeper
+spec:
+  minAvailable: {{ .Values.zookeeper.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "herddb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zookeeper
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-pdb_test.yaml
@@ -1,0 +1,52 @@
+suite: bookkeeper PodDisruptionBudget
+templates:
+  - templates/bookkeeper-pdb.yaml
+tests:
+  - it: should not render by default (bookkeeper disabled, pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when bookkeeper.enabled is true but pdb is off
+    set:
+      bookkeeper.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is on but bookkeeper.enabled is false
+    set:
+      bookkeeper.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when bookkeeper.enabled and bookkeeper.pdb.enabled
+    set:
+      bookkeeper.enabled: true
+      bookkeeper.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-bookkeeper
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: bookkeeper
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: bookkeeper
+
+  - it: should honour a custom bookkeeper.pdb.minAvailable value
+    set:
+      bookkeeper.enabled: true
+      bookkeeper.pdb.enabled: true
+      bookkeeper.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/tests/file-server-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/file-server-pdb_test.yaml
@@ -1,0 +1,51 @@
+suite: file-server PodDisruptionBudget
+templates:
+  - templates/file-server-pdb.yaml
+tests:
+  - it: should not render by default (storageMode=remote, but pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when fileServer.pdb.enabled is true
+    set:
+      fileServer.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-file-server
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: file-server
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: file-server
+
+  - it: should honour a custom fileServer.pdb.minAvailable value
+    set:
+      fileServer.pdb.enabled: true
+      fileServer.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should not render when fileServer.pdb.enabled is false
+    set:
+      fileServer.pdb.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when server.storageMode is local even if pdb enabled
+    set:
+      server.storageMode: local
+      fileServer.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/grafana-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/grafana-pdb_test.yaml
@@ -1,0 +1,52 @@
+suite: grafana PodDisruptionBudget
+templates:
+  - templates/grafana-pdb.yaml
+tests:
+  - it: should not render by default (grafana disabled, pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when grafana.enabled is true but pdb is off
+    set:
+      grafana.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is on but grafana.enabled is false
+    set:
+      grafana.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when grafana.enabled and grafana.pdb.enabled
+    set:
+      grafana.enabled: true
+      grafana.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-grafana
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: grafana
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: grafana
+
+  - it: should honour a custom grafana.pdb.minAvailable value
+    set:
+      grafana.enabled: true
+      grafana.pdb.enabled: true
+      grafana.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-pdb_test.yaml
@@ -1,0 +1,52 @@
+suite: indexing-service PodDisruptionBudget
+templates:
+  - templates/indexing-service-pdb.yaml
+tests:
+  - it: should not render by default (indexingService disabled, pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when indexingService.enabled is true but pdb is off
+    set:
+      indexingService.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is on but indexingService.enabled is false
+    set:
+      indexingService.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when indexingService.enabled and indexingService.pdb.enabled
+    set:
+      indexingService.enabled: true
+      indexingService.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-indexing-service
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: indexing-service
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: indexing-service
+
+  - it: should honour a custom indexingService.pdb.minAvailable value
+    set:
+      indexingService.enabled: true
+      indexingService.pdb.enabled: true
+      indexingService.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/tests/minio-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/minio-pdb_test.yaml
@@ -1,0 +1,52 @@
+suite: minio PodDisruptionBudget
+templates:
+  - templates/minio-pdb.yaml
+tests:
+  - it: should not render by default (minio disabled, pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when minio.enabled is true but pdb is off
+    set:
+      minio.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is on but minio.enabled is false
+    set:
+      minio.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when minio.enabled and minio.pdb.enabled
+    set:
+      minio.enabled: true
+      minio.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-minio
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: minio
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: minio
+
+  - it: should honour a custom minio.pdb.minAvailable value
+    set:
+      minio.enabled: true
+      minio.pdb.enabled: true
+      minio.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/tests/prometheus-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/prometheus-pdb_test.yaml
@@ -1,0 +1,52 @@
+suite: prometheus PodDisruptionBudget
+templates:
+  - templates/prometheus-pdb.yaml
+tests:
+  - it: should not render by default (prometheus disabled, pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when prometheus.enabled is true but pdb is off
+    set:
+      prometheus.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is on but prometheus.enabled is false
+    set:
+      prometheus.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when prometheus.enabled and prometheus.pdb.enabled
+    set:
+      prometheus.enabled: true
+      prometheus.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-prometheus
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: prometheus
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: prometheus
+
+  - it: should honour a custom prometheus.pdb.minAvailable value
+    set:
+      prometheus.enabled: true
+      prometheus.pdb.enabled: true
+      prometheus.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/tests/server-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/server-pdb_test.yaml
@@ -1,0 +1,43 @@
+suite: server PodDisruptionBudget
+templates:
+  - templates/server-pdb.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when server.pdb.enabled is true
+    set:
+      server.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-server
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: server
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: server
+
+  - it: should honour a custom server.pdb.minAvailable value
+    set:
+      server.pdb.enabled: true
+      server.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should not render when server.pdb.enabled is false
+    set:
+      server.pdb.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/tools-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/tools-pdb_test.yaml
@@ -1,0 +1,42 @@
+suite: tools PodDisruptionBudget
+templates:
+  - templates/tools-pdb.yaml
+tests:
+  - it: should render by default (tools.enabled and tools.pdb.enabled both default true)
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-tools
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: tools
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: tools
+
+  - it: should honour a custom tools.pdb.minAvailable value
+    set:
+      tools.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should not render when tools.pdb.enabled is false
+    set:
+      tools.pdb.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when tools.enabled is false
+    set:
+      tools.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/zookeeper-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/zookeeper-pdb_test.yaml
@@ -1,0 +1,52 @@
+suite: zookeeper PodDisruptionBudget
+templates:
+  - templates/zookeeper-pdb.yaml
+tests:
+  - it: should not render by default (zookeeper disabled, pdb disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when zookeeper.enabled is true but pdb is off
+    set:
+      zookeeper.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb is on but zookeeper.enabled is false
+    set:
+      zookeeper.pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when zookeeper.enabled and zookeeper.pdb.enabled
+    set:
+      zookeeper.enabled: true
+      zookeeper.pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-herddb-zookeeper
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: zookeeper
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: zookeeper
+
+  - it: should honour a custom zookeeper.pdb.minAvailable value
+    set:
+      zookeeper.enabled: true
+      zookeeper.pdb.enabled: true
+      zookeeper.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -42,6 +42,13 @@ server:
   loggingProperties: ""
   # Extra key=value entries appended to server.properties
   extraConfig: {}
+  # PodDisruptionBudget — blocks voluntary node evictions (cluster-autoscaler
+  # scale-down, kubectl drain) so that a single-replica server cannot be
+  # involuntarily killed mid-operation. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   storage:
     data:
       size: 10Gi
@@ -105,6 +112,11 @@ fileServer:
     size: 10Gi
     storageClass: ""
   extraConfig: {}
+  # PodDisruptionBudget — see server.pdb above. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "1Gi"
@@ -126,6 +138,11 @@ minio:
   storage:
     size: 10Gi
     storageClass: ""
+  # PodDisruptionBudget — see server.pdb above. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "512Mi"
@@ -152,6 +169,15 @@ zookeeper:
   storage:
     size: 2Gi
     storageClass: ""
+  # PodDisruptionBudget — strongly recommended for ZooKeeper. The original
+  # motivation for the chart-wide PDB knob was a GKE cluster-autoscaler
+  # scale-down event that evicted herddb-zookeeper-0 and expired all client
+  # sessions, permanently losing a tablespace (issue #332). Disabled by
+  # default to keep the standalone helm install drainable; enable in any
+  # cluster-mode deployment.
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "256Mi"
@@ -180,6 +206,11 @@ bookkeeper:
     ledger:
       size: 5Gi
       storageClass: ""
+  # PodDisruptionBudget — see server.pdb above. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "512Mi"
@@ -222,6 +253,11 @@ indexingService:
     log:
       size: 5Gi
       storageClass: ""
+  # PodDisruptionBudget — see server.pdb above. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "1Gi"
@@ -246,6 +282,7 @@ tools:
   # when tools is enabled. Set to false only for short-lived / disposable runs.
   pdb:
     enabled: true
+    minAvailable: 1
   gcs:
     # Kubernetes Secret containing GCS HMAC credentials (keys: S3_ACCESS_KEY, S3_SECRET_KEY).
     # When set, the tools pod can download datasets from gs:// URLs using the S3-compatible API.
@@ -281,6 +318,11 @@ prometheus:
   storage:
     size: 10Gi
     storageClass: ""
+  # PodDisruptionBudget — see server.pdb above. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "512Mi"
@@ -296,6 +338,11 @@ grafana:
     repository: grafana/grafana
     tag: "11.1.0"
   port: 3000
+  # PodDisruptionBudget — see server.pdb above. Disabled by default; enable in
+  # production / long-running benchmarks (see issue #332).
+  pdb:
+    enabled: false
+    minAvailable: 1
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
Refs #332.

## Summary

Issue #332 documents a GKE cluster auto-scaler scale-down event that evicted `herddb-zookeeper-0` and `herddb-bookkeeper-1`, expired all four ZK client sessions, and permanently lost the `herd` tablespace. The issue proposes three fixes; **this PR implements only Fix #1**: ensure every StatefulSet and Deployment in the Helm chart has an opt-in PodDisruptionBudget so voluntary evictions (cluster-autoscaler drain, kubectl drain, node upgrade) cannot kill the pod when only one replica exists.

## Changes

### New PDB templates (one per workload)
- `templates/server-pdb.yaml`
- `templates/file-server-pdb.yaml` — gated on `eq .Values.server.storageMode "remote"` to mirror the StatefulSet condition
- `templates/zookeeper-pdb.yaml` — primary mitigation for issue #332
- `templates/bookkeeper-pdb.yaml`
- `templates/indexing-service-pdb.yaml`
- `templates/minio-pdb.yaml`
- `templates/prometheus-pdb.yaml`
- `templates/grafana-pdb.yaml`

Each template follows the existing `tools-pdb.yaml` shape: `policy/v1` PDB, `minAvailable: 1` default, selector matching `app.kubernetes.io/component=<workload>`. Gating: each PDB renders only when the parent component is enabled AND the new `<component>.pdb.enabled` knob is true.

### Existing template
- `templates/tools-pdb.yaml` — replaced hardcoded `minAvailable: 1` with `{{ .Values.tools.pdb.minAvailable | default 1 }}` for consistency. Default behavior unchanged (`tools.pdb.enabled: true`).

### values.yaml
- Added `pdb: { enabled: false, minAvailable: 1 }` to `server`, `fileServer`, `minio`, `zookeeper`, `bookkeeper`, `indexingService`, `prometheus`, `grafana`. Each block carries an explanatory comment referencing issue #332.
- Added explicit `minAvailable: 1` to the existing `tools.pdb` block.
- **`tools.pdb.enabled` stays `true` by default** (no behavior change for existing tools deployments).
- All other PDBs default to `enabled: false` so vanilla `helm install` (k3s-local, dev) remains drainable.

### examples/gke/values.yaml
Enabled PDBs for every workload that runs in this example: `server`, `fileServer`, `zookeeper`, `bookkeeper`, `indexingService`, `tools` (explicit). The original failure in issue #332 happened on this configuration. Top-of-file comment explains the rationale.

## Tests

Added 9 helm-unittest YAML files under `tests/` covering each new PDB plus the existing `tools` PDB:
- Default rendering (off for all except tools; tools renders by default).
- Renders when `<component>.pdb.enabled=true` (and parent component enabled).
- `minAvailable` defaults to 1 and respects override.
- Suppressed when `pdb.enabled=false`.
- Suppressed when parent component disabled even if `pdb.enabled=true`.
- For `file-server-pdb`: also covers the `server.storageMode=local` gate.

All 170 helm-unittest assertions pass; `helm lint` is clean.

## Validation

```
helm lint   herddb-kubernetes/src/main/helm/herddb           # 1 chart(s) linted, 0 chart(s) failed
helm unittest herddb-kubernetes/src/main/helm/herddb         # 20 suites, 170 tests, all pass
mvn -B checkstyle:check apache-rat:check spotbugs:check \
    install -DskipTests -Pci                                  # BUILD SUCCESS
```

Smoke-tested with the GKE example values: `helm template` renders all 6 expected PDBs (server, file-server, zookeeper, bookkeeper, indexing-service, tools).

🤖 Implemented by the `pr-worker` agent.