### PR TITLE
issue #342: fast-fail Phase C writes on file-server removal; protect transactions during long checkpoints

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -215,6 +215,14 @@ public class TableSpaceManager {
      * Duration in milliseconds of the last completed checkpoint; {@code 0} until the first one.
      */
     private volatile long lastCheckpointDurationMs;
+    /**
+     * Wall-clock timestamp (epoch millis) at which the last checkpoint acquired
+     * {@link #checkpointMutex} (i.e. when Phase A started). Used by
+     * {@link #processAbandonedTransactions} to avoid abandoning transactions that
+     * were merely blocked by a long Phase C (e.g. writing PK-index pages to a
+     * remote file-server that was restarting). {@code 0} until the first checkpoint runs.
+     */
+    private volatile long lastCheckpointStartTs;
 
     // only for tests
     private Runnable afterTableCheckPointAction;
@@ -1325,6 +1333,27 @@ public class TableSpaceManager {
             return;
         }
         long abandonedTransactionTimeout = now - timeout;
+
+        // A long checkpoint (e.g. Phase C writing PK-index pages to a remote
+        // file-server that is restarting) blocks the activator thread and prevents
+        // clients from receiving server responses. Their implicit transactions appear
+        // idle even though the clients are still connected and waiting.
+        //
+        // Guard: if a checkpoint finished recently (within the last 'timeout' ms),
+        // shift the effective cutoff back to (checkpointStart - timeout). This way a
+        // transaction is only declared abandoned if it was idle BEFORE the checkpoint
+        // started AND for longer than the configured timeout. The protection expires
+        // automatically once 'timeout' ms have elapsed after the checkpoint ended,
+        // reverting to the normal abandonment window.
+        long cpEndTs = this.lastCheckpointTimestamp;
+        long cpStartTs = this.lastCheckpointStartTs;
+        if (cpEndTs > 0 && cpStartTs > 0 && (now - cpEndTs) < timeout) {
+            long cpAwareCutoff = cpStartTs - timeout;
+            if (cpAwareCutoff < abandonedTransactionTimeout) {
+                abandonedTransactionTimeout = cpAwareCutoff;
+            }
+        }
+
         for (Transaction t : transactions.values()) {
             if (t.isAbandoned(abandonedTransactionTimeout)) {
                 LOGGER.log(Level.SEVERE, "forcing rollback of abandoned transaction {0},"
@@ -2779,6 +2808,7 @@ public class TableSpaceManager {
                     LOGGER.log(Level.INFO, "Checkpoint for tablespace {0} skipped. Another checkpoint is already running", tableSpaceName);
                     return null;
                 }
+                lastCheckpointStartTs = System.currentTimeMillis();
                 try {
                     List<AbstractTableManager> tablesToCheckpoint;
 
@@ -3289,6 +3319,33 @@ public class TableSpaceManager {
      */
     public long getLastCheckpointDurationMs() {
         return lastCheckpointDurationMs;
+    }
+
+    /**
+     * Wall-clock timestamp (epoch millis) at which the most-recent checkpoint acquired the
+     * checkpoint mutex (start of Phase A), or {@code 0} if no checkpoint has started yet.
+     * Exposed for tests that exercise {@link #processAbandonedTransactions()}.
+     */
+    public long getLastCheckpointStartTs() {
+        return lastCheckpointStartTs;
+    }
+
+    /**
+     * For testing only: directly set {@link #lastCheckpointStartTs} so unit tests can
+     * simulate a checkpoint having started at an arbitrary wall-clock time without
+     * running a full checkpoint cycle.
+     */
+    void setLastCheckpointStartTs(long ts) {
+        this.lastCheckpointStartTs = ts;
+    }
+
+    /**
+     * For testing only: directly set {@link #lastCheckpointTimestamp} (the checkpoint
+     * completion time) so unit tests can simulate a checkpoint having finished at an
+     * arbitrary wall-clock time without running a full checkpoint cycle.
+     */
+    void setLastCheckpointTimestamp(long ts) {
+        this.lastCheckpointTimestamp = ts;
     }
 
     public ExecutorService getCallbacksExecutor() {

--- a/herddb-core/src/main/java/herddb/core/system/SyslogstatusManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SyslogstatusManager.java
@@ -56,6 +56,7 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
             .column("checkpoint_offset", ColumnTypes.LONG)
             .column("checkpoint_timestamp", ColumnTypes.TIMESTAMP)
             .column("checkpoint_duration_ms", ColumnTypes.LONG)
+            .column("checkpoint_start_ts", ColumnTypes.TIMESTAMP)
             .column("dirty_ledgers_count", ColumnTypes.INTEGER)
             .primaryKey("tablespace_uuid", false)
             .primaryKey("nodeid", false)
@@ -73,6 +74,7 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
         LogSequenceNumber checkpointLsn = isVirtual ? null : tableSpaceManager.getLastCheckpointSequenceNumber();
         long checkpointTimestamp = isVirtual ? 0L : tableSpaceManager.getLastCheckpointTimestamp();
         long checkpointDurationMs = isVirtual ? 0L : tableSpaceManager.getLastCheckpointDurationMs();
+        long checkpointStartTs = isVirtual ? 0L : tableSpaceManager.getLastCheckpointStartTs();
 
         Long ledger = isVirtual ? 0L : logSequenceNumber.ledgerId;
         Long offset = isVirtual ? 0L : logSequenceNumber.offset;
@@ -80,6 +82,7 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
         Long cpOffset = checkpointLsn != null ? checkpointLsn.offset : null;
         Timestamp cpTs = checkpointTimestamp > 0 ? new Timestamp(checkpointTimestamp) : null;
         Long cpDuration = checkpointTimestamp > 0 ? checkpointDurationMs : null;
+        Timestamp cpStartTs = checkpointStartTs > 0 ? new Timestamp(checkpointStartTs) : null;
         Integer dirtyLedgers = (!isVirtual && checkpointLsn != null)
                 ? (int) Math.max(0L, logSequenceNumber.ledgerId - checkpointLsn.ledgerId)
                 : null;
@@ -97,6 +100,7 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
                 "checkpoint_offset", cpOffset,
                 "checkpoint_timestamp", cpTs,
                 "checkpoint_duration_ms", cpDuration,
+                "checkpoint_start_ts", cpStartTs,
                 "dirty_ledgers_count", dirtyLedgers
         ));
         return result;

--- a/herddb-core/src/test/java/herddb/core/AbandonedTransactionCheckpointProtectionTest.java
+++ b/herddb-core/src/test/java/herddb/core/AbandonedTransactionCheckpointProtectionTest.java
@@ -1,0 +1,131 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.TransactionResult;
+import herddb.model.commands.BeginTransactionStatement;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link TableSpaceManager#processAbandonedTransactions()} does
+ * not prematurely roll back transactions that were merely blocked by a long
+ * Phase C checkpoint (issue #342: file-server restart stalling Phase C and
+ * causing the activator to abandon still-live VectorBench transactions).
+ *
+ * <p>The guard logic shifts the abandonment cutoff back to
+ * {@code (checkpointStart - timeout)} for the first {@code timeout} ms after
+ * a checkpoint finishes. Once that cooling period expires the normal timeout
+ * resumes, so genuinely idle transactions are still cleaned up.
+ */
+public class AbandonedTransactionCheckpointProtectionTest extends BaseTestcase {
+
+    /**
+     * Scenario: a checkpoint ran for longer than the abandoned-transaction
+     * timeout. The moment the checkpoint finishes, {@code processAbandonedTransactions}
+     * must NOT roll back transactions whose last activity fell inside the
+     * checkpoint window. After the cooling period expires the transaction IS
+     * eventually cleaned up.
+     */
+    @Test
+    public void testTransactionProtectedDuringCheckpointWindow() throws Exception {
+        // Short timeout so the test runs quickly.
+        final long timeoutMs = 300;
+        manager.setAbandonedTransactionsTimeout(timeoutMs);
+
+        // Open a transaction and do not commit it (simulates a VectorBench implicit tx).
+        long tx = ((TransactionResult) manager.executeStatement(
+                new BeginTransactionStatement(tableSpace),
+                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                TransactionContext.NO_TRANSACTION)).getTransactionId();
+
+        TableSpaceManager tsm = manager.getTableSpaceManager(tableSpace);
+
+        // Wait long enough for the transaction to be "old" (> timeout).
+        Thread.sleep(timeoutMs + 100);
+
+        // Simulate: a checkpoint started just before the transaction was last
+        // active and ended just now. The cooling window is still open.
+        long now = System.currentTimeMillis();
+        // Checkpoint started (timeoutMs + 200ms) ago — before the transaction
+        // was last touched — and finished 50 ms ago (still within the window).
+        tsm.setLastCheckpointStartTs(now - timeoutMs - 200);
+        tsm.setLastCheckpointTimestamp(now - 50);
+
+        // The transaction should be PROTECTED: last activity falls inside the
+        // [cpStart - timeout, now] window so the cutoff is pushed back.
+        tsm.processAbandonedTransactions();
+        assertFalse(
+                "Transaction should not be abandoned while checkpoint cooling window is open",
+                tsm.getTransactions().isEmpty());
+
+        // Now advance time: simulate the cooling period expiring by setting
+        // checkpoint end to (timeout + 1 ms) ago.
+        now = System.currentTimeMillis();
+        tsm.setLastCheckpointTimestamp(now - timeoutMs - 1);
+        // checkpointStartTs stays the same — it's now old enough that
+        // cpAwareCutoff > abandonedTransactionTimeout no longer holds.
+
+        // The transaction is now OLD ENOUGH to be abandoned normally.
+        // Wait one more timeout period to ensure the transaction truly crosses
+        // the normal cutoff regardless of small clock skew.
+        Thread.sleep(timeoutMs + 100);
+
+        tsm.processAbandonedTransactions();
+        assertTrue(
+                "Transaction should be abandoned once the cooling period expires",
+                tsm.getTransactions().isEmpty());
+    }
+
+    /**
+     * Sanity: without any checkpoint history, the normal timeout applies and
+     * transactions are abandoned as usual.
+     */
+    @Test
+    public void testNormalAbandonmentWithoutCheckpoint() throws Exception {
+        final long timeoutMs = 300;
+        manager.setAbandonedTransactionsTimeout(timeoutMs);
+
+        long tx = ((TransactionResult) manager.executeStatement(
+                new BeginTransactionStatement(tableSpace),
+                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                TransactionContext.NO_TRANSACTION)).getTransactionId();
+
+        TableSpaceManager tsm = manager.getTableSpaceManager(tableSpace);
+
+        // No checkpoint has run (lastCheckpointStartTs = 0, lastCheckpointTimestamp = 0).
+        // Normal abandonment must still work.
+        tsm.processAbandonedTransactions();
+        assertFalse(
+                "Transaction not yet timed-out, should not be abandoned",
+                tsm.getTransactions().isEmpty());
+
+        Thread.sleep(timeoutMs + 100);
+
+        tsm.processAbandonedTransactions();
+        assertTrue(
+                "Transaction should be abandoned after timeout with no checkpoint protection",
+                tsm.getTransactions().isEmpty());
+    }
+}

--- a/herddb-core/src/test/java/herddb/sql/SyslogstatusTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SyslogstatusTest.java
@@ -80,6 +80,8 @@ public class SyslogstatusTest {
                         row.get("checkpoint_timestamp"));
                 assertNull("checkpoint_duration_ms must be null before any checkpoint",
                         row.get("checkpoint_duration_ms"));
+                assertNull("checkpoint_start_ts must be null before any checkpoint",
+                        row.get("checkpoint_start_ts"));
                 assertNull("dirty_ledgers_count must be null before any checkpoint",
                         row.get("dirty_ledgers_count"));
             }
@@ -151,6 +153,15 @@ public class SyslogstatusTest {
                         cpTsMs >= beforeCheckpointMs);
                 assertTrue("checkpoint_timestamp must not be in the future",
                         cpTsMs <= System.currentTimeMillis() + 1000);
+
+                // checkpoint_start_ts: set when checkpointMutex is acquired (Phase A start)
+                Object cpStartTs = row.get("checkpoint_start_ts");
+                assertNotNull("checkpoint_start_ts should be populated after checkpoint", cpStartTs);
+                long cpStartTsMs = ((java.sql.Timestamp) cpStartTs).getTime();
+                assertTrue("checkpoint_start_ts must be >= before-checkpoint time",
+                        cpStartTsMs >= beforeCheckpointMs);
+                assertTrue("checkpoint_start_ts must be <= checkpoint_timestamp (start before or equal to end)",
+                        cpStartTsMs <= cpTsMs + 1);
 
                 int dirtyLedgersVal = ((Number) dirtyLedgers).intValue();
                 assertTrue("dirty_ledgers_count must be >= 0", dirtyLedgersVal >= 0);

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -439,7 +439,12 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         LOGGER.log(Level.INFO, "Updated remote file servers: {0} (added: {1}, removed: {2})",
                 new Object[]{newServers, added, removed});
 
-        // Gracefully shutdown removed channel pairs in background
+        // Cancel in-flight RPCs to removed servers immediately via shutdownNow().
+        // Graceful shutdown (awaitTermination) is intentionally skipped: a server
+        // is removed because it crashed or deregistered from ZooKeeper, so any
+        // in-flight write to it is already lost. Using shutdownNow() ensures that
+        // callers blocking on writeFile() (e.g. during a Phase C checkpoint) fail
+        // fast rather than hanging for up to clientTimeoutSeconds (default 30 min).
         if (!removed.isEmpty()) {
             List<ManagedChannel> toShutdown = new ArrayList<>();
             for (String server : removed) {
@@ -454,12 +459,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
             }
             Thread shutdownThread = new Thread(() -> {
                 for (ManagedChannel ch : toShutdown) {
-                    try {
-                        ch.shutdown().awaitTermination(10, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        ch.shutdownNow();
-                    }
+                    ch.shutdownNow();
                 }
             }, "remote-file-channel-shutdown");
             shutdownThread.setDaemon(true);

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientDynamicTest.java
@@ -26,13 +26,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -220,6 +225,93 @@ public class RemoteFileServiceClientDynamicTest {
 
             // The list should eventually succeed
             listFuture.get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Reproducer for issue #342: when a file-server pod crashes during Phase C
+     * checkpoint, in-flight gRPC write calls to that server must fail promptly
+     * after {@link RemoteFileServiceClient#updateServers} removes it — not hang
+     * for up to {@code clientTimeoutSeconds} (default 30 min).
+     *
+     * <p>Uses a TCP "black-hole" server (accepts connections, never sends data)
+     * so the gRPC HTTP/2 handshake never completes and the write future stays
+     * pending indefinitely. After {@code updateServers} removes the black-hole
+     * address, {@code shutdownNow()} must cancel the in-flight call within a
+     * short window.
+     */
+    @Test
+    public void testRemovedServerWritesCancelledPromptly() throws Exception {
+        // Open a "black-hole" TCP server: accepts connections but never sends
+        // any bytes, so the gRPC HTTP/2 handshake never completes and any
+        // pending RPC hangs until the channel is forcibly shut down.
+        try (ServerSocket blackHole = new ServerSocket(0)) {
+            final String blackHoleAddr = "localhost:" + blackHole.getLocalPort();
+            final String addr1 = "localhost:" + server1.getPort();
+
+            // Accept connections silently in the background.
+            Thread acceptor = new Thread(() -> {
+                while (!blackHole.isClosed()) {
+                    try {
+                        Socket s = blackHole.accept();
+                        // Keep the socket open but do not write anything —
+                        // this simulates a server that is TCP-reachable but
+                        // application-layer unresponsive (e.g. OOM-killed process
+                        // where the OS still has the port bound briefly).
+                        s.setSoTimeout(0);
+                    } catch (IOException e) {
+                        break; // socket closed; exit
+                    }
+                }
+            }, "black-hole-acceptor");
+            acceptor.setDaemon(true);
+            acceptor.start();
+
+            try (RemoteFileServiceClient client = new RemoteFileServiceClient(
+                    Arrays.asList(addr1, blackHoleAddr))) {
+
+                // Find a path that the consistent-hash ring routes to the black-hole.
+                String pathToBlackHole = null;
+                for (int i = 0; i < 500; i++) {
+                    String candidate = "issue342/probe" + i + ".dat";
+                    if (blackHoleAddr.equals(client.getServerForPath(candidate))) {
+                        pathToBlackHole = candidate;
+                        break;
+                    }
+                }
+                assertNotNull("Could not find a path routing to the black-hole server", pathToBlackHole);
+
+                // Start an async write to the black-hole — this will be pending
+                // forever because the channel can never become READY.
+                CompletableFuture<Long> writeFuture = client.writeFileAsync(
+                        pathToBlackHole, "checkpoint-page-data".getBytes());
+
+                // Give the gRPC machinery a moment to attempt the connection.
+                Thread.sleep(300);
+                assertFalse("Write to black-hole should not have completed yet",
+                        writeFuture.isDone());
+
+                // Remove the black-hole from the server list (mirrors what ZK
+                // does when a pod deregisters). shutdownNow() must cancel the
+                // in-flight call so the future completes exceptionally, quickly.
+                long t0 = System.currentTimeMillis();
+                client.updateServers(Collections.singletonList(addr1));
+
+                // The write must fail within a short window — NOT after 30 min.
+                try {
+                    writeFuture.get(5, TimeUnit.SECONDS);
+                    fail("Expected write to black-hole to fail after updateServers removed it");
+                } catch (ExecutionException e) {
+                    // Expected: the gRPC channel was shut down by shutdownNow().
+                } catch (TimeoutException e) {
+                    fail("Write to removed server did not fail within 5 s; "
+                            + "shutdownNow() may not have cancelled the in-flight call");
+                }
+
+                long elapsed = System.currentTimeMillis() - t0;
+                assertTrue("Write should fail promptly after server removal (got " + elapsed + " ms)",
+                        elapsed < 5_000);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #342.

## Changes

### Phase 1 — `RemoteFileServiceClient` (herddb-remote-file-service)
When `updateServers()` removes a server (because ZooKeeper deregistered it), the old
ManagedChannel is now closed via `shutdownNow()` immediately, replacing the previous
graceful 10-second `awaitTermination` + `shutdownNow()` sequence.

**Why**: a file-server pod crash during Phase C leaves in-flight gRPC write calls stuck
until the per-call deadline fires (default: 1800 s / 30 min). `shutdownNow()` cancels
all pending RPCs on the channel immediately, so Phase C fails fast and the next
scheduled checkpoint can run with the surviving server only.

### Phase 2 — `TableSpaceManager` (herddb-core)
- Added `lastCheckpointStartTs` field, set atomically when `checkpointMutex.tryLock()`
  succeeds (start of Phase A).
- In `processAbandonedTransactions()`, if a checkpoint finished within the last
  `abandonedTransactionsTimeout` ms, the effective abandonment cutoff is shifted back
  to `(checkpointStart - timeout)`. This means a transaction is only declared abandoned
  if it was idle **before the checkpoint started** and for longer than the configured
  timeout. The protection expires automatically one full timeout period after the
  checkpoint ends, reverting to normal behaviour.
- Added package-private `setLastCheckpointStartTs` / `setLastCheckpointTimestamp`
  setters (test-only) and a `getLastCheckpointStartTs` getter.

**Why**: during a 32-minute Phase C stall, VectorBench implicit transactions could not
make DML progress (clients were blocked waiting for server responses). The first
`processAbandonedTransactions` run after the checkpoint saw 32-minute-old transactions
and rolled them back — even though the clients were still connected.

## Tests

- `RemoteFileServiceClientDynamicTest#testRemovedServerWritesCancelledPromptly` — starts
  a TCP "black-hole" server (accepts connections, never responds), submits an async write
  to it, then calls `updateServers()` to remove it; verifies the write future fails within
  5 s rather than hanging for the full client timeout.
- `AbandonedTransactionCheckpointProtectionTest#testTransactionProtectedDuringCheckpointWindow`
  — opens a transaction, sets a fake recent checkpoint window, calls
  `processAbandonedTransactions()`, asserts the transaction survives; advances the clock
  past the cooling period and asserts the transaction is then cleaned up.
- `AbandonedTransactionCheckpointProtectionTest#testNormalAbandonmentWithoutCheckpoint` —
  sanity check that without any checkpoint history the normal timeout still applies.
- Hammer suite (two passes, 12/12 green):
  `DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`,
  `DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest`,
  `DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest`

> **Note**: Fix 4 (capture previous container logs in collect-logs.sh) from the issue is
> already implemented in both the GKE and k3s-local scripts — no code change needed.
> Fix 3 (DNS probe before reconnecting a re-registered file-server) is deferred to a
> follow-up issue.

🤖 Implemented by the `pr-worker` agent.