### PR TITLE
issue #370: fix segment-count back-pressure deadlock (empty candidates + failure paths)

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -615,6 +615,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * Generation counter incremented inside {@link #notifySegmentCountMonitor}
      * to satisfy SpotBugs NN_NAKED_NOTIFY: the monitor must see a visible
      * state change before {@code notifyAll()} is called.
+     * Always accessed while holding {@link #segmentCountMonitor}, so no
+     * {@code volatile} is needed; {@link #getSegmentCountGeneration()} acquires
+     * the same lock so external readers also see the latest value.
      */
     private int segmentCountGeneration;
 
@@ -1387,9 +1390,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /**
      * Sets the maximum wall-clock time (ms) a caller may spend in
      * segment-count back-pressure before it is force-released (issue #370).
-     * Use {@link Long#MAX_VALUE} to disable the safety timeout.
+     * Must be {@code > 0}.  Use {@link Long#MAX_VALUE} to disable the
+     * safety timeout entirely.
+     *
+     * @throws IllegalArgumentException if {@code maxWaitMs <= 0}
      */
     public void setCompactionBackpressureMaxWaitMs(long maxWaitMs) {
+        if (maxWaitMs <= 0) {
+            throw new IllegalArgumentException(
+                    "compactionBackpressureMaxWaitMs must be > 0; use Long.MAX_VALUE to disable");
+        }
         this.compactionBackpressureMaxWaitMs = maxWaitMs;
     }
 
@@ -1755,20 +1765,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
                                     now, sinceGen));
                         }
                     }
-                    // Notify parked apply threads even on failure (issue #370): without
-                    // this, threads wait up to 100 ms per poll cycle and cannot react to
-                    // the safety timeout while compaction is failing with back-off.
+                    // Notify parked apply threads immediately on failure (issue #370):
+                    // wakes threads right after the cycle rather than waiting up to 100 ms
+                    // for the next poll — letting them detect the safety timeout sooner.
                     notifySegmentCountMonitor();
                 } catch (IOException e) {
                     recordCompactionFailure(VectorIndexCompactor.FailureReason.WRITE_IO);
                     LOGGER.log(Level.WARNING,
                             "vector store " + indexName + ": compaction I/O failure", e);
-                    notifySegmentCountMonitor(); // issue #370
+                    notifySegmentCountMonitor(); // immediate wakeup (issue #370)
                 } catch (DataStorageManagerException e) {
                     recordCompactionFailure(VectorIndexCompactor.FailureReason.METADATA_IO);
                     LOGGER.log(Level.WARNING,
                             "vector store " + indexName + ": compaction metadata failure", e);
-                    notifySegmentCountMonitor(); // issue #370
+                    notifySegmentCountMonitor(); // immediate wakeup (issue #370)
                 }
             } finally {
                 // Drop the temporary BLink storages regardless of outcome so
@@ -1792,6 +1802,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         } finally {
             compactionActive.set(0);
             compactionLock.unlock();
+            // Belt-and-suspenders notify (issue #370): all normal and checked-exception
+            // exit paths call notifySegmentCountMonitor() explicitly above for immediate
+            // wakeup.  This backstop ensures unchecked-exception paths (e.g. RuntimeException
+            // from createTempPagedPkSet / createTempCompactionAuthorityMap, or unchecked
+            // throws from buildAuthorityMap) also signal waiting apply threads rather than
+            // leaving them parked until the safety timeout.  A redundant notify is harmless:
+            // waiting threads re-check the segment count and immediately re-park if still
+            // above the threshold.
+            notifySegmentCountMonitor();
         }
     }
 
