### PR TITLE
Natural sort order for INTEGER/LONG/TIMESTAMP primary keys

### DIFF
--- a/herddb-backward-compatibility/src/test/java/herddb/upgrade/RunHerdDB070Test.java
+++ b/herddb-backward-compatibility/src/test/java/herddb/upgrade/RunHerdDB070Test.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -56,6 +57,13 @@ public class RunHerdDB070Test {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
+    // Disabled: the on-disk encoding for INTEGER/LONG primary keys was
+    // changed to be order-preserving (sign-bit flipped). A 0.7.0 snapshot
+    // stores INTEGER PKs in the old raw big-endian encoding, so point
+    // lookups against customer_id, license_id etc. miss every row.
+    // The snapshot zip is kept in resources for any future explicit
+    // upgrade-path test.
+    @Ignore
     @Test
     public void test() throws Exception {
         String file = "herddb.070.joinerror.zip";

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -953,7 +953,7 @@ public class TableSpaceManager {
             return FastMinMaxResult.of(null);
         }
         try {
-            if (isByteSortableType(pkType)) {
+            if (ColumnTypes.isByteSortable(pkType)) {
                 // For byte-sortable types the byte-extreme key IS the
                 // natural-extreme. Use the index's getMin/MaxKey API,
                 // which is O(log n) on BLink-backed implementations and
@@ -965,9 +965,9 @@ public class TableSpaceManager {
                 }
                 return FastMinMaxResult.of(RecordSerializer.deserialize(extreme, pkType));
             }
-            // Numeric / non-byte-sortable PK: stream all keys and decode
-            // each, picking the natural-order extreme. O(n_keys) CPU and
-            // *no data-page IO*.
+            // Non-byte-sortable PK (e.g. DOUBLE): stream all keys and
+            // decode each, picking the natural-order extreme. O(n_keys)
+            // CPU and *no data-page IO*.
             Object value = decodeExtremeFromKeyStream(idx, pkType, max);
             return FastMinMaxResult.of(value);
         } catch (UnsupportedOperationException err) {
@@ -979,11 +979,11 @@ public class TableSpaceManager {
 
     /**
      * Fast-path {@code MIN(col)} / {@code MAX(col)} for a column covered
-     * by a single-column BRIN secondary index. Currently only fires for
-     * byte-sortable column types (STRING / BYTEARRAY) — for numeric
-     * BRIN-indexed columns the caller falls back to the regular scan,
-     * because the BRIN's byte-wise key ordering does not match natural
-     * order for two's-complement numerics.
+     * by a single-column BRIN secondary index. Fires for any
+     * {@link ColumnTypes#isByteSortable byte-sortable} column type — for
+     * non-byte-sortable columns (DOUBLE / FLOAT) the caller falls back to
+     * the regular scan, because the BRIN's byte-wise key ordering does not
+     * match natural order for those types.
      *
      * <p>Returns {@link FastMinMaxResult#notApplied()} when the fast-path
      * does not apply.
@@ -1008,9 +1008,10 @@ public class TableSpaceManager {
             return FastMinMaxResult.notApplied();
         }
         int colType = col.type;
-        if (!isByteSortableType(colType)) {
-            // BRIN orders keys byte-wise; for numeric types we'd need a
-            // full key scan with decode (not supported here yet).
+        if (!ColumnTypes.isByteSortable(colType)) {
+            // BRIN orders keys byte-wise; non-byte-sortable types (DOUBLE
+            // / FLOAT) would need a full key scan with decode (not
+            // supported here yet).
             return FastMinMaxResult.notApplied();
         }
         // Find a BRIN index whose first/only indexed column equals `column`.
@@ -1045,8 +1046,9 @@ public class TableSpaceManager {
      * Streams every key currently in the primary-key index, decodes each
      * to the given column type, and returns the natural-order min or max.
      * Used by {@link #fastMinMaxPrimaryKeyNoTransaction} for column types
-     * whose byte order does not match natural order (e.g. mixed-sign
-     * INTEGER / LONG / TIMESTAMP / DOUBLE).
+     * whose byte order does not match natural order (DOUBLE / FLOAT
+     * IEEE-754 patterns are the remaining case after the
+     * order-preserving int/long/timestamp encoding).
      *
      * <p>This still avoids data-page IO entirely — only the BLink leaf
      * pages are touched.
@@ -1080,18 +1082,6 @@ public class TableSpaceManager {
             throw new StatementExecutionException(err);
         }
         return best;
-    }
-
-    private static boolean isByteSortableType(int type) {
-        switch (type) {
-            case ColumnTypes.STRING:
-            case ColumnTypes.NOTNULL_STRING:
-            case ColumnTypes.BYTEARRAY:
-            case ColumnTypes.NOTNULL_BYTEARRAY:
-                return true;
-            default:
-                return false;
-        }
     }
 
     private void downloadTableSpaceData() throws MetadataStorageManagerException, DataStorageManagerException, LogNotAvailableException {

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -205,9 +205,17 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             case ColumnTypes.NOTNULL_STRING:
             case ColumnTypes.STRING:
             case ColumnTypes.BYTEARRAY:
+            case ColumnTypes.INTEGER:
+            case ColumnTypes.NOTNULL_INTEGER:
+            case ColumnTypes.LONG:
+            case ColumnTypes.NOTNULL_LONG:
+            case ColumnTypes.TIMESTAMP:
+            case ColumnTypes.NOTNULL_TIMESTAMP:
+                // Bytes encodes int/long/timestamp with a sign-bit flip
+                // (herddb.utils.Bytes#putInt / #putLong), so unsigned-lex byte
+                // comparison matches signed numeric order.
                 return true;
             default:
-                // numbers are not really sorted as we are using arraywise comparation
                 return false;
         }
     }

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -198,26 +198,10 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
     @Override
     public boolean isSortedAscending(int[] pkTypes) {
-        if (pkTypes.length != 1) {
-            return false;
-        }
-        switch (pkTypes[0]) {
-            case ColumnTypes.NOTNULL_STRING:
-            case ColumnTypes.STRING:
-            case ColumnTypes.BYTEARRAY:
-            case ColumnTypes.INTEGER:
-            case ColumnTypes.NOTNULL_INTEGER:
-            case ColumnTypes.LONG:
-            case ColumnTypes.NOTNULL_LONG:
-            case ColumnTypes.TIMESTAMP:
-            case ColumnTypes.NOTNULL_TIMESTAMP:
-                // Bytes encodes int/long/timestamp with a sign-bit flip
-                // (herddb.utils.Bytes#putInt / #putLong), so unsigned-lex byte
-                // comparison matches signed numeric order.
-                return true;
-            default:
-                return false;
-        }
+        // Composite PKs are byte-sortable when every component is, but the
+        // planner currently only consumes single-column ascending PKs, so
+        // we keep the simple guard here.
+        return pkTypes.length == 1 && ColumnTypes.isByteSortable(pkTypes[0]);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -236,6 +236,15 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             case ColumnTypes.NOTNULL_STRING:
             case ColumnTypes.STRING:
             case ColumnTypes.BYTEARRAY:
+            case ColumnTypes.INTEGER:
+            case ColumnTypes.NOTNULL_INTEGER:
+            case ColumnTypes.LONG:
+            case ColumnTypes.NOTNULL_LONG:
+            case ColumnTypes.TIMESTAMP:
+            case ColumnTypes.NOTNULL_TIMESTAMP:
+                // Bytes encodes int/long/timestamp with a sign-bit flip
+                // (herddb.utils.Bytes#putInt / #putLong), so unsigned-lex byte
+                // comparison matches signed numeric order.
                 return true;
             default:
                 return false;

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -229,26 +229,10 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
 
     @Override
     public boolean isSortedAscending(int[] pkTypes) {
-        if (pkTypes.length != 1) {
-            return false;
-        }
-        switch (pkTypes[0]) {
-            case ColumnTypes.NOTNULL_STRING:
-            case ColumnTypes.STRING:
-            case ColumnTypes.BYTEARRAY:
-            case ColumnTypes.INTEGER:
-            case ColumnTypes.NOTNULL_INTEGER:
-            case ColumnTypes.LONG:
-            case ColumnTypes.NOTNULL_LONG:
-            case ColumnTypes.TIMESTAMP:
-            case ColumnTypes.NOTNULL_TIMESTAMP:
-                // Bytes encodes int/long/timestamp with a sign-bit flip
-                // (herddb.utils.Bytes#putInt / #putLong), so unsigned-lex byte
-                // comparison matches signed numeric order.
-                return true;
-            default:
-                return false;
-        }
+        // Composite PKs are byte-sortable when every component is, but the
+        // planner currently only consumes single-column ascending PKs, so
+        // we keep the simple guard here.
+        return pkTypes.length == 1 && ColumnTypes.isByteSortable(pkTypes[0]);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/ColumnTypes.java
+++ b/herddb-core/src/main/java/herddb/model/ColumnTypes.java
@@ -229,6 +229,46 @@ public class ColumnTypes {
                                 && ColumnTypes.getNonNullTypeForPrimitiveType(newType) == oldType);
     }
 
+    /**
+     * Returns {@code true} when values of {@code type} encoded by
+     * {@link herddb.codec.RecordSerializer} sort in natural order under
+     * unsigned-lex byte comparison (i.e. {@code herddb.utils.Bytes.compareTo}).
+     *
+     * <p>This unlocks several index fast paths:
+     * <ul>
+     *   <li>{@code BLinkKeyToPageIndex#isSortedAscending} → ORDER BY
+     *       and range-scan pushdown to the primary-key index.</li>
+     *   <li>{@code TableSpaceManager#fastMinMaxPrimaryKeyNoTransaction}
+     *       and {@code fastMinMaxBrinNoTransaction} → use the index's
+     *       byte-extreme key directly instead of streaming + decoding.</li>
+     * </ul>
+     *
+     * <p>STRING and BYTEARRAY are sortable by construction (UTF-8 / raw
+     * bytes). INTEGER, LONG and TIMESTAMP are sortable because
+     * {@link herddb.utils.Bytes#putInt}/{@link herddb.utils.Bytes#putLong}
+     * apply a sign-bit flip so two's-complement order matches unsigned-lex.
+     * DOUBLE and FLOAT are <strong>not</strong> sortable: IEEE-754 bit
+     * patterns require a separate transformation and the encoder keeps the
+     * raw bit pattern for round-trip fidelity.
+     */
+    public static boolean isByteSortable(int type) {
+        switch (type) {
+            case STRING:
+            case NOTNULL_STRING:
+            case BYTEARRAY:
+            case NOTNULL_BYTEARRAY:
+            case INTEGER:
+            case NOTNULL_INTEGER:
+            case LONG:
+            case NOTNULL_LONG:
+            case TIMESTAMP:
+            case NOTNULL_TIMESTAMP:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public static boolean isNullToNotNullConversion(int oldType, int newType) {
         return (ColumnTypes.isNotNullDataType(newType)
                                 && !ColumnTypes.isNotNullDataType(oldType)

--- a/herddb-core/src/test/java/herddb/core/MinMaxFastPathTest.java
+++ b/herddb-core/src/test/java/herddb/core/MinMaxFastPathTest.java
@@ -59,27 +59,29 @@ import org.junit.runners.Parameterized;
 /**
  * Exercises the {@code SELECT MIN(pk) FROM t} / {@code SELECT MAX(pk) FROM t}
  * fast-path introduced for issue #307. The fast-path bypasses the row-by-row
- * scan and reads the value directly from the primary-key index in autocommit:
- * O(log n) for byte-sortable PK types (STRING / BYTEARRAY) and O(n_keys)
- * with zero data-page reads for numeric PK types.
+ * scan and reads the value directly from the primary-key index in autocommit.
+ *
+ * <p>After the order-preserving int/long/timestamp encoding (PR #343)
+ * INTEGER, LONG and TIMESTAMP PKs are byte-sortable too, so the
+ * {@code getMin/MaxKey()} O(log n) path now applies for them as well as
+ * for STRING / BYTEARRAY. The decode-stream fallback (still in
+ * {@code TableSpaceManager.decodeExtremeFromKeyStream}) is reserved for
+ * the remaining non-byte-sortable types (DOUBLE / FLOAT IEEE-754).
  *
  * <p>The instrumentation hooks count two distinct events on the primary-key
  * index:
  * <ul>
- *   <li>{@code scanner()} calls — the entry point used by both the slow
- *       scan path and the numeric-PK fast-path "iterate keys" loop;</li>
+ *   <li>{@code scanner()} calls — the entry point used by the slow
+ *       row-scan path and by the decode-stream fallback;</li>
  *   <li>{@code getMinKey()} / {@code getMaxKey()} calls — the entry point
  *       used only by the byte-sortable fast-path.</li>
  * </ul>
  *
- * <p>For the byte-sortable case (STRING PK) we assert
- * {@code scannerCalls == 0}, proving the slow scan was bypassed entirely.
- * For the numeric case (INTEGER PK) we cannot use a scanner counter to
- * prove the fast-path was taken (both the fast and slow path call
- * {@code scanner()}); instead we use a mixed-sign INTEGER dataset where
- * the byte-extreme answer differs from the natural-extreme answer — a
- * correct result is therefore the smoking gun for the decode-and-compare
- * fast-path.</p>
+ * <p>The mixed-sign INTEGER PK test is the strict correctness check: it
+ * uses a dataset where the old byte-wise extreme differed from the
+ * natural extreme (negatives have the high bit set in raw two's
+ * complement). After the encoding fix the byte-extreme path produces the
+ * same answer as a decode-and-compare scan would.</p>
  *
  * <p>The test is parameterised over the two SQL planners.</p>
  */

--- a/herddb-core/src/test/java/herddb/core/PrimaryIndexScanRangeTest.java
+++ b/herddb-core/src/test/java/herddb/core/PrimaryIndexScanRangeTest.java
@@ -94,6 +94,8 @@ public class PrimaryIndexScanRangeTest {
 
             performBasicPlannerTests(manager);
 
+            // MemoryDataStorageManager uses ConcurrentMapKeyToPageIndex (HashMap-backed),
+            // which is unordered regardless of PK type.
             assertFalse(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
         }
 
@@ -129,7 +131,7 @@ public class PrimaryIndexScanRangeTest {
             TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,n2,name) values('b',2,5,'n1')", Collections.emptyList());
             TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,n2,name) values('c',-3,6,'n2')", Collections.emptyList());
 
-            assertFalse(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
+            assertTrue(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
 
              {
                 TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT n1,n2 "
@@ -232,7 +234,7 @@ public class PrimaryIndexScanRangeTest {
 
             performBasicPlannerTests(manager);
 
-            assertFalse(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
+            assertTrue(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
 
             {
                 TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT n1,n2 "
@@ -1242,6 +1244,222 @@ public class PrimaryIndexScanRangeTest {
             assertFalse(scan.getComparator().isOnlyPrimaryKeyAndAscending());
             try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
                 assertEquals(3, scan1.consume().size());
+            }
+        }
+    }
+
+    @Test
+    public void scanByPKOfLongsWithNegativeValues() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(),
+                new FileDataStorageManager(dataPath), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            Table table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("n1", ColumnTypes.LONG)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("n1")
+                    .build();
+
+            CreateTableStatement st2 = new CreateTableStatement(table);
+            manager.executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            // include Long.MIN_VALUE/MAX_VALUE to exercise the sign-bit boundary
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,name) values(?,?)",
+                    java.util.Arrays.asList(Long.MIN_VALUE, "min"));
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,name) values(-1,'minus_one')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,name) values(0,'zero')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,name) values(1,'one')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,name) values(?,?)",
+                    java.util.Arrays.asList(Long.MAX_VALUE, "max"));
+
+            assertTrue(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
+
+            {
+                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT,
+                        "SELECT n1 FROM tblspace1.t1 ORDER BY n1",
+                        Collections.emptyList(), true, true, false, -1);
+                ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+                assertTrue(scan.getComparator().isOnlyPrimaryKeyAndAscending());
+                try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                    List<DataAccessor> tuples = scan1.consume();
+                    assertEquals(5, tuples.size());
+                    assertEquals(Long.MIN_VALUE, tuples.get(0).get("n1"));
+                    assertEquals(-1L, tuples.get(1).get("n1"));
+                    assertEquals(0L, tuples.get(2).get("n1"));
+                    assertEquals(1L, tuples.get(3).get("n1"));
+                    assertEquals(Long.MAX_VALUE, tuples.get(4).get("n1"));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void rangeScanByPKBetweenNegativeAndPositive() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(),
+                new FileDataStorageManager(dataPath), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            Table table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("n1", ColumnTypes.INTEGER)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("n1")
+                    .build();
+
+            CreateTableStatement st2 = new CreateTableStatement(table);
+            manager.executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            for (int v : new int[] {-100, -10, -5, -1, 0, 1, 5, 10, 100}) {
+                TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,name) values(?,?)",
+                        java.util.Arrays.asList(v, "v" + v));
+            }
+
+            assertTrue(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
+
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT,
+                    "SELECT n1 FROM tblspace1.t1 WHERE n1 BETWEEN -10 AND 10 ORDER BY n1",
+                    Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            assertTrue(scan.getPredicate().getIndexOperation() instanceof PrimaryIndexRangeScan);
+            assertTrue(scan.getComparator().isOnlyPrimaryKeyAndAscending());
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                List<DataAccessor> tuples = scan1.consume();
+                assertEquals(7, tuples.size());
+                assertEquals(-10, tuples.get(0).get("n1"));
+                assertEquals(-5, tuples.get(1).get("n1"));
+                assertEquals(-1, tuples.get(2).get("n1"));
+                assertEquals(0, tuples.get(3).get("n1"));
+                assertEquals(1, tuples.get(4).get("n1"));
+                assertEquals(5, tuples.get(5).get("n1"));
+                assertEquals(10, tuples.get(6).get("n1"));
+            }
+        }
+    }
+
+    @Test
+    public void scanByPKOfTimestamps() throws Exception {
+        // Note: Bytes.toTimestamp returns null when the decoded long is negative,
+        // which makes pre-1970 timestamps unusable (pre-existing limitation).
+        // This test only exercises post-1970 values.
+        Path dataPath = folder.newFolder("data").toPath();
+
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(),
+                new FileDataStorageManager(dataPath), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            Table table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("ts", ColumnTypes.TIMESTAMP)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("ts")
+                    .build();
+
+            CreateTableStatement st2 = new CreateTableStatement(table);
+            manager.executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            java.sql.Timestamp tsEarly = new java.sql.Timestamp(1_000_000L);
+            java.sql.Timestamp tsMid = new java.sql.Timestamp(2_000_000_000L);
+            java.sql.Timestamp tsLate = new java.sql.Timestamp(4_000_000_000L);
+
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(ts,name) values(?,?)",
+                    java.util.Arrays.asList(tsLate, "late"));
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(ts,name) values(?,?)",
+                    java.util.Arrays.asList(tsEarly, "early"));
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(ts,name) values(?,?)",
+                    java.util.Arrays.asList(tsMid, "mid"));
+
+            assertTrue(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
+
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT,
+                    "SELECT name FROM tblspace1.t1 ORDER BY ts",
+                    Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            assertTrue(scan.getComparator().isOnlyPrimaryKeyAndAscending());
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                List<DataAccessor> tuples = scan1.consume();
+                assertEquals(3, tuples.size());
+                assertEquals(RawString.of("early"), tuples.get(0).get("name"));
+                assertEquals(RawString.of("mid"), tuples.get(1).get("name"));
+                assertEquals(RawString.of("late"), tuples.get(2).get("name"));
+            }
+        }
+    }
+
+    @Test
+    public void scanByCompositePKContainingInteger() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(),
+                new FileDataStorageManager(dataPath), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            Table table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("n1", ColumnTypes.INTEGER)
+                    .column("id", ColumnTypes.STRING)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("n1")
+                    .primaryKey("id")
+                    .build();
+
+            CreateTableStatement st2 = new CreateTableStatement(table);
+            manager.executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,id,name) values(-5,'a','minus5_a')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,id,name) values(-5,'b','minus5_b')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,id,name) values(0,'a','zero_a')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(n1,id,name) values(7,'a','seven_a')", Collections.emptyList());
+
+            // composite PK does not advertise sorted ascending
+            assertFalse(manager.getTableSpaceManager("tblspace1").getTableManager("t1").isKeyToPageSortedAscending());
+
+            // point lookup must round-trip the negative-int component correctly
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT,
+                    "SELECT name FROM tblspace1.t1 WHERE n1=-5 AND id='b'",
+                    Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                List<DataAccessor> tuples = scan1.consume();
+                assertEquals(1, tuples.size());
+                assertEquals(RawString.of("minus5_b"), tuples.get(0).get("name"));
+            }
+
+            // prefix scan on the leading int component must return all matching rows
+            TranslatedQuery translatedPrefix = manager.getPlanner().translate(TableSpace.DEFAULT,
+                    "SELECT id FROM tblspace1.t1 WHERE n1=-5",
+                    Collections.emptyList(), true, true, false, -1);
+            ScanStatement scanPrefix = translatedPrefix.plan.mainStatement.unwrap(ScanStatement.class);
+            try (DataScanner scan1 = manager.scan(scanPrefix, translatedPrefix.context, TransactionContext.NO_TRANSACTION)) {
+                assertEquals(2, scan1.consume().size());
             }
         }
     }

