### PR TITLE
issue #355: fix ledger drop when IS tailer is frozen in Phase A (START_OF_TIME floor)

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -913,16 +913,29 @@ public class BookkeeperCommitLog extends CommitLog {
         // Time-based retention must never delete them. When no checkpoint has happened yet
         // (START_OF_TIME, ledgerId = -1) the floor is -1 and every active ledger is kept.
         long ledgerLimit = Math.min(lastCheckPointSequenceNumber.ledgerId, currentLedgerId);
-        // Honor an external tailers floor (e.g. remote indexing services): we must not
-        // delete ledgers any tailer still needs to read. START_OF_TIME (ledgerId = -1)
-        // means "no tailer constraint" and collapses to the pre-tailer behavior; any
-        // real floor pins retention at min(ledgerLimit, tailersFloor.ledgerId).
-        if (tailersFloor != null && tailersFloor.ledgerId >= 0
-                && tailersFloor.ledgerId < ledgerLimit) {
-            LOGGER.log(Level.INFO,
-                    "dropOldLedgers pinning retention at tailersFloor {0} (was {1}), tablespace {2}",
-                    new Object[]{tailersFloor, ledgerLimit, tableSpaceDescription()});
-            ledgerLimit = tailersFloor.ledgerId;
+        // Honor an external tailers floor (e.g. remote IndexingService via gRPC):
+        // we must not delete ledgers any tailer still needs to read.
+        //
+        // null                  → no external tailer; fall back to time-based retention.
+        // START_OF_TIME (-1,-1) → IS is present but frozen in Phase A compaction or
+        //                         temporarily unreachable.  The IS tailer position is
+        //                         unknown / at the very beginning of the log — protect
+        //                         every ledger until the IS recovers (issue #355).
+        // any other LSN         → pin retention at min(ledgerLimit, tailersFloor.ledgerId).
+        if (tailersFloor != null) {
+            if (LogSequenceNumber.START_OF_TIME.equals(tailersFloor)) {
+                LOGGER.log(Level.INFO,
+                        "dropOldLedgers: tailersFloor=START_OF_TIME (IS frozen/unreachable) "
+                        + "— keeping all ledgers, tablespace {0}",
+                        tableSpaceDescription());
+                return;
+            }
+            if (tailersFloor.ledgerId < ledgerLimit) {
+                LOGGER.log(Level.INFO,
+                        "dropOldLedgers pinning retention at tailersFloor {0} (was {1}), tablespace {2}",
+                        new Object[]{tailersFloor, ledgerLimit, tableSpaceDescription()});
+                ledgerLimit = tailersFloor.ledgerId;
+            }
         }
         LOGGER.log(Level.INFO,
                 "dropOldLedgers lastCheckPointSequenceNumber: {0}, tailersFloor: {1}, ledgersRetentionPeriod: {2}, ledgerLimit: {3}, lastLedgerId: {4}, currentLedgerId: {5}, tablespace {6}, actualLedgersList {7}",

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -2979,11 +2979,25 @@ public class TableSpaceManager {
 
     /**
      * Computes the commit-log retention floor contributed by external tailers
-     * across every index in this tablespace. Returns {@link LogSequenceNumber#START_OF_TIME}
-     * when no index contributes a floor (meaning: no tailer constraint; the
-     * commit log falls back to its default retention behavior). Short-circuits
-     * to {@code START_OF_TIME} the moment any index reports it — a tailer we
-     * can't reach pins retention entirely.
+     * across every index in this tablespace.
+     *
+     * <p>Returns {@code null} when no index contributes a floor — meaning there is
+     * no external tailer constraint and the commit log can fall back to its default
+     * time-based retention behaviour.
+     *
+     * <p>Returns {@link LogSequenceNumber#START_OF_TIME} the moment any index
+     * reports it.  This signals that a remote IndexingService is present but its
+     * tailer is frozen (e.g. Phase A compaction) or temporarily unreachable via
+     * gRPC.  {@code START_OF_TIME} must be interpreted by
+     * {@link herddb.log.CommitLog#dropOldLedgers} as "protect all ledgers" — the IS
+     * needs to replay from the beginning once it recovers, and any ledger drop now
+     * would cause a permanent gap.
+     *
+     * <p>Fix for issue #355: previously this method returned {@code START_OF_TIME}
+     * for <em>both</em> cases (no indexes AND IS frozen), and
+     * {@code dropOldLedgers} treated {@code START_OF_TIME} as "no constraint"
+     * because {@code ledgerId == -1 &lt; 0}.  Returning {@code null} for the
+     * "no-indexes" case makes the two situations distinguishable.
      */
     private LogSequenceNumber computeTailersRetentionFloor() {
         LogSequenceNumber floor = null;
@@ -2994,13 +3008,15 @@ public class TableSpaceManager {
             }
             LogSequenceNumber lsn = contributed.get();
             if (LogSequenceNumber.START_OF_TIME.equals(lsn)) {
+                // IS is present but frozen or unreachable — protect all ledgers.
                 return LogSequenceNumber.START_OF_TIME;
             }
             if (floor == null || floor.after(lsn)) {
                 floor = lsn;
             }
         }
-        return floor != null ? floor : LogSequenceNumber.START_OF_TIME;
+        // null = no external tailer constraint (no vector indexes in this tablespace).
+        return floor;
     }
 
     private CompletableFuture<StatementExecutionResult> beginTransactionAsync(StatementEvaluationContext context, boolean releaseLock) throws StatementExecutionException {

--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -746,13 +746,25 @@ public class FileCommitLog extends CommitLog {
 
             long ledgerLimit = Math.min(lastCheckPointSequenceNumber.ledgerId, currentLedgerId);
             // Tailer floor: don't delete files any external tailer still needs.
-            // START_OF_TIME (ledgerId = -1) means "no constraint".
-            if (tailersFloor != null && tailersFloor.ledgerId >= 0
-                    && tailersFloor.ledgerId < ledgerLimit) {
-                LOGGER.log(Level.INFO,
-                        "dropOldLedgers {0}: pinning retention at tailersFloor {1} (was {2})",
-                        new Object[]{tableSpaceName, tailersFloor, ledgerLimit});
-                ledgerLimit = tailersFloor.ledgerId;
+            //
+            // null                  → no external tailer; fall back to time-based retention.
+            // START_OF_TIME (-1,-1) → IS present but frozen (Phase A) or unreachable;
+            //                         protect all ledgers until the IS recovers (issue #355).
+            // any other LSN         → pin retention at min(ledgerLimit, tailersFloor.ledgerId).
+            if (tailersFloor != null) {
+                if (LogSequenceNumber.START_OF_TIME.equals(tailersFloor)) {
+                    LOGGER.log(Level.INFO,
+                            "dropOldLedgers {0}: tailersFloor=START_OF_TIME "
+                            + "(IS frozen/unreachable) — keeping all ledgers",
+                            tableSpaceName);
+                    return;
+                }
+                if (tailersFloor.ledgerId < ledgerLimit) {
+                    LOGGER.log(Level.INFO,
+                            "dropOldLedgers {0}: pinning retention at tailersFloor {1} (was {2})",
+                            new Object[]{tableSpaceName, tailersFloor, ledgerLimit});
+                    ledgerLimit = tailersFloor.ledgerId;
+                }
             }
 
             for (Path path : names) {

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -658,7 +658,10 @@ public class BookKeeperCommitLogTest {
                 info.setLedgersTimestamps(backdated);
                 man.saveActualLedgersList(tableSpaceUUID, info);
 
-                writer.dropOldLedgers(checkpointLsn, LogSequenceNumber.START_OF_TIME);
+                // null = no external tailer constraint (tablespace has no vector index).
+                // After issue #355, START_OF_TIME means "IS present but frozen — protect all",
+                // so we must pass null here to exercise the time-based drop path.
+                writer.dropOldLedgers(checkpointLsn, null);
 
                 List<Long> remaining = writer.getActualLedgersList().getActiveLedgers();
                 for (Long id : below) {

--- a/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
@@ -1,0 +1,294 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.core.indexes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.file.FileCommitLog;
+import herddb.file.FileCommitLogManager;
+import herddb.index.vector.RemoteVectorIndexService;
+import herddb.index.vector.VectorIndexManager;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.server.ServerConfiguration;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Reproduces issue #355: the server drops commit-log ledgers while the
+ * IndexingService (IS) tailer is frozen in Phase A compaction.
+ *
+ * <h2>Code path under test</h2>
+ * <pre>
+ *   TableSpaceManager.checkpoint()
+ *     → computeTailersRetentionFloor()
+ *         → VectorIndexManager.getTailersMinLsn()
+ *             → RemoteVectorIndexService.getMinProcessedLsn()   (gRPC call)
+ *                 returns Optional.of(START_OF_TIME)            (IS frozen/unreachable)
+ *         → returns START_OF_TIME
+ *     → BookkeeperCommitLog/FileCommitLog.dropOldLedgers(checkpoint, START_OF_TIME)
+ *         BUG: START_OF_TIME.ledgerId == -1 &lt; 0, so the
+ *              "tailersFloor.ledgerId &gt;= 0" guard is false → no floor applied
+ *         → ledgers ARE dropped (wrong)
+ * </pre>
+ *
+ * <h2>Root cause</h2>
+ * {@code computeTailersRetentionFloor()} returns {@code START_OF_TIME} in two
+ * semantically opposite cases:
+ * <ol>
+ *   <li>No vector indexes present → "no constraint, drop freely" (intended).</li>
+ *   <li>IS present but frozen / gRPC call timed out → "protect all ledgers" (intended
+ *       by the JavaDoc, but NOT honoured by {@code dropOldLedgers}).</li>
+ * </ol>
+ * {@code dropOldLedgers} treats both cases identically: drop freely.  Case 2 is
+ * therefore silently treated as case 1, destroying commit-log ledgers the IS still
+ * needs to replay once Phase A finishes.
+ *
+ * <h2>Tests</h2>
+ * <ul>
+ *   <li>{@link #frozenIsReturnsStartOfTimeFromGetTailersMinLsn()} — documents that
+ *       {@code VectorIndexManager.getTailersMinLsn()} faithfully returns
+ *       {@code START_OF_TIME} when the mock IS returns {@code (-1,-1)} as its last
+ *       processed LSN.  This is the correct behaviour of the VIM layer; the bug is
+ *       downstream.</li>
+ *   <li>{@link #issue355StartOfTimeFloorFromFrozenIsDoesNotProtectLedgers()} — the
+ *       reproducing failing test.  It asserts that {@code dropOldLedgers(checkpoint,
+ *       START_OF_TIME)} must NOT drop any ledger.  The assertion currently fails,
+ *       confirming the bug.</li>
+ * </ul>
+ */
+public class Issue355FrozenIsTailerLedgerRetentionTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static final String TS_UUID = "test-tablespace-uuid-355";
+
+    /**
+     * Builds a minimal non-unique vector {@link Index}.  VectorIndexManager
+     * requires a single FLOATARRAY column; uniqueness must be {@code false}
+     * (enforced by the Index builder for vector type).
+     */
+    private static Index buildVectorIndex() {
+        return Index.builder()
+                .name("vec_idx")
+                .type(Index.TYPE_VECTOR)
+                .table("t1")
+                .tablespace("ts")
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    /**
+     * Creates a {@link VectorIndexManager} whose remote service returns
+     * {@code reportedLsn} from {@link RemoteVectorIndexService#getMinProcessedLsn}.
+     * Parameters that are unused by {@code getTailersMinLsn()} are passed as
+     * {@code null} / zero.
+     */
+    private static VectorIndexManager buildVim(Optional<LogSequenceNumber> reportedLsn) {
+        Index index = buildVectorIndex();
+        RemoteVectorIndexService mockIs = new RemoteVectorIndexService() {
+            @Override
+            public List<Map.Entry<herddb.utils.Bytes, Float>> search(
+                    String tablespace, String table, String idx, float[] vector, int topK) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public IndexStatusInfo getIndexStatus(String tablespace, String table, String idx) {
+                // Returns the frozen IS LSN (ledgerId=-1, offset=-1 = START_OF_TIME).
+                long l = reportedLsn.isPresent() ? reportedLsn.get().ledgerId : -1L;
+                long o = reportedLsn.isPresent() ? reportedLsn.get().offset  : -1L;
+                return new IndexStatusInfo(0, 1, l, o, "phase-a-frozen");
+            }
+
+            @Override
+            public boolean waitForCatchUp(String tablespace, LogSequenceNumber lsn, long timeoutMs) {
+                return true;
+            }
+
+            @Override
+            public Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace) {
+                return reportedLsn;
+            }
+
+            @Override
+            public void close() { }
+        };
+
+        return new VectorIndexManager(
+                index,
+                /* tableManager   */ null,
+                /* log            */ null,
+                /* dsm            */ null,
+                TS_UUID,
+                /* transaction    */ 0L,
+                /* writeLockTimeout */ 30_000,
+                /* readLockTimeout  */ 30_000,
+                () -> mockIs,
+                NullStatsLogger.INSTANCE);
+    }
+
+    private FileCommitLogManager newManager(Path base) {
+        return new FileCommitLogManager(base,
+                /* maxLogFileSize */ 1L,       // one entry per file → many ledger files
+                ServerConfiguration.PROPERTY_MAX_UNSYNCHED_BATCH_DEFAULT,
+                ServerConfiguration.PROPERTY_MAX_UNSYNCHED_BATCH_BYTES_DEFAULT,
+                ServerConfiguration.PROPERTY_MAX_SYNC_TIME_DEFAULT,
+                /* requireSync */ false,
+                /* enableO_DIRECT */ false,
+                ServerConfiguration.PROPERTY_DEFERRED_SYNC_PERIOD_DEFAULT,
+                NullStatsLogger.INSTANCE);
+    }
+
+    private Path tsFolder(Path base) {
+        return base.resolve("ts.txlog");
+    }
+
+    private List<Long> listLogLedgers(Path logDir) throws java.io.IOException {
+        List<Long> ids = new ArrayList<>();
+        try (java.util.stream.Stream<Path> s = Files.list(logDir)) {
+            for (Path p : (Iterable<Path>) s::iterator) {
+                String name = p.getFileName().toString();
+                if (name.endsWith(".txlog")) {
+                    ids.add(Long.parseLong(name.replace(".txlog", ""), 16));
+                }
+            }
+        }
+        ids.sort(Comparator.naturalOrder());
+        return ids;
+    }
+
+    private LogSequenceNumber writeEntry(FileCommitLog log) throws Exception {
+        return log.log(LogEntryFactory.beginTransaction(0L), true).getLogSequenceNumber();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Documents the VectorIndexManager behaviour: when the IS reports
+     * {@code (-1,-1)} (= {@code START_OF_TIME}) as its last processed LSN — which
+     * happens when the tailer is frozen in Phase A and has not yet advanced past the
+     * beginning of the commit log — {@code getTailersMinLsn()} returns
+     * {@code Optional.of(START_OF_TIME)}.
+     *
+     * <p>This behaviour is <em>correct</em> at the VIM level.  The bug (#355) is
+     * that the caller ({@code computeTailersRetentionFloor}) passes this value on to
+     * {@code dropOldLedgers}, which misinterprets it as "no constraint".
+     */
+    @Test
+    public void frozenIsReturnsStartOfTimeFromGetTailersMinLsn() {
+        // IS frozen in Phase A: reports (-1,-1) = START_OF_TIME.
+        VectorIndexManager vim = buildVim(Optional.of(LogSequenceNumber.START_OF_TIME));
+
+        Optional<LogSequenceNumber> floor = vim.getTailersMinLsn();
+
+        assertTrue("VectorIndexManager must relay the IS's (-1,-1) as START_OF_TIME",
+                floor.isPresent());
+        assertEquals("VectorIndexManager floor should be START_OF_TIME when IS reports (-1,-1)",
+                LogSequenceNumber.START_OF_TIME, floor.get());
+    }
+
+    /**
+     * Reproducing failing test for issue #355.
+     *
+     * <p>Scenario: the IS is present, has been seen by the server (so the
+     * {@code peakChannelCount} guard in {@code IndexingServiceClient} does not fire),
+     * but its tailer is frozen in Phase A.  The gRPC {@code GetIndexStatus} response
+     * carries {@code lastLsnLedger=-1, lastLsnOffset=-1}.
+     * {@code IndexingServiceClient.getMinProcessedLsn} therefore returns
+     * {@code Optional.of(START_OF_TIME)}.
+     * {@code VectorIndexManager.getTailersMinLsn()} relays this unchanged.
+     * {@code computeTailersRetentionFloor()} short-circuits and returns
+     * {@code START_OF_TIME}.  This value is then passed to
+     * {@code dropOldLedgers(checkpoint, START_OF_TIME)}.
+     *
+     * <p>The correct post-fix behaviour: because the IS is present (a floor was
+     * contributed), {@code START_OF_TIME} means "the tailer is at the very beginning —
+     * protect <em>all</em> ledgers."  No ledger file should be deleted.
+     *
+     * <p><strong>This assertion currently FAILS</strong>, reproducing the bug: the
+     * guard {@code tailersFloor.ledgerId >= 0} is false for {@code -1}, so no floor
+     * is applied and ledgers are silently dropped.
+     */
+    @Test
+    public void issue355StartOfTimeFloorFromFrozenIsDoesNotProtectLedgers() throws Exception {
+        // Step 1: VIM with a frozen IS reporting (-1,-1).
+        VectorIndexManager vim = buildVim(Optional.of(LogSequenceNumber.START_OF_TIME));
+        Optional<LogSequenceNumber> contributed = vim.getTailersMinLsn();
+        assertTrue("IS must contribute a floor", contributed.isPresent());
+        // computeTailersRetentionFloor() would short-circuit here and return START_OF_TIME.
+        assertEquals(LogSequenceNumber.START_OF_TIME, contributed.get());
+        LogSequenceNumber tailersFloor = contributed.get(); // = START_OF_TIME = (-1,-1)
+
+        // Step 2: set up a FileCommitLog with several ledgers.
+        Path base = folder.newFolder().toPath();
+        LogSequenceNumber checkpoint;
+        List<Long> before;
+        try (FileCommitLogManager manager = newManager(base)) {
+            manager.start();
+            try (FileCommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                writeEntry(log);
+                writeEntry(log);
+                checkpoint = writeEntry(log);
+                writeEntry(log);
+                writeEntry(log);
+                before = listLogLedgers(tsFolder(base));
+                assertTrue("need multiple ledgers to exercise drop logic; got " + before,
+                        before.size() >= 3);
+
+                // Step 3: simulate what TableSpaceManager.checkpoint() does —
+                // pass the tailersFloor (START_OF_TIME from frozen IS) to dropOldLedgers.
+                log.dropOldLedgers(checkpoint, tailersFloor);
+            }
+
+            List<Long> after = listLogLedgers(tsFolder(base));
+
+            // Step 4: assert the correct post-fix behaviour.
+            // BUG (issue #355): currently FAILS because START_OF_TIME is treated as
+            // "no constraint" → ledgers below checkpoint are deleted even though
+            // the IS tailer is frozen and cannot yet read them.
+            assertEquals(
+                    "No ledger must be dropped when tailersFloor=START_OF_TIME "
+                            + "(IS present but frozen in Phase A, issue #355). "
+                            + "before=" + before + " after=" + after,
+                    before.size(), after.size());
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/file/FileCommitLogTailerFloorTest.java
+++ b/herddb-core/src/test/java/herddb/file/FileCommitLogTailerFloorTest.java
@@ -81,12 +81,16 @@ public class FileCommitLogTailerFloorTest {
     }
 
     /**
-     * Without a tailer floor ({@code START_OF_TIME}), deletion is governed solely by the
-     * checkpoint LSN — existing behavior. Ledgers below the checkpoint are deleted;
+     * Without a tailers floor ({@code null}), deletion is governed solely by the
+     * checkpoint LSN — baseline behavior. Ledgers below the checkpoint are deleted;
      * the last file is always retained.
+     *
+     * <p>Note: before issue #355 was fixed, {@code START_OF_TIME} was used here to
+     * mean "no constraint."  After the fix {@code null} is the "no external tailer"
+     * signal; {@code START_OF_TIME} now means "IS present but frozen — protect all."
      */
     @Test
-    public void startOfTimeFloorBehavesLikeBefore() throws Exception {
+    public void nullFloorBehavesLikeNoConstraint() throws Exception {
         Path base = folder.newFolder().toPath();
         LogSequenceNumber checkpoint;
         try (FileCommitLogManager manager = newManager(base)) {
@@ -101,7 +105,8 @@ public class FileCommitLogTailerFloorTest {
                 List<Long> before = listLogLedgers(tsFolder(base));
                 assertTrue("expected multiple ledgers to be created, got " + before,
                         before.size() >= 3);
-                log.dropOldLedgers(checkpoint, LogSequenceNumber.START_OF_TIME);
+                // null = no external tailer constraint (no vector index in this tablespace).
+                log.dropOldLedgers(checkpoint, null);
             }
             List<Long> after = listLogLedgers(tsFolder(base));
             for (long id : after) {

--- a/herddb-core/src/test/java/herddb/file/FileCommitLogTailerFloorTest.java
+++ b/herddb-core/src/test/java/herddb/file/FileCommitLogTailerFloorTest.java
@@ -20,6 +20,7 @@
 
 package herddb.file;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.log.LogEntryFactory;
 import herddb.log.LogSequenceNumber;
@@ -136,6 +137,65 @@ public class FileCommitLogTailerFloorTest {
             List<Long> after = listLogLedgers(tsFolder(base));
             assertTrue("ledger " + oldLsn.ledgerId + " must be kept (tailer still needs it); got " + after,
                     after.contains(oldLsn.ledgerId));
+        }
+    }
+
+    /**
+     * Issue #355 regression test.
+     *
+     * <p>When a remote IndexingService (IS) is present but its tailer is frozen
+     * in Phase A compaction, {@code VectorIndexManager.getTailersMinLsn()} returns
+     * {@code Optional.of(START_OF_TIME)} (either because {@code getMinProcessedLsn}
+     * received a gRPC response with {@code lastLsnLedger=-1, lastLsnOffset=-1}, or
+     * because the gRPC call timed out while Phase A was consuming all CPU).
+     *
+     * <p>{@code computeTailersRetentionFloor()} short-circuits to {@code START_OF_TIME}
+     * in this case and passes it to {@code dropOldLedgers}.  The intent of that
+     * short-circuit is "a tailer we can't safely pin — protect everything."  However
+     * the guard in {@code dropOldLedgers} is:
+     * <pre>
+     *     if (tailersFloor != null {@code &&} tailersFloor.ledgerId &gt;= 0 ...)
+     * </pre>
+     * {@code START_OF_TIME.ledgerId == -1 &lt; 0}, so the guard is <em>never entered</em>
+     * and the log files are dropped as if no floor existed — destroying commit-log
+     * ledgers the frozen IS still needs.
+     *
+     * <p>This test asserts the <em>correct post-fix behaviour</em>: when the tailers
+     * floor is {@code START_OF_TIME} (IS present but frozen), <strong>no</strong>
+     * ledger file must be deleted.  The test currently <em>fails</em>, thereby
+     * reproducing the bug.
+     */
+    @Test
+    public void issue355FrozenIsAtStartOfTimePreventsLedgerDrop() throws Exception {
+        Path base = folder.newFolder().toPath();
+        LogSequenceNumber checkpoint;
+        List<Long> before;
+        try (FileCommitLogManager manager = newManager(base)) {
+            manager.start();
+            try (FileCommitLog log = manager.createCommitLog("ts", "ts", "n1")) {
+                log.startWriting(1);
+                writeEntry(log);
+                writeEntry(log);
+                checkpoint = writeEntry(log);
+                writeEntry(log);
+                writeEntry(log);
+                before = listLogLedgers(tsFolder(base));
+                assertTrue("expected multiple ledgers before drop, got " + before,
+                        before.size() >= 3);
+
+                // Simulate the IS being frozen in Phase A: computeTailersRetentionFloor()
+                // returns START_OF_TIME. The floor should prevent ANY ledger from being
+                // dropped because the IS tailer position is unknown / at the very beginning.
+                log.dropOldLedgers(checkpoint, LogSequenceNumber.START_OF_TIME);
+            }
+            List<Long> after = listLogLedgers(tsFolder(base));
+            // BUG (issue #355): currently dropOldLedgers treats START_OF_TIME as
+            // "no constraint" and drops ledgers below the checkpoint.
+            // After the fix START_OF_TIME must mean "IS present but frozen — keep all".
+            assertEquals(
+                    "No ledger must be dropped when the IS tailer floor is START_OF_TIME "
+                            + "(frozen IS, issue #355); before=" + before + " after=" + after,
+                    before.size(), after.size());
         }
     }
 


### PR DESCRIPTION
Fixes #355.

## Root cause

`computeTailersRetentionFloor()` returned `START_OF_TIME` (`-1,-1`) in two semantically opposite cases:
1. **No vector indexes** present → "no constraint, drop freely" (intended)
2. **IS present but frozen** in Phase A compaction, or gRPC call timed out → returned `Optional.of(START_OF_TIME)` from `getMinProcessedLsn()` → intent was "protect all ledgers"

`dropOldLedgers()` used the guard `tailersFloor.ledgerId >= 0`, which is `false` for `START_OF_TIME.ledgerId == -1`. Both cases were treated as "no constraint", so commit-log ledgers the IS still needed were silently dropped — causing a permanent ledger gap once Phase A finished.

The IS reports `(-1,-1)` via gRPC `GetIndexStatus` when its tailer hasn't advanced past the beginning of the commit log yet (either because it is frozen in Phase A, or because it started with no persisted watermark). The server reads this via gRPC, not ZK.

## Changes

| File | Change |
|---|---|
| `TableSpaceManager.computeTailersRetentionFloor()` | Return `null` (not `START_OF_TIME`) when no index contributes a floor — distinguishes "no vector index" from "IS frozen". Updated JavaDoc. |
| `BookkeeperCommitLog.dropOldLedgers()` | Treat `START_OF_TIME` floor as "IS present but frozen/unreachable — protect all ledgers, return early". Update comment. |
| `FileCommitLog.dropOldLedgers()` | Same fix. |
| `FileCommitLogTailerFloorTest` | Rename `startOfTimeFloorBehavesLikeBefore` → `nullFloorBehavesLikeNoConstraint` (passes `null`, the new "no constraint" signal). New failing→passing test `issue355FrozenIsAtStartOfTimePreventsLedgerDrop`. |
| `BookKeeperCommitLogTest` | Update `testDropOldLedgersHonorsCheckpointLsn` to pass `null` instead of `START_OF_TIME`. |

## Tests

- `FileCommitLogTailerFloorTest#issue355FrozenIsAtStartOfTimePreventsLedgerDrop` — asserts `dropOldLedgers(checkpoint, START_OF_TIME)` keeps all ledgers (was failing before fix)
- `Issue355FrozenIsTailerLedgerRetentionTest` — two tests: (a) documents that `VectorIndexManager.getTailersMinLsn()` returns `START_OF_TIME` when the mock IS reports `(-1,-1)` via gRPC; (b) shows the full path and asserts correct behaviour (was failing before fix)
- All 21 tests in `BookKeeperCommitLogTest`, `FileCommitLogTailerFloorTest`, `MemoryCommitLogTailerFloorTest`, `Issue355FrozenIsTailerLedgerRetentionTest` pass

🤖 Implemented by the `pr-worker` agent.