@@ -2160,7 +2179,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private void waitForSegmentCountRelief() {
         long startMs = System.currentTimeMillis();
         long maxWaitMs = compactionBackpressureMaxWaitMs;
-        long deadlineMs = maxWaitMs == Long.MAX_VALUE ? Long.MAX_VALUE : startMs + maxWaitMs;
+        // Compute deadline with overflow protection: if startMs + maxWaitMs wraps
+        // (possible for very large but non-MAX_VALUE values) treat as no deadline.
+        long deadlineMs;
+        if (maxWaitMs == Long.MAX_VALUE || maxWaitMs >= Long.MAX_VALUE - startMs) {
+            deadlineMs = Long.MAX_VALUE;
+        } else {
+            deadlineMs = startMs + maxWaitMs;
+        }
         segmentCountBackpressureActive = 1;
         segmentCountBackpressureTotal.incrementAndGet();
         int threshold = compactionBackpressureThreshold;
@@ -5504,9 +5530,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * Incremented by every {@link #notifySegmentCountMonitor()} call.
      * Exposed for testing — callers can verify that a compaction cycle
      * (including the empty-candidates and failure paths) notified the monitor.
+     *
+     * <p>Acquires {@code segmentCountMonitor} to guarantee the latest value is
+     * visible to any calling thread, matching the lock used by the writer.
      */
     public int getSegmentCountGeneration() {
-        return segmentCountGeneration;
+        synchronized (segmentCountMonitor) {
+            return segmentCountGeneration;
+        }
     }
 
     public long getMaxVectorMemoryBytes() {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -439,6 +439,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private volatile int compactionBackpressureThreshold = 500;
 
     /**
+     * Maximum wall-clock time (ms) a caller may spend in
+     * {@link #waitForSegmentCountRelief} before back-pressure is
+     * force-released with a SEVERE log (issue #370).
+     * Default is 300 000 ms (5 min).  Set to {@link Long#MAX_VALUE} to
+     * disable the safety timeout.
+     */
+    private volatile long compactionBackpressureMaxWaitMs = 300_000L;
+
+    /**
      * Log a WARNING during Phase A when the total on-disk segment count
      * exceeds this threshold, making runaway accumulation visible without
      * having to parse checkpoint log lines.
@@ -595,6 +604,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private volatile int segmentCountBackpressureActive;
     private final AtomicLong segmentCountBackpressureTotal = new AtomicLong(0);
     private final AtomicLong segmentCountBackpressureTimeMs = new AtomicLong(0);
+    /**
+     * Number of times segment-count back-pressure was force-released by
+     * the safety timeout ({@link #compactionBackpressureMaxWaitMs}) rather
+     * than by a successful compaction that reduced the segment count below
+     * the threshold (issue #370).
+     */
+    private final AtomicLong segmentCountBackpressureTimeouts = new AtomicLong(0);
     /**
      * Generation counter incremented inside {@link #notifySegmentCountMonitor}
      * to satisfy SpotBugs NN_NAKED_NOTIFY: the monitor must see a visible
@@ -1368,6 +1384,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.compactionBackpressureThreshold = threshold;
     }
 
+    /**
+     * Sets the maximum wall-clock time (ms) a caller may spend in
+     * segment-count back-pressure before it is force-released (issue #370).
+     * Use {@link Long#MAX_VALUE} to disable the safety timeout.
+     */
+    public void setCompactionBackpressureMaxWaitMs(long maxWaitMs) {
+        this.compactionBackpressureMaxWaitMs = maxWaitMs;
+    }
+
     /** Wakes the compaction thread. Called by tests and the retention reaper. */
     public void wakeVectorIndexCompaction() {
         synchronized (vectorIndexCompactionWakeup) {
@@ -1618,6 +1643,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
                                     vectorIndexCompactionMinBytes,
                                     vectorIndexCompactionMaxCount});
                 }
+                // Notify even when no candidates were selected (issue #370): apply
+                // threads parked in waitForSegmentCountRelief() must be woken after
+                // every cycle so they can re-check the segment count and, if the
+                // safety timeout has expired, release back-pressure.
+                notifySegmentCountMonitor();
                 return;
             }
 
@@ -1725,14 +1755,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
                                     now, sinceGen));
                         }
                     }
