### PR TITLE
issue #348: disable page/index checksums by default to save Phase C CPU

### DIFF
--- a/herddb-core/src/main/java/herddb/server/RemoteFileServiceFactory.java
+++ b/herddb-core/src/main/java/herddb/server/RemoteFileServiceFactory.java
@@ -90,6 +90,23 @@ public interface RemoteFileServiceFactory {
             int swapThreshold);
 
     /**
+     * Config-aware overload of {@link #createPromotableDataStorageManager}.
+     * Accepts the same {@code config} map used by
+     * {@link #createDataStorageManager(Path, Path, int, RemoteFileClient, Map)}
+     * so that page-checksum knobs flow through to the promoted write manager.
+     * The default delegates to the legacy method for backward compatibility.
+     */
+    default DataStorageManager createPromotableDataStorageManager(
+            RemoteFileClient client,
+            SharedCheckpointMetadata metadata,
+            Path dataDirectory,
+            Path tmpDirectory,
+            int swapThreshold,
+            Map<String, Object> config) {
+        return createPromotableDataStorageManager(client, metadata, dataDirectory, tmpDirectory, swapThreshold);
+    }
+
+    /**
      * Creates a strictly read-only data storage manager for indexing-service
      * shadow replicas. Unlike the promotable variant, this one never transitions
      * to writable and throws {@link UnsupportedOperationException} on any

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -478,6 +478,14 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                         configuration.getInt(
                                 ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM,
                                 ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT));
+                dsmConfig.put(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED,
+                        configuration.getBoolean(
+                                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED,
+                                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT));
+                dsmConfig.put(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED,
+                        configuration.getBoolean(
+                                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED,
+                                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT));
                 DataStorageManager dsm = factory.createDataStorageManager(
                         dataDirectory, tmpDirectory, diskswapThreshold, client, dsmConfig);
 
@@ -578,8 +586,17 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         // Create SharedCheckpointMetadata + PromotableRemoteFileDataStorageManager
         // (wraps a ReadReplicaDataStorageManager) for failover support.
         SharedCheckpointMetadata metaMgr = factory.createSharedCheckpointMetadata(client);
+        Map<String, Object> sharedConfig = new HashMap<>();
+        sharedConfig.put(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED,
+                configuration.getBoolean(
+                        ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED,
+                        ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT));
+        sharedConfig.put(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED,
+                configuration.getBoolean(
+                        ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED,
+                        ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT));
         return factory.createPromotableDataStorageManager(
-                client, metaMgr, dataDirectory, tmpDirectory, diskswapThreshold);
+                client, metaMgr, dataDirectory, tmpDirectory, diskswapThreshold, sharedConfig);
     }
 
     protected CommitLogManager buildCommitLogManager() {

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -227,12 +227,18 @@ public final class ServerConfiguration {
     public static final boolean PROPERTY_INDEX_USE_ODIRECT_DEFAULT = USE_O_DIRECT_DEFAULT;
 
     /**
-     * In some cases the usage of XXHash64 might to be overkilling
+     * Whether to compute and verify XXHash64 checksums on data and index page files.
+     * Disabled by default: writing zero instead of the hash and skipping checksum
+     * verification on reads saves significant CPU during Phase C checkpoints.
+     * Set to {@code true} to restore integrity checking (e.g. after a suspected
+     * hardware-level data corruption event).
+     * Note: checkpoint metadata files (table/index status) always carry checksums
+     * regardless of this setting.
      */
     public static final String PROPERTY_HASH_CHECKS_ENABLED = "server.filedatastorage.checkhash";
-    public static final boolean PROPERTY_HASH_CHECKS_ENABLED_DEFAULT = true;
+    public static final boolean PROPERTY_HASH_CHECKS_ENABLED_DEFAULT = false;
     public static final String PROPERTY_HASH_WRITES_ENABLED = "server.filedatastorage.writehash";
-    public static final boolean PROPERTY_HASH_WRITES_ENABLED_DEFAULT = true;
+    public static final boolean PROPERTY_HASH_WRITES_ENABLED_DEFAULT = false;
 
     public static final String PROPERTY_TMPDIR = "server.tmp.dir";
     public static final String PROPERTY_TMPDIR_DEFAULT = "tmp";

