### PR TITLE
issue #373: fix SegmentBlockCache removal-listener dispatch to be synchronous

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -100,6 +100,15 @@ public final class SegmentBlockCache {
             this.cache = Caffeine.newBuilder()
                     .maximumWeight(maxBytes)
                     .weigher((BlockKey k, ByteBuf v) -> v == null ? 0 : v.capacity())
+                    // Use a synchronous (caller-thread) executor so that the
+                    // removal listener is invoked inline during the maintenance
+                    // pass rather than dispatched asynchronously to
+                    // ForkJoinPool.commonPool(). This guarantees that after
+                    // cleanUp() or invalidateAll() returns, every
+                    // safeRelease() has already executed and no ByteBuf
+                    // reference is left dangling. The listener only does an
+                    // atomic ref-count decrement, so the cost is negligible.
+                    .executor(Runnable::run)
                     .removalListener((BlockKey k, ByteBuf v, RemovalCause cause) -> {
                         // Release the cache's reference when the entry leaves
                         // the cache. Callers receive retained slices, so an

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheHammerTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheHammerTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -256,13 +255,6 @@ public class SegmentBlockCacheHammerTest {
         // All remaining cached entries must be releasable cleanly.
         cache.clear();
         cache.cleanUp();
-        // Caffeine dispatches removal-listener calls through
-        // ForkJoinPool.commonPool() asynchronously (via executor.execute()).
-        // cleanUp() triggers the maintenance pass that *schedules* those calls,
-        // but they may not have run yet by the time we inspect refCounts.
-        // awaitQuiescence() blocks until the common pool has no remaining tasks,
-        // guaranteeing every safeRelease() has completed before the assertions.
-        ForkJoinPool.commonPool().awaitQuiescence(10, TimeUnit.SECONDS);
         assertEquals("cache fully drained", 0L, cache.estimatedSize());
 
         // Final invariant: every buffer the loader allocated must now be

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheHammerTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheHammerTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -255,6 +256,13 @@ public class SegmentBlockCacheHammerTest {
         // All remaining cached entries must be releasable cleanly.
         cache.clear();
         cache.cleanUp();
+        // Caffeine dispatches removal-listener calls through
+        // ForkJoinPool.commonPool() asynchronously (via executor.execute()).
+        // cleanUp() triggers the maintenance pass that *schedules* those calls,
+        // but they may not have run yet by the time we inspect refCounts.
+        // awaitQuiescence() blocks until the common pool has no remaining tasks,
+        // guaranteeing every safeRelease() has completed before the assertions.
+        ForkJoinPool.commonPool().awaitQuiescence(10, TimeUnit.SECONDS);
         assertEquals("cache fully drained", 0L, cache.estimatedSize());
 
         // Final invariant: every buffer the loader allocated must now be


### PR DESCRIPTION
Fixes #373.

## Root cause

Caffeine dispatches removal-listener calls through `ForkJoinPool.commonPool()`
**asynchronously** by default (confirmed in Caffeine 3.1.8 bytecode:
`notifyRemoval()` calls `executor.execute(runnable)`). After `cache.cleanUp()`
or `invalidateAll()` returns, those ForkJoinPool tasks may not have run yet,
leaving `ByteBuf` references with `refCnt > 0`. On CI machines with few CPUs
the ForkJoinPool tasks genuinely lag behind the test thread, making the
`SegmentBlockCacheHammerTest` refCount assertions flaky.

## Changes

- **`SegmentBlockCache.java`** — add `.executor(Runnable::run)` to the Caffeine
  builder. This makes the removal listener run inline in the maintenance thread
  rather than being dispatched to a ForkJoinPool. Every `safeRelease()` now
  completes before `cleanUp()` / `invalidateAll()` returns. The listener only
  does an atomic ref-count decrement so the synchronous overhead is negligible.

- **`SegmentBlockCacheHammerTest.java`** — restored to its original form
  (reverted a previous `ForkJoinPool.awaitQuiescence` workaround that coupled
  the test to Caffeine internals and ignored the return value of `awaitQuiescence`).

## Tests

- `SegmentBlockCacheHammerTest` — 20/20 local runs pass.
- `SegmentBlockCacheTest` — existing unit suite unaffected, all 13 tests green.

🤖 Implemented by the `pr-worker` agent.