+                    // Notify parked apply threads even on failure (issue #370): without
+                    // this, threads wait up to 100 ms per poll cycle and cannot react to
+                    // the safety timeout while compaction is failing with back-off.
+                    notifySegmentCountMonitor();
                 } catch (IOException e) {
                     recordCompactionFailure(VectorIndexCompactor.FailureReason.WRITE_IO);
                     LOGGER.log(Level.WARNING,
                             "vector store " + indexName + ": compaction I/O failure", e);
+                    notifySegmentCountMonitor(); // issue #370
                 } catch (DataStorageManagerException e) {
                     recordCompactionFailure(VectorIndexCompactor.FailureReason.METADATA_IO);
                     LOGGER.log(Level.WARNING,
                             "vector store " + indexName + ": compaction metadata failure", e);
+                    notifySegmentCountMonitor(); // issue #370
                 }
             } finally {
                 // Drop the temporary BLink storages regardless of outcome so
@@ -2123,6 +2159,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     private void waitForSegmentCountRelief() {
         long startMs = System.currentTimeMillis();
+        long maxWaitMs = compactionBackpressureMaxWaitMs;
+        long deadlineMs = maxWaitMs == Long.MAX_VALUE ? Long.MAX_VALUE : startMs + maxWaitMs;
         segmentCountBackpressureActive = 1;
         segmentCountBackpressureTotal.incrementAndGet();
         int threshold = compactionBackpressureThreshold;
@@ -2137,13 +2175,24 @@ public class PersistentVectorStore extends AbstractVectorStore {
             vectorIndexCompactionWakeup.notifyAll();
         }
 
+        boolean timedOut = false;
         synchronized (segmentCountMonitor) {
             // segmentCountGeneration is incremented by notifySegmentCountMonitor each
             // time a compaction cycle completes, giving SpotBugs a traceable
             // producer-consumer relationship (NN_NAKED_NOTIFY avoidance).
             while (running && segments.size() > threshold && segmentCountGeneration >= 0) {
+                long remaining = deadlineMs - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    // Safety net (issue #370): compaction has not been able to relieve
+                    // back-pressure within maxWaitMs.  Log SEVERE and break out so the
+                    // IS does not hang permanently.  The caller will continue inserting
+                    // even though segment count is still above the threshold; operators
+                    // must investigate compaction failures reported in preceding WARNINGs.
+                    timedOut = true;
+                    break;
+                }
                 try {
-                    segmentCountMonitor.wait(100);
+                    segmentCountMonitor.wait(Math.min(100, remaining));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     break;
@@ -2153,10 +2202,23 @@ public class PersistentVectorStore extends AbstractVectorStore {
         segmentCountBackpressureActive = 0;
         long elapsedMs = System.currentTimeMillis() - startMs;
         segmentCountBackpressureTimeMs.addAndGet(elapsedMs);
-        LOGGER.log(Level.INFO,
-                "vector store {0} segment-count back-pressure released after {1} ms "
-                        + "({2} segments remaining)",
-                new Object[]{indexName, elapsedMs, segments.size()});
+        if (timedOut) {
+            segmentCountBackpressureTimeouts.incrementAndGet();
+            LOGGER.log(Level.SEVERE,
+                    "vector store {0}: segment-count back-pressure safety timeout after {1} ms "
+                            + "({2} segments still exceeds threshold {3}, consecutive compaction "
+                            + "failures={4}). Releasing back-pressure to prevent permanent IS hang. "
+                            + "Investigate compaction failures and consider raising "
+                            + "vector.index.compaction.backpressure.max.wait.ms or adjusting "
+                            + "compaction policy settings.",
+                    new Object[]{indexName, elapsedMs, segments.size(), threshold,
+                            compactionConsecutiveFailures.get()});
+        } else {
+            LOGGER.log(Level.INFO,
+                    "vector store {0} segment-count back-pressure released after {1} ms "
+                            + "({2} segments remaining)",
+                    new Object[]{indexName, elapsedMs, segments.size()});
+        }
     }
 
     /**
@@ -5427,6 +5489,24 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** Returns {@code true} while a caller is blocked in segment-count back-pressure (issue #354). */
     public boolean isSegmentCountBackpressureActive() {
         return segmentCountBackpressureActive != 0;
+    }
+
+    /**
+     * Returns the number of times segment-count back-pressure was force-released
+     * by the safety timeout rather than by a successful compaction (issue #370).
+     */
+    public long getSegmentCountBackpressureTimeouts() {
+        return segmentCountBackpressureTimeouts.get();
+    }
+
+    /**
+     * Returns the current segment-count-monitor generation counter.
+     * Incremented by every {@link #notifySegmentCountMonitor()} call.
+     * Exposed for testing — callers can verify that a compaction cycle
+     * (including the empty-candidates and failure paths) notified the monitor.
+     */
+    public int getSegmentCountGeneration() {
+        return segmentCountGeneration;
     }
 
     public long getMaxVectorMemoryBytes() {

--- a/herddb-core/src/test/java/herddb/index/vector/Issue370BackpressureDeadlockTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue370BackpressureDeadlockTest.java
@@ -22,8 +22,10 @@ package herddb.index.vector;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import herddb.core.MemoryManager;
 import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
 import java.nio.file.Path;
 import java.util.Random;
@@ -52,6 +54,12 @@ import org.junit.rules.TemporaryFolder;
  *       segment count (empty candidates or repeated failures) the blocked
  *       apply thread is force-released after {@code compactionBackpressureMaxWaitMs}
  *       milliseconds with a SEVERE log, preventing a permanent IS hang.</li>
+ *   <li><b>Fix 3 (outer-finally backstop):</b> {@code runCompactionCycle()}
+ *       calls {@code notifySegmentCountMonitor()} in its outer {@code finally}
+ *       block as a belt-and-suspenders backstop, covering unchecked-exception
+ *       paths (e.g. {@code RuntimeException} from {@code createTempPagedPkSet}
+ *       or {@code createTempCompactionAuthorityMap}) that bypass the per-catch
+ *       notifies.</li>
  * </ol>
  */
 public class Issue370BackpressureDeadlockTest {
@@ -59,14 +67,18 @@ public class Issue370BackpressureDeadlockTest {
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
+    /** Saved original so @After can restore without hard-coding a constant. */
+    private int originalMinLiveVectorsForCheckpoint;
+
     @Before
     public void disableDeferral() {
+        originalMinLiveVectorsForCheckpoint = PersistentVectorStore.minLiveVectorsForCheckpoint;
         PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
     }
 
     @After
     public void restoreDeferral() {
-        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = originalMinLiveVectorsForCheckpoint;
     }
 
     private static float[] randomVector(Random rng, int dim) {
@@ -149,15 +161,15 @@ public class Issue370BackpressureDeadlockTest {
      * apply threads park forever.  With Fix 2 the apply thread is released
      * after {@code maxWaitMs} and ingestion resumes.
      */
-    @Test(timeout = 30_000)
+    @Test(timeout = 60_000)
     public void backpressureReleasesAfterTimeoutWhenCompactionCannotHelp() throws Exception {
         Path tmpDir = tmpFolder.newFolder("bp370-timeout").toPath();
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
 
         int threshold = 5;
-        // Very short safety timeout so the test runs in < 5 s.
-        long maxWaitMs = 1_500L;
+        // Generous timeout so the test never flakes on slow CI runners.
+        long maxWaitMs = 5_000L;
 
         PersistentVectorStore store = new PersistentVectorStore(
                 "testidx370b", "testtable", "tstblspace", "vec",
@@ -191,6 +203,8 @@ public class Issue370BackpressureDeadlockTest {
             int segsBefore = store.getSegmentCount();
             assertTrue("need more than threshold segments; got " + segsBefore,
                     segsBefore > threshold);
+            // Baseline: no timeout should have fired during setup.
+            assertEquals("no timeout during setup", 0L, store.getSegmentCountBackpressureTimeouts());
 
             // Phase 2: launch a background thread that will hit back-pressure.
             CountDownLatch started = new CountDownLatch(1);
@@ -209,31 +223,148 @@ public class Issue370BackpressureDeadlockTest {
 
             assertTrue("adder thread must start", started.await(5, TimeUnit.SECONDS));
 
-            // Phase 3: periodically drive compaction cycles (which find no
-            // candidates) so Fix 1 notifications are interleaved with Fix 2's
-            // timeout check.  The timeout alone would also suffice.
-            for (int round = 0; round < 5 && !completed.get(); round++) {
+            // Phase 3: drive compaction cycles (which find no candidates) so that
+            // Fix 1 notifications are interleaved with Fix 2's timeout check.
+            // The timeout alone would also release the thread, but we drive cycles
+            // to exercise both fixes together.
+            while (!done.await(500, TimeUnit.MILLISECONDS)) {
                 store.runCompactionCycle();
-                Thread.sleep(200);
             }
 
             // Phase 4: the safety timeout must have fired and released the thread.
-            assertTrue(
-                    "addVector must complete after the back-pressure safety timeout",
-                    done.await(10, TimeUnit.SECONDS));
             assertTrue("addVector must actually complete", completed.get());
 
             // Verify timeout was recorded — the segment count did NOT go below
             // threshold (compaction never selected candidates), so the release
             // was caused by the timeout, not by successful compaction.
-            assertEquals("segment count must still be above threshold after timeout release",
-                    segsBefore, store.getSegmentCount()); // no segments were merged
+            assertEquals("segment count must be unchanged (compaction did nothing)",
+                    segsBefore, store.getSegmentCount());
             assertTrue(
                     "safety timeout counter must be incremented",
                     store.getSegmentCountBackpressureTimeouts() >= 1);
             // Back-pressure must not be active after the release.
             assertFalse("back-pressure must not be active after release",
                     store.isSegmentCountBackpressureActive());
+        }
+    }
+
+    /**
+     * Fix 3 (outer-finally backstop): verifies that {@code notifySegmentCountMonitor()}
+     * is called even when {@code runCompactionCycle()} exits via an unchecked
+     * exception thrown before the inner {@code try} block — specifically when
+     * {@code createTempCompactionAuthorityMap()} fails because the backing
+     * {@link herddb.storage.DataStorageManager} throws {@link DataStorageManagerException}
+     * from {@code initIndex()}.
+     *
+     * <p>Before the outer-finally backstop was added, this path exited the
+     * outer {@code try} without notifying; the parked apply thread had to wait
+     * for the 100 ms poll or the safety timeout.
+     */
+    @Test(timeout = 30_000)
+    public void uncheckedExceptionInCompactionNotifiesMonitorViaOuterFinally() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bp370-outer-finally").toPath();
+
+        // DSM that fails initIndex for temporary authority-map store names.
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager() {
+            @Override
+            public void initIndex(String tableSpace, String name)
+                    throws DataStorageManagerException {
+                if (name.contains("_tmp_cmpaut_")) {
+                    throw new DataStorageManagerException(
+                            "Injected failure for test: " + name);
+                }
+                super.initIndex(tableSpace, name);
+            }
+        };
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx370d", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        // Configure compaction so candidates ARE chosen (minBytes=1, minCount=2);
+        // the failure is injected at authority-map init, before rebuildSegment.
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ 1,
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ 2,
+                /*maxCount*/ Integer.MAX_VALUE,
+                /*retentionMs*/ 0);
+        store.setTieredCompactionEnabled(false);
+        store.setCompactionBackpressureThreshold(Integer.MAX_VALUE); // don't block addVector
+
+        try (store) {
+            store.start();
+            Random rng = new Random(370_4);
+            int dim = 8;
+
+            // Build a few segments so there are candidates to merge.
+            for (int c = 0; c < 3; c++) {
+                for (int i = 0; i < 20; i++) {
+                    store.addVector(Bytes.from_int(c * 100 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+
+            int genBefore = store.getSegmentCountGeneration();
+
+            // Drive a compaction cycle; it will select candidates, then
+            // createTempCompactionAuthorityMap will throw a RuntimeException
+            // (wrapping DataStorageManagerException).
+            try {
+                store.runCompactionCycle();
+                fail("expected RuntimeException from injected DSM failure");
+            } catch (RuntimeException expected) {
+                // Good — the cycle failed as expected.
+            }
+
+            int genAfter = store.getSegmentCountGeneration();
+            assertTrue(
+                    "runCompactionCycle() must call notifySegmentCountMonitor() via outer "
+                            + "finally even when createTempCompactionAuthorityMap throws "
+                            + "(generation before=" + genBefore + ", after=" + genAfter + ")",
+                    genAfter > genBefore);
+            // The safety timeout must not have fired (no back-pressure active).
+            assertEquals("timeout counter must be 0 — no back-pressure was active",
+                    0L, store.getSegmentCountBackpressureTimeouts());
+        }
+    }
+
+    /**
+     * Validates input: {@link PersistentVectorStore#setCompactionBackpressureMaxWaitMs}
+     * must reject non-positive values with {@link IllegalArgumentException}.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void setCompactionBackpressureMaxWaitMsRejectsZero() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bp370-validation").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx370e", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        try (store) {
+            store.start();
+            store.setCompactionBackpressureMaxWaitMs(0); // must throw
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setCompactionBackpressureMaxWaitMsRejectsNegative() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bp370-validation-neg").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx370f", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        try (store) {
+            store.start();
+            store.setCompactionBackpressureMaxWaitMs(-1); // must throw
         }
     }
 
@@ -301,15 +432,10 @@ public class Issue370BackpressureDeadlockTest {
             assertTrue("adder thread must start", started.await(5, TimeUnit.SECONDS));
 
             // Drive compaction cycles until the adder completes.
-            int maxRounds = 30;
-            for (int round = 0; round < maxRounds && !completed.get(); round++) {
+            while (!done.await(100, TimeUnit.MILLISECONDS)) {
                 store.runCompactionCycle();
-                Thread.sleep(50);
             }
 
-            assertTrue(
-                    "addVector must complete after compaction reduces segment count",
-                    done.await(10, TimeUnit.SECONDS));
             assertTrue("addVector must actually complete", completed.get());
 
             // No timeout should have fired — compaction did the job.

--- a/herddb-core/src/test/java/herddb/index/vector/Issue370BackpressureDeadlockTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue370BackpressureDeadlockTest.java
@@ -1,0 +1,322 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for issue #370: segment-count back-pressure deadlock.
+ *
+ * <p>Verifies two fixes:
+ * <ol>
+ *   <li><b>Fix 1 (Bug A):</b> {@code runCompactionCycle()} calls
+ *       {@code notifySegmentCountMonitor()} even when
+ *       {@code chooseSegmentsToMerge()} returns an empty candidate list.
+ *       Without this fix, apply threads stay in back-pressure until the
+ *       100 ms poll wakes them — but they never receive an explicit signal
+ *       from the cycle that found no work to do.</li>
+ *   <li><b>Fix 2:</b> {@link PersistentVectorStore#waitForSegmentCountRelief}
+ *       has a configurable safety timeout.  When compaction cannot drain the
+ *       segment count (empty candidates or repeated failures) the blocked
+ *       apply thread is force-released after {@code compactionBackpressureMaxWaitMs}
+ *       milliseconds with a SEVERE log, preventing a permanent IS hang.</li>
+ * </ol>
+ */
+public class Issue370BackpressureDeadlockTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int d = 0; d < dim; d++) {
+            v[d] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Fix 1 (Bug A): verifies that {@code runCompactionCycle()} increments the
+     * segment-count-monitor generation even when it returns an empty candidate
+     * list (i.e. {@code notifySegmentCountMonitor()} is called on the
+     * empty-candidates path).
+     *
+     * <p>The generation counter is incremented inside every
+     * {@code notifySegmentCountMonitor()} call.  Before the fix the
+     * empty-candidates path skipped the notification, leaving the generation
+     * unchanged.
+     */
+    @Test(timeout = 30_000)
+    public void emptyCandidatesPathNotifiesSegmentCountMonitor() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bp370-bug-a").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx370a", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        // Configure compaction so that no candidates are ever chosen:
+        // minBytes = Long.MAX_VALUE and minCount = Integer.MAX_VALUE together
+        // guarantee chooseSegmentsToMerge() always returns an empty list.
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ Long.MAX_VALUE,
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ Integer.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE,
+                /*retentionMs*/ 0);
+        store.setTieredCompactionEnabled(false);
+        store.setCompactionBackpressureThreshold(Integer.MAX_VALUE); // don't trigger back-pressure
+
+        try (store) {
+            store.start();
+            Random rng = new Random(370_1);
+            int dim = 8;
+
+            // Build a few segments so runCompactionCycle has a non-empty snapshot.
+            for (int c = 0; c < 3; c++) {
+                for (int i = 0; i < 20; i++) {
+                    store.addVector(Bytes.from_int(c * 100 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+
+            int genBefore = store.getSegmentCountGeneration();
+
+            // Drive one compaction cycle — it must find no candidates and still
+            // call notifySegmentCountMonitor(), incrementing the generation.
+            store.runCompactionCycle();
+
+            int genAfter = store.getSegmentCountGeneration();
+            assertTrue(
+                    "runCompactionCycle() with empty candidates must call notifySegmentCountMonitor()"
+                            + " (generation before=" + genBefore + ", after=" + genAfter + ")",
+                    genAfter > genBefore);
+        }
+    }
+
+    /**
+     * Fix 2: verifies that a thread blocked in segment-count back-pressure is
+     * force-released after the safety timeout ({@code backpressureMaxWaitMs})
+     * even when compaction cannot reduce the segment count.
+     *
+     * <p>This is the real deadlock scenario from the BIGANN 1B GKE run:
+     * segment count > threshold, compaction returns empty candidates,
+     * apply threads park forever.  With Fix 2 the apply thread is released
+     * after {@code maxWaitMs} and ingestion resumes.
+     */
+    @Test(timeout = 30_000)
+    public void backpressureReleasesAfterTimeoutWhenCompactionCannotHelp() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bp370-timeout").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int threshold = 5;
+        // Very short safety timeout so the test runs in < 5 s.
+        long maxWaitMs = 1_500L;
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx370b", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        // Compaction configured to never select candidates.
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ Long.MAX_VALUE,
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ Integer.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE,
+                /*retentionMs*/ 0);
+        store.setTieredCompactionEnabled(false);
+        store.setCompactionBackpressureThreshold(threshold);
+        store.setCompactionBackpressureMaxWaitMs(maxWaitMs);
+
+        try (store) {
+            store.start();
+            Random rng = new Random(370_2);
+            int dim = 8;
+
+            // Phase 1: build threshold+1 segments — back-pressure will fire.
+            for (int c = 0; c <= threshold; c++) {
+                for (int i = 0; i < 20; i++) {
+                    store.addVector(Bytes.from_int(c * 1_000 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segsBefore = store.getSegmentCount();
+            assertTrue("need more than threshold segments; got " + segsBefore,
+                    segsBefore > threshold);
+
+            // Phase 2: launch a background thread that will hit back-pressure.
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(1);
+            AtomicBoolean completed = new AtomicBoolean(false);
+
+            Thread adder = new Thread(() -> {
+                started.countDown();
+                // This will enter waitForSegmentCountRelief() since segments > threshold.
+                store.addVector(Bytes.from_int(999_370), randomVector(rng, dim));
+                completed.set(true);
+                done.countDown();
+            }, "adder-370");
+            adder.setDaemon(true);
+            adder.start();
+
+            assertTrue("adder thread must start", started.await(5, TimeUnit.SECONDS));
+
+            // Phase 3: periodically drive compaction cycles (which find no
+            // candidates) so Fix 1 notifications are interleaved with Fix 2's
+            // timeout check.  The timeout alone would also suffice.
+            for (int round = 0; round < 5 && !completed.get(); round++) {
+                store.runCompactionCycle();
+                Thread.sleep(200);
+            }
+
+            // Phase 4: the safety timeout must have fired and released the thread.
+            assertTrue(
+                    "addVector must complete after the back-pressure safety timeout",
+                    done.await(10, TimeUnit.SECONDS));
+            assertTrue("addVector must actually complete", completed.get());
+
+            // Verify timeout was recorded — the segment count did NOT go below
+            // threshold (compaction never selected candidates), so the release
+            // was caused by the timeout, not by successful compaction.
+            assertEquals("segment count must still be above threshold after timeout release",
+                    segsBefore, store.getSegmentCount()); // no segments were merged
+            assertTrue(
+                    "safety timeout counter must be incremented",
+                    store.getSegmentCountBackpressureTimeouts() >= 1);
+            // Back-pressure must not be active after the release.
+            assertFalse("back-pressure must not be active after release",
+                    store.isSegmentCountBackpressureActive());
+        }
+    }
+
+    /**
+     * Regression guard: verifies that the normal (happy-path) back-pressure
+     * release — compaction successfully merges segments below the threshold —
+     * still works correctly after the Fix 2 changes to
+     * {@code waitForSegmentCountRelief()}.  No timeout should fire.
+     */
+    @Test(timeout = 60_000)
+    public void backpressureReleasesAfterSuccessfulCompactionWithoutTimeout() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bp370-happy").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int threshold = 5;
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx370c", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        // Compaction can select candidates (minBytes=1, minCount=2).
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ 1,
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ 2,
+                /*maxCount*/ Integer.MAX_VALUE,
+                /*retentionMs*/ 0);
+        store.setTieredCompactionEnabled(false);
+        store.setCompactionBackpressureThreshold(threshold);
+        // Long timeout — must not fire during a normal compaction-driven release.
+        store.setCompactionBackpressureMaxWaitMs(60_000L);
+
+        try (store) {
+            store.start();
+            Random rng = new Random(370_3);
+            int dim = 8;
+
+            // Build threshold+1 segments to trigger back-pressure.
+            for (int c = 0; c <= threshold; c++) {
+                for (int i = 0; i < 50; i++) {
+                    store.addVector(Bytes.from_int(c * 1_000 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            assertTrue("need more than threshold segments",
+                    store.getSegmentCount() > threshold);
+
+            // Launch background thread that will block in back-pressure.
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(1);
+            AtomicBoolean completed = new AtomicBoolean(false);
+
+            Thread adder = new Thread(() -> {
+                started.countDown();
+                store.addVector(Bytes.from_int(999_371), randomVector(rng, dim));
+                completed.set(true);
+                done.countDown();
+            }, "adder-370c");
+            adder.setDaemon(true);
+            adder.start();
+
+            assertTrue("adder thread must start", started.await(5, TimeUnit.SECONDS));
+
+            // Drive compaction cycles until the adder completes.
+            int maxRounds = 30;
+            for (int round = 0; round < maxRounds && !completed.get(); round++) {
+                store.runCompactionCycle();
+                Thread.sleep(50);
+            }
+
+            assertTrue(
+                    "addVector must complete after compaction reduces segment count",
+                    done.await(10, TimeUnit.SECONDS));
+            assertTrue("addVector must actually complete", completed.get());
+
+            // No timeout should have fired — compaction did the job.
+            assertEquals("safety timeout must NOT fire on successful compaction path",
+                    0L, store.getSegmentCountBackpressureTimeouts());
+            assertFalse("back-pressure must not be active",
+                    store.isSegmentCountBackpressureActive());
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -231,6 +231,17 @@ public final class IndexingServerConfiguration {
             "vector.index.compaction.backpressure.segments";
     public static final int PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_SEGMENTS_DEFAULT = 500;
 
+    /**
+     * Maximum wall-clock time (ms) an apply thread may spend in segment-count
+     * back-pressure before it is force-released with a SEVERE log (issue #370).
+     * Default is 300 000 ms (5 minutes).  Set to {@link Long#MAX_VALUE} to
+     * disable the safety timeout.
+     */
+    public static final String PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_MAX_WAIT_MS =
+            "vector.index.compaction.backpressure.max.wait.ms";
+    public static final long PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_MAX_WAIT_MS_DEFAULT =
+            300_000L;
+
     // Apply parallelism
     public static final String PROPERTY_APPLY_PARALLELISM = "indexing.apply.parallelism";
     public static final int PROPERTY_APPLY_PARALLELISM_DEFAULT = 0; // 0 = auto: max(1, availableProcessors/2)

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -515,9 +515,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             final int vectorCompactionBackpressureSegments = config.getInt(
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_SEGMENTS,
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_SEGMENTS_DEFAULT);
+            final long vectorCompactionBackpressureMaxWaitMs = config.getLong(
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_MAX_WAIT_MS,
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_BACKPRESSURE_MAX_WAIT_MS_DEFAULT);
             LOGGER.log(Level.INFO,
-                    "vector index compaction: tieredEnabled={0}, backpressureSegments={1}",
-                    new Object[]{vectorCompactionTieredEnabled, vectorCompactionBackpressureSegments});
+                    "vector index compaction: tieredEnabled={0}, backpressureSegments={1}, "
+                            + "backpressureMaxWaitMs={2}",
+                    new Object[]{vectorCompactionTieredEnabled, vectorCompactionBackpressureSegments,
+                            vectorCompactionBackpressureMaxWaitMs});
             final long maxLiveBytesPerCheckpoint = config.getLong(
                     IndexingServerConfiguration.PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT,
                     IndexingServerConfiguration.PROPERTY_VECTOR_MAX_LIVE_BYTES_PER_CHECKPOINT_DEFAULT);
@@ -619,6 +624,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         vectorCompactionRetentionMs);
                 store.setTieredCompactionEnabled(vectorCompactionTieredEnabled);
                 store.setCompactionBackpressureThreshold(vectorCompactionBackpressureSegments);
+                store.setCompactionBackpressureMaxWaitMs(vectorCompactionBackpressureMaxWaitMs);
                 try {
                     store.start();
                 } catch (Exception e) {
@@ -2638,6 +2644,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 @Override
                 public Long getSample() {
                     return pvs.getSegmentCountBackpressureTimeMs();
+                }
+            });
+            indexStats.registerGauge("segment_count_backpressure_timeouts", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getSegmentCountBackpressureTimeouts();
                 }
             });
             indexStats.registerGauge("max_vector_memory_bytes", new Gauge<Long>() {

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -2302,6 +2302,45 @@
               "show": true
             }
           ]
+        },
+        {
+          "datasource": "Prometheus",
+          "id": 617,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_count_backpressure_timeouts\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0.5",
+          "title": "Back-Pressure Safety Timeout Fires (cumulative)",
+          "description": "Number of times the segment-count back-pressure safety timeout (vector.index.compaction.backpressure.max.wait.ms, default 300 s) fired and force-released a blocked addVector caller because compaction could not drain the segment count below the threshold. Any non-zero value means the IS was at risk of a permanent hang; investigate compaction failure logs (SEVERE entries) and consider adjusting compaction policy or raising the back-pressure threshold.",
+          "type": "singlestat",
+          "valueName": "current",
+          "colorBackground": true,
+          "colors": [
+            "#299c46",
+            "#d44a3a",
+            "#d44a3a"
+          ],
+          "valueMaps": [
+            {
+              "value": "0",
+              "text": "OK",
+              "op": "="
+            }
+          ],
+          "rangeMaps": [
+            {
+              "from": "1",
+              "to": "999999999",
+              "text": "TIMEOUT FIRED"
+            }
+          ]
         }
       ],
       "showTitle": true,


### PR DESCRIPTION
Fixes #370.

## Changes

- **`PersistentVectorStore.java`** — Fix 1: add `notifySegmentCountMonitor()` to the `candidates.isEmpty()` early-return path and to all three exception catch blocks (`CompactionException`, `IOException`, `DataStorageManagerException`) in `runCompactionCycle()` for immediate wakeup of parked apply threads. Fix 2: add a configurable `compactionBackpressureMaxWaitMs` field (default 300 s) and a safety-timeout loop inside `waitForSegmentCountRelief()` that force-releases the blocked caller with SEVERE log when the deadline expires; validates input (`> 0`; `Long.MAX_VALUE` disables), adds overflow-safe deadline computation. Fix 3: add `notifySegmentCountMonitor()` to the outer `finally` of `runCompactionCycle()` as a belt-and-suspenders backstop covering unchecked-exception paths (e.g. `RuntimeException` from `createTempPagedPkSet` / `createTempCompactionAuthorityMap`) that bypass the per-catch notifies. Also: `segmentCountBackpressureTimeouts` counter, `setCompactionBackpressureMaxWaitMs(long)` setter, test-visible getters `getSegmentCountBackpressureTimeouts()` / `getSegmentCountGeneration()` (synchronized on monitor for safe cross-thread reads).

- **`IndexingServerConfiguration.java`** — add `vector.index.compaction.backpressure.max.wait.ms` property constant (default 300 000 ms).

- **`IndexingServiceEngine.java`** — read the new property, call `store.setCompactionBackpressureMaxWaitMs(...)` in the store factory, and register a `segment_count_backpressure_timeouts` metric.

- **`indexing-service-dashboard.json`** — add `segment_count_backpressure_timeouts` singlestat panel (green=OK, red=TIMEOUT FIRED) to the Segment-Count Back-Pressure row.

## Tests

- **`Issue370BackpressureDeadlockTest`** (6 tests, `herddb-core`, plain):
  1. `emptyCandidatesPathNotifiesSegmentCountMonitor` — generation counter increments when cycle finds empty candidates (Bug A fix).
  2. `backpressureReleasesAfterTimeoutWhenCompactionCannotHelp` — blocked thread released after 5 s timeout; `segmentCountBackpressureTimeouts >= 1`; segment count unchanged.
  3. `uncheckedExceptionInCompactionNotifiesMonitorViaOuterFinally` — injects `DataStorageManagerException` from a `MemoryDataStorageManager` subclass for `_tmp_cmpaut_*` names; asserts generation increments even though `RuntimeException` bypasses all inner catch blocks.
  4. `setCompactionBackpressureMaxWaitMsRejectsZero` / `…RejectsNegative` — `IllegalArgumentException` on invalid input.
  5. `backpressureReleasesAfterSuccessfulCompactionWithoutTimeout` — regression guard; timeout counter stays zero on happy path.

## Validation

- All 8 tests pass (`Issue370BackpressureDeadlockTest` + `Issue354SegmentCountBackpressureTest`).
- `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` passes.
- Hammer suite run twice (both passes green):
  ```
  DirectMultipleConcurrentUpdatesSuiteNoIndexesTest        — 4/4 PASS
  DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest — 4/4 PASS
  DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest — 4/4 PASS
  ```
  The back-pressure/notify change is contained to the vector-index path and does not touch the primary-key index or checkpoint pipeline; hammer suite passes confirm no regression in the transaction isolation / checkpoint machinery.

🤖 Implemented by the `pr-worker` agent.