--- a/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPageFormat.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPageFormat.java
@@ -166,8 +166,12 @@ public final class LazyDataPageFormat {
      * Serialises {@code records} into a fresh pooled heap {@link ByteBuf}
      * containing a v2 page. Caller takes ownership and must release the
      * returned buffer.
+     *
+     * <p>When {@code checksumEnabled} is {@code false}, the footer slot is
+     * written as {@code 0L} (the {@code NO_HASH_PRESENT} sentinel) and no
+     * hash computation is performed, saving CPU on the write path.
      */
-    public static ByteBuf write(Collection<Record> records) {
+    public static ByteBuf write(Collection<Record> records, boolean checksumEnabled) {
         final int numRecords = records.size();
         long totalValueBytes = 0L;
         long estimatedIndexBytes = 0L;
@@ -206,14 +210,23 @@ public final class LazyDataPageFormat {
             buf.setInt(OFFSET_NUM_RECORDS, numRecords);
             buf.setInt(OFFSET_INDEX_SIZE, indexSize);
             buf.setLong(OFFSET_VALUE_SIZE, valueSize);
-            // footer: xxhash64 over everything written so far
-            final long hash = hashBytes(buf, 0, valueEnd);
+            // footer: xxhash64 when checksums are enabled, 0L (NO_HASH_PRESENT) otherwise
+            final long hash = checksumEnabled ? hashBytes(buf, 0, valueEnd) : 0L;
             buf.writeLong(hash);
             return buf;
         } catch (RuntimeException t) {
             buf.release();
             throw t;
         }
+    }
+
+    /**
+     * Convenience overload with checksums disabled (default). Use
+     * {@link #write(Collection, boolean)} when checksum behaviour must be
+     * controlled explicitly.
+     */
+    public static ByteBuf write(Collection<Record> records) {
+        return write(records, false);
     }
 
     /**
@@ -276,11 +289,14 @@ public final class LazyDataPageFormat {
 
     /**
      * Eagerly parses a complete v2 page and returns the full list of
-     * {@link Record}s, verifying the xxhash64 footer. Used by code paths that
-     * always need every value (e.g. {@code fullTableScan}) or by fallback
-     * paths.
+     * {@link Record}s. When {@code checksumEnabled} is {@code true}, the
+     * xxhash64 footer is verified and a {@link DataStorageManagerException}
+     * is thrown on mismatch. When {@code false}, footer verification is
+     * skipped entirely (no CPU spent on hashing), regardless of the stored
+     * footer value.
      */
-    public static List<Record> readAllRecords(ByteBuf wholeFile) throws DataStorageManagerException {
+    public static List<Record> readAllRecords(ByteBuf wholeFile, boolean checksumEnabled)
+            throws DataStorageManagerException {
         final int startIdx = wholeFile.readerIndex();
         final int available = wholeFile.readableBytes();
         if (available < FIXED_HEADER_SIZE + FOOTER_SIZE) {
@@ -292,12 +308,14 @@ public final class LazyDataPageFormat {
             throw new DataStorageManagerException("v2 page shorter than declared: "
                     + available + " < " + declared);
         }
-        // verify footer hash (over bytes [startIdx .. startIdx + footerOffset))
-        final int footerPos = startIdx + (int) h.footerOffset();
-        final long expected = wholeFile.getLong(footerPos);
-        final long actual = hashBytes(wholeFile, startIdx, (int) h.footerOffset());
-        if (expected != actual) {
-            throw new DataStorageManagerException("v2 page footer hash mismatch");
+        // verify footer hash only when checksums are enabled
+        if (checksumEnabled) {
+            final int footerPos = startIdx + (int) h.footerOffset();
+            final long expected = wholeFile.getLong(footerPos);
+            final long actual = hashBytes(wholeFile, startIdx, (int) h.footerOffset());
+            if (expected != actual) {
+                throw new DataStorageManagerException("v2 page footer hash mismatch");
+            }
         }
         // parse index
         final ByteBuf indexSlice = wholeFile.slice(startIdx + FIXED_HEADER_SIZE, h.indexSize);
@@ -313,6 +331,15 @@ public final class LazyDataPageFormat {
             result.add(new Record(m.key, Bytes.from_array(value)));
         }
         return result;
+    }
+
+    /**
+     * Convenience overload with checksums disabled (default). Use
+     * {@link #readAllRecords(ByteBuf, boolean)} when checksum behaviour must
+     * be controlled explicitly.
+     */
+    public static List<Record> readAllRecords(ByteBuf wholeFile) throws DataStorageManagerException {
+        return readAllRecords(wholeFile, false);
     }
 
     /**

--- a/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/PromotableRemoteFileDataStorageManager.java
@@ -62,6 +62,8 @@ public class PromotableRemoteFileDataStorageManager extends DataStorageManager {
     private final Path dataDirectory;
     private final Path tmpDirectory;
     private final int swapThreshold;
+    private final boolean pageHashWritesEnabled;
+    private final boolean pageHashChecksEnabled;
 
     private volatile DataStorageManager activeDelegate;
     private volatile boolean promoted = false;
@@ -73,12 +75,28 @@ public class PromotableRemoteFileDataStorageManager extends DataStorageManager {
             Path dataDirectory,
             Path tmpDirectory,
             int swapThreshold) {
+        this(readOnlyDelegate, client, metadataManager, dataDirectory, tmpDirectory, swapThreshold,
+                herddb.server.ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT,
+                herddb.server.ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
+    }
+
+    public PromotableRemoteFileDataStorageManager(
+            ReadReplicaDataStorageManager readOnlyDelegate,
+            RemoteFileServiceClient client,
+            SharedCheckpointMetadataManager metadataManager,
+            Path dataDirectory,
+            Path tmpDirectory,
+            int swapThreshold,
+            boolean pageHashWritesEnabled,
+            boolean pageHashChecksEnabled) {
         this.readOnlyDelegate = readOnlyDelegate;
         this.client = client;
         this.metadataManager = metadataManager;
         this.dataDirectory = dataDirectory;
         this.tmpDirectory = tmpDirectory;
         this.swapThreshold = swapThreshold;
+        this.pageHashWritesEnabled = pageHashWritesEnabled;
+        this.pageHashChecksEnabled = pageHashChecksEnabled;
         this.activeDelegate = readOnlyDelegate;
     }
 
@@ -94,7 +112,10 @@ public class PromotableRemoteFileDataStorageManager extends DataStorageManager {
         LOGGER.log(Level.INFO, "Promoting storage manager to writable mode");
 
         RemoteFileDataStorageManager writableDelegate = new RemoteFileDataStorageManager(
-                dataDirectory, tmpDirectory, swapThreshold, client);
+                dataDirectory, tmpDirectory, swapThreshold, client,
+                new LazyValueCache(0L),
+                herddb.server.ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT,
+                pageHashWritesEnabled, pageHashChecksEnabled);
         writableDelegate.setSharedCheckpointMetadataManager(metadataManager);
         writableDelegate.start();
 

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -152,29 +152,59 @@ public class RemoteFileDataStorageManager extends DataStorageManager
      */
     private volatile StatsLogger readerStatsLogger = NullStatsLogger.INSTANCE;
 
+    /**
+     * Whether to compute XXHash64 and write it as a page footer on the write path.
+     * When {@code false}, {@code 0L} (NO_HASH_PRESENT) is stored instead, saving
+     * significant CPU during Phase C checkpoints.
+     */
+    private final boolean pageHashWritesEnabled;
+
+    /**
+     * Whether to verify the page footer hash on the read path.
+     * When {@code false}, footer verification is skipped entirely.
+     */
+    private final boolean pageHashChecksEnabled;
+
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client) {
         this(localMetadataDir, tmpDir, swapThreshold, client, new LazyValueCache(0L),
-                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT);
+                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
     }
 
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client, LazyValueCache lazyValueCache) {
         this(localMetadataDir, tmpDir, swapThreshold, client, lazyValueCache,
-                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT);
+                ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
     }
 
     public RemoteFileDataStorageManager(
             Path localMetadataDir, Path tmpDir, int swapThreshold,
             RemoteFileServiceClient client, LazyValueCache lazyValueCache,
             int blockUploadParallelism) {
+        this(localMetadataDir, tmpDir, swapThreshold, client, lazyValueCache,
+                blockUploadParallelism,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
+    }
+
+    public RemoteFileDataStorageManager(
+            Path localMetadataDir, Path tmpDir, int swapThreshold,
+            RemoteFileServiceClient client, LazyValueCache lazyValueCache,
+            int blockUploadParallelism,
+            boolean pageHashWritesEnabled, boolean pageHashChecksEnabled) {
         this.tmpDir = tmpDir;
         this.swapThreshold = swapThreshold;
         this.client = client;
         this.lazyValueCache = lazyValueCache == null ? new LazyValueCache(0L) : lazyValueCache;
         this.blockUploadParallelism = Math.max(1, blockUploadParallelism);
+        this.pageHashWritesEnabled = pageHashWritesEnabled;
+        this.pageHashChecksEnabled = pageHashChecksEnabled;
         this.localMetadataManager = new FileDataStorageManager(
                 localMetadataDir, tmpDir, swapThreshold,
                 false, false, false, false, false,
@@ -420,19 +450,30 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     // Page serialization (matches FileDataStorageManager format)
     // -------------------------------------------------------------------------
 
-    private static ByteBuf serializeIndexPage(DataWriter writer) throws IOException {
+    private ByteBuf serializeIndexPage(DataWriter writer) throws IOException {
         ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(4096);
         try {
             ByteBufOutputStream bufOut = new ByteBufOutputStream(buf);
-            XXHash64Utils.HashingOutputStream hashOut = new XXHash64Utils.HashingOutputStream(bufOut);
-            try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(hashOut)) {
-                out.writeVLong(1); // version
-                out.writeVLong(0); // flags
-                writer.write(out);
-                out.flush();
-                long hash = hashOut.hash(); // hash of data bytes only, before footer
-                out.writeLong(hash); // footer
-                out.flush();
+            if (pageHashWritesEnabled) {
+                XXHash64Utils.HashingOutputStream hashOut = new XXHash64Utils.HashingOutputStream(bufOut);
+                try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(hashOut)) {
+                    out.writeVLong(1); // version
+                    out.writeVLong(0); // flags
+                    writer.write(out);
+                    out.flush();
+                    long hash = hashOut.hash(); // hash of data bytes only, before footer
+                    out.writeLong(hash); // footer
+                    out.flush();
+                }
+            } else {
+                try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(bufOut)) {
+                    out.writeVLong(1); // version
+                    out.writeVLong(0); // flags
+                    writer.write(out);
+                    out.flush();
+                    out.writeLong(0L); // NO_HASH_PRESENT footer
+                    out.flush();
+                }
             }
         } catch (IOException e) {
             buf.release();
@@ -488,7 +529,7 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         }
         ByteBuf buf = io.netty.buffer.Unpooled.wrappedBuffer(full);
         try {
-            return LazyDataPageFormat.readAllRecords(buf);
+            return LazyDataPageFormat.readAllRecords(buf, pageHashChecksEnabled);
         } finally {
             buf.release();
         }
@@ -498,7 +539,7 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     public void writePage(String tableSpace, String uuid, long pageId,
             Collection<Record> newPage) throws DataStorageManagerException {
         String path = remoteDataPagePath(tableSpace, uuid, pageId);
-        ByteBuf buf = LazyDataPageFormat.write(newPage);
+        ByteBuf buf = LazyDataPageFormat.write(newPage, pageHashWritesEnabled);
         try {
             writeAsMultipart(path, buf);
         } finally {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceFactoryImpl.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceFactoryImpl.java
@@ -67,10 +67,17 @@ public class RemoteFileServiceFactoryImpl implements RemoteFileServiceFactory {
         int blockParallelism = readInt(config,
                 ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM,
                 ServerConfiguration.PROPERTY_REMOTE_FILE_BLOCK_PARALLELISM_DEFAULT);
+        boolean hashWritesEnabled = readBoolean(config,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT);
+        boolean hashChecksEnabled = readBoolean(config,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
         LazyValueCache cache = new LazyValueCache(valueCacheBytes);
         return new RemoteFileDataStorageManager(
                 dataDirectory, tmpDirectory, swapThreshold,
-                (RemoteFileServiceClient) client, cache, blockParallelism);
+                (RemoteFileServiceClient) client, cache, blockParallelism,
+                hashWritesEnabled, hashChecksEnabled);
     }
 
     private static long readLong(Map<String, Object> config, String key, long defaultValue) {
@@ -103,6 +110,17 @@ public class RemoteFileServiceFactoryImpl implements RemoteFileServiceFactory {
         }
     }
 
+    private static boolean readBoolean(Map<String, Object> config, String key, boolean defaultValue) {
+        Object v = config.get(key);
+        if (v == null) {
+            return defaultValue;
+        }
+        if (v instanceof Boolean) {
+            return (Boolean) v;
+        }
+        return Boolean.parseBoolean(v.toString());
+    }
+
     @Override
     public DataStorageManager createPromotableDataStorageManager(
             RemoteFileClient client,
@@ -110,13 +128,32 @@ public class RemoteFileServiceFactoryImpl implements RemoteFileServiceFactory {
             Path dataDirectory,
             Path tmpDirectory,
             int swapThreshold) {
+        return createPromotableDataStorageManager(client, metadata, dataDirectory, tmpDirectory,
+                swapThreshold, java.util.Collections.emptyMap());
+    }
+
+    @Override
+    public DataStorageManager createPromotableDataStorageManager(
+            RemoteFileClient client,
+            SharedCheckpointMetadata metadata,
+            Path dataDirectory,
+            Path tmpDirectory,
+            int swapThreshold,
+            Map<String, Object> config) {
         RemoteFileServiceClient concreteClient = (RemoteFileServiceClient) client;
         SharedCheckpointMetadataManager concreteMetadata = (SharedCheckpointMetadataManager) metadata;
+        boolean hashWritesEnabled = readBoolean(config,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT);
+        boolean hashChecksEnabled = readBoolean(config,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
         ReadReplicaDataStorageManager readReplica = new ReadReplicaDataStorageManager(
                 concreteClient, concreteMetadata, tmpDirectory, swapThreshold);
         return new PromotableRemoteFileDataStorageManager(
                 readReplica, concreteClient, concreteMetadata,
-                dataDirectory, tmpDirectory, swapThreshold);
+                dataDirectory, tmpDirectory, swapThreshold,
+                hashWritesEnabled, hashChecksEnabled);
     }
 
     @Override

--- a/herddb-remote-file-service/src/test/java/herddb/remote/LazyDataPageFormatTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/LazyDataPageFormatTest.java
@@ -192,13 +192,14 @@ public class LazyDataPageFormatTest {
     @Test
     public void corruptedFooterIsDetected() {
         List<Record> records = makeRecords(3, 16);
-        ByteBuf buf = LazyDataPageFormat.write(records);
+        // write with checksums enabled so there is a real hash in the footer
+        ByteBuf buf = LazyDataPageFormat.write(records, true);
         try {
             // flip a byte in the footer
             int footerPos = buf.readableBytes() - LazyDataPageFormat.FOOTER_SIZE;
             buf.setByte(footerPos, buf.getByte(footerPos) ^ 0xFF);
             try {
-                LazyDataPageFormat.readAllRecords(buf);
+                LazyDataPageFormat.readAllRecords(buf, true);
                 fail("expected footer hash mismatch");
             } catch (DataStorageManagerException expected) {
                 assertTrue(expected.getMessage().contains("footer hash mismatch"));
@@ -211,16 +212,42 @@ public class LazyDataPageFormatTest {
     @Test
     public void corruptedBodyIsDetectedByHash() {
         List<Record> records = makeRecords(5, 16);
-        ByteBuf buf = LazyDataPageFormat.write(records);
+        // write with checksums enabled so there is a real hash to catch body corruption
+        ByteBuf buf = LazyDataPageFormat.write(records, true);
         try {
             // flip a byte in the middle of the values section
             int mid = buf.readableBytes() / 2;
             buf.setByte(mid, buf.getByte(mid) ^ 0x01);
             try {
-                LazyDataPageFormat.readAllRecords(buf);
+                LazyDataPageFormat.readAllRecords(buf, true);
                 fail("expected footer hash mismatch from body corruption");
             } catch (DataStorageManagerException expected) {
                 assertTrue(expected.getMessage().contains("footer hash mismatch"));
+            }
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void noChecksumZeroFooterRoundTrip() throws DataStorageManagerException {
+        // When checksums are disabled the footer slot must be 0L (NO_HASH_PRESENT)
+        // and readAllRecords must parse the page correctly without verifying the footer.
+        List<Record> records = makeRecords(4, 32);
+        ByteBuf buf = LazyDataPageFormat.write(records, false);
+        try {
+            // verify the footer is exactly 0L
+            int footerPos = buf.readableBytes() - LazyDataPageFormat.FOOTER_SIZE;
+            assertEquals("footer must be 0L when checksums are disabled",
+                    0L, buf.getLong(footerPos));
+
+            // readAllRecords with checksums disabled must succeed and return the original records
+            List<Record> out = LazyDataPageFormat.readAllRecords(buf, false);
+            assertEquals(records.size(), out.size());
+            for (int i = 0; i < records.size(); i++) {
+                assertEquals("key mismatch at " + i, records.get(i).key, out.get(i).key);
+                assertArrayEquals("value mismatch at " + i,
+                        records.get(i).value.to_array(), out.get(i).value.to_array());
             }
         } finally {
             buf.release();


### PR DESCRIPTION
Fixes #348.

## Changes

- **`ServerConfiguration`**: change `PROPERTY_HASH_CHECKS_ENABLED_DEFAULT` and `PROPERTY_HASH_WRITES_ENABLED_DEFAULT` from `true` → `false`. The existing server properties `server.filedatastorage.writehash` / `server.filedatastorage.checkhash` can be set to `true` in `server.properties` to restore integrity checking when desired.
- **`LazyDataPageFormat`**: `write()` and `readAllRecords()` now accept an explicit `boolean checksumEnabled` parameter. Convenience no-arg overloads default to `false`. When disabled, `0L` (the `NO_HASH_PRESENT` sentinel) is written in the footer slot and footer verification is entirely skipped on reads — no hash bytes are computed at all.
- **`RemoteFileDataStorageManager`**: add `pageHashWritesEnabled` / `pageHashChecksEnabled` instance fields. Shorter constructors default to the `ServerConfiguration` defaults (`false`). `serializeIndexPage()` is now an instance method that bypasses `HashingOutputStream` entirely when writes are disabled.
- **`PromotableRemoteFileDataStorageManager`**: carry the hash flags so they flow through to the `RemoteFileDataStorageManager` created on promotion.
- **`RemoteFileServiceFactoryImpl`**: read hash flags from the `dsmConfig` / `sharedConfig` map and wire them into both storage manager constructors.
- **`Server`**: add hash flags to `dsmConfig` (REMOTE storage path) and `sharedConfig` (shared-storage replica path).
- **`RemoteFileServiceFactory`**: add a `default` config-aware overload of `createPromotableDataStorageManager()`.

Metadata checkpoint files (`SharedCheckpointMetadataManager`, `FileDataStorageManager` status files) **keep** their existing checksums unchanged — only data pages and index pages are affected.

## Tests

- `LazyDataPageFormatTest.corruptedFooterIsDetected()` / `corruptedBodyIsDetectedByHash()`: now call `write(records, true)` / `readAllRecords(buf, true)` explicitly so they test the checksum-enabled path regardless of the default.
- `LazyDataPageFormatTest.noChecksumZeroFooterRoundTrip()` (new): verifies that with `checksumEnabled=false` the footer is exactly `0L`, and that `readAllRecords(buf, false)` returns the original records correctly.
- All 47 existing tests in `LazyDataPageFormatTest`, `RemoteFileDataStorageManagerBasicTest`, `LazyDataPageTest`, and `RemoteFileDataStorageManagerRangeReadTest` pass.

🤖 Implemented by the `pr-worker` agent.