### PR TITLE
issue #325: add --background flag to run-bench.sh; decouple JVM from kubectl pipe

### DIFF
--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -49,14 +49,21 @@ directory.
   only when the user explicitly asks to fully remove HerdDB. Does
   **not** touch GCS buckets.
 - `./scripts/check-cluster.sh` — pod health check. Exit 0 = healthy.
-- `./scripts/run-bench.sh <vector-bench args>` — run the workload
-  inside `sts/herddb-tools`. The last line of stdout is
-  `RUN_LOG=<path>` — capture it. Must be launched with
-  `run_in_background: true` so the supervision loop can run in
-  parallel. The script always prepends `--no-progress` to
-  `vector-bench.sh`, so the captured `RUN_LOG` is `\n`-terminated
-  plain-text output. You can and should `Read` this file during
-  supervision.
+- `./scripts/run-bench.sh [--background] <vector-bench args>` — run
+  the workload inside `sts/herddb-tools`. The last line of stdout is
+  `RUN_LOG=<path>` — capture it. **Always pass `--background`** so the
+  JVM runs as a pod-resident `nohup` process fully decoupled from the
+  kubectl connection; the script then exits 0 immediately and you enter
+  the supervision loop (see §Supervision and issue #325). In background
+  mode the benchmark log lives inside the pod at
+  `/tmp/vector-bench-<TS>.log` (path printed on stdout as `Pod log:`);
+  progress is monitored via `GET /status` on the admin HTTP API.
+  Without `--background` the script blocks until the JVM exits,
+  redirecting kubectl output directly to `$RUN_LOG` (no tee) — do not
+  use that mode for automated runs.
+- `./scripts/kill-bench.sh` — kill any running vector-bench process
+  inside the tools pod. Safe if no bench is running (exits 0). Use
+  this to stop a benchmark that was started with `--background`.
 - `./scripts/reset-cluster.sh [--yes]` — wipe all durable HerdDB state
   between runs: scale StatefulSets to 0, delete their PVCs, empty
   the file-server pages bucket in GCS, scale back up. The tools pod
@@ -303,13 +310,16 @@ Rules that apply to every workload, including user-specified ones:
 3. **Health check.** Run `./scripts/check-cluster.sh`. On failure go
    to the failure path.
 
-4. **Run the workload.** Launch `./scripts/run-bench.sh …` with
-   `run_in_background: true`. Capture the background task ID. Enter
-   the supervision loop (§Supervision) until the background task
-   finishes OR the loop detects a fatal signal.
+4. **Run the workload.** Call `./scripts/run-bench.sh --background …`
+   (without `run_in_background: true` — the `--background` flag starts
+   the JVM inside the pod as a `nohup` process and the script exits
+   immediately). Capture `RUN_LOG=<path>` from the last line of stdout.
+   Enter the supervision loop (§Supervision) immediately; poll until
+   `GET /status` returns `phase=done` or the benchmark process is gone,
+   or the loop detects a fatal signal.
 
-   - If the bench exits 0 and supervision saw no fatal signals →
-     capture `RUN_LOG=<path>` and go to step 5.
+   - If supervision ends with `phase=done` and no fatal signals →
+     go to step 5.
    - Otherwise → go to the failure path.
 
 5. **Generate report.** Run `./scripts/write-report.sh <RUN_LOG>`
@@ -322,28 +332,44 @@ Rules that apply to every workload, including user-specified ones:
 
 ## Supervision
 
-While `run-bench.sh` runs in the background, poll the cluster at
-least every 60 seconds (minimum 30 s, maximum 90 s between polls).
-**On each tick: spawn the `herddb-cluster-monitor` sub-agent** (see
-§Supervision delegation above) and wait for its TICK SUMMARY.
+Once `run-bench.sh --background` has started the JVM inside the pod and
+returned, poll the cluster at least every 60 seconds (minimum 30 s,
+maximum 90 s between polls). **On each tick: spawn the
+`herddb-cluster-monitor` sub-agent** (see §Supervision delegation
+above) and wait for its TICK SUMMARY.
+
+The primary progress source is always `GET /status` via the admin HTTP
+API:
+```
+kubectl -n default exec herddb-tools-0 -- curl -s http://localhost:8080/status
+```
+In background mode the local `$RUN_LOG` contains only the header and
+start marker — the benchmark output lives inside the pod at
+`/tmp/vector-bench-<TS>.log` (path recorded in `$RUN_LOG` as
+`remote-log:`). Fetch the pod log tail for raw output when needed:
+```
+kubectl -n default exec sts/herddb-tools -- tail -n 50 /tmp/vector-bench-<TS>.log
+```
 
 The cluster-monitor sub-agent handles all per-tick diagnostics:
-- Polling the VectorBench admin API (`GET /status`) for rows, rate, commits
-- Reading the run log tail as fallback / supplemental
-- Checking pod status for crashes / increasing RESTARTS
+- Polling `GET /status` for rows, rate, commits (primary source)
+- Pod status checks for crashes / increasing RESTARTS
 - Scanning component logs for error keywords
 - `indexing-admin list-indexes` per IS replica for vector counts
 - `indexing-admin engine-stats` per IS replica for queue/memory state
 - IS and server log scanning for checkpoint phase / back-pressure signals
 - Polling file-server metrics (query phases)
 
-You receive a structured TICK SUMMARY (~300 tokens, ~20 lines) with a VERDICT:
+You receive a structured TICK SUMMARY (~300 tokens, ~20 lines) with a
+VERDICT:
 - `healthy` — continue to next tick
 - `warning` — log the warning and continue
-- `fatal` — stop the background task, proceed to §Failure handling
+- `fatal` — run `./scripts/kill-bench.sh`, then proceed to §Failure
+  handling
 
-Between ticks, wait for the background task completion notification or
-schedule the next tick ~60 s after the previous one.
+The benchmark is complete when `GET /status` returns `phase=done` (or
+the vector-bench process is gone from the pod). Schedule the next tick
+~60 s after the previous one.
 
 Example cluster-monitor invocation:
 
@@ -401,9 +427,9 @@ Agent(
 - **Bookie line**: omit entirely when `blocked=0`, `rejected=0`, `skipThr=0`.
   Only surface it when at least one of those counters is non-zero.
 
-If any VERDICT is `fatal`: stop the background `run-bench.sh` task
-immediately, then proceed to §Failure handling. Do NOT attempt to mitigate
-on the running cluster.
+If any VERDICT is `fatal`: run `./scripts/kill-bench.sh` to stop the
+pod-resident vector-bench process immediately, then proceed to §Failure
+handling. Do NOT attempt to mitigate on the running cluster.
 
 ---
 
@@ -413,7 +439,7 @@ You never try to recover a broken cluster. Every failure produces a
 reproducible GitHub issue. On any failure (install, health check,
 bench non-zero exit, or supervision-detected fault):
 
-1. If the bench is still running in the background, stop it.
+1. If the bench is still running, stop it: `./scripts/kill-bench.sh`.
 
 2. **OOM only — collect profiles and heap dump while the pod is
    still live.** If the fatal signal was an `OutOfMemoryError` and
@@ -473,7 +499,7 @@ path always ends in "stop".
 
 Ceremony:
 
-1. Make sure any background `run-bench.sh` is already stopped.
+1. Make sure any background benchmark is already stopped: `./scripts/kill-bench.sh`.
 2. `./scripts/reset-cluster.sh --yes` — the script scales down the
    relevant StatefulSets, deletes their PVCs, empties the file-server
    pages bucket, then scales back up. The tools pod and its dataset

--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -37,21 +37,23 @@ before running anything. All paths below are relative to that directory.
   explicitly asks, OR as step 1 of a PVC-resize ceremony after the user
   explicitly asks for a retry with a bigger PVC.
 - `./scripts/check-cluster.sh` — pod health check. Exit 0 = healthy.
-- `./scripts/run-bench.sh <vector-bench args>` — run the workload. The last
-  line of stdout is `RUN_LOG=<path>` — capture it. Must be launched with
-  `run_in_background: true` so the supervision loop can run in parallel.
-  The script always prepends `--no-progress` to `vector-bench.sh`, so the
-  captured `RUN_LOG` is `\n`-terminated plain-text output (no `\r` spinner
-  frames). You can and should `Read` this file during supervision to see
-  the current phase and live progress samples (one line every ~5 s) — see
-  §Supervision. If the user explicitly asks for structured output, pass
-  `--output-format json` through to `run-bench.sh` and the log will become
-  NDJSON (one JSON object per line with `event` values `config`,
-  `phase_start`, `progress`, `phase_end`, `summary`, `done`, or `error`).
-  `--output-format json` implicitly enables `--no-progress`.
-  `write-report.sh` still parses plain mode (`^phase=` lines + SUMMARY
-  block) — do not switch to NDJSON unless the user asks for it, or
-  `write-report.sh` will not produce a report.
+- `./scripts/run-bench.sh [--background] <vector-bench args>` — run the
+  workload inside `sts/herddb-tools`. The last line of stdout is
+  `RUN_LOG=<path>` — capture it. **Always pass `--background`** so the JVM
+  runs as a pod-resident `nohup` process fully decoupled from the kubectl
+  connection; the script then exits 0 immediately and you enter the
+  supervision loop (see §Supervision and issue #325). Without `--background`
+  the script blocks until the JVM exits, streaming output through a tee pipe
+  that is vulnerable to SIGPIPE on output-buffer exhaustion — do not use that
+  mode for automated runs. The script always prepends `--no-progress` to
+  `vector-bench.sh`; in background mode the benchmark log lives inside the
+  pod at `/tmp/vector-bench-<TS>.log` (path printed on stdout as `Pod log:`).
+  Progress is monitored via `GET /status` on the admin HTTP API. If the user
+  explicitly asks for structured output, pass `--output-format json` through
+  to `run-bench.sh` and the log will become NDJSON. `write-report.sh` still
+  parses plain mode (`^phase=` lines + SUMMARY block) — do not switch to
+  NDJSON unless the user asks for it, or `write-report.sh` will not produce a
+  report.
 - `./scripts/collect-logs.sh` — dump pod logs into a timestamped dir. Last
   line is `LOGS_DIR=<path>`.
 - `./scripts/analyze-server-checkpoints.sh [--run-log <f>] [--lines N] [--previous]`
@@ -290,13 +292,16 @@ Rules that apply to every workload, including user-specified ones:
 3. **Health check.** Run `./scripts/check-cluster.sh`. On failure go to the
    failure path.
 
-4. **Run the workload.** Launch `./scripts/run-bench.sh …` with
-   `run_in_background: true`. Capture the background task ID. Enter the
-   supervision loop (§Supervision) until the background task finishes OR
-   the loop detects a fatal signal.
+4. **Run the workload.** Call `./scripts/run-bench.sh --background …`
+   (without `run_in_background: true` — the `--background` flag starts the
+   JVM inside the pod as a `nohup` process and the script exits immediately).
+   Capture `RUN_LOG=<path>` from the last line of stdout. Enter the
+   supervision loop (§Supervision) immediately; poll until `GET /status`
+   returns `phase=done` or the benchmark process is gone, or the loop detects
+   a fatal signal.
 
-   - If the bench exits 0 and supervision saw no fatal signals → capture
-     `RUN_LOG=<path>` and go to step 5.
+   - If supervision ends with `phase=done` and no fatal signals → go to
+     step 5.
    - Otherwise → go to the failure path.
 
 5. **Generate report.** Run `./scripts/write-report.sh <RUN_LOG>` and
@@ -309,15 +314,26 @@ Rules that apply to every workload, including user-specified ones:
 
 ## Supervision
 
-While `run-bench.sh` runs in the background, poll the cluster at least every
-60 seconds (minimum 30 s, maximum 90 s between polls). **On each tick: spawn
-the `herddb-cluster-monitor` sub-agent** (see §Supervision delegation above)
-and wait for its TICK SUMMARY.
+Once `run-bench.sh --background` has started the JVM inside the pod and
+returned, poll the cluster at least every 60 seconds (minimum 30 s, maximum
+90 s between polls). **On each tick: spawn the `herddb-cluster-monitor`
+sub-agent** (see §Supervision delegation above) and wait for its TICK SUMMARY.
+
+The primary progress source is always `GET /status` via the admin HTTP API:
+```
+kubectl --kubeconfig .kubeconfig -n default exec herddb-tools-0 -- curl -s http://localhost:8080/status
+```
+In background mode the local `$RUN_LOG` contains only the header and start
+marker — the benchmark output lives inside the pod at
+`/tmp/vector-bench-<TS>.log` (path recorded in `$RUN_LOG` as `remote-log:`).
+You can fetch the pod log tail for raw output when needed:
+```
+kubectl --kubeconfig .kubeconfig -n default exec sts/herddb-tools -- tail -n 50 /tmp/vector-bench-<TS>.log
+```
 
 The cluster-monitor sub-agent handles all per-tick diagnostics:
-- Polling the VectorBench admin API (`GET /status`) for rows, rate, commits
-- Reading the run log tail as fallback / supplemental
-- Checking pod status for crashes / increasing RESTARTS
+- Polling `GET /status` for rows, rate, commits (primary source)
+- Pod status checks for crashes / increasing RESTARTS
 - Scanning component logs for error keywords
 - Running `indexing-admin list-indexes` per IS replica for vector counts
 - Running `indexing-admin engine-stats` per IS replica for queue/memory state
@@ -327,10 +343,12 @@ The cluster-monitor sub-agent handles all per-tick diagnostics:
 You receive a structured TICK SUMMARY (~300 tokens, ~20 lines) with a VERDICT:
 - `healthy` — continue to next tick
 - `warning` — log the warning and continue
-- `fatal` — stop the background task, proceed to §Failure handling
+- `fatal` — run `./scripts/kill-bench.sh`, then proceed to §Failure handling
 
-Between ticks, wait for the background task completion notification or
-schedule the next tick ~60 s after the previous one.
+The benchmark is complete when `GET /status` returns `phase=done` (or the
+vector-bench process no longer exists in the pod, detectable via
+`kubectl --kubeconfig .kubeconfig -n default exec sts/herddb-tools -- kill -0 <REMOTE_PID> 2>/dev/null || echo gone`).
+Schedule the next tick ~60 s after the previous one.
 
 Example cluster-monitor invocation:
 
@@ -388,9 +406,9 @@ Agent(
 - **Bookie line**: omit entirely when `blocked=0`, `rejected=0`, `skipThr=0`.
   Only surface it when at least one of those counters is non-zero.
 
-If any VERDICT is `fatal`: stop the background `run-bench.sh` task immediately,
-then proceed to §Failure handling. Do NOT attempt to mitigate on the running
-cluster.
+If any VERDICT is `fatal`: run `./scripts/kill-bench.sh` to stop the
+pod-resident vector-bench process immediately, then proceed to §Failure
+handling. Do NOT attempt to mitigate on the running cluster.
 
 **Checkpoint timeout escalation (warning-level, non-fatal):** If a TICK
 SUMMARY contains any of the following signals, immediately spawn the
@@ -415,7 +433,7 @@ You never try to recover a broken cluster. Every failure produces a
 reproducible GitHub issue. On any failure (install, health check, bench
 non-zero exit, or supervision-detected fault):
 
-1. If the bench is still running in the background, stop it.
+1. If the bench is still running, stop it: `./scripts/kill-bench.sh`.
 
 2. **OOM only — collect profiles and heap dump while the pod is still
    live.** If the fatal signal was an `OutOfMemoryError` and the affected
@@ -690,12 +708,13 @@ is inactive; prefer the direct `--server` flag.
 (Moved from the repository-level `CLAUDE.md`.)
 
 ### Supervision loop
-The agent supervises a running benchmark at ≤60 s cadence. Each tick:
-0. `Read` the `RUN_LOG` (tail) — `run-bench.sh` drives `vector-bench.sh`
-   with `--no-progress` so the log is `\n`-terminated plain-text
-   (~one progress line every 5 s, phase boundaries visible as
-   `phase=<name>` lines). `--output-format json` is also available for
-   NDJSON consumers.
+The agent supervises a running benchmark at ≤60 s cadence. When started with
+`--background`, the JVM runs inside the pod as a nohup process; the primary
+progress source is the admin HTTP API, not the local log file. Each tick:
+0. `GET /status` via `kubectl --kubeconfig .kubeconfig -n default exec herddb-tools-0 -- curl -s http://localhost:8080/status`
+   — primary source for phase, rows, rate, commits.
+   The pod log at `/tmp/vector-bench-<TS>.log` (path in `$RUN_LOG`) can be
+   fetched for raw output: `kubectl --kubeconfig .kubeconfig -n default exec sts/herddb-tools -- tail -n 50 /tmp/vector-bench-<TS>.log`
 1. `./scripts/check-cluster.sh`
 2. `kubectl get pods -o wide` — watch RESTARTS column
 3. `kubectl logs --tail=200 <pod>` for each component — scan for OOM/Exception/FATAL

--- a/.claude/agents/herddb-local-bench.md
+++ b/.claude/agents/herddb-local-bench.md
@@ -56,18 +56,21 @@ under `$HERDDB_TESTS_HOME/reports/`.
 - `./scripts/process-status.sh` — compact table (NAME, PID, STATUS, RSS_MB).
   Use in the supervision loop instead of `ps` / `top` to keep token usage
   down.
-- `./scripts/run-bench.sh <vector-bench args>` — run the workload via the
-  local `bin/vector-bench.sh`. The last line of stdout is
-  `RUN_LOG=<path>` — capture it. Must be launched with
-  `run_in_background: true` so the supervision loop can run in parallel.
-  The script always prepends `--no-progress` to `vector-bench.sh`, so the
-  captured `RUN_LOG` is `\n`-terminated plain-text output (no `\r` spinner
-  frames). You can and should `Read` this file during supervision to see
-  the current phase and live progress samples. If the user explicitly
-  asks for structured output, pass `--output-format json`; the log will
-  become NDJSON. `write-report.sh` still parses plain mode (`^phase=`
-  lines + SUMMARY block) — do not switch to NDJSON unless the user asks
-  for it, or `write-report.sh` will not produce a report.
+- `./scripts/run-bench.sh [--background] <vector-bench args>` — run the
+  workload via the local `bin/vector-bench.sh`. The last line of stdout
+  is `RUN_LOG=<path>` — capture it. **Always pass `--background`** so the
+  JVM runs as a local `nohup` background process fully decoupled from any
+  pipe; the script then exits 0 immediately and you enter the supervision
+  loop (see §Supervision and issue #325). A PID file is written to
+  `$REPORTS_DIR/run-<TS>.pid`. In background mode the benchmark output is
+  appended to the same `$RUN_LOG`; progress is monitored via
+  `curl -s http://localhost:8080/status` on the admin HTTP API. Without
+  `--background` the script blocks until the JVM exits, streaming output
+  through a tee pipe — do not use that mode for automated runs. If the
+  user explicitly asks for structured output, pass `--output-format json`;
+  the log will become NDJSON. `write-report.sh` still parses plain mode
+  (`^phase=` lines + SUMMARY block) — do not switch to NDJSON unless the
+  user asks for it, or `write-report.sh` will not produce a report.
 - `./scripts/collect-logs.sh [--tail N]` — copy the two service logs
   (`server.service.log`, `indexing-service.service.log`) into a
   timestamped dir under `$REPORTS_DIR` and print `LOGS_DIR=<path>`.
@@ -249,13 +252,16 @@ Rules that apply to every workload, including user-specified ones:
 3. **Health check.** Run `./scripts/check-cluster.sh`. On failure go to
    the failure path.
 
-4. **Run the workload.** Launch `./scripts/run-bench.sh …` with
-   `run_in_background: true`. Capture the background task ID. Enter the
-   supervision loop (§Supervision) until the background task finishes OR
-   the loop detects a fatal signal.
+4. **Run the workload.** Call `./scripts/run-bench.sh --background …`
+   (without `run_in_background: true` — the `--background` flag launches
+   the JVM as a local `nohup` process and the script exits immediately).
+   Capture `RUN_LOG=<path>` from the last line of stdout. Enter the
+   supervision loop (§Supervision) immediately; poll until
+   `curl -s http://localhost:8080/status` returns `phase=done` or the
+   benchmark process is gone, or the loop detects a fatal signal.
 
-   - If the bench exits 0 and supervision saw no fatal signals → capture
-     `RUN_LOG=<path>` and go to step 5.
+   - If supervision ends with `phase=done` and no fatal signals →
+     go to step 5.
    - Otherwise → go to the failure path.
 
 5. **Generate report.** Run `./scripts/write-report.sh <RUN_LOG>` and
@@ -268,15 +274,28 @@ Rules that apply to every workload, including user-specified ones:
 
 ## Supervision
 
-While `run-bench.sh` runs in the background, poll at least every 60
-seconds (minimum 30 s, maximum 90 s between polls). Each tick does:
+Once `run-bench.sh --background` has launched the JVM and returned, poll
+at least every 60 seconds (minimum 30 s, maximum 90 s between polls).
+
+The primary progress source is always the admin HTTP API:
+```
+curl -s http://localhost:8080/status
+```
+In background mode the benchmark output is appended directly to `$RUN_LOG`
+via nohup, so `Read`ing `$RUN_LOG` still works for raw output. The PID
+file at `$REPORTS_DIR/run-<TS>.pid` can be used to verify the process is
+still alive (`kill -0 $(cat <pid-file>)`).
+
+Each tick does:
 
 1. `./scripts/process-status.sh` — confirm both services still running,
    note RSS.
 2. `curl -s http://localhost:8080/status` — read VectorBench progress
    (phase, rows/total, ops_per_sec, commits, recovered_commits,
-   commit_latency).
-3. `Read` the tail of `$RUN_LOG` for new phase boundaries.
+   commit_latency). **This is the primary completion signal**: when
+   `phase=done` the benchmark has finished.
+3. `Read` the tail of `$RUN_LOG` for new phase boundaries (output is
+   appended by the nohup process).
 4. `Read` the tail of `$CLUSTER_DIR/server.service.log` and
    `$CLUSTER_DIR/indexing-service.service.log` (last 30–50 lines) and
    scan for error keywords: `OutOfMemoryError`, `SEVERE`, `Exception in
@@ -307,7 +326,7 @@ Verdict: <healthy|warning|fatal>
 Verdicts:
 - `healthy` — continue to next tick
 - `warning` — log it and continue
-- `fatal` — stop the background run-bench task, proceed to §Failure
+- `fatal` — run `./scripts/kill-bench.sh`, then proceed to §Failure
   handling. Do NOT attempt to mitigate on the running cluster.
 
 **Checkpoint timeout escalation (warning-level, non-fatal):** If a tick
@@ -330,9 +349,7 @@ You never try to recover a broken cluster. Every failure produces a
 reproducible GitHub issue. On any failure (install, health check, bench
 non-zero exit, or supervision-detected fault):
 
-1. If the bench is still running in the background, stop it (either let
-   it exit naturally if it is already in the fatal state, or run
-   `./scripts/kill-bench.sh`).
+1. If the bench is still running, stop it: `./scripts/kill-bench.sh`.
 
 2. **OOM only — collect profiles and heap dump while the JVM is still
    live.** If the fatal signal was an `OutOfMemoryError` and the

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/kill-bench.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/kill-bench.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Kill any running vector-bench Java process inside the herddb-tools pod.
+# Safe to call even if no bench is running — exits 0 in that case.
+#
+# This is particularly useful when the benchmark was started with
+# ./scripts/run-bench.sh --background, in which case the JVM runs as a
+# nohup process inside the pod and must be stopped via pkill rather than
+# by closing the kubectl session.
+#
+# Usage:
+#   ./scripts/kill-bench.sh [--help]
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    sed -n '2,/^set -/p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit 0
+fi
+
+section "Killing vector-bench process in herddb-tools pod"
+
+if kubectl -n default exec sts/herddb-tools -- pkill -f "vector-testings" 2>&1; then
+    echo "  vector-bench process(es) terminated."
+else
+    echo "  No vector-bench process found (or already stopped) — OK."
+fi

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/run-bench.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/scripts/run-bench.sh
@@ -10,10 +10,18 @@
 # supervision agents and much smaller on long runs.
 #
 # Usage:
-#   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 \
+#   ./scripts/run-bench.sh [--background] --dataset sift10k -n 10000 -k 100 \
 #       --ingest-max-ops 1000 --checkpoint
-#   ./scripts/run-bench.sh --dataset-url "$VECTORBENCH_DATASETS_BUCKET/mycorpus.fvecs.gz" \
+#   ./scripts/run-bench.sh [--background] \
+#       --dataset-url "gs://herddb-datasets/bigann/published/bigann_descriptor.json" \
 #       -n 100000 --checkpoint
+#
+# --background: start the benchmark inside the pod as a pod-resident nohup
+#   process and exit immediately.  The JVM writes its log to a file inside
+#   the pod (/tmp/vector-bench-<TS>.log) and is fully decoupled from the
+#   kubectl connection — a broken pipe, TCP timeout, or output-buffer
+#   exhaustion cannot kill it.  Progress is monitored via the admin HTTP
+#   API (GET /status) rather than streaming the log.  See issue #325.
 #
 # On success: writes reports/run-<timestamp>.log and prints its path
 # on the last line (prefixed "RUN_LOG="). Exits non-zero on failure.
@@ -24,8 +32,21 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=common.sh
 source "$SCRIPT_DIR/common.sh"
 
-if [[ $# -eq 0 ]]; then
-    echo "Usage: $0 <vector-bench args>" >&2
+# ---------------------------------------------------------------------------
+# Parse --background flag; collect the remaining vector-bench args.
+# ---------------------------------------------------------------------------
+BACKGROUND=false
+BENCH_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--background" ]]; then
+        BACKGROUND=true
+    else
+        BENCH_ARGS+=("$arg")
+    fi
+done
+
+if [[ ${#BENCH_ARGS[@]} -eq 0 ]]; then
+    echo "Usage: $0 [--background] <vector-bench args>" >&2
     echo "Example: $0 --dataset sift10k -n 10000 -k 100 --ingest-max-ops 1000 --checkpoint" >&2
     exit 2
 fi
@@ -34,21 +55,57 @@ TS="$(timestamp)"
 RUN_LOG="$REPORTS_DIR/run-$TS.log"
 
 section "Running vector-bench inside sts/herddb-tools"
-echo "  args: $*"
+echo "  args: ${BENCH_ARGS[*]}"
 echo "  log:  $RUN_LOG"
 echo ""
 
 {
     echo "# vector-bench run $TS"
-    echo "# args: $*"
+    echo "# args: ${BENCH_ARGS[*]}"
     echo "# start: $(date -Iseconds)"
     echo ""
 } > "$RUN_LOG"
 
+if [[ "$BACKGROUND" == "true" ]]; then
+    # -----------------------------------------------------------------------
+    # Background mode (issue #325): start the JVM inside the pod as a nohup
+    # process so its lifecycle is fully decoupled from the kubectl connection.
+    # A broken kubectl TCP session will NOT send SIGPIPE to the VectorBench
+    # JVM.  The benchmark log lives inside the pod at REMOTE_LOG; progress is
+    # available at any time via the admin HTTP API at /status.
+    # -----------------------------------------------------------------------
+    REMOTE_LOG="/tmp/vector-bench-${TS}.log"
+    # printf %q safely escapes each arg for embedding inside a bash -c string.
+    ESCAPED_ARGS=$(printf ' %q' "${BENCH_ARGS[@]}")
+    REMOTE_PID=$(kubectl -n default exec sts/herddb-tools -- bash -c \
+        "nohup /opt/herddb/bin/vector-bench.sh --no-progress${ESCAPED_ARGS} > '${REMOTE_LOG}' 2>&1 & echo \$!")
+    {
+        echo "# mode: background (pod-resident nohup, issue #325)"
+        echo "# remote-log: $REMOTE_LOG"
+        echo "# remote-pid: $REMOTE_PID"
+    } >> "$RUN_LOG"
+    echo "  Benchmark started in background inside pod (PID: $REMOTE_PID)."
+    echo "  Pod log:    $REMOTE_LOG"
+    echo "  Local log:  $RUN_LOG"
+    echo ""
+    echo "  Check status: kubectl -n default exec herddb-tools-0 -- curl -s http://localhost:8080/status"
+    echo "  Follow log:   kubectl -n default exec sts/herddb-tools -- tail -f $REMOTE_LOG"
+    echo "  Stop bench:   ./scripts/kill-bench.sh"
+    echo ""
+    echo "RUN_LOG=$RUN_LOG"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Foreground mode: redirect kubectl output directly to the log file (no tee)
+# to avoid the automation output buffer (~4 k lines) filling up and sending
+# SIGPIPE to the VectorBench JVM mid-run.  Supervision agents read the log
+# file via Read; the admin API provides live progress.  See issue #325.
+# ---------------------------------------------------------------------------
 set +e
 kubectl -n default exec sts/herddb-tools -- \
-    /opt/herddb/bin/vector-bench.sh --no-progress "$@" 2>&1 | tee -a "$RUN_LOG"
-status=${PIPESTATUS[0]}
+    /opt/herddb/bin/vector-bench.sh --no-progress "${BENCH_ARGS[@]}" >> "$RUN_LOG" 2>&1
+status=$?
 set -e
 
 {

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/run-bench.sh
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/scripts/run-bench.sh
@@ -10,8 +10,15 @@
 # much smaller on long runs. See issue #89 for background.
 #
 # Usage:
-#   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
-#   ./scripts/run-bench.sh --dataset sift1m -n 100000 --checkpoint
+#   ./scripts/run-bench.sh [--background] --dataset sift10k -n 10000 -k 100 --checkpoint
+#   ./scripts/run-bench.sh [--background] --dataset sift1m -n 100000 --checkpoint
+#
+# --background: start the benchmark inside the pod as a pod-resident nohup
+#   process and exit immediately.  The JVM writes its log to a file inside
+#   the pod (/tmp/vector-bench-<TS>.log) and is fully decoupled from the
+#   kubectl connection — a broken pipe or buffer overflow cannot kill it.
+#   Progress is monitored via the admin HTTP API (GET /status) rather than
+#   streaming the log.  See issue #325.
 #
 # On success: writes reports/run-<timestamp>.log and prints its path
 # on the last line (prefixed "RUN_LOG="). Exits non-zero on failure.
@@ -22,8 +29,21 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=common.sh
 source "$SCRIPT_DIR/common.sh"
 
-if [[ $# -eq 0 ]]; then
-    echo "Usage: $0 <vector-bench args>" >&2
+# ---------------------------------------------------------------------------
+# Parse --background flag; collect the remaining vector-bench args.
+# ---------------------------------------------------------------------------
+BACKGROUND=false
+BENCH_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--background" ]]; then
+        BACKGROUND=true
+    else
+        BENCH_ARGS+=("$arg")
+    fi
+done
+
+if [[ ${#BENCH_ARGS[@]} -eq 0 ]]; then
+    echo "Usage: $0 [--background] <vector-bench args>" >&2
     echo "Example: $0 --dataset sift10k -n 10000 -k 100 --checkpoint" >&2
     exit 2
 fi
@@ -32,20 +52,54 @@ TS="$(timestamp)"
 RUN_LOG="$REPORTS_DIR/run-$TS.log"
 
 section "Running vector-bench inside sts/herddb-tools"
-echo "  args: $*"
+echo "  args: ${BENCH_ARGS[*]}"
 echo "  log:  $RUN_LOG"
 echo ""
 
 {
     echo "# vector-bench run $TS"
-    echo "# args: $*"
+    echo "# args: ${BENCH_ARGS[*]}"
     echo "# start: $(date -Iseconds)"
     echo ""
 } > "$RUN_LOG"
 
+if [[ "$BACKGROUND" == "true" ]]; then
+    # -----------------------------------------------------------------------
+    # Background mode (issue #325): start the JVM inside the pod as a nohup
+    # process so its lifecycle is fully decoupled from the kubectl connection.
+    # A broken kubectl TCP session will NOT send SIGPIPE to the VectorBench
+    # JVM.  The benchmark log lives inside the pod at REMOTE_LOG; progress is
+    # available at any time via the admin HTTP API at /status.
+    # -----------------------------------------------------------------------
+    REMOTE_LOG="/tmp/vector-bench-${TS}.log"
+    # printf %q safely escapes each arg for embedding inside a bash -c string.
+    ESCAPED_ARGS=$(printf ' %q' "${BENCH_ARGS[@]}")
+    REMOTE_PID=$(kubectl --kubeconfig "$KUBECONFIG" -n default exec sts/herddb-tools -- bash -c \
+        "nohup /opt/herddb/bin/vector-bench.sh --no-progress${ESCAPED_ARGS} > '${REMOTE_LOG}' 2>&1 & echo \$!")
+    {
+        echo "# mode: background (pod-resident nohup, issue #325)"
+        echo "# remote-log: $REMOTE_LOG"
+        echo "# remote-pid: $REMOTE_PID"
+    } >> "$RUN_LOG"
+    echo "  Benchmark started in background inside pod (PID: $REMOTE_PID)."
+    echo "  Pod log:    $REMOTE_LOG"
+    echo "  Local log:  $RUN_LOG"
+    echo ""
+    echo "  Check status: kubectl --kubeconfig $KUBECONFIG -n default exec herddb-tools-0 -- curl -s http://localhost:8080/status"
+    echo "  Follow log:   kubectl --kubeconfig $KUBECONFIG -n default exec sts/herddb-tools -- tail -f $REMOTE_LOG"
+    echo "  Stop bench:   ./scripts/kill-bench.sh"
+    echo ""
+    echo "RUN_LOG=$RUN_LOG"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Foreground mode: stream output through tee so the operator can watch live
+# progress while also capturing it to the log file.
+# ---------------------------------------------------------------------------
 set +e
-kubectl -n default exec sts/herddb-tools -- \
-    /opt/herddb/bin/vector-bench.sh --no-progress "$@" 2>&1 | tee -a "$RUN_LOG"
+kubectl --kubeconfig "$KUBECONFIG" -n default exec sts/herddb-tools -- \
+    /opt/herddb/bin/vector-bench.sh --no-progress "${BENCH_ARGS[@]}" 2>&1 | tee -a "$RUN_LOG"
 status=${PIPESTATUS[0]}
 set -e
 

--- a/herddb-services/examples/local-bench/scripts/run-bench.sh
+++ b/herddb-services/examples/local-bench/scripts/run-bench.sh
@@ -26,8 +26,14 @@
 # much smaller on long runs.
 #
 # Usage:
-#   ./scripts/run-bench.sh --dataset sift10k -n 10000 -k 100 --checkpoint
-#   ./scripts/run-bench.sh --dataset sift1m -n 100000 --checkpoint
+#   ./scripts/run-bench.sh [--background] --dataset sift10k -n 10000 -k 100 --checkpoint
+#   ./scripts/run-bench.sh [--background] --dataset sift1m -n 100000 --checkpoint
+#
+# --background: launch the VectorBench JVM as a local nohup background
+#   process and exit immediately.  Output is appended to the same RUN_LOG.
+#   A PID file is written to $REPORTS_DIR/run-<TS>.pid so the process can be
+#   found and killed later.  Progress is monitored via the admin HTTP API
+#   (GET /status) rather than following the log.  See issue #325.
 #
 # On success: writes $REPORTS_DIR/run-<timestamp>.log and prints its path
 # on the last line (prefixed "RUN_LOG="). Exits non-zero on failure.
@@ -40,8 +46,21 @@ source "$SCRIPT_DIR/common.sh"
 
 require_cluster_dir
 
-if [[ $# -eq 0 ]]; then
-    echo "Usage: $0 <vector-bench args>" >&2
+# ---------------------------------------------------------------------------
+# Parse --background flag; collect the remaining vector-bench args.
+# ---------------------------------------------------------------------------
+BACKGROUND=false
+BENCH_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--background" ]]; then
+        BACKGROUND=true
+    else
+        BENCH_ARGS+=("$arg")
+    fi
+done
+
+if [[ ${#BENCH_ARGS[@]} -eq 0 ]]; then
+    echo "Usage: $0 [--background] <vector-bench args>" >&2
     echo "Example: $0 --dataset sift10k -n 10000 -k 100 --checkpoint" >&2
     exit 2
 fi
@@ -51,13 +70,13 @@ RUN_LOG="$REPORTS_DIR/run-$TS.log"
 
 section "Running vector-bench against local cluster"
 echo "  cluster: $CLUSTER_DIR"
-echo "  args:    $*"
+echo "  args:    ${BENCH_ARGS[*]}"
 echo "  log:     $RUN_LOG"
 echo ""
 
 {
     echo "# vector-bench run $TS"
-    echo "# args: $*"
+    echo "# args: ${BENCH_ARGS[*]}"
     echo "# start: $(date -Iseconds)"
     echo ""
 } > "$RUN_LOG"
@@ -72,8 +91,40 @@ if [[ -z "${VECTORBENCH_DATASET_DIR:-}" && -n "${HERDDB_TESTS_HOME:-}" ]]; then
     export VECTORBENCH_DATASET_DIR="$HERDDB_TESTS_HOME"
 fi
 
+if [[ "$BACKGROUND" == "true" ]]; then
+    # -----------------------------------------------------------------------
+    # Background mode (issue #325): launch the JVM as a local nohup process
+    # so it survives shell/terminal closure and is decoupled from any pipe.
+    # Output is appended to RUN_LOG.  PID is saved to a .pid file so the
+    # process can be stopped later via kill-bench.sh.
+    # -----------------------------------------------------------------------
+    PID_FILE="$REPORTS_DIR/run-${TS}.pid"
+    nohup "$CLUSTER_DIR/bin/vector-bench.sh" --no-progress "${BENCH_ARGS[@]}" >> "$RUN_LOG" 2>&1 &
+    BENCH_PID=$!
+    echo "$BENCH_PID" > "$PID_FILE"
+    {
+        echo "# mode: background (local nohup, issue #325)"
+        echo "# pid: $BENCH_PID"
+        echo "# pid-file: $PID_FILE"
+    } >> "$RUN_LOG"
+    echo "  Benchmark started in background (PID: $BENCH_PID)."
+    echo "  PID file:   $PID_FILE"
+    echo "  Log:        $RUN_LOG"
+    echo ""
+    echo "  Check status: curl -s http://localhost:8080/status"
+    echo "  Follow log:   tail -f $RUN_LOG"
+    echo "  Stop bench:   ./scripts/kill-bench.sh"
+    echo ""
+    echo "RUN_LOG=$RUN_LOG"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Foreground mode: stream output through tee so the operator can watch live
+# progress while also capturing it to the log file.
+# ---------------------------------------------------------------------------
 set +e
-"$CLUSTER_DIR/bin/vector-bench.sh" --no-progress "$@" 2>&1 | tee -a "$RUN_LOG"
+"$CLUSTER_DIR/bin/vector-bench.sh" --no-progress "${BENCH_ARGS[@]}" 2>&1 | tee -a "$RUN_LOG"
 status=${PIPESTATUS[0]}
 set -e
 


### PR DESCRIPTION
Fixes #325.

## Changes

- **`k3s-local/scripts/run-bench.sh`**: Added `--background` flag. In background mode, starts the VectorBench JVM inside the pod via `kubectl exec -- bash -c "nohup … &"` and exits 0 immediately. The JVM lifecycle is decoupled from the kubectl connection — a broken pipe, TCP timeout, or output-buffer overflow cannot send SIGPIPE to the JVM. Foreground mode is unchanged (tee).

- **`gke/scripts/run-bench.sh`**: Same `--background` mode. Foreground mode upgraded from `tee` to direct `>>` redirect (incorporates the local workaround that was already in the working tree, as described in the issue).

- **`gke/scripts/kill-bench.sh`**: New script (analogous to the existing k3s version) to stop a pod-resident benchmark process via `pkill -f vector-testings`.

- **`local-bench/scripts/run-bench.sh`**: Added `--background` flag. In background mode, uses local `nohup … &`, saves PID to `$REPORTS_DIR/run-<TS>.pid`, prints `curl -s http://localhost:8080/status` as the status check command, and exits 0 immediately.

## Agent documentation updates (all three agents)

- Documents the `[--background]` synopsis and the pod-resident/nohup behaviour.
- Removes `run_in_background: true` from step 4 of each agent's workflow — the `--background` flag handles backgrounding inside the script.
- Updates step 4 to use `run-bench.sh --background …` and enter the supervision loop immediately, with `GET /status` as the primary completion signal.
- Updates the Supervision section to note that in background mode the local `$RUN_LOG` holds only the header/start marker (k3s/gke) or live nohup output (local-bench), and that `GET /status` is the authoritative progress source.
- Adds `kill-bench.sh` to the GKE allowed-commands list.
- Changes all "stop the background task" failure-handling instructions to `./scripts/kill-bench.sh`.

## Tests

- No Java code changes; no unit tests required.
- Apache RAT check passes on `herddb-services` (the only module where the modified script is not under a RAT-excluded path).

🤖 Implemented by the `pr-worker` agent.