--- a/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
+++ b/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
@@ -53,15 +53,12 @@ public class BytesCompareJavaTest {
     public void checkCompare() {
 
         /* Builds 08000000000008d47f */
-
-        Bytes suffix = Bytes.from_long(578687L);
-
-        byte[] array = new byte[suffix.getLength() + 1];
-        array[0] = 8;
-
-        System.arraycopy(suffix.getBuffer(), suffix.getOffset(), array, 1, suffix.getLength());
-
-        Bytes low = Bytes.from_array(array);
+        byte[] lowArray = new byte[] {
+                (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00, (byte) 0x08, (byte) 0xd4,
+                (byte) 0x7f
+        };
+        Bytes low = Bytes.from_array(lowArray);
 
         Assert.assertEquals("08000000000008d47f", low.toString());
 

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -42,6 +42,17 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     private static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
     /**
+     * Sign-bit XOR masks used by {@link #putInt}/{@link #putLong}/{@link #toInt}/{@link #toLong}
+     * to produce an order-preserving big-endian encoding: unsigned-lex byte comparison on the
+     * encoded bytes matches signed numeric order, so int/long primary keys naturally sort.
+     * Encoders and decoders both flip the sign bit, so Java values round-trip identically.
+     * The IEEE-754 bit transport for float/double goes through the raw variants
+     * ({@link #putRawInt}/{@link #putRawLong}/{@link #toRawInt}/{@link #toRawLong}) and is unaffected.
+     */
+    private static final int INT_SIGN_FLIP_MASK = 0x80000000;
+    private static final long LONG_SIGN_FLIP_MASK = 0x8000000000000000L;
+
+    /**
      * Estimated size of a Bytes instance (excluding the data array contents).
      * <p>
      * With compressed oops (heap &lt; 32GB):
@@ -92,7 +103,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public static byte[] doubleToByteArray(double value) {
         byte[] res = new byte[8];
-        putLong(res, 0, Double.doubleToLongBits(value));
+        putRawLong(res, 0, Double.doubleToLongBits(value));
         return res;
     }
 
@@ -178,7 +189,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         byte[] res = new byte[length * 4];
         int offset = 0;
         for (float f : floatArray) {
-            putInt(res, offset, Float.floatToRawIntBits(f));
+            putRawInt(res, offset, Float.floatToRawIntBits(f));
             offset += 4;
         }
         return new Bytes(res);
@@ -202,7 +213,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public static Bytes from_double(double value) {
         byte[] res = new byte[8];
-        putDouble(res, 0, value);
+        putRawLong(res, 0, Double.doubleToRawLongBits(value));
         return new Bytes(res);
     }
 
@@ -288,7 +299,27 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         }
     }
 
+    /**
+     * Encodes {@code value} as 8 order-preserving big-endian bytes (sign bit flipped),
+     * so unsigned-lex comparison on the resulting bytes matches signed numeric order.
+     */
     public static void putLong(byte[] array, int index, long value) {
+        putRawLong(array, index, value ^ LONG_SIGN_FLIP_MASK);
+    }
+
+    /**
+     * Encodes {@code value} as 4 order-preserving big-endian bytes (sign bit flipped),
+     * so unsigned-lex comparison on the resulting bytes matches signed numeric order.
+     */
+    public static void putInt(byte[] array, int index, int value) {
+        putRawInt(array, index, value ^ INT_SIGN_FLIP_MASK);
+    }
+
+    /**
+     * Writes {@code value} as 8 plain big-endian bytes. Used for IEEE-754 bit
+     * transport (double); not order-preserving.
+     */
+    public static void putRawLong(byte[] array, int index, long value) {
         if (HAS_UNSAFE && UNALIGNED) {
             PlatformDependent.putLong(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Long.reverseBytes(value));
         } else {
@@ -303,7 +334,11 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         }
     }
 
-    public static void putInt(byte[] array, int index, int value) {
+    /**
+     * Writes {@code value} as 4 plain big-endian bytes. Used for IEEE-754 bit
+     * transport (float); not order-preserving.
+     */
+    public static void putRawInt(byte[] array, int index, int value) {
         if (HAS_UNSAFE && UNALIGNED) {
             PlatformDependent.putInt(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Integer.reverseBytes(value));
         } else {
@@ -323,10 +358,22 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public static void putDouble(byte[] bytes, int offset, double val) {
-        putLong(bytes, offset, Double.doubleToRawLongBits(val));
+        putRawLong(bytes, offset, Double.doubleToRawLongBits(val));
     }
 
+    /**
+     * Decodes 8 order-preserving big-endian bytes (written by {@link #putLong})
+     * back to a {@code long}.
+     */
     public static long toLong(byte[] array, int index) {
+        return toRawLong(array, index) ^ LONG_SIGN_FLIP_MASK;
+    }
+
+    /**
+     * Reads 8 plain big-endian bytes. Used for IEEE-754 bit transport (double);
+     * pairs with {@link #putRawLong}.
+     */
+    public static long toRawLong(byte[] array, int index) {
         if (HAS_UNSAFE && UNALIGNED) {
             long v = PlatformDependent.getLong(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Long.reverseBytes(v);
@@ -365,7 +412,19 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         return Long.compare(toLong(array, index), value);
     }
 
+    /**
+     * Decodes 4 order-preserving big-endian bytes (written by {@link #putInt})
+     * back to an {@code int}.
+     */
     public static int toInt(byte[] array, int index) {
+        return toRawInt(array, index) ^ INT_SIGN_FLIP_MASK;
+    }
+
+    /**
+     * Reads 4 plain big-endian bytes. Used for IEEE-754 bit transport (float);
+     * pairs with {@link #putRawInt}.
+     */
+    public static int toRawInt(byte[] array, int index) {
         if (HAS_UNSAFE && UNALIGNED) {
             int v = PlatformDependent.getInt(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Integer.reverseBytes(v);
@@ -393,7 +452,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public static double toDouble(byte[] bytes, int offset) {
-        return Double.longBitsToDouble(toLong(bytes, offset));
+        return Double.longBitsToDouble(toRawLong(bytes, offset));
     }
 
     public static int compare(byte[] left, byte[] right) {

--- a/herddb-utils/src/main/java/herddb/utils/XXHash64Utils.java
+++ b/herddb-utils/src/main/java/herddb/utils/XXHash64Utils.java
@@ -42,7 +42,11 @@ public class XXHash64Utils {
 
     public static byte[] digest(byte[] array, int offset, int len) {
         long hash = HASHER.hash(array, offset, len, DEFAULT_SEED);
-        byte[] digest = Bytes.longToByteArray(hash);
+        // hashes are bit patterns, not signed integers: store raw big-endian
+        // so the on-disk format matches canonical XXHash64 and pairs with
+        // DataOutputStream.writeLong on the writer side.
+        byte[] digest = new byte[HASH_LEN];
+        Bytes.putRawLong(digest, 0, hash);
         return digest;
     }
 
@@ -53,7 +57,7 @@ public class XXHash64Utils {
     public static boolean verifyBlockWithFooter(byte[] array, int offset, int len) {
         byte[] expectedFooter = Arrays.copyOfRange(array, len - HASH_LEN, len);
         long expectedHash = HASHER.hash(array, offset, len - HASH_LEN, DEFAULT_SEED);
-        long hash = Bytes.toLong(expectedFooter, 0);
+        long hash = Bytes.toRawLong(expectedFooter, 0);
         return hash == expectedHash;
     }
 

--- a/herddb-utils/src/test/java/herddb/utils/BytesTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesTest.java
@@ -22,7 +22,9 @@ package herddb.utils;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.nio.charset.StandardCharsets;
+import java.util.Random;
 import org.junit.Test;
 
 /**
@@ -132,6 +134,103 @@ public class BytesTest {
 
         assertEquals(bytes.getLength(), next.getLength());
 
+    }
+
+    @Test
+    public void testIntRoundTrip() {
+        for (int v : new int[] {Integer.MIN_VALUE, Integer.MIN_VALUE + 1, -1_000_000, -1, 0, 1, 1_000_000,
+                Integer.MAX_VALUE - 1, Integer.MAX_VALUE}) {
+            assertEquals(v, Bytes.toInt(Bytes.intToByteArray(v), 0));
+            assertEquals(v, Bytes.from_int(v).to_int());
+        }
+    }
+
+    @Test
+    public void testLongRoundTrip() {
+        for (long v : new long[] {Long.MIN_VALUE, Long.MIN_VALUE + 1, -1_000_000_000_000L, -1L, 0L, 1L,
+                1_000_000_000_000L, Long.MAX_VALUE - 1, Long.MAX_VALUE}) {
+            assertEquals(v, Bytes.toLong(Bytes.longToByteArray(v), 0));
+            assertEquals(v, Bytes.from_long(v).to_long());
+        }
+    }
+
+    /**
+     * After {@link Bytes#intToByteArray(int)} the unsigned-lex byte order matches signed numeric
+     * order, so the BLink primary-key index naturally sorts INTEGER PKs.
+     */
+    @Test
+    public void testIntOrderPreservation() {
+        int[] curated = {Integer.MIN_VALUE, Integer.MIN_VALUE + 1, -1_000_000, -2, -1, 0, 1, 2, 1_000_000,
+                Integer.MAX_VALUE - 1, Integer.MAX_VALUE};
+        for (int i = 0; i < curated.length; i++) {
+            for (int j = 0; j < curated.length; j++) {
+                assertOrderMatches(curated[i], curated[j]);
+            }
+        }
+        Random rng = new Random(0xC0FFEE);
+        for (int n = 0; n < 1000; n++) {
+            assertOrderMatches(rng.nextInt(), rng.nextInt());
+        }
+    }
+
+    /**
+     * After {@link Bytes#longToByteArray(long)} unsigned-lex byte order matches signed numeric order.
+     */
+    @Test
+    public void testLongOrderPreservation() {
+        long[] curated = {Long.MIN_VALUE, Long.MIN_VALUE + 1, -1_000_000_000_000L, -2L, -1L, 0L, 1L, 2L,
+                1_000_000_000_000L, Long.MAX_VALUE - 1, Long.MAX_VALUE};
+        for (int i = 0; i < curated.length; i++) {
+            for (int j = 0; j < curated.length; j++) {
+                assertOrderMatches(curated[i], curated[j]);
+            }
+        }
+        Random rng = new Random(0xCAFE);
+        for (int n = 0; n < 1000; n++) {
+            assertOrderMatches(rng.nextLong(), rng.nextLong());
+        }
+    }
+
+    /**
+     * Doubles must keep the IEEE-754 bit pattern intact (not order-preserving — that's by design,
+     * see {@link Bytes#putDouble(byte[], int, double)} delegating to putRawLong).
+     */
+    @Test
+    public void testDoubleRoundTripStaysRaw() {
+        for (double v : new double[] {Double.NEGATIVE_INFINITY, -Math.PI, -1.0, -0.0, 0.0, 1.0, Math.PI,
+                Double.POSITIVE_INFINITY, Double.MAX_VALUE, Double.MIN_VALUE}) {
+            byte[] bytes = Bytes.doubleToByteArray(v);
+            assertEquals(8, bytes.length);
+            assertEquals(Double.doubleToRawLongBits(v), Bytes.toRawLong(bytes, 0));
+            assertEquals(Double.compare(v, v), Double.compare(Bytes.toDouble(bytes, 0), v));
+        }
+    }
+
+    /**
+     * Floats must keep the IEEE-754 bit pattern intact too.
+     */
+    @Test
+    public void testFloatArrayRoundTripStaysRaw() {
+        float[] in = {Float.NEGATIVE_INFINITY, -1.0f, -0.0f, 0.0f, 1.0f, Float.POSITIVE_INFINITY};
+        float[] out = Bytes.from_float_array(in).to_float_array();
+        assertEquals(in.length, out.length);
+        for (int i = 0; i < in.length; i++) {
+            assertEquals(Float.floatToRawIntBits(in[i]), Float.floatToRawIntBits(out[i]));
+        }
+    }
+
+    private static void assertOrderMatches(int a, int b) {
+        int signed = Integer.compare(a, b);
+        int lex = CompareBytesUtils.compare(Bytes.intToByteArray(a), Bytes.intToByteArray(b));
+        assertTrue("a=" + a + " b=" + b + " signed=" + signed + " lex=" + lex,
+                Integer.signum(signed) == Integer.signum(lex));
+    }
+
+    private static void assertOrderMatches(long a, long b) {
+        int signed = Long.compare(a, b);
+        int lex = CompareBytesUtils.compare(Bytes.longToByteArray(a), Bytes.longToByteArray(b));
+        assertTrue("a=" + a + " b=" + b + " signed=" + signed + " lex=" + lex,
+                Integer.signum(signed) == Integer.signum(lex));
     }
 
 }


### PR DESCRIPTION
## Summary

- Encode int/long values with the sign bit flipped (XOR 0x80…) in `Bytes#putInt`/`putLong` and reverse on `toInt`/`toLong`, so unsigned-lex byte comparison matches signed numeric order. The BLink primary-key index uses `Bytes#compareTo`, so INTEGER/LONG/TIMESTAMP PKs now sort naturally on disk, including negatives.
- Broaden `BLinkKeyToPageIndex.isSortedAscending` (and the incremental variant) to return `true` for single-column INTEGER/LONG/TIMESTAMP PKs. The planner can now push ORDER BY and range scans down to the PK index instead of materializing and sorting in memory.
- IEEE-754 transport for double/float stays on canonical bit-pattern bytes via the new `putRawInt`/`putRawLong`/`toRawInt`/`toRawLong` helpers. `XXHash64Utils` uses the raw variants too — hashes are bit patterns, and the writer side uses `DataOutputStream.writeLong` (canonical big-endian).

## Disk format change — NOT backwards compatible

Every persisted int/long value changes byte representation: BLink pages, row payloads, table-status counters, log sequence numbers. Existing data directories need to be regenerated. This was explicitly accepted in the design discussion. PK column values are not duplicated in the row payload (`RecordSerializer.serializeValueRaw` excludes PK columns), so the encoding flip stays consistent.

## Test plan

- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` (clean)
- [x] `BytesTest`: 13 tests pass — order-preservation property for int and long (curated boundaries + 1k random pairs), round-trip, IEEE-754 raw round-trip for double/float
- [x] `PrimaryIndexScanRangeTest`: 9 tests pass — existing `scanByPKOfIntsWithNegativeValues` and `primaryIndexPrefixScanFileTest` assertions flipped to `assertTrue`; new tests for LONG PK with `Long.MIN/MAX`, range scan crossing zero, post-1970 TIMESTAMP PK, composite PK with INTEGER component
- [x] `RecordSerializerTest`, `BLinkKeyToPageIndexTest`, `IncrementalBLinkKeyToPageIndexTest`, `KeyToPageIndexTest`, `FileMetadataStorageManagerTest`, `FileDataStorageManagerTest` and friends — all green
- [x] `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` (hammer suite) — green twice in a row

## Out of scope / follow-up

- Composite-PK ordered pushdown — every primitive component is now byte-sortable (string/bytearray/int/long/timestamp), so concatenated composite PKs with byte-sortable components are also byte-sortable. Enabling `isSortedAscending = true` for composites needs the planner side checked too; left for a follow-up.
- DOUBLE PKs are still not byte-sortable (IEEE-754 fix-up is a different transformation than the int sign-flip). Not requested.
- `Bytes.toTimestamp` returns `null` when the decoded long is negative — this makes pre-1970 timestamps unusable, but it's a pre-existing limitation independent of this change. The new TIMESTAMP test sticks to post-1970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)