### PR TITLE
Multi-checkpoint ground truth + DatasetDescribe CLI

### DIFF
--- a/.claude/agents/herddb-dataset-generator.md
+++ b/.claude/agents/herddb-dataset-generator.md
@@ -11,13 +11,18 @@ datasets that the HerdDB bench agents (`herddb-local-bench`,
 user request — push them to a Google Cloud Storage bucket.
 
 You do **not** run benchmarks, install HerdDB, or touch the cluster. You
-only invoke the three scripts under `vector-testings/`:
+only invoke the four scripts under `vector-testings/`:
 
 - `./run_generate.sh` — synthetic dataset generation via Ollama embeddings
   (`DatasetGenerator`, see `vector-testings/DATASET_GENERATOR.md`).
 - `./run_publish_standard_datasets.sh` — stage BIGANN or GIST1M with a
   generated descriptor (`StandardDatasetPublisher`).
 - `./push_dataset_gcs.sh` — upload a dataset directory to GCS via `gsutil`.
+- `./run_describe.sh` — read-only descriptor inspector (`DatasetDescribe`).
+  Use this to discover what `--rows` values support recall on a multi-
+  checkpoint dataset, either before generating (to confirm the layout of
+  an existing dataset) or after generating (to verify the descriptor and
+  share the available checkpoint counts with the user).
 
 You never compose multi-line bash, never edit the scripts, never bypass
 their flags. Your tool calls are single-line invocations of these scripts
@@ -71,10 +76,18 @@ not.
 - `./run_generate.sh --total <N> --name <name> --output-dir <path>
   [--model <ollama-model>] [--ollama-url <url>] [--num-queries <N>]
   [--ground-truth-k <K>] [--batch-size <N>] [--similarity euclidean|cosine]
+  [--ground-truth-checkpoints <csv>]
   [--csv] [--zip]`
   — generate a synthetic dataset. Auto-builds the uber-jar if missing.
   Default model `all-minilm` (384 dim). See
   `vector-testings/DATASET_GENERATOR.md` for the full flag table.
+  `--ground-truth-checkpoints` accepts an ascending comma-separated list
+  of base-vector counts (e.g. `1000000,10000000,50000000`) at which an
+  intermediate ground-truth IVECS file is written; the final ground
+  truth at `--total` is always emitted under the legacy
+  `{name}_groundtruth.ivecs` name. Each entry must be `>` `--num-queries`
+  and `≤` `--total`. Use this when the user wants one dataset to back
+  recall benches at multiple prefix sizes.
 - `./run_publish_standard_datasets.sh --dataset bigann|gist1m
   [--dataset-dir <dir>] [--output-dir <dir>] [--gs-path gs://...]`
   — stage a standard benchmark dataset (downloads from FTP on first run
@@ -88,7 +101,19 @@ not.
   trailing-slash convention matters: `gs://bucket/path/` appends the
   dataset directory name, `gs://bucket/path` uses it verbatim. Always
   print the resolved `GS_PATH=<gs://...>` on the last line of your
-  report.
+  report. The script uploads every file in the directory, so all
+  per-checkpoint IVECS files (`{name}_groundtruth_<count>.ivecs`) come
+  along with the descriptor automatically — no extra step needed.
+
+### Descriptor inspection
+
+- `./run_describe.sh --descriptor <path-or-url>` — print the descriptor
+  in a fixed-width key/value layout, including the list of available
+  `groundTruthCheckpoints`. Accepts a local path or `http(s)://`,
+  `ftp://`, or `gs://` URL. Use it after generation to confirm the
+  descriptor shape and to extract the list of checkpoint counts to
+  surface in your final report. Output is greppable, e.g.
+  `./run_describe.sh ... | grep -E '^groundTruthCheckpoints|^  '`.
 
 ### Read-only checks
 
@@ -106,8 +131,10 @@ One invocation per tool call, no pipes:
 - `ls -lh <path>` — inspect the staged output directory.
 - `du -sh <path>` — report dataset size after generation.
 
-You should prefer `Read` on the descriptor JSON to confirm dimensions,
-similarity, totalVectors, and file names before reporting back.
+You should prefer `Read` on the descriptor JSON, or run
+`./run_describe.sh --descriptor <path>`, to confirm dimensions,
+similarity, totalVectors, file names, and the
+`groundTruthCheckpoints` list before reporting back.
 
 ## Preflight per mode
 
@@ -124,6 +151,13 @@ Before invoking the script:
    pulling a multi-GB model is the user's call, not yours.
 4. Resolve and create the output directory (see "Standard dataset
    directory" above). Pass it to the script with `--output-dir`.
+5. If the user wants ground truth at multiple prefix sizes (e.g. for
+   recall benches at 1M, 10M, 50M against the same dataset), pass
+   `--ground-truth-checkpoints` with the ascending CSV. Validate the
+   list yourself before invoking: every entry must be `>`
+   `--num-queries` and `≤` `--total`. The legacy single GT file at
+   `--total` is always written, so you do not need to add `--total`
+   to the CSV — the script appends it.
 
 ### Standard dataset staging (`run_publish_standard_datasets.sh`)
 
@@ -171,6 +205,7 @@ Return a compact report:
 - Total vectors: <N>
 - Queries: <N>
 - Ground-truth K: <K>
+- Ground-truth checkpoints: <comma-separated counts, or "single (= total)">
 
 ## On disk
 DATASET_DIR=<absolute path>
@@ -182,14 +217,23 @@ GS_PATH=gs://herddb-datasets/<name>/
 Descriptor URL: gs://herddb-datasets/<name>/<name>_descriptor.json
 
 ## Next steps
-Run a benchmark via the appropriate bench agent, e.g.:
-  --dataset custom --dataset-url file://<DESCRIPTOR>
+Run a benchmark via the appropriate bench agent. The bench's `--rows N`
+must match one of the ground-truth checkpoint counts above for recall
+to be computed; any other value runs the bench but skips recall.
+  --dataset custom --dataset-url file://<DESCRIPTOR> --rows <one of the checkpoints>
 or, after a GCS push:
-  --dataset custom --dataset-url <GS_PATH>/<name>_descriptor.json
+  --dataset custom --dataset-url <GS_PATH>/<name>_descriptor.json --rows <one of the checkpoints>
 ```
 
-Keep the report ≤ 60 lines. The user wants the paths and the next
-command, not a re-run of the script's stdout.
+Always populate the "Ground-truth checkpoints" line by reading them
+back from the descriptor (either via `Read` on the JSON or via
+`./run_describe.sh --descriptor <DESCRIPTOR>`); do not infer them from
+the CLI args you passed, since the script always appends `--total` to
+the list.
+
+Keep the report ≤ 60 lines. The user wants the paths, the available
+checkpoint counts, and the next command, not a re-run of the script's
+stdout.
 
 ## What you must NOT do
 

--- a/vector-testings/DATASET_GENERATOR.md
+++ b/vector-testings/DATASET_GENERATOR.md
@@ -97,6 +97,7 @@ cd vector-testings
 | `--zip` | off | Compress output into a ZIP archive and remove individual files |
 | `--batch-size` | `100` | Sentences per Ollama API call |
 | `--similarity` | `euclidean` | Distance function: `euclidean` or `cosine` |
+| `--ground-truth-checkpoints` | (only at `--total`) | Comma-separated ascending base-vector counts at which intermediate ground-truth IVECS files are written. Each value must be > `--num-queries` and ≤ `--total`. The final ground truth at `--total` is always emitted; this flag adds extra ground-truth files for prefix runs (so a single 1B-vector dataset can serve recall benches at 1M, 10M, 50M, …). |
 
 ### Examples
 
@@ -127,6 +128,22 @@ cd vector-testings
     --output-dir ./datasets/cosine-100k
 ```
 
+**Multi-checkpoint ground truth for prefix benchmarking:**
+
+```bash
+./run_generate.sh \
+    --total 1000000000 \
+    --name multi-1b \
+    --num-queries 1000 \
+    --ground-truth-k 100 \
+    --ground-truth-checkpoints 1000000,10000000,50000000,500000000
+```
+
+Produces five ground-truth files — at 1M, 10M, 50M, 500M, and 1B — letting the
+same generated dataset back recall benchmarks against any of those prefix
+sizes. The dataset descriptor records all checkpoints; VectorBench picks the
+file matching `--rows N` automatically when running with `--dataset custom`.
+
 **Using a remote Ollama instance:**
 
 ```bash
@@ -143,7 +160,8 @@ All files are written to the `--output-dir` directory, prefixed with `--name`
 | `{name}_descriptor.json` | JSON | Dataset metadata (dimensions, similarity, file names, etc.) |
 | `{name}_base.fvecs` | FVECS | All base vectors. IDs are implicit (position 0, 1, 2, ...) |
 | `{name}_query.fvecs` | FVECS | First N query vectors (also included in base) |
-| `{name}_groundtruth.ivecs` | IVECS | K nearest neighbor IDs per query, sorted nearest-first |
+| `{name}_groundtruth.ivecs` | IVECS | K nearest neighbor IDs per query, sorted nearest-first. Always corresponds to the full dataset (matches `--total`). |
+| `{name}_groundtruth_<count>.ivecs` | IVECS | (if `--ground-truth-checkpoints`) Per-checkpoint ground truth, one file per intermediate count. The final checkpoint reuses the legacy `{name}_groundtruth.ivecs` name and is not duplicated. |
 | `{name}_sentences.csv` | CSV | (if `--csv`) Columns: id, sentence, vector |
 | `{name}_dataset.zip` | ZIP | (if `--zip`) All above files compressed; individual files are removed |
 
@@ -164,6 +182,10 @@ The descriptor file contains all metadata needed to auto-configure VectorBench:
   "baseFile": "my-dataset_base.fvecs",
   "queryFile": "my-dataset_query.fvecs",
   "groundTruthFile": "my-dataset_groundtruth.ivecs",
+  "groundTruthCheckpoints": [
+    {"baseVectorCount": 5000, "file": "my-dataset_groundtruth_5000.ivecs"},
+    {"baseVectorCount": 10000, "file": "my-dataset_groundtruth.ivecs"}
+  ],
   "createdAt": "2026-04-09T10:00:00Z"
 }
 ```
@@ -300,6 +322,42 @@ For BIGANN, the tool flattens the native `bigann_gnd/idx_1000000000.ivecs` to
 
 VectorBench downloads the descriptor, then the base / query / ground-truth
 files named in it, and auto-configures similarity, row count, and top-K.
+
+## Describing a Dataset
+
+`./run_describe.sh --descriptor <path-or-url>` prints the descriptor in a
+fixed-width key/value layout, including the list of available
+`groundTruthCheckpoints`. The descriptor argument can be a local file or any
+URL supported by VectorBench (`http://`, `https://`, `ftp://`, `gs://`).
+
+```bash
+./run_describe.sh --descriptor ./datasets/multi-1b/multi-1b_descriptor.json
+./run_describe.sh --descriptor gs://herddb-datasets/multi-1b/multi-1b_descriptor.json
+```
+
+Example output:
+
+```
+name                   multi-1b
+dimensions             384
+similarity             euclidean
+format                 fvecs
+totalVectors           1000000000
+numQueries             1000
+groundTruthK           100
+baseFile               multi-1b_base.fvecs
+queryFile              multi-1b_query.fvecs
+groundTruthFile        multi-1b_groundtruth.ivecs
+groundTruthCheckpoints 5
+  1000000              multi-1b_groundtruth_1000000.ivecs
+  10000000             multi-1b_groundtruth_10000000.ivecs
+  50000000             multi-1b_groundtruth_50000000.ivecs
+  500000000            multi-1b_groundtruth_500000000.ivecs
+  1000000000           multi-1b_groundtruth.ivecs
+```
+
+The output is deliberately greppable by automation — bench-driving agents use
+this to discover what `--rows` values support recall before dispatching a run.
 
 ## How It Works
 

--- a/vector-testings/VECTOR_BENCH.md
+++ b/vector-testings/VECTOR_BENCH.md
@@ -27,7 +27,7 @@ Invocation: `java -jar vector-testings-*.jar [options]`.
 | `--dataset <preset>` | `SIFT1M` | Built-in dataset preset, or `CUSTOM` for a descriptor-driven dataset. |
 | `--dataset-dir <path>` | `./datasets` | Local cache directory for dataset files. |
 | `--dataset-url <url>` | — | Override the download URL for the selected preset. |
-| `--rows <N>` | `100000` | Vectors to ingest. For `CUSTOM`, auto-derived from the descriptor if left at default. |
+| `--rows <N>` | `100000` | Vectors to ingest. For `CUSTOM`, auto-derived from the descriptor if left at default. For multi-checkpoint custom datasets, `N` must match one of the descriptor's `groundTruthCheckpoints` entries to enable recall — otherwise the bench logs the available counts and continues without recall. Discover the available counts with `./run_describe.sh --descriptor <path-or-url>`. |
 
 ### Ingestion
 

--- a/vector-testings/run_describe.sh
+++ b/vector-testings/run_describe.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Describe a dataset by reading its descriptor JSON. Accepts a local file path or a
+# remote URL (http://, https://, ftp://, gs://). Used by automation/agents to discover
+# what sizes a custom dataset supports without spinning up VectorBench.
+#
+#   ./run_describe.sh --descriptor ./datasets/generated/my-dataset_descriptor.json
+#   ./run_describe.sh --descriptor gs://herddb-datasets/big/big_descriptor.json
+#
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Build if jar doesn't exist
+JAR=$(ls "$SCRIPT_DIR"/target/vector-testings-*.jar 2>/dev/null | grep -v original | head -1)
+if [ -z "$JAR" ]; then
+    echo "Building vector-testings..."
+    mvn -f "$SCRIPT_DIR/pom.xml" package -DskipTests -q
+    JAR=$(ls "$SCRIPT_DIR"/target/vector-testings-*.jar 2>/dev/null | grep -v original | head -1)
+fi
+
+if [ -z "$JAR" ]; then
+    echo "ERROR: Could not find uber-jar. Run: mvn -f $SCRIPT_DIR/pom.xml package -DskipTests"
+    exit 1
+fi
+
+JAVA_HEAP="${VECTORBENCH_HEAP:--Xms256m -Xmx512m}"
+
+java $JAVA_HEAP -cp "$JAR" herddb.vectortesting.DatasetDescribe "$@"

--- a/vector-testings/src/main/java/herddb/vectortesting/DatasetDescribe.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/DatasetDescribe.java
@@ -1,0 +1,128 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Read-only CLI tool that prints the contents of a dataset descriptor JSON. Designed to
+ * be invoked by automation (bench-driving agents) that need to discover what sizes and
+ * similarity a dataset supports without spinning up the full {@code VectorBench} JVM.
+ *
+ * <p>Accepts a local file path or a remote URL ({@code http://}, {@code https://},
+ * {@code ftp://}, {@code gs://}). Remote URLs are downloaded to a temp file via
+ * {@link DatasetLoader#downloadSmartUrl(String, java.io.File)} so credentials and
+ * GCS routing work the same as for the bench loader.</p>
+ */
+public final class DatasetDescribe {
+
+    private DatasetDescribe() {
+        // entry point only
+    }
+
+    public static void main(String[] args) {
+        Options opts = new Options();
+        opts.addOption(null, "descriptor", true,
+                "Path or URL of the dataset descriptor JSON (required). Supported schemes:"
+                        + " file:// (or local path), http(s)://, ftp://, gs://.");
+        opts.addOption("h", "help", false, "Show help");
+
+        CommandLine cmd;
+        try {
+            cmd = new DefaultParser().parse(opts, args);
+        } catch (ParseException e) {
+            System.err.println("ERROR: " + e.getMessage());
+            new HelpFormatter().printHelp("dataset-describe", opts);
+            System.exit(1);
+            return;
+        }
+
+        if (cmd.hasOption("help") || !cmd.hasOption("descriptor")) {
+            new HelpFormatter().printHelp("dataset-describe", opts);
+            System.exit(cmd.hasOption("help") ? 0 : 1);
+            return;
+        }
+
+        String descriptorArg = cmd.getOptionValue("descriptor");
+        try {
+            File descriptorFile = resolveDescriptor(descriptorArg);
+            DatasetLoader.DatasetDescriptor desc = DatasetLoader.DatasetDescriptor.load(descriptorFile);
+            print(System.out, desc);
+        } catch (IOException e) {
+            System.err.println("ERROR: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Returns a local {@link File} for the descriptor argument. Local paths are returned
+     * verbatim; URLs are downloaded to a temp file (deleted on JVM exit) using the same
+     * smart-URL logic as the dataset loader.
+     */
+    static File resolveDescriptor(String arg) throws IOException {
+        if (arg.startsWith("http://") || arg.startsWith("https://")
+                || arg.startsWith("ftp://") || arg.startsWith("gs://")) {
+            File tmp = Files.createTempFile("descriptor-", ".json").toFile();
+            tmp.deleteOnExit();
+            // Construct a throwaway DatasetLoader to reuse its URL-resolution code path.
+            // The constructor arguments don't matter for downloadSmartUrl (it doesn't
+            // touch the dataset directory). Using CUSTOM with a null URL is the
+            // lightest-weight option.
+            DatasetLoader loader = new DatasetLoader("/tmp", DatasetLoader.DatasetPreset.CUSTOM, null);
+            loader.downloadSmartUrl(arg, tmp);
+            return tmp;
+        }
+        if (arg.startsWith("file://")) {
+            return new File(arg.substring("file://".length()));
+        }
+        return new File(arg);
+    }
+
+    /**
+     * Pretty-prints the descriptor as fixed-width key/value lines, easy for agents
+     * to grep. Followed by a {@code groundTruthCheckpoints} block listing each
+     * (count, file) pair on its own indented line.
+     */
+    static void print(PrintStream out, DatasetLoader.DatasetDescriptor desc) {
+        out.printf("%-22s %s%n", "name", desc.name);
+        out.printf("%-22s %d%n", "dimensions", desc.dimensions);
+        out.printf("%-22s %s%n", "similarity", desc.similarity);
+        out.printf("%-22s %s%n", "format", desc.format.name().toLowerCase(java.util.Locale.ROOT));
+        out.printf("%-22s %d%n", "totalVectors", desc.totalVectors);
+        out.printf("%-22s %d%n", "numQueries", desc.numQueries);
+        out.printf("%-22s %d%n", "groundTruthK", desc.groundTruthK);
+        out.printf("%-22s %s%n", "baseFile", desc.baseFile == null ? "" : desc.baseFile);
+        out.printf("%-22s %s%n", "queryFile", desc.queryFile == null ? "" : desc.queryFile);
+        out.printf("%-22s %s%n", "groundTruthFile",
+                desc.groundTruthFile == null ? "" : desc.groundTruthFile);
+        out.printf("%-22s %d%n", "groundTruthCheckpoints", desc.groundTruthCheckpoints.size());
+        for (DatasetLoader.DatasetDescriptor.GroundTruthCheckpoint cp : desc.groundTruthCheckpoints) {
+            out.printf("  %-20d %s%n", cp.baseVectorCount, cp.file);
+        }
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/DatasetGenerator.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/DatasetGenerator.java
@@ -21,6 +21,7 @@ package herddb.vectortesting;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,7 +30,9 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -62,15 +65,28 @@ public class DatasetGenerator {
 
         File baseFile = new File(outputDir, prefix + "_base.fvecs");
         File queryFile = new File(outputDir, prefix + "_query.fvecs");
-        File groundTruthFile = new File(outputDir, prefix + "_groundtruth.ivecs");
         File csvFile = new File(outputDir, prefix + "_sentences.csv");
         File descriptorFile = new File(outputDir, prefix + "_descriptor.json");
+
+        // Resolve checkpoint plan: ascending base-vector counts → file. The final
+        // checkpoint always equals config.total and uses the legacy
+        // {prefix}_groundtruth.ivecs name, so old descriptor consumers keep working.
+        long[] checkpointCounts = config.groundTruthCheckpoints;
+        Map<Long, File> checkpointFiles = new LinkedHashMap<>();
+        for (long count : checkpointCounts) {
+            String fileName = (count == config.total)
+                    ? prefix + "_groundtruth.ivecs"
+                    : prefix + "_groundtruth_" + count + ".ivecs";
+            checkpointFiles.put(count, new File(outputDir, fileName));
+        }
 
         // Buffer first numQueries vectors in memory for ground truth tracker
         List<float[]> queryVectorsList = new ArrayList<>(config.numQueries);
         GroundTruthTracker tracker = null;
 
         long startTime = System.currentTimeMillis();
+        // Index of the next checkpoint to emit; advances each time we cross one.
+        int nextCheckpointIdx = 0;
 
         try (SiftWriter baseWriter = new SiftWriter(baseFile);
              SiftWriter queryWriter = new SiftWriter(queryFile);
@@ -118,6 +134,22 @@ public class DatasetGenerator {
                         csvWriter.print(',');
                         csvWriter.println(vectorToString(vec));
                     }
+
+                    // Emit any pending checkpoints we just crossed. Multiple checkpoints can
+                    // theoretically share a count if the user's CSV is malformed, but
+                    // GeneratorConfig.parseCheckpoints already rejects duplicates, so this is
+                    // a single iteration in practice.
+                    long crossedCount = (long) globalIdx + 1L;
+                    while (tracker != null
+                            && nextCheckpointIdx < checkpointCounts.length
+                            && checkpointCounts[nextCheckpointIdx] == crossedCount) {
+                        long count = checkpointCounts[nextCheckpointIdx];
+                        File gtFile = checkpointFiles.get(count);
+                        writeGroundTruthFile(gtFile, tracker);
+                        System.out.printf("%n  Wrote ground truth checkpoint @ %,d vectors → %s%n",
+                                count, gtFile.getName());
+                        nextCheckpointIdx++;
+                    }
                 }
 
                 generated += embeddings.length;
@@ -130,45 +162,55 @@ public class DatasetGenerator {
             System.out.println();
         }
 
-        // Handle edge case where total == numQueries (tracker never initialized in the else-if branch)
-        if (tracker == null && !queryVectorsList.isEmpty()) {
-            float[][] queryVectors = queryVectorsList.toArray(new float[0][]);
-            tracker = new GroundTruthTracker(queryVectors, config.groundTruthK, config.similarity);
-            for (int j = 0; j < queryVectors.length; j++) {
-                tracker.offer(j, queryVectors[j]);
-            }
-        }
-
-        // Write ground truth
-        if (tracker != null) {
-            System.out.println("Writing ground truth...");
-            int[][] groundTruth = tracker.getGroundTruth();
-            try (SiftWriter gtWriter = new SiftWriter(groundTruthFile)) {
-                for (int[] row : groundTruth) {
-                    gtWriter.writeIvec(row);
+        // Defensive fallback: if no checkpoint was emitted (e.g. a future code path leaves
+        // total < numQueries), still write the final ground-truth file at config.total so
+        // older consumers find {prefix}_groundtruth.ivecs.
+        if (nextCheckpointIdx < checkpointCounts.length) {
+            if (tracker == null && !queryVectorsList.isEmpty()) {
+                float[][] queryVectors = queryVectorsList.toArray(new float[0][]);
+                tracker = new GroundTruthTracker(queryVectors, config.groundTruthK, config.similarity);
+                for (int j = 0; j < queryVectors.length; j++) {
+                    tracker.offer(j, queryVectors[j]);
                 }
             }
-            System.out.println("Ground truth: " + groundTruth.length + " queries, "
-                    + config.groundTruthK + " neighbors each");
+            while (nextCheckpointIdx < checkpointCounts.length && tracker != null) {
+                long count = checkpointCounts[nextCheckpointIdx];
+                File gtFile = checkpointFiles.get(count);
+                writeGroundTruthFile(gtFile, tracker);
+                System.out.printf("  Wrote ground truth checkpoint @ %,d vectors → %s%n",
+                        count, gtFile.getName());
+                nextCheckpointIdx++;
+            }
         }
 
         // Write dataset descriptor
         System.out.println("Writing dataset descriptor...");
-        writeDescriptor(descriptorFile, config, prefix, dim);
+        writeDescriptor(descriptorFile, config, prefix, dim, checkpointFiles);
 
         // Optional ZIP compression
         File zipFile = null;
         if (config.zip) {
             zipFile = new File(outputDir, prefix + "_dataset.zip");
             System.out.println("Creating ZIP archive: " + zipFile.getName());
-            createZip(zipFile, baseFile, queryFile, groundTruthFile, descriptorFile,
-                    config.csv ? csvFile : null);
+            List<File> zipEntries = new ArrayList<>();
+            zipEntries.add(baseFile);
+            zipEntries.add(queryFile);
+            for (File gt : checkpointFiles.values()) {
+                zipEntries.add(gt);
+            }
+            zipEntries.add(descriptorFile);
+            if (config.csv) {
+                zipEntries.add(csvFile);
+            }
+            createZip(zipFile, zipEntries.toArray(new File[0]));
 
             // Remove individual files — the ZIP is the single deliverable
             System.out.println("Removing individual files (kept in ZIP)...");
             deleteQuietly(baseFile);
             deleteQuietly(queryFile);
-            deleteQuietly(groundTruthFile);
+            for (File gt : checkpointFiles.values()) {
+                deleteQuietly(gt);
+            }
             deleteQuietly(descriptorFile);
             deleteQuietly(csvFile);
         }
@@ -183,15 +225,34 @@ public class DatasetGenerator {
             System.out.println("  Descriptor:     " + descriptorFile.getName());
             System.out.println("  Base vectors:   " + baseFile.getName() + " (" + formatSize(baseFile.length()) + ")");
             System.out.println("  Query vectors:  " + queryFile.getName() + " (" + formatSize(queryFile.length()) + ")");
-            System.out.println("  Ground truth:   " + groundTruthFile.getName() + " (" + formatSize(groundTruthFile.length()) + ")");
+            for (Map.Entry<Long, File> e : checkpointFiles.entrySet()) {
+                File gt = e.getValue();
+                System.out.printf("  Ground truth @ %,d: %s (%s)%n",
+                        e.getKey(), gt.getName(), formatSize(gt.length()));
+            }
             if (config.csv) {
                 System.out.println("  CSV:            " + csvFile.getName() + " (" + formatSize(csvFile.length()) + ")");
             }
         }
     }
 
+    /**
+     * Writes one IVECS ground-truth file using the tracker's current snapshot. Safe to
+     * call multiple times during a generation run — {@link GroundTruthTracker#getGroundTruth()}
+     * is non-destructive.
+     */
+    private static void writeGroundTruthFile(File gtFile, GroundTruthTracker tracker) throws Exception {
+        int[][] groundTruth = tracker.getGroundTruth();
+        try (SiftWriter gtWriter = new SiftWriter(gtFile)) {
+            for (int[] row : groundTruth) {
+                gtWriter.writeIvec(row);
+            }
+        }
+    }
+
     private static void writeDescriptor(File descriptorFile, GeneratorConfig config,
-                                          String prefix, int dimensions) throws Exception {
+                                          String prefix, int dimensions,
+                                          Map<Long, File> checkpointFiles) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
         ObjectNode root = mapper.createObjectNode();
@@ -205,7 +266,19 @@ public class DatasetGenerator {
         root.put("embeddingModel", config.model);
         root.put("baseFile", prefix + "_base.fvecs");
         root.put("queryFile", prefix + "_query.fvecs");
+        // Legacy field: always points to the ground-truth file matching --total. This
+        // duplicates the last entry of groundTruthCheckpoints, but old descriptor
+        // consumers only look at this field.
         root.put("groundTruthFile", prefix + "_groundtruth.ivecs");
+        // New field: list of (baseVectorCount, file) pairs in ascending order, including
+        // the final entry whose file equals groundTruthFile. Consumers that want recall
+        // for prefix runs (--rows N) look up the matching baseVectorCount here.
+        ArrayNode checkpoints = root.putArray("groundTruthCheckpoints");
+        for (Map.Entry<Long, File> e : checkpointFiles.entrySet()) {
+            ObjectNode entry = checkpoints.addObject();
+            entry.put("baseVectorCount", e.getKey());
+            entry.put("file", e.getValue().getName());
+        }
         root.put("createdAt", Instant.now().toString());
         mapper.writeValue(descriptorFile, root);
     }

--- a/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
@@ -41,6 +41,7 @@ import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -231,11 +232,25 @@ public class DatasetLoader {
         // Parse descriptor to find data files
         DatasetDescriptor desc = DatasetDescriptor.load(descriptorFile);
 
-        // Download each data file
-        for (String fileName : new String[]{desc.baseFile, desc.queryFile, desc.groundTruthFile}) {
-            if (fileName == null) {
-                continue;
-            }
+        // Build a deduped list of files to fetch: base + query + legacy ground-truth
+        // file + every entry from groundTruthCheckpoints. The last checkpoint's file
+        // typically equals desc.groundTruthFile, so a LinkedHashSet keeps insertion
+        // order while suppressing the duplicate.
+        java.util.LinkedHashSet<String> filesToFetch = new java.util.LinkedHashSet<>();
+        if (desc.baseFile != null) {
+            filesToFetch.add(desc.baseFile);
+        }
+        if (desc.queryFile != null) {
+            filesToFetch.add(desc.queryFile);
+        }
+        if (desc.groundTruthFile != null) {
+            filesToFetch.add(desc.groundTruthFile);
+        }
+        for (DatasetDescriptor.GroundTruthCheckpoint cp : desc.groundTruthCheckpoints) {
+            filesToFetch.add(cp.file);
+        }
+
+        for (String fileName : filesToFetch) {
             File target = new File(dir, fileName);
             if (!target.exists()) {
                 String fileUrl = baseUrl + "/" + fileName;
@@ -276,8 +291,11 @@ public class DatasetLoader {
     /**
      * Downloads a file, routing gs:// URLs through the S3-compatible GCS API
      * and all other URLs through HTTP/FTP.
+     *
+     * <p>Package-private so the {@code DatasetDescribe} CLI tool can reuse the
+     * same URL-resolution path as the bench loader.</p>
      */
-    private void downloadSmartUrl(String url, File dest) throws IOException {
+    void downloadSmartUrl(String url, File dest) throws IOException {
         if (url.startsWith("gs://")) {
             downloadGsFile(url, dest);
         } else {
@@ -787,13 +805,78 @@ public class DatasetLoader {
     }
 
     public List<int[]> loadGroundTruth(int maxVectors) throws IOException {
+        // Delegate to the count-aware variant. For non-CUSTOM presets the count is ignored;
+        // for CUSTOM datasets we ask for the ground truth matching totalVectors (the legacy
+        // file). Callers that want recall for a prefix run should call
+        // loadGroundTruth(maxVectors, baseVectorCount) directly.
+        long defaultCount = preset == DatasetPreset.CUSTOM && customDescriptor != null
+                ? customDescriptor.totalVectors
+                : Long.MIN_VALUE; // sentinel: ignored for non-CUSTOM presets
+        return loadGroundTruth(maxVectors, defaultCount);
+    }
+
+    /**
+     * Loads ground truth for a specific base-vector count. Used when a custom dataset
+     * ships multiple ground-truth files keyed by prefix size (e.g. for prefix runs at
+     * 1M, 10M, 1B base vectors).
+     *
+     * @param maxVectors      max ground-truth records to load (typically the query count).
+     * @param baseVectorCount the number of base vectors the bench will run against.
+     *                        For CUSTOM datasets, the descriptor's
+     *                        {@code groundTruthCheckpoints} list must contain an entry
+     *                        with this exact count, or an IOException is thrown.
+     *                        Ignored for HDF5 and non-CUSTOM presets.
+     * @throws IOException if the matching ground truth file is missing, or, for CUSTOM
+     *                     datasets, no checkpoint matches {@code baseVectorCount}.
+     */
+    public List<int[]> loadGroundTruth(int maxVectors, long baseVectorCount) throws IOException {
         if (preset.baseFormat == VecFormat.HDF5) {
             return loadHdf5GroundTruth(maxVectors);
         }
-        String gtFileName = preset == DatasetPreset.CUSTOM && customDescriptor != null
-                ? customDescriptor.groundTruthFile : preset.groundTruthFile;
+        String gtFileName;
+        if (preset == DatasetPreset.CUSTOM && customDescriptor != null) {
+            gtFileName = resolveCustomGroundTruthFile(baseVectorCount);
+        } else {
+            gtFileName = preset.groundTruthFile;
+        }
         File file = new File(getDatasetSubDir(), gtFileName);
         return loadIvecs(openInputStream(file), maxVectors);
+    }
+
+    /**
+     * Picks the ground-truth file from {@link DatasetDescriptor#groundTruthCheckpoints}
+     * matching {@code baseVectorCount} exactly. Recall against a non-matching ground
+     * truth is mathematically meaningless, so we fail hard rather than silently use a
+     * close-but-wrong file.
+     */
+    private String resolveCustomGroundTruthFile(long baseVectorCount) throws IOException {
+        List<DatasetDescriptor.GroundTruthCheckpoint> checkpoints =
+                customDescriptor.groundTruthCheckpoints;
+        if (checkpoints == null || checkpoints.isEmpty()) {
+            // Old descriptor with neither field present, or HDF5-style: fall back to the
+            // legacy single-file field. If that's also null the IO read will fail with a
+            // clear message.
+            if (customDescriptor.groundTruthFile == null) {
+                throw new IOException("Custom dataset has no ground truth file configured");
+            }
+            return customDescriptor.groundTruthFile;
+        }
+        for (DatasetDescriptor.GroundTruthCheckpoint cp : checkpoints) {
+            if (cp.baseVectorCount == baseVectorCount) {
+                return cp.file;
+            }
+        }
+        StringBuilder available = new StringBuilder();
+        for (int i = 0; i < checkpoints.size(); i++) {
+            if (i > 0) {
+                available.append(", ");
+            }
+            available.append(checkpoints.get(i).baseVectorCount);
+        }
+        throw new IOException("No ground truth checkpoint matches baseVectorCount=" + baseVectorCount
+                + " for custom dataset; available checkpoints: [" + available + "]."
+                + " Pass --rows N where N is one of the listed values to enable recall;"
+                + " or omit --rows to use the full dataset.");
     }
 
     private List<float[]> loadFvecs(InputStream in, int maxVectors) throws IOException {
@@ -891,12 +974,22 @@ public class DatasetLoader {
         final int groundTruthK;
         final String baseFile;
         final String queryFile;
+        // Legacy single ground-truth file. Always points at the file matching
+        // {@code totalVectors}. New descriptors duplicate this entry as the last
+        // element of {@link #groundTruthCheckpoints}.
         final String groundTruthFile;
+        // Ascending list of (baseVectorCount, file) pairs. For new descriptors the
+        // last entry's file equals {@link #groundTruthFile} and its baseVectorCount
+        // equals {@link #totalVectors}. For old descriptors that lack the
+        // groundTruthCheckpoints array, this is synthesised from groundTruthFile +
+        // totalVectors so callers see a uniform shape.
+        final List<GroundTruthCheckpoint> groundTruthCheckpoints;
 
         DatasetDescriptor(String name, String similarity, VecFormat format,
                           int dimensions, long totalVectors,
                           long numQueries, int groundTruthK,
-                          String baseFile, String queryFile, String groundTruthFile) {
+                          String baseFile, String queryFile, String groundTruthFile,
+                          List<GroundTruthCheckpoint> groundTruthCheckpoints) {
             this.name = name;
             this.similarity = similarity;
             this.format = format;
@@ -907,23 +1000,70 @@ public class DatasetLoader {
             this.baseFile = baseFile;
             this.queryFile = queryFile;
             this.groundTruthFile = groundTruthFile;
+            this.groundTruthCheckpoints = groundTruthCheckpoints == null
+                    ? Collections.emptyList()
+                    : Collections.unmodifiableList(new ArrayList<>(groundTruthCheckpoints));
+        }
+
+        /**
+         * One ground-truth file in a multi-checkpoint custom dataset. {@code file} is a
+         * relative path resolved against the dataset directory.
+         */
+        static final class GroundTruthCheckpoint {
+            final long baseVectorCount;
+            final String file;
+
+            GroundTruthCheckpoint(long baseVectorCount, String file) {
+                this.baseVectorCount = baseVectorCount;
+                this.file = file;
+            }
         }
 
         static DatasetDescriptor load(File jsonFile) throws IOException {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(jsonFile);
+            String groundTruthFile = root.path("groundTruthFile").asText(null);
+            long totalVectors = root.path("totalVectors").asLong(0L);
+            List<GroundTruthCheckpoint> checkpoints = parseCheckpoints(
+                    root.path("groundTruthCheckpoints"), totalVectors, groundTruthFile);
             return new DatasetDescriptor(
                     root.path("name").asText("custom"),
                     root.path("similarity").asText("euclidean"),
                     parseFormat(root.path("format").asText("fvecs")),
                     root.path("dimensions").asInt(0),
-                    root.path("totalVectors").asLong(0L),
+                    totalVectors,
                     root.path("numQueries").asLong(0L),
                     root.path("groundTruthK").asInt(0),
                     root.path("baseFile").asText(null),
                     root.path("queryFile").asText(null),
-                    root.path("groundTruthFile").asText(null)
+                    groundTruthFile,
+                    checkpoints
             );
+        }
+
+        /**
+         * Parses the {@code groundTruthCheckpoints} array. When the array is missing
+         * or empty, synthesises a singleton from the legacy {@code groundTruthFile} +
+         * {@code totalVectors} so old descriptors still resolve to a single ground-truth
+         * file via the new lookup path.
+         */
+        private static List<GroundTruthCheckpoint> parseCheckpoints(
+                JsonNode arrayNode, long totalVectors, String groundTruthFile) {
+            List<GroundTruthCheckpoint> out = new ArrayList<>();
+            if (arrayNode != null && arrayNode.isArray() && arrayNode.size() > 0) {
+                for (JsonNode entry : arrayNode) {
+                    long count = entry.path("baseVectorCount").asLong(-1L);
+                    String file = entry.path("file").asText(null);
+                    if (count <= 0 || file == null) {
+                        continue;
+                    }
+                    out.add(new GroundTruthCheckpoint(count, file));
+                }
+            }
+            if (out.isEmpty() && groundTruthFile != null && totalVectors > 0) {
+                out.add(new GroundTruthCheckpoint(totalVectors, groundTruthFile));
+            }
+            return out;
         }
 
         private static VecFormat parseFormat(String s) throws IOException {
@@ -964,6 +1104,16 @@ public class DatasetLoader {
                 + ", Format: " + customDescriptor.format
                 + ", Queries: " + customDescriptor.numQueries
                 + ", GroundTruth-K: " + customDescriptor.groundTruthK);
+        if (!customDescriptor.groundTruthCheckpoints.isEmpty()) {
+            StringBuilder cps = new StringBuilder();
+            for (int i = 0; i < customDescriptor.groundTruthCheckpoints.size(); i++) {
+                if (i > 0) {
+                    cps.append(", ");
+                }
+                cps.append(customDescriptor.groundTruthCheckpoints.get(i).baseVectorCount);
+            }
+            System.out.println("  Ground-truth checkpoints (base-vector counts): [" + cps + "]");
+        }
         return customDescriptor;
     }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/GeneratorConfig.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/GeneratorConfig.java
@@ -19,6 +19,10 @@
  */
 package herddb.vectortesting;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -38,6 +42,14 @@ public class GeneratorConfig {
     boolean zip = false;
     int batchSize = 100;
     String similarity = "euclidean";
+    /**
+     * Ascending list of base-vector counts at which a ground-truth IVECS
+     * file must be emitted. The final entry always equals {@link #total}
+     * (so the legacy single ground-truth file is always produced). When
+     * the user does not pass {@code --ground-truth-checkpoints}, this is
+     * a singleton {@code [total]}.
+     */
+    long[] groundTruthCheckpoints = null;
 
     private static Options buildOptions() {
         Options opts = new Options();
@@ -52,6 +64,11 @@ public class GeneratorConfig {
         opts.addOption(null, "zip", false, "Compress output files into a ZIP archive");
         opts.addOption(null, "batch-size", true, "Sentences per Ollama API call (default: 100)");
         opts.addOption(null, "similarity", true, "Distance function: euclidean, cosine (default: euclidean)");
+        opts.addOption(null, "ground-truth-checkpoints", true,
+                "Comma-separated ascending base-vector counts at which intermediate ground-truth"
+                        + " IVECS files are emitted (e.g. 1000000,10000000,50000000). The final ground"
+                        + " truth at --total is always written; checkpoint counts must be strictly"
+                        + " greater than --num-queries and not exceed --total.");
         opts.addOption("h", "help", false, "Show help");
         return opts;
     }
@@ -112,7 +129,74 @@ public class GeneratorConfig {
             System.exit(1);
         }
 
+        cfg.groundTruthCheckpoints = parseCheckpoints(
+                cmd.getOptionValue("ground-truth-checkpoints"), cfg.total, cfg.numQueries);
+
         return cfg;
+    }
+
+    /**
+     * Parse the {@code --ground-truth-checkpoints} CSV value into a sorted, deduped,
+     * ascending {@code long[]} that always ends with {@code total}.
+     *
+     * <p>Validation rules:</p>
+     * <ul>
+     *   <li>Each entry must parse as a positive long.</li>
+     *   <li>Each entry must be {@code > numQueries} (a checkpoint at or below the query
+     *       count would yield meaningless ground truth, since the tracker is only
+     *       initialised after the first {@code numQueries} vectors).</li>
+     *   <li>Each entry must be {@code <= total}.</li>
+     *   <li>{@code total} is always appended (deduped) so the legacy single ground
+     *       truth file is produced.</li>
+     * </ul>
+     *
+     * <p>When {@code csv} is {@code null} or blank, returns a singleton {@code [total]}
+     * — i.e. the historical single-ground-truth behaviour.</p>
+     *
+     * @throws IllegalArgumentException for any validation failure (unparseable entry,
+     *     duplicate, out-of-range value).
+     */
+    static long[] parseCheckpoints(String csv, int total, int numQueries) {
+        Set<Long> sorted = new TreeSet<>();
+        if (csv != null && !csv.trim().isEmpty()) {
+            // Use LinkedHashSet first to detect duplicates (a duplicate checkpoint count
+            // is almost certainly a typo and silently swallowing it would be confusing).
+            Set<Long> seen = new LinkedHashSet<>();
+            for (String token : csv.split(",")) {
+                String t = token.trim();
+                if (t.isEmpty()) {
+                    continue;
+                }
+                long v;
+                try {
+                    v = Long.parseLong(t);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            "Invalid --ground-truth-checkpoints entry: '" + t + "' is not a number");
+                }
+                if (v <= numQueries) {
+                    throw new IllegalArgumentException("Ground-truth checkpoint " + v
+                            + " must be greater than --num-queries (" + numQueries + ")");
+                }
+                if (v > total) {
+                    throw new IllegalArgumentException("Ground-truth checkpoint " + v
+                            + " exceeds --total (" + total + ")");
+                }
+                if (!seen.add(v)) {
+                    throw new IllegalArgumentException(
+                            "Duplicate --ground-truth-checkpoints entry: " + v);
+                }
+                sorted.add(v);
+            }
+        }
+        // The total checkpoint is always emitted; deduped automatically by TreeSet.
+        sorted.add((long) total);
+        long[] out = new long[sorted.size()];
+        int i = 0;
+        for (long v : sorted) {
+            out[i++] = v;
+        }
+        return out;
     }
 
     @Override
@@ -129,6 +213,7 @@ public class GeneratorConfig {
                 + ", zip=" + zip
                 + ", batchSize=" + batchSize
                 + ", similarity=" + similarity
+                + ", groundTruthCheckpoints=" + Arrays.toString(groundTruthCheckpoints)
                 + '}';
     }
 }

--- a/vector-testings/src/main/java/herddb/vectortesting/GroundTruthTracker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/GroundTruthTracker.java
@@ -75,6 +75,12 @@ public class GroundTruthTracker {
     /**
      * Returns the ground truth as int[][] (one row per query, K columns),
      * sorted nearest-first (ascending distance).
+     *
+     * <p>This method is non-destructive: it copies each heap into a fresh
+     * array and sorts the copy, so the internal state is untouched. Callers
+     * may invoke it multiple times during a generation run (e.g. to write
+     * intermediate ground-truth files at user-specified base-vector
+     * checkpoints) and obtain a consistent snapshot at every call.</p>
      */
     public int[][] getGroundTruth() {
         int[][] result = new int[queryVectors.length][];

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -227,8 +227,13 @@ public class VectorBench {
 
         List<int[]> groundTruth = null;
         try {
-            groundTruth = loader.loadGroundTruth(queryVectors.size());
-            out.info("Loaded " + groundTruth.size() + " ground truth entries");
+            // Pass config.numRows so multi-checkpoint custom datasets can pick the
+            // ground-truth file matching the prefix being benched (e.g. recall against
+            // the first 10M of a 1B-vector dataset uses the 10M ground truth, not the 1B
+            // one). Non-CUSTOM presets ignore the count.
+            groundTruth = loader.loadGroundTruth(queryVectors.size(), config.numRows);
+            out.info("Loaded " + groundTruth.size() + " ground truth entries"
+                    + " (matched checkpoint at " + config.numRows + " base vectors)");
         } catch (java.io.IOException e) {
             out.info("Ground truth not available: " + e.getMessage());
         }

--- a/vector-testings/src/test/java/herddb/vectortesting/DatasetDescribeTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/DatasetDescribeTest.java
@@ -1,0 +1,94 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import herddb.vectortesting.DatasetLoader.DatasetDescriptor;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DatasetDescribeTest {
+
+    @Test
+    void prettyPrintsAllKeyFieldsAndCheckpoints(@TempDir Path tmp) throws Exception {
+        String json = "{\n"
+                + "  \"name\": \"smoke\",\n"
+                + "  \"format\": \"fvecs\",\n"
+                + "  \"dimensions\": 64,\n"
+                + "  \"similarity\": \"cosine\",\n"
+                + "  \"totalVectors\": 5000,\n"
+                + "  \"numQueries\": 100,\n"
+                + "  \"groundTruthK\": 10,\n"
+                + "  \"baseFile\": \"smoke_base.fvecs\",\n"
+                + "  \"queryFile\": \"smoke_query.fvecs\",\n"
+                + "  \"groundTruthFile\": \"smoke_groundtruth.ivecs\",\n"
+                + "  \"groundTruthCheckpoints\": [\n"
+                + "    {\"baseVectorCount\": 1000, \"file\": \"smoke_groundtruth_1000.ivecs\"},\n"
+                + "    {\"baseVectorCount\": 5000, \"file\": \"smoke_groundtruth.ivecs\"}\n"
+                + "  ]\n"
+                + "}\n";
+        File descriptorFile = tmp.resolve("smoke_descriptor.json").toFile();
+        Files.writeString(descriptorFile.toPath(), json);
+
+        DatasetDescriptor desc = DatasetDescriptor.load(descriptorFile);
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        DatasetDescribe.print(new PrintStream(buf, true, StandardCharsets.UTF_8), desc);
+
+        String output = buf.toString(StandardCharsets.UTF_8);
+        // Spot-check each significant field appears verbatim. The fixed-width formatting
+        // is intentionally agent-greppable, so any drift here is a contract violation.
+        assertTrue(output.contains("name"), output);
+        assertTrue(output.contains("smoke"), output);
+        assertTrue(output.contains("dimensions"), output);
+        assertTrue(output.contains("64"), output);
+        assertTrue(output.contains("similarity"), output);
+        assertTrue(output.contains("cosine"), output);
+        assertTrue(output.contains("format"), output);
+        assertTrue(output.contains("fvecs"), output);
+        assertTrue(output.contains("totalVectors"), output);
+        assertTrue(output.contains("5000"), output);
+        assertTrue(output.contains("groundTruthCheckpoints"), output);
+        assertTrue(output.contains("smoke_groundtruth_1000.ivecs"), output);
+        assertTrue(output.contains("smoke_groundtruth.ivecs"), output);
+    }
+
+    @Test
+    void resolveDescriptorReturnsLocalFileVerbatim(@TempDir Path tmp) throws Exception {
+        File descriptorFile = tmp.resolve("local_descriptor.json").toFile();
+        Files.writeString(descriptorFile.toPath(), "{}");
+        File resolved = DatasetDescribe.resolveDescriptor(descriptorFile.getAbsolutePath());
+        assertTrue(resolved.exists());
+        assertTrue(resolved.getAbsolutePath().endsWith("local_descriptor.json"));
+    }
+
+    @Test
+    void resolveDescriptorStripsFileScheme(@TempDir Path tmp) throws Exception {
+        File descriptorFile = tmp.resolve("schemed_descriptor.json").toFile();
+        Files.writeString(descriptorFile.toPath(), "{}");
+        File resolved = DatasetDescribe.resolveDescriptor("file://" + descriptorFile.getAbsolutePath());
+        assertTrue(resolved.exists());
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/DatasetDescriptorTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/DatasetDescriptorTest.java
@@ -1,0 +1,127 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import herddb.vectortesting.DatasetLoader.DatasetDescriptor;
+import herddb.vectortesting.DatasetLoader.DatasetDescriptor.GroundTruthCheckpoint;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises {@link DatasetDescriptor#load(File)} for both the legacy descriptor
+ * shape (no {@code groundTruthCheckpoints} array) and the new multi-checkpoint
+ * shape, including the synthesised-singleton fallback path.
+ */
+class DatasetDescriptorTest {
+
+    @Test
+    void legacyDescriptorSynthesizesSingletonCheckpoint(@TempDir Path tmp) throws Exception {
+        // Old-format descriptor with only the legacy groundTruthFile field.
+        String json = "{\n"
+                + "  \"name\": \"legacy\",\n"
+                + "  \"format\": \"fvecs\",\n"
+                + "  \"dimensions\": 32,\n"
+                + "  \"similarity\": \"euclidean\",\n"
+                + "  \"totalVectors\": 1000000,\n"
+                + "  \"numQueries\": 1000,\n"
+                + "  \"groundTruthK\": 100,\n"
+                + "  \"baseFile\": \"legacy_base.fvecs\",\n"
+                + "  \"queryFile\": \"legacy_query.fvecs\",\n"
+                + "  \"groundTruthFile\": \"legacy_groundtruth.ivecs\"\n"
+                + "}\n";
+        File f = tmp.resolve("legacy_descriptor.json").toFile();
+        Files.writeString(f.toPath(), json);
+
+        DatasetDescriptor desc = DatasetDescriptor.load(f);
+
+        assertEquals(1_000_000L, desc.totalVectors);
+        assertEquals("legacy_groundtruth.ivecs", desc.groundTruthFile);
+        assertEquals(1, desc.groundTruthCheckpoints.size(),
+                "Old descriptor should synthesize a singleton checkpoint at totalVectors");
+        GroundTruthCheckpoint cp = desc.groundTruthCheckpoints.get(0);
+        assertEquals(1_000_000L, cp.baseVectorCount);
+        assertEquals("legacy_groundtruth.ivecs", cp.file);
+    }
+
+    @Test
+    void newDescriptorPreservesCheckpointArray(@TempDir Path tmp) throws Exception {
+        String json = "{\n"
+                + "  \"name\": \"multi\",\n"
+                + "  \"format\": \"fvecs\",\n"
+                + "  \"dimensions\": 4,\n"
+                + "  \"similarity\": \"cosine\",\n"
+                + "  \"totalVectors\": 1000000000,\n"
+                + "  \"numQueries\": 1000,\n"
+                + "  \"groundTruthK\": 100,\n"
+                + "  \"baseFile\": \"multi_base.fvecs\",\n"
+                + "  \"queryFile\": \"multi_query.fvecs\",\n"
+                + "  \"groundTruthFile\": \"multi_groundtruth.ivecs\",\n"
+                + "  \"groundTruthCheckpoints\": [\n"
+                + "    {\"baseVectorCount\": 1000000, \"file\": \"multi_groundtruth_1000000.ivecs\"},\n"
+                + "    {\"baseVectorCount\": 50000000, \"file\": \"multi_groundtruth_50000000.ivecs\"},\n"
+                + "    {\"baseVectorCount\": 1000000000, \"file\": \"multi_groundtruth.ivecs\"}\n"
+                + "  ]\n"
+                + "}\n";
+        File f = tmp.resolve("multi_descriptor.json").toFile();
+        Files.writeString(f.toPath(), json);
+
+        DatasetDescriptor desc = DatasetDescriptor.load(f);
+
+        List<GroundTruthCheckpoint> cps = desc.groundTruthCheckpoints;
+        assertEquals(3, cps.size());
+        assertEquals(1_000_000L, cps.get(0).baseVectorCount);
+        assertEquals("multi_groundtruth_1000000.ivecs", cps.get(0).file);
+        assertEquals(50_000_000L, cps.get(1).baseVectorCount);
+        assertEquals(1_000_000_000L, cps.get(2).baseVectorCount);
+        assertEquals("multi_groundtruth.ivecs", cps.get(2).file);
+    }
+
+    @Test
+    void descriptorWithoutAnyGroundTruthYieldsEmptyCheckpointList(@TempDir Path tmp) throws Exception {
+        // Hypothetical HDF5-style or in-flight descriptor where ground truth is not yet
+        // present. Should not crash and should return an empty list, letting the loader
+        // fall through to its own error path at use time.
+        String json = "{\n"
+                + "  \"name\": \"empty\",\n"
+                + "  \"format\": \"fvecs\",\n"
+                + "  \"dimensions\": 16,\n"
+                + "  \"similarity\": \"euclidean\",\n"
+                + "  \"totalVectors\": 100,\n"
+                + "  \"numQueries\": 0,\n"
+                + "  \"groundTruthK\": 0,\n"
+                + "  \"baseFile\": \"empty_base.fvecs\",\n"
+                + "  \"queryFile\": null\n"
+                + "}\n";
+        File f = tmp.resolve("empty_descriptor.json").toFile();
+        Files.writeString(f.toPath(), json);
+
+        DatasetDescriptor desc = DatasetDescriptor.load(f);
+
+        assertTrue(desc.groundTruthCheckpoints.isEmpty(),
+                "Descriptor missing both groundTruthFile and groundTruthCheckpoints "
+                        + "should yield an empty list");
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/DatasetLoaderGroundTruthTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/DatasetLoaderGroundTruthTest.java
@@ -1,0 +1,151 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import herddb.vectortesting.DatasetLoader.DatasetPreset;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies {@link DatasetLoader#loadGroundTruth(int, long)} picks the right per-prefix
+ * ground-truth file out of a multi-checkpoint custom descriptor and fails hard on a
+ * count that does not match any checkpoint.
+ */
+class DatasetLoaderGroundTruthTest {
+
+    private static final int Q = 2;
+    private static final int K = 3;
+
+    @Test
+    void exactMatchSelectsTheRightCheckpointFile(@TempDir Path tmp) throws Exception {
+        Path subDir = setupCustomDataset(tmp, true);
+        // Each ivecs file has a sentinel first id encoded as the size of the prefix it
+        // represents, so we can confirm which file the loader actually opened.
+        writeIvecs(subDir.resolve("multi_groundtruth_1000.ivecs").toFile(), 1000);
+        writeIvecs(subDir.resolve("multi_groundtruth_5000.ivecs").toFile(), 5000);
+        writeIvecs(subDir.resolve("multi_groundtruth.ivecs").toFile(), 100_000);
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset(); // short-circuits because the descriptor is already on disk
+        loader.loadDescriptor();
+
+        assertEquals(1000, firstId(loader.loadGroundTruth(Q, 1000)));
+        assertEquals(5000, firstId(loader.loadGroundTruth(Q, 5000)));
+        assertEquals(100_000, firstId(loader.loadGroundTruth(Q, 100_000)));
+    }
+
+    @Test
+    void noMatchThrowsWithAvailableCheckpointsListed(@TempDir Path tmp) throws Exception {
+        Path subDir = setupCustomDataset(tmp, true);
+        writeIvecs(subDir.resolve("multi_groundtruth_1000.ivecs").toFile(), 1000);
+        writeIvecs(subDir.resolve("multi_groundtruth_5000.ivecs").toFile(), 5000);
+        writeIvecs(subDir.resolve("multi_groundtruth.ivecs").toFile(), 100_000);
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset();
+        loader.loadDescriptor();
+
+        IOException ex = assertThrows(IOException.class,
+                () -> loader.loadGroundTruth(Q, 7777));
+        String msg = ex.getMessage();
+        assertTrue(msg.contains("baseVectorCount=7777"), msg);
+        assertTrue(msg.contains("1000"), msg);
+        assertTrue(msg.contains("5000"), msg);
+        assertTrue(msg.contains("100000"), msg);
+    }
+
+    @Test
+    void legacyDescriptorSingleFileResolvesAtTotalVectors(@TempDir Path tmp) throws Exception {
+        // Old descriptor with only groundTruthFile. The synthesised singleton should be
+        // the one returned for baseVectorCount == totalVectors.
+        Path subDir = setupCustomDataset(tmp, false);
+        writeIvecs(subDir.resolve("legacy_groundtruth.ivecs").toFile(), 100_000);
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset();
+        loader.loadDescriptor();
+
+        assertEquals(100_000, firstId(loader.loadGroundTruth(Q, 100_000)));
+        assertThrows(IOException.class, () -> loader.loadGroundTruth(Q, 50_000));
+    }
+
+    private static Path setupCustomDataset(Path tmp, boolean withCheckpoints) throws IOException {
+        // CUSTOM preset's subDir is "custom". We seed it with a descriptor and the IVECS
+        // files the test wants to exercise.
+        Path subDir = tmp.resolve(DatasetPreset.CUSTOM.subDir);
+        Files.createDirectories(subDir);
+        String prefix = withCheckpoints ? "multi" : "legacy";
+        StringBuilder json = new StringBuilder();
+        json.append("{\n");
+        json.append("  \"name\": \"").append(prefix).append("\",\n");
+        json.append("  \"format\": \"fvecs\",\n");
+        json.append("  \"dimensions\": 4,\n");
+        json.append("  \"similarity\": \"euclidean\",\n");
+        json.append("  \"totalVectors\": 100000,\n");
+        json.append("  \"numQueries\": 2,\n");
+        json.append("  \"groundTruthK\": 3,\n");
+        json.append("  \"baseFile\": \"").append(prefix).append("_base.fvecs\",\n");
+        json.append("  \"queryFile\": \"").append(prefix).append("_query.fvecs\",\n");
+        json.append("  \"groundTruthFile\": \"").append(prefix).append("_groundtruth.ivecs\"");
+        if (withCheckpoints) {
+            json.append(",\n  \"groundTruthCheckpoints\": [\n");
+            json.append("    {\"baseVectorCount\": 1000, \"file\": \"multi_groundtruth_1000.ivecs\"},\n");
+            json.append("    {\"baseVectorCount\": 5000, \"file\": \"multi_groundtruth_5000.ivecs\"},\n");
+            json.append("    {\"baseVectorCount\": 100000, \"file\": \"multi_groundtruth.ivecs\"}\n");
+            json.append("  ]");
+        }
+        json.append("\n}\n");
+        Files.writeString(subDir.resolve(prefix + "_descriptor.json"), json.toString());
+        return subDir;
+    }
+
+    /**
+     * Writes a tiny IVECS file with {@code Q} rows each of length {@code K}. The first
+     * value of the first row is set to {@code sentinel} so the test can identify which
+     * file the loader actually opened.
+     */
+    private static void writeIvecs(File file, int sentinel) throws IOException {
+        try (SiftWriter w = new SiftWriter(file)) {
+            int[] firstRow = new int[K];
+            firstRow[0] = sentinel;
+            for (int i = 1; i < K; i++) {
+                firstRow[i] = i;
+            }
+            w.writeIvec(firstRow);
+            int[] secondRow = new int[K];
+            for (int i = 0; i < K; i++) {
+                secondRow[i] = sentinel + 100 + i;
+            }
+            w.writeIvec(secondRow);
+        }
+    }
+
+    private static int firstId(List<int[]> gt) {
+        return gt.get(0)[0];
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/GeneratorConfigTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GeneratorConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+class GeneratorConfigTest {
+
+    @Test
+    void nullCsvDefaultsToTotalSingleton() {
+        long[] result = GeneratorConfig.parseCheckpoints(null, 1_000_000, 1000);
+        assertArrayEquals(new long[]{1_000_000L}, result);
+    }
+
+    @Test
+    void emptyCsvDefaultsToTotalSingleton() {
+        long[] result = GeneratorConfig.parseCheckpoints("   ", 1_000_000, 1000);
+        assertArrayEquals(new long[]{1_000_000L}, result);
+    }
+
+    @Test
+    void csvIsSortedAndAlwaysIncludesTotal() {
+        long[] result = GeneratorConfig.parseCheckpoints("100000,5000,20000", 200_000, 1000);
+        assertArrayEquals(new long[]{5000L, 20_000L, 100_000L, 200_000L}, result);
+    }
+
+    @Test
+    void totalAlreadyInCsvIsNotDuplicated() {
+        long[] result = GeneratorConfig.parseCheckpoints("10000,200000", 200_000, 1000);
+        assertArrayEquals(new long[]{10_000L, 200_000L}, result);
+    }
+
+    @Test
+    void rejectsCheckpointAtOrBelowNumQueries() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GeneratorConfig.parseCheckpoints("1000,5000", 100_000, 1000));
+        assertThrows(IllegalArgumentException.class,
+                () -> GeneratorConfig.parseCheckpoints("500", 100_000, 1000));
+    }
+
+    @Test
+    void rejectsCheckpointAboveTotal() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GeneratorConfig.parseCheckpoints("200000", 100_000, 1000));
+    }
+
+    @Test
+    void rejectsDuplicateCheckpoints() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GeneratorConfig.parseCheckpoints("5000,5000", 100_000, 1000));
+    }
+
+    @Test
+    void rejectsNonNumericTokens() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GeneratorConfig.parseCheckpoints("5000,abc", 100_000, 1000));
+    }
+
+    @Test
+    void emptyTokensSilentlyIgnored() {
+        // Trailing/leading commas are common when scripts assemble the value programmatically;
+        // be lenient about those rather than failing on a typo nobody will spot.
+        long[] result = GeneratorConfig.parseCheckpoints(",5000,,10000,", 100_000, 1000);
+        assertArrayEquals(new long[]{5000L, 10_000L, 100_000L}, result);
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/GroundTruthTrackerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GroundTruthTrackerTest.java
@@ -1,0 +1,64 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the contract that {@link GroundTruthTracker#getGroundTruth()} is
+ * non-destructive — i.e. callable multiple times during generation to emit
+ * intermediate ground-truth checkpoint files without disturbing tracker state.
+ */
+class GroundTruthTrackerTest {
+
+    @Test
+    void getGroundTruthIsIdempotent() {
+        // Two query vectors, K=2, three offered base vectors.
+        float[][] queries = new float[][]{
+                {0.0f, 0.0f},
+                {10.0f, 10.0f}
+        };
+        GroundTruthTracker tracker = new GroundTruthTracker(queries, 2, "euclidean");
+        // Offer the queries themselves (they are part of the base set in practice).
+        tracker.offer(0, queries[0]);
+        tracker.offer(1, queries[1]);
+        tracker.offer(2, new float[]{1.0f, 1.0f});
+        tracker.offer(3, new float[]{9.5f, 9.5f});
+
+        int[][] firstCall = tracker.getGroundTruth();
+        int[][] secondCall = tracker.getGroundTruth();
+
+        assertEquals(firstCall.length, secondCall.length);
+        for (int i = 0; i < firstCall.length; i++) {
+            assertArrayEquals(firstCall[i], secondCall[i],
+                    "Snapshot at row " + i + " differs between back-to-back calls");
+        }
+
+        // Adding more vectors after the snapshots should change subsequent results,
+        // but not retroactively change the snapshots we already captured (defensive
+        // copy contract: the int[][] handed to callers is safe to retain).
+        int[] originalFirstRow = firstCall[0].clone();
+        tracker.offer(4, new float[]{0.5f, 0.5f});
+        assertArrayEquals(originalFirstRow, firstCall[0],
+                "Earlier snapshot mutated by later offer()");
+    }
+}


### PR DESCRIPTION
## Summary
- `DatasetGenerator` can now emit intermediate ground-truth IVECS files at user-specified base-vector counts via `--ground-truth-checkpoints 1000000,10000000,...`. The final ground truth at `--total` is still written under the legacy `{prefix}_groundtruth.ivecs` name, so existing descriptors keep working unchanged.
- The dataset descriptor JSON adds a `groundTruthCheckpoints` array of `(baseVectorCount, file)` pairs. `DatasetLoader.DatasetDescriptor.load()` parses it; old descriptors that lack the array synthesise a singleton at `totalVectors` from the legacy `groundTruthFile` so the new lookup path is uniform.
- New API `DatasetLoader.loadGroundTruth(numQueries, baseVectorCount)` picks the file by exact match — recall against a non-matching ground truth is mathematically meaningless, so we fail hard and list available checkpoints.
- `VectorBench` (line 230) now passes `config.numRows` so prefix runs against multi-checkpoint custom datasets compute recall against the matching ground truth. The existing try/catch absorbs the IOException when no checkpoint matches and continues without recall.
- New `DatasetDescribe` main class (+ `run_describe.sh` wrapper) prints a descriptor in fixed-width, agent-greppable form. Designed for bench-driving agents to discover what `--rows` values support recall before dispatching a run. Accepts local paths and `http(s)://` / `ftp://` / `gs://` URLs.

## Files
- New: `vector-testings/src/main/java/herddb/vectortesting/DatasetDescribe.java`
- New: `vector-testings/run_describe.sh`
- New tests: `GroundTruthTrackerTest`, `GeneratorConfigTest`, `DatasetDescriptorTest`, `DatasetLoaderGroundTruthTest`, `DatasetDescribeTest`
- Modified: `DatasetGenerator`, `GeneratorConfig`, `DatasetLoader`, `VectorBench`, `GroundTruthTracker` (Javadoc only), `DATASET_GENERATOR.md`, `VECTOR_BENCH.md`

## Backward compatibility
- Existing descriptors (no `groundTruthCheckpoints` field) parse cleanly and resolve via the synthesised singleton.
- Existing `loadGroundTruth(int)` is preserved as a thin wrapper that delegates to the new method using `customDescriptor.totalVectors`.
- `StandardDatasetPublisher` is unchanged: BIGANN/GIST1M descriptors keep their current single-file shape.

## Test plan
- [x] New unit tests pass (19 new tests, covering tracker idempotency, parseCheckpoints validation, descriptor parse for legacy + new shapes, loadGroundTruth exact-match + no-match, DatasetDescribe pretty-print + URL resolution).
- [x] Full vector-testings module test suite still green (136 tests).
- [x] CI gate passes locally: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` (vector-testings + dependencies).
- [ ] End-to-end smoke against a running HerdDB cluster: generate a tiny dataset with `--ground-truth-checkpoints`, run `vector-bench --dataset custom --rows N` for each checkpoint, confirm "matched checkpoint at N base vectors" in the log and recall is reported.
- [ ] Backward-compat: bench an existing GIST1M descriptor (no `groundTruthCheckpoints`) — must still compute recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)