### PR TITLE
issue #336: add disk-cache metrics, gRPC admin service, and fileserver-admin CLI

### DIFF
--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/remote-file-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/remote-file-service-dashboard.json
@@ -1975,6 +1975,299 @@
       "showTitle": false,
       "title": "GC Row",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 210,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_disk_cache_hit_bytes{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hit bytes/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(rfs_disk_cache_miss_bytes{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "miss bytes/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Disk Cache Hit / Miss Bytes (1m)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 211,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_disk_cache_hit_count{instance=~\"$instance\"}[1m]) / clamp_min(rate(rfs_disk_cache_hit_count{instance=~\"$instance\"}[1m]) + rate(rfs_disk_cache_miss_count{instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hit ratio [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "title": "Disk Cache Hit Ratio (1m)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "logBase": 1,
+              "max": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Disk Cache Rates Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 212,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rfs_disk_cache_max_bytes{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "max [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "title": "Disk Cache Max Bytes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 213,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_disk_cache_eviction_count{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "evictions [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_disk_cache_estimated_entries{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "entries [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Disk Cache Evictions (1m) & Entries",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Disk Cache Size Row",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,

--- a/herddb-kubernetes/src/main/helm/herddb/templates/_helpers.tpl
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/_helpers.tpl
@@ -102,3 +102,15 @@ address is needed in the JDBC URL even when server.mode=cluster.
     .Release.Namespace
     (int .Values.server.port) -}}
 {{- end }}
+
+{{/*
+gRPC address of the first file-server pod, used by fileserver-admin CLI.
+The admin service shares the same gRPC port as the data-plane service.
+*/}}
+{{- define "herddb.fileServerAdminAddress" -}}
+{{- printf "%s-file-server-0.%s-file-server.%s.svc.cluster.local:%d"
+    (include "herddb.fullname" .)
+    (include "herddb.fullname" .)
+    .Release.Namespace
+    (int .Values.fileServer.port) -}}
+{{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-configmap.yaml
@@ -13,6 +13,9 @@ data:
   indexing-admin: |
     #!/bin/bash
     exec /opt/herddb/bin/indexing-admin.sh "$@"
+  fileserver-admin: |
+    #!/bin/bash
+    exec /opt/herddb/bin/fileserver-admin.sh "$@"
   vector-bench: |
     #!/bin/bash
     exec /opt/herddb/bin/vector-bench.sh "$@"

--- a/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/tools-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
               value: {{ include "herddb.jdbcUrl" . | quote }}
             - name: HERDDB_INDEXING_ZK
               value: {{ include "herddb.zkAddress" . | quote }}
+            - name: HERDDB_FILESERVER_SERVER
+              value: {{ include "herddb.fileServerAdminAddress" . | quote }}
             - name: JAVA_OPTS
               value: {{ .Values.tools.javaOpts | default "-Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true" | quote }}
             - name: VECTORBENCH_DATASET_DIR
@@ -83,6 +85,9 @@ spec:
             - name: tools-scripts
               mountPath: /usr/local/bin/indexing-admin
               subPath: indexing-admin
+            - name: tools-scripts
+              mountPath: /usr/local/bin/fileserver-admin
+              subPath: fileserver-admin
             - name: datasets
               mountPath: /opt/herddb/vector-datasets
       volumes:

--- a/herddb-remote-file-service/pom.xml
+++ b/herddb-remote-file-service/pom.xml
@@ -111,14 +111,25 @@
             <artifactId>jetty-servlet</artifactId>
             <version>9.4.51.v20230217</version>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <!--
+          slf4j-jdk14 is included at compile scope so it is bundled into the
+          shaded fileserver-admin-cli uber jar. Without it slf4j-api 2.x would
+          fall back to the NOP logger inside the standalone CLI jar and print
+          a "No SLF4J providers were found" warning (mirrors the setup in
+          herddb-indexing-service, issue #336).
+        -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+        <!-- Used by the fileserver-admin CLI (herddb.remote.admin package, issue #336). -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
         <!--
@@ -182,6 +193,69 @@
                         <DOCKER_API_VERSION>1.43</DOCKER_API_VERSION>
                     </environmentVariables>
                 </configuration>
+            </plugin>
+            <!--
+              Secondary shade execution that produces
+              herddb-remote-file-service-<version>-admin-cli.jar, an uber-jar
+              bundling the main remote-file-service classes plus commons-cli,
+              with herddb.remote.admin.FileServerAdminCli as Main-Class.
+
+              Used by the fileserver-admin launcher script shipped in
+              herddb-services; the regular (unshaded) jar produced by
+              maven-jar-plugin is unaffected and is the artifact published
+              for downstream modules. Mirrors the pattern in
+              herddb-indexing-service (issue #336).
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fileserver-admin-cli</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>admin-cli</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>herddb.remote.admin.FileServerAdminCli</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <!--
+                                  log4j-slf4j-impl is pulled in transitively
+                                  via bookkeeper-server. It targets the
+                                  slf4j 1.7 API and does not register as a
+                                  ServiceLoader provider for slf4j 2.x, so
+                                  leaving it in the uber jar produces a
+                                  spurious "No SLF4J providers were found"
+                                  warning and a log4j getCallerClass warning
+                                  on modern JDKs. slf4j-jdk14 (above) is the
+                                  actual provider we want to use.
+                                -->
+                                <filter>
+                                    <artifact>org.apache.logging.log4j:log4j-slf4j-impl</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -24,6 +24,7 @@ import herddb.auth.oidc.OidcBootstrap;
 import herddb.auth.oidc.OidcTokenValidator;
 import herddb.auth.oidc.grpc.JwtAuthServerInterceptor;
 import herddb.metadata.MetadataStorageManager;
+import herddb.remote.admin.RemoteFileServerAdminImpl;
 import herddb.remote.storage.CachingObjectStorage;
 import herddb.remote.storage.InMemoryBlockCacheObjectStorage;
 import herddb.remote.storage.LocalObjectStorage;
@@ -72,6 +73,10 @@ import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 /**
  * Configurable gRPC server for RemoteFileService.
  * Supports local filesystem (default) and S3 storage backends via {@code storage.mode} property.
+ * <p>
+ * Also hosts the {@link RemoteFileServerAdminImpl} gRPC admin service on the same port
+ * (issue #336): operators can query cache stats and resize the disk cache at runtime
+ * without restarting the pod.
  *
  * @author enrico.olivelli
  */
@@ -116,6 +121,12 @@ public class RemoteFileServer implements AutoCloseable {
     private org.eclipse.jetty.server.Server httpServer;
     private MetadataStorageManager metadataStorageManager;
     private String registeredServiceId;
+    /** Non-null when storage.mode=s3; exposed to {@link RemoteFileServerAdminImpl} (issue #336). */
+    private CachingObjectStorage diskCache;
+    /** Non-null when block.cache.enabled=true; exposed to {@link RemoteFileServerAdminImpl} (issue #336). */
+    private InMemoryBlockCacheObjectStorage blockCacheRef;
+    /** Storage mode string used in admin GetServerInfo response. */
+    private String storageMode;
 
     public RemoteFileServer(String host, int port, Path dataDirectory, int ioThreads, Properties config) {
         this.host = host;
@@ -167,7 +178,7 @@ public class RemoteFileServer implements AutoCloseable {
         readExecutor = buildLaneExecutor("remote-file-read-exec-", readExecutorThreads);
         writeExecutor = buildLaneExecutor("remote-file-write-exec-", writeExecutorThreads);
 
-        String storageMode = config.getProperty("storage.mode", "local");
+        storageMode = config.getProperty("storage.mode", "local");
         if ("s3".equals(storageMode)) {
             objectStorage = buildS3ObjectStorage(statsLogger);
         } else {
@@ -192,8 +203,12 @@ public class RemoteFileServer implements AutoCloseable {
         } else {
             LOGGER.log(Level.INFO, "block cache disabled");
         }
+        blockCacheRef = blockCache;
         if (blockCache != null) {
             registerBlockCacheGauges(statsLogger, blockCache);
+        }
+        if (diskCache != null) {
+            registerDiskCacheGauges(statsLogger, diskCache);
         }
 
         int ioRatio = Integer.getInteger("herddb.fileserver.netty.ioRatio", DEFAULT_IO_RATIO);
@@ -218,6 +233,9 @@ public class RemoteFileServer implements AutoCloseable {
                 .workerEventLoopGroup(workerGroup)
                 .channelType(NioServerSocketChannel.class)
                 .addService(serviceImpl)
+                // Admin service (issue #336): live cache stats and disk-cache resize.
+                // Runs on the same port as the data service; gRPC multiplexes by service name.
+                .addService(new RemoteFileServerAdminImpl(this))
                 .maxInboundMessageSize(blockSize + 1024 * 1024);
         if (OidcBootstrap.isEnabled(config)) {
             try {
@@ -270,6 +288,39 @@ public class RemoteFileServer implements AutoCloseable {
                 new Object[]{port, storageMode, ioThreads, ioRatio, this.blockSize,
                         readExecutorThreads, writeExecutorThreads});
     }
+
+    // -----------------------------------------------------------------------
+    // Admin accessors (issue #336) — used by RemoteFileServerAdminImpl
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the on-disk cache instance, or {@code null} when storage.mode is not s3.
+     * Used by {@link herddb.remote.admin.RemoteFileServerAdminImpl} to query stats
+     * and resize the cache at runtime.
+     */
+    public CachingObjectStorage getDiskCache() {
+        return diskCache;
+    }
+
+    /**
+     * Returns the in-heap block cache instance, or {@code null} when disabled.
+     * Used by {@link herddb.remote.admin.RemoteFileServerAdminImpl} to expose stats.
+     */
+    public InMemoryBlockCacheObjectStorage getBlockCache() {
+        return blockCacheRef;
+    }
+
+    /**
+     * Returns the configured storage mode string ({@code "s3"} or {@code "local"}).
+     * Available after {@link #start()} completes.
+     */
+    public String getStorageMode() {
+        return storageMode != null ? storageMode : "local";
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
 
     private ThreadPoolExecutor buildLaneExecutor(String namePrefix, int threads) {
         AtomicInteger counter = new AtomicInteger();
@@ -419,7 +470,11 @@ public class RemoteFileServer implements AutoCloseable {
 
         S3ObjectStorage s3Storage = new S3ObjectStorage(s3Client, bucket, s3Prefix, statsLogger);
         try {
-            return new CachingObjectStorage(s3Storage, cacheDirPath, metadataExecutor, cacheMaxBytes);
+            CachingObjectStorage cache = new CachingObjectStorage(
+                    s3Storage, cacheDirPath, metadataExecutor, cacheMaxBytes);
+            // Keep the reference so RemoteFileServerAdminImpl can read stats and resize.
+            diskCache = cache;
+            return cache;
         } catch (IOException e) {
             s3Client.close();
             throw e;
@@ -532,6 +587,91 @@ public class RemoteFileServer implements AutoCloseable {
             @Override
             public Long getSample() {
                 return cache.stats().evictionWeight();
+            }
+        });
+    }
+
+    /**
+     * Registers Prometheus gauges for the on-disk cache ({@link CachingObjectStorage})
+     * under the {@code rfs_disk_cache_*} namespace (issue #336).
+     */
+    private static void registerDiskCacheGauges(StatsLogger root, CachingObjectStorage cache) {
+        StatsLogger scope = root.scope("rfs").scope("disk_cache");
+        scope.registerGauge("max_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.getMaxCacheBytes();
+            }
+        });
+        scope.registerGauge("estimated_entries", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.estimatedEntries();
+            }
+        });
+        scope.registerGauge("hit_count", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.diskLruStats().hitCount();
+            }
+        });
+        scope.registerGauge("miss_count", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.diskLruStats().missCount();
+            }
+        });
+        scope.registerGauge("eviction_count", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.diskLruStats().evictionCount();
+            }
+        });
+        scope.registerGauge("hit_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.getHitBytes();
+            }
+        });
+        scope.registerGauge("miss_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.getMissBytes();
             }
         });
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/admin/FileServerAdminCli.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/admin/FileServerAdminCli.java
@@ -94,11 +94,10 @@ public final class FileServerAdminCli {
         } catch (ParseException e) {
             err.println("Invalid arguments: " + e.getMessage());
             return 2;
-        } catch (RuntimeException e) {
-            err.println("ERROR: " + e.getMessage());
-            return 1;
         } catch (Exception e) {
-            err.println("ERROR: " + e.getMessage());
+            // Broad catch: top-level CLI entry point; any unhandled exception must map to
+            // a non-zero exit code rather than an unformatted stack trace on stderr.
+            err.println("ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage());
             return 1;
         }
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/admin/FileServerAdminCli.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/admin/FileServerAdminCli.java
@@ -1,0 +1,325 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.admin;
+
+import herddb.remote.proto.GetServerInfoResponse;
+import herddb.remote.proto.ResizeDiskCacheResponse;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Diagnostic and management CLI for a HerdDB file-server instance (issue #336).
+ *
+ * <p>Usage:
+ * <pre>
+ *   fileserver-admin &lt;command&gt; [options]
+ *
+ *   Commands:
+ *     server-info    Print identity, JVM, disk-cache and block-cache stats
+ *     resize-cache   Dynamically resize the disk-cache LRU (non-persistent)
+ * </pre>
+ *
+ * <p>All RPCs target one file-server pod selected via {@code --server host:port}.
+ *
+ * @author enrico.olivelli
+ */
+public final class FileServerAdminCli {
+
+    static final String COMMAND_SERVER_INFO = "server-info";
+    static final String COMMAND_RESIZE_CACHE = "resize-cache";
+
+    private final PrintStream out;
+    private final PrintStream err;
+
+    public FileServerAdminCli(PrintStream out, PrintStream err) {
+        this.out = out;
+        this.err = err;
+    }
+
+    public static void main(String[] args) {
+        int rc = new FileServerAdminCli(System.out, System.err).run(args);
+        System.exit(rc);
+    }
+
+    /**
+     * Entry point used by {@link #main(String[])} and by tests.
+     * Returns 0 on success, 1 on command failure, 2 on bad usage.
+     */
+    public int run(String[] args) {
+        if (args.length == 0 || "-h".equals(args[0]) || "--help".equals(args[0])) {
+            printUsage();
+            return args.length == 0 ? 2 : 0;
+        }
+        String command = args[0];
+        String[] rest = Arrays.copyOfRange(args, 1, args.length);
+        try {
+            switch (command) {
+                case COMMAND_SERVER_INFO:
+                    return runServerInfo(rest);
+                case COMMAND_RESIZE_CACHE:
+                    return runResizeCache(rest);
+                default:
+                    err.println("Unknown command: " + command);
+                    printUsage();
+                    return 2;
+            }
+        } catch (ParseException e) {
+            err.println("Invalid arguments: " + e.getMessage());
+            return 2;
+        } catch (RuntimeException e) {
+            err.println("ERROR: " + e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            err.println("ERROR: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    private void printUsage() {
+        out.println("Usage: fileserver-admin <command> [options]");
+        out.println();
+        out.println("Commands:");
+        out.println("  server-info    Print identity, JVM, disk-cache and block-cache stats");
+        out.println("  resize-cache   Dynamically resize the disk-cache LRU (non-persistent)");
+        out.println();
+        out.println("Run 'fileserver-admin <command> --help' for command-specific flags.");
+    }
+
+    // ---------------------------------------------------------------
+    // Command implementations
+    // ---------------------------------------------------------------
+
+    private int runServerInfo(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+
+        CommandLine cli = parse(opts, args, COMMAND_SERVER_INFO);
+        if (cli == null) {
+            return 0;
+        }
+        try (FileServerAdminClient client = buildClient(cli)) {
+            GetServerInfoResponse resp = client.getServerInfo();
+            if (cli.hasOption("json")) {
+                out.println(toJson(serverInfoToMap(resp)));
+            } else {
+                printServerInfoText(resp);
+            }
+        }
+        return 0;
+    }
+
+    private int runResizeCache(String[] args) throws Exception {
+        Options opts = new Options();
+        addCommonOptions(opts);
+        addServerOption(opts);
+        opts.addOption(Option.builder().longOpt("max-bytes").hasArg().argName("BYTES")
+                .desc("new maximum size for the disk-cache LRU in bytes (required)").required().build());
+
+        CommandLine cli = parse(opts, args, COMMAND_RESIZE_CACHE);
+        if (cli == null) {
+            return 0;
+        }
+        long newMax = Long.parseLong(cli.getOptionValue("max-bytes"));
+        try (FileServerAdminClient client = buildClient(cli)) {
+            ResizeDiskCacheResponse resp = client.resizeDiskCache(newMax);
+            if (cli.hasOption("json")) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("previous_max_bytes", resp.getPreviousMaxBytes());
+                m.put("new_max_bytes", resp.getNewMaxBytes());
+                out.println(toJson(m));
+            } else {
+                out.printf(Locale.ROOT,
+                        "disk cache resized: previous=%d bytes (%d MiB), new=%d bytes (%d MiB)%n",
+                        resp.getPreviousMaxBytes(), resp.getPreviousMaxBytes() / (1024 * 1024),
+                        resp.getNewMaxBytes(), resp.getNewMaxBytes() / (1024 * 1024));
+            }
+        }
+        return 0;
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static void addCommonOptions(Options opts) {
+        opts.addOption(Option.builder("h").longOpt("help")
+                .desc("show help for this command").build());
+        opts.addOption(Option.builder().longOpt("json")
+                .desc("emit JSON instead of plain text").build());
+        opts.addOption(Option.builder().longOpt("timeout-seconds").hasArg().argName("SECS")
+                .desc("gRPC call deadline in seconds (default 30)").build());
+    }
+
+    private static void addServerOption(Options opts) {
+        opts.addOption(Option.builder().longOpt("server").hasArg().argName("HOST:PORT")
+                .desc("file-server gRPC endpoint (required)").required().build());
+    }
+
+    private CommandLine parse(Options opts, String[] args, String commandName) throws ParseException {
+        if (args.length == 1 && ("-h".equals(args[0]) || "--help".equals(args[0]))) {
+            java.io.PrintWriter pw = new java.io.PrintWriter(
+                    new java.io.OutputStreamWriter(out, java.nio.charset.StandardCharsets.UTF_8), true);
+            HelpFormatter hf = new HelpFormatter();
+            hf.printHelp(pw, 100, "fileserver-admin " + commandName + " [options]",
+                    "", opts, 2, 4, "", true);
+            pw.flush();
+            return null;
+        }
+        CommandLineParser parser = new DefaultParser();
+        return parser.parse(opts, args);
+    }
+
+    private FileServerAdminClient buildClient(CommandLine cli) {
+        long timeout = Long.parseLong(cli.getOptionValue("timeout-seconds", "30"));
+        return new FileServerAdminClient(cli.getOptionValue("server"), timeout);
+    }
+
+    private static Map<String, Object> serverInfoToMap(GetServerInfoResponse r) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("grpc_host", r.getGrpcHost());
+        m.put("grpc_port", r.getGrpcPort());
+        m.put("storage_mode", r.getStorageMode());
+        m.put("jvm_heap_used_bytes", r.getJvmHeapUsedBytes());
+        m.put("jvm_heap_max_bytes", r.getJvmHeapMaxBytes());
+        // disk cache
+        m.put("disk_cache_max_bytes", r.getDiskCacheMaxBytes());
+        m.put("disk_cache_hit_count", r.getDiskCacheHitCount());
+        m.put("disk_cache_miss_count", r.getDiskCacheMissCount());
+        m.put("disk_cache_eviction_count", r.getDiskCacheEvictionCount());
+        m.put("disk_cache_hit_bytes", r.getDiskCacheHitBytes());
+        m.put("disk_cache_miss_bytes", r.getDiskCacheMissBytes());
+        m.put("disk_cache_estimated_entries", r.getDiskCacheEstimatedEntries());
+        // block cache
+        m.put("block_cache_max_bytes", r.getBlockCacheMaxBytes());
+        m.put("block_cache_estimated_bytes", r.getBlockCacheEstimatedBytes());
+        m.put("block_cache_estimated_entries", r.getBlockCacheEstimatedEntries());
+        m.put("block_cache_hits", r.getBlockCacheHits());
+        m.put("block_cache_misses", r.getBlockCacheMisses());
+        m.put("block_cache_evictions", r.getBlockCacheEvictions());
+        return m;
+    }
+
+    private void printServerInfoText(GetServerInfoResponse r) {
+        out.println("Server info:");
+        out.printf(Locale.ROOT, "  grpc_host          = %s%n", r.getGrpcHost());
+        out.printf(Locale.ROOT, "  grpc_port          = %d%n", r.getGrpcPort());
+        out.printf(Locale.ROOT, "  storage_mode       = %s%n", r.getStorageMode());
+        long heapMiB = r.getJvmHeapMaxBytes() / (1024 * 1024);
+        long heapUsedMiB = r.getJvmHeapUsedBytes() / (1024 * 1024);
+        out.printf(Locale.ROOT, "  jvm_heap           = %d / %d MiB%n", heapUsedMiB, heapMiB);
+        out.println();
+        out.println("Disk cache (s3 disk-cache LRU):");
+        if (r.getDiskCacheMaxBytes() == 0) {
+            out.println("  (not available — storage.mode is not s3)");
+        } else {
+            long maxMiB = r.getDiskCacheMaxBytes() / (1024 * 1024);
+            long hitTotal = r.getDiskCacheHitCount() + r.getDiskCacheMissCount();
+            double hitRatio = hitTotal > 0
+                    ? (100.0 * r.getDiskCacheHitCount() / hitTotal)
+                    : 0.0;
+            out.printf(Locale.ROOT, "  max_bytes          = %d (%d MiB)%n",
+                    r.getDiskCacheMaxBytes(), maxMiB);
+            out.printf(Locale.ROOT, "  estimated_entries  = %d%n", r.getDiskCacheEstimatedEntries());
+            out.printf(Locale.ROOT, "  hit_count          = %d%n", r.getDiskCacheHitCount());
+            out.printf(Locale.ROOT, "  miss_count         = %d%n", r.getDiskCacheMissCount());
+            out.printf(Locale.ROOT, "  hit_ratio          = %.1f%%%n", hitRatio);
+            out.printf(Locale.ROOT, "  eviction_count     = %d%n", r.getDiskCacheEvictionCount());
+            out.printf(Locale.ROOT, "  hit_bytes          = %d (%d MiB)%n",
+                    r.getDiskCacheHitBytes(), r.getDiskCacheHitBytes() / (1024 * 1024));
+            out.printf(Locale.ROOT, "  miss_bytes         = %d (%d MiB)%n",
+                    r.getDiskCacheMissBytes(), r.getDiskCacheMissBytes() / (1024 * 1024));
+        }
+        out.println();
+        out.println("Block cache (in-heap block LRU):");
+        if (r.getBlockCacheMaxBytes() == 0) {
+            out.println("  (not available — block.cache.enabled=false)");
+        } else {
+            long bcMaxMiB = r.getBlockCacheMaxBytes() / (1024 * 1024);
+            long bcSizeMiB = r.getBlockCacheEstimatedBytes() / (1024 * 1024);
+            long bcHitTotal = r.getBlockCacheHits() + r.getBlockCacheMisses();
+            double bcHitRatio = bcHitTotal > 0
+                    ? (100.0 * r.getBlockCacheHits() / bcHitTotal)
+                    : 0.0;
+            out.printf(Locale.ROOT, "  max_bytes          = %d (%d MiB)%n",
+                    r.getBlockCacheMaxBytes(), bcMaxMiB);
+            out.printf(Locale.ROOT, "  estimated_bytes    = %d (%d MiB)%n",
+                    r.getBlockCacheEstimatedBytes(), bcSizeMiB);
+            out.printf(Locale.ROOT, "  estimated_entries  = %d%n", r.getBlockCacheEstimatedEntries());
+            out.printf(Locale.ROOT, "  hits               = %d%n", r.getBlockCacheHits());
+            out.printf(Locale.ROOT, "  misses             = %d%n", r.getBlockCacheMisses());
+            out.printf(Locale.ROOT, "  hit_ratio          = %.1f%%%n", bcHitRatio);
+            out.printf(Locale.ROOT, "  evictions          = %d%n", r.getBlockCacheEvictions());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Minimal JSON serialiser (no external deps)
+    // ---------------------------------------------------------------
+
+    /**
+     * Converts a {@code Map<String, Object>} to a compact JSON string.
+     * Supports Long, Integer, Double, Boolean, String, and null values.
+     */
+    static String toJson(Map<String, Object> map) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(escapeJson(entry.getKey())).append('"').append(':');
+            appendJsonValue(sb, entry.getValue());
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static void appendJsonValue(StringBuilder sb, Object value) {
+        if (value == null) {
+            sb.append("null");
+        } else if (value instanceof String) {
+            sb.append('"').append(escapeJson((String) value)).append('"');
+        } else if (value instanceof Boolean) {
+            sb.append(value);
+        } else if (value instanceof Number) {
+            sb.append(value);
+        } else {
+            sb.append('"').append(escapeJson(value.toString())).append('"');
+        }
+    }
+
+    private static String escapeJson(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"")
+                .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/admin/FileServerAdminClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/admin/FileServerAdminClient.java
@@ -1,0 +1,99 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.admin;
+
+import herddb.remote.proto.GetServerInfoRequest;
+import herddb.remote.proto.GetServerInfoResponse;
+import herddb.remote.proto.RemoteFileServerAdminGrpc;
+import herddb.remote.proto.ResizeDiskCacheRequest;
+import herddb.remote.proto.ResizeDiskCacheResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thin blocking gRPC client for the {@link RemoteFileServerAdminImpl} admin service.
+ * <p>
+ * Targets exactly one file-server {@code host:port} selected by the CLI user.
+ * Unlike the data-plane {@link herddb.remote.RemoteFileServiceClient}, this class
+ * does not participate in ZooKeeper discovery or fan out to multiple replicas.
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * try (FileServerAdminClient client = new FileServerAdminClient("localhost:9845", 30)) {
+ *     GetServerInfoResponse info = client.getServerInfo();
+ *     ...
+ * }
+ * }</pre>
+ *
+ * @author enrico.olivelli
+ */
+public final class FileServerAdminClient implements Closeable {
+
+    private final ManagedChannel channel;
+    private final RemoteFileServerAdminGrpc.RemoteFileServerAdminBlockingStub stub;
+    private final long timeoutSeconds;
+
+    public FileServerAdminClient(String target, long timeoutSeconds) {
+        this.channel = ManagedChannelBuilder.forTarget(target)
+                .usePlaintext()
+                .keepAliveTime(60, TimeUnit.SECONDS)
+                .keepAliveTimeout(20, TimeUnit.SECONDS)
+                .build();
+        this.stub = RemoteFileServerAdminGrpc.newBlockingStub(channel);
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    private RemoteFileServerAdminGrpc.RemoteFileServerAdminBlockingStub stub() {
+        return stub.withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Returns a snapshot of server identity, JVM stats, and both cache layers.
+     */
+    public GetServerInfoResponse getServerInfo() {
+        return stub().getServerInfo(GetServerInfoRequest.newBuilder().build());
+    }
+
+    /**
+     * Resizes the on-disk cache LRU to {@code newMaxBytes}.
+     * Returns the previous and new limits. The change is not persistent.
+     */
+    public ResizeDiskCacheResponse resizeDiskCache(long newMaxBytes) {
+        return stub().resizeDiskCache(ResizeDiskCacheRequest.newBuilder()
+                .setNewMaxBytes(newMaxBytes)
+                .build());
+    }
+
+    @Override
+    public void close() {
+        channel.shutdown();
+        try {
+            if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                channel.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            channel.shutdownNow();
+        }
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/admin/RemoteFileServerAdminImpl.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/admin/RemoteFileServerAdminImpl.java
@@ -104,6 +104,8 @@ public class RemoteFileServerAdminImpl extends RemoteFileServerAdminGrpc.RemoteF
             responseObserver.onNext(builder.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
+            // Broad catch: gRPC service entry point — must not let an unchecked exception
+            // kill the worker thread without returning a status reply to the client.
             LOGGER.log(Level.WARNING, "GetServerInfo failed", e);
             responseObserver.onError(
                     Status.INTERNAL.withDescription(e.getMessage()).withCause(e).asRuntimeException());

--- a/herddb-remote-file-service/src/main/java/herddb/remote/admin/RemoteFileServerAdminImpl.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/admin/RemoteFileServerAdminImpl.java
@@ -1,0 +1,140 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.admin;
+
+import herddb.remote.RemoteFileServer;
+import herddb.remote.proto.GetServerInfoRequest;
+import herddb.remote.proto.GetServerInfoResponse;
+import herddb.remote.proto.RemoteFileServerAdminGrpc;
+import herddb.remote.proto.ResizeDiskCacheRequest;
+import herddb.remote.proto.ResizeDiskCacheResponse;
+import herddb.remote.storage.CachingObjectStorage;
+import herddb.remote.storage.InMemoryBlockCacheObjectStorage;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * gRPC admin service for the file server (issue #336).
+ * <p>
+ * Registered on the same gRPC port as {@link herddb.remote.RemoteFileServiceImpl};
+ * gRPC multiplexes both services by their service descriptor name so no extra port
+ * is needed.
+ * <p>
+ * Provides two RPCs:
+ * <ul>
+ *   <li>{@code GetServerInfo} — returns a snapshot of JVM, disk-cache, and block-cache
+ *       stats. Safe to call at any time; all reads are lock-free.</li>
+ *   <li>{@code ResizeDiskCache} — calls {@link CachingObjectStorage#setMaxCacheBytes(long)}
+ *       to resize the disk-LRU on the fly. The change is not persistent.</li>
+ * </ul>
+ *
+ * @author enrico.olivelli
+ */
+public class RemoteFileServerAdminImpl extends RemoteFileServerAdminGrpc.RemoteFileServerAdminImplBase {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoteFileServerAdminImpl.class.getName());
+
+    private final RemoteFileServer server;
+
+    public RemoteFileServerAdminImpl(RemoteFileServer server) {
+        this.server = server;
+    }
+
+    @Override
+    public void getServerInfo(GetServerInfoRequest request,
+                              StreamObserver<GetServerInfoResponse> responseObserver) {
+        try {
+            GetServerInfoResponse.Builder builder = GetServerInfoResponse.newBuilder()
+                    .setGrpcHost(server.getHost())
+                    .setGrpcPort(server.getPort())
+                    .setStorageMode(server.getStorageMode());
+
+            // JVM heap stats
+            Runtime rt = Runtime.getRuntime();
+            long heapUsed = rt.totalMemory() - rt.freeMemory();
+            long heapMax = rt.maxMemory();
+            builder.setJvmHeapUsedBytes(heapUsed)
+                   .setJvmHeapMaxBytes(heapMax);
+
+            // Disk cache (populated when storage.mode=s3)
+            CachingObjectStorage dc = server.getDiskCache();
+            if (dc != null) {
+                com.github.benmanes.caffeine.cache.stats.CacheStats stats = dc.diskLruStats();
+                builder.setDiskCacheMaxBytes(dc.getMaxCacheBytes())
+                       .setDiskCacheHitCount(stats.hitCount())
+                       .setDiskCacheMissCount(stats.missCount())
+                       .setDiskCacheEvictionCount(stats.evictionCount())
+                       .setDiskCacheHitBytes(dc.getHitBytes())
+                       .setDiskCacheMissBytes(dc.getMissBytes())
+                       .setDiskCacheEstimatedEntries(dc.estimatedEntries());
+            }
+
+            // In-heap block cache (populated when block.cache.enabled=true)
+            InMemoryBlockCacheObjectStorage bc = server.getBlockCache();
+            if (bc != null) {
+                com.github.benmanes.caffeine.cache.stats.CacheStats bStats = bc.stats();
+                builder.setBlockCacheMaxBytes(bc.getMaxBytes())
+                       .setBlockCacheEstimatedBytes(bc.estimatedBytes())
+                       .setBlockCacheEstimatedEntries(bc.estimatedSize())
+                       .setBlockCacheHits(bStats.hitCount())
+                       .setBlockCacheMisses(bStats.missCount())
+                       .setBlockCacheEvictions(bStats.evictionCount());
+            }
+
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.WARNING, "GetServerInfo failed", e);
+            responseObserver.onError(
+                    Status.INTERNAL.withDescription(e.getMessage()).withCause(e).asRuntimeException());
+        }
+    }
+
+    @Override
+    public void resizeDiskCache(ResizeDiskCacheRequest request,
+                                StreamObserver<ResizeDiskCacheResponse> responseObserver) {
+        CachingObjectStorage dc = server.getDiskCache();
+        if (dc == null) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("disk cache not available: storage.mode is not s3")
+                    .asRuntimeException());
+            return;
+        }
+        long newMax = request.getNewMaxBytes();
+        if (newMax <= 0) {
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("new_max_bytes must be > 0, got " + newMax)
+                    .asRuntimeException());
+            return;
+        }
+        long prev = dc.setMaxCacheBytes(newMax);
+        LOGGER.log(Level.INFO,
+                "ResizeDiskCache: previousMax={0} bytes, newMax={1} bytes",
+                new Object[]{prev, newMax});
+        responseObserver.onNext(ResizeDiskCacheResponse.newBuilder()
+                .setPreviousMaxBytes(prev)
+                .setNewMaxBytes(newMax)
+                .build());
+        responseObserver.onCompleted();
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
@@ -189,6 +189,9 @@ public class CachingObjectStorage implements ObjectStorage {
      * @return the previous maximum, or 0 if the policy is not available
      */
     public long setMaxCacheBytes(long newMaxBytes) {
+        if (newMaxBytes <= 0) {
+            throw new IllegalArgumentException("newMaxBytes must be > 0, got: " + newMaxBytes);
+        }
         long[] prev = {0L};
         diskLru.policy().eviction().ifPresent(e -> {
             prev[0] = e.getMaximum();

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
@@ -23,6 +23,7 @@ package herddb.remote.storage;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.util.concurrent.Striped;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -60,6 +62,11 @@ import java.util.stream.Stream;
  * <p>
  * The cache directory is cleared on construction. Cache files are stored flat in
  * {@code cacheDir} with {@code /} replaced by {@code _} in filenames.
+ * <p>
+ * Metrics (issue #336): Caffeine {@code recordStats()} is enabled so callers can query
+ * hit/miss/eviction counts via {@link #diskLruStats()}. Byte-level hit/miss counters are
+ * maintained via {@link AtomicLong} fields incremented in {@link #readRange}. The maximum
+ * cache weight can be changed at runtime via {@link #setMaxCacheBytes(long)}.
  *
  * @author enrico.olivelli
  */
@@ -76,6 +83,18 @@ public class CachingObjectStorage implements ObjectStorage {
     private final ConcurrentHashMap<String, CompletableFuture<ByteBuf>> inFlightReads = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlightWrites = new ConcurrentHashMap<>();
 
+    /**
+     * Bytes served from the on-disk cache in {@link #readRange} calls.
+     * Incremented on a cache hit in the readRange hot path (issue #336).
+     */
+    private final AtomicLong hitBytes = new AtomicLong();
+
+    /**
+     * Bytes fetched from inner storage in {@link #readRange} calls (cache miss path).
+     * Incremented when readRange falls through to the inner storage (issue #336).
+     */
+    private final AtomicLong missBytes = new AtomicLong();
+
     public CachingObjectStorage(ObjectStorage inner, Path cacheDir, ExecutorService executor,
                                 long maxCacheBytes) throws IOException {
         this.inner = inner;
@@ -90,6 +109,10 @@ public class CachingObjectStorage implements ObjectStorage {
                     long s = size == null ? 0L : size;
                     return s > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) s;
                 })
+                // recordStats() is required for hit/miss/eviction counters exposed via
+                // diskLruStats(). The cost is negligible (a few AtomicLong increments
+                // per cache operation).
+                .recordStats()
                 .evictionListener((RemovalListener<String, Long>) (key, value, cause) -> {
                     // Synchronous, best-effort delete. Runs on Caffeine's maintenance thread
                     // (or inline on a put() that triggers eviction) — does NOT take the stripe
@@ -103,6 +126,83 @@ public class CachingObjectStorage implements ObjectStorage {
                 })
                 .build();
     }
+
+    // -----------------------------------------------------------------------
+    // Stats and dynamic resize (issue #336)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns a snapshot of Caffeine's stats for the disk-LRU index cache.
+     * Provides cumulative hit, miss, eviction and eviction-weight counts since pod start.
+     * Safe to call from gauge samplers (lock-free read of Caffeine's internal counters).
+     */
+    public CacheStats diskLruStats() {
+        return diskLru.stats();
+    }
+
+    /**
+     * Bytes served from the on-disk cache across all {@link #readRange} calls since pod start.
+     * Incremented once per successful disk-cache hit, before the I/O completes, so the counter
+     * counts <em>intended</em> hit bytes (matching the {@code length} parameter of readRange).
+     */
+    public long getHitBytes() {
+        return hitBytes.get();
+    }
+
+    /**
+     * Bytes fetched from the inner storage (GCS / S3 fallback) across all {@link #readRange}
+     * calls since pod start. Incremented on every cache miss.
+     */
+    public long getMissBytes() {
+        return missBytes.get();
+    }
+
+    /**
+     * Approximate number of entries currently tracked in the disk-LRU index.
+     * Safe to call from gauge samplers (Caffeine's {@code estimatedSize()} is thread-safe).
+     */
+    public long estimatedEntries() {
+        return diskLru.estimatedSize();
+    }
+
+    /**
+     * Returns the current maximum weight (bytes) of the disk-cache LRU as reported
+     * by Caffeine's eviction policy. Returns 0 if the policy is not weight-based.
+     */
+    public long getMaxCacheBytes() {
+        return diskLru.policy().eviction()
+                .map(e -> e.getMaximum())
+                .orElse(0L);
+    }
+
+    /**
+     * Dynamically resizes the disk-cache LRU to {@code newMaxBytes}.
+     * <p>
+     * The change is applied immediately via Caffeine's live policy API.
+     * If {@code newMaxBytes} is smaller than the current total weight, Caffeine will
+     * evict excess entries lazily on the next cache access or maintenance cycle.
+     * <p>
+     * <b>This change is NOT persistent</b>: a pod restart will revert to the value
+     * configured in {@code fileserver.properties} / Helm values (issue #336).
+     *
+     * @param newMaxBytes new maximum weight in bytes; must be &gt; 0
+     * @return the previous maximum, or 0 if the policy is not available
+     */
+    public long setMaxCacheBytes(long newMaxBytes) {
+        long[] prev = {0L};
+        diskLru.policy().eviction().ifPresent(e -> {
+            prev[0] = e.getMaximum();
+            e.setMaximum(newMaxBytes);
+        });
+        LOGGER.log(Level.INFO,
+                "Disk cache resized: previousMax={0} bytes, newMax={1} bytes",
+                new Object[]{prev[0], newMaxBytes});
+        return prev[0];
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
 
     private void clearCacheDir() throws IOException {
         if (Files.exists(cacheDir)) {
@@ -290,6 +390,10 @@ public class CachingObjectStorage implements ObjectStorage {
         return pending;
     }
 
+    // -----------------------------------------------------------------------
+    // ObjectStorage implementation
+    // -----------------------------------------------------------------------
+
     @Override
     public CompletableFuture<Void> write(String path, byte[] content) {
         return inner.write(path, content).thenCompose(v -> admitToDisk(path, content));
@@ -458,6 +562,10 @@ public class CachingObjectStorage implements ObjectStorage {
         return ReadResult.found(buf.retainedDuplicate());
     }
 
+    /**
+     * Serves a block slice from the disk cache (hit path) or from the inner storage
+     * (miss path), updating hit/miss byte counters for Prometheus metrics (issue #336).
+     */
     @Override
     public CompletableFuture<ReadResult> readRange(String path, long offset, int length, int blockSize) {
         long blockIndex = offset / blockSize;
@@ -466,8 +574,12 @@ public class CachingObjectStorage implements ObjectStorage {
         return tryReadSliceFromDiskAsync(blockPath, offsetInBlock, length)
                 .thenCompose(cached -> {
                     if (cached != null) {
+                        // Cache HIT: increment byte counter for Prometheus gauge.
+                        hitBytes.addAndGet(length);
                         return CompletableFuture.completedFuture(cached);
                     }
+                    // Cache MISS: increment byte counter and fall through to inner storage.
+                    missBytes.addAndGet(length);
                     return loadAndCache(blockPath).thenApply(full -> sliceFromFull(full, offsetInBlock, length));
                 });
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
@@ -97,7 +97,31 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
     }
 
     public long getMaxBytes() {
-        return maxBytes;
+        return cache.policy().eviction()
+                .map(e -> e.getMaximum())
+                .orElse(maxBytes);
+    }
+
+    /**
+     * Dynamically resizes the in-heap block-cache LRU to {@code newMaxBytes}.
+     * <p>
+     * Applied immediately via Caffeine's live policy API. If {@code newMaxBytes} is
+     * smaller than the current total weight, excess entries are evicted lazily on
+     * the next access or maintenance cycle.
+     * <p>
+     * <b>This change is NOT persistent</b>: a pod restart reverts to the value
+     * configured at construction time (issue #336).
+     *
+     * @param newMaxBytes new maximum weight in bytes; must be &gt; 0
+     * @return the previous maximum, or 0 if the policy is not available
+     */
+    public long setMaxBytes(long newMaxBytes) {
+        long[] prev = {0L};
+        cache.policy().eviction().ifPresent(e -> {
+            prev[0] = e.getMaximum();
+            e.setMaximum(newMaxBytes);
+        });
+        return prev[0];
     }
 
     /**

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/InMemoryBlockCacheObjectStorage.java
@@ -116,6 +116,9 @@ public class InMemoryBlockCacheObjectStorage implements ObjectStorage {
      * @return the previous maximum, or 0 if the policy is not available
      */
     public long setMaxBytes(long newMaxBytes) {
+        if (newMaxBytes <= 0) {
+            throw new IllegalArgumentException("newMaxBytes must be > 0, got: " + newMaxBytes);
+        }
         long[] prev = {0L};
         cache.policy().eviction().ifPresent(e -> {
             prev[0] = e.getMaximum();

--- a/herddb-remote-file-service/src/main/proto/remote_file_service.proto
+++ b/herddb-remote-file-service/src/main/proto/remote_file_service.proto
@@ -96,3 +96,61 @@ message DeleteByPrefixRequest {
 message DeleteByPrefixResponse {
     int32 deleted_count = 1;
 }
+
+// Admin service for file-server management operations (issue #336).
+// Runs on the same gRPC port as RemoteFileService; gRPC multiplexes by service name.
+service RemoteFileServerAdmin {
+    // Returns a snapshot of server identity, JVM stats, disk-cache stats, and
+    // in-heap block-cache stats. Fields for absent subsystems are left at zero.
+    rpc GetServerInfo (GetServerInfoRequest) returns (GetServerInfoResponse);
+
+    // Dynamically changes the maximum weight (bytes) of the disk-cache LRU.
+    // The new limit is applied immediately via Caffeine's policy API.
+    // The change is NOT persistent: a pod restart will revert to the
+    // value configured in fileserver.properties / Helm values.
+    rpc ResizeDiskCache (ResizeDiskCacheRequest) returns (ResizeDiskCacheResponse);
+}
+
+message GetServerInfoRequest {}
+
+message GetServerInfoResponse {
+    // Server identity
+    string grpc_host = 1;
+    int32  grpc_port = 2;
+    string storage_mode = 3;
+
+    // JVM heap
+    int64 jvm_heap_used_bytes = 4;
+    int64 jvm_heap_max_bytes  = 5;
+
+    // Disk cache (CachingObjectStorage) — populated when storage_mode = s3.
+    // Counts are cumulative since pod start.
+    int64 disk_cache_max_bytes        = 6;
+    int64 disk_cache_hit_count        = 7;
+    int64 disk_cache_miss_count       = 8;
+    int64 disk_cache_eviction_count   = 9;
+    int64 disk_cache_hit_bytes        = 10;
+    int64 disk_cache_miss_bytes       = 11;
+    int64 disk_cache_estimated_entries = 12;
+
+    // In-heap block cache (InMemoryBlockCacheObjectStorage) —
+    // populated when block.cache.enabled = true.
+    int64 block_cache_max_bytes         = 13;
+    int64 block_cache_estimated_bytes   = 14;
+    int64 block_cache_estimated_entries = 15;
+    int64 block_cache_hits              = 16;
+    int64 block_cache_misses            = 17;
+    int64 block_cache_evictions         = 18;
+}
+
+message ResizeDiskCacheRequest {
+    // New maximum weight in bytes for the disk-cache LRU.
+    // Must be > 0. Returns INVALID_ARGUMENT if not.
+    // Returns FAILED_PRECONDITION if storage_mode is not s3.
+    int64 new_max_bytes = 1;
+}
+
+message ResizeDiskCacheResponse {
+    int64 previous_max_bytes = 1;
+    int64 new_max_bytes      = 2;
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/admin/FileServerAdminCliTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/admin/FileServerAdminCliTest.java
@@ -1,0 +1,204 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.remote.RemoteFileServer;
+import herddb.remote.proto.GetServerInfoResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Integration tests for the fileserver-admin CLI and gRPC admin service (issue #336).
+ * <p>
+ * Uses a {@link RemoteFileServer} in local-storage mode (no S3 needed) to verify:
+ * <ul>
+ *   <li>{@code server-info} returns JVM and block-cache stats</li>
+ *   <li>{@code resize-cache} correctly rejects when disk cache is absent</li>
+ *   <li>gRPC admin client works end-to-end</li>
+ *   <li>JSON output contains expected keys</li>
+ * </ul>
+ *
+ * @author enrico.olivelli
+ */
+public class FileServerAdminCliTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private RemoteFileServer fileServer;
+    private String serverAddress;
+
+    @Before
+    public void setUp() throws Exception {
+        Path dataDir = tmp.newFolder("data").toPath();
+        Properties config = new Properties();
+        // Local mode — no S3, no disk cache, but block cache enabled
+        config.setProperty("storage.mode", "local");
+        config.setProperty("block.cache.enabled", "true");
+        config.setProperty("block.cache.max.bytes", String.valueOf(16 * 1024 * 1024)); // 16 MB
+
+        fileServer = new RemoteFileServer("127.0.0.1", 0, dataDir, 2, config);
+        fileServer.start();
+        serverAddress = "127.0.0.1:" + fileServer.getPort();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (fileServer != null) {
+            fileServer.stop();
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // gRPC client tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetServerInfoViaClient() {
+        try (FileServerAdminClient client = new FileServerAdminClient(serverAddress, 10)) {
+            GetServerInfoResponse resp = client.getServerInfo();
+            assertNotNull(resp);
+            assertEquals("local", resp.getStorageMode());
+            assertTrue("jvm_heap_max_bytes must be > 0", resp.getJvmHeapMaxBytes() > 0);
+            assertTrue("jvm_heap_used_bytes must be > 0", resp.getJvmHeapUsedBytes() > 0);
+            // Block cache should be populated
+            assertTrue("block_cache_max_bytes must be > 0", resp.getBlockCacheMaxBytes() > 0);
+            // Disk cache absent in local mode — all fields zero
+            assertEquals("disk_cache_max_bytes must be 0 in local mode",
+                    0L, resp.getDiskCacheMaxBytes());
+        }
+    }
+
+    @Test
+    public void testResizeDiskCacheFailsInLocalMode() {
+        // In local mode there is no disk cache; resize must return FAILED_PRECONDITION
+        try (FileServerAdminClient client = new FileServerAdminClient(serverAddress, 10)) {
+            try {
+                client.resizeDiskCache(1024 * 1024 * 512L);
+                // Should not reach here
+                throw new AssertionError("Expected gRPC status exception");
+            } catch (io.grpc.StatusRuntimeException e) {
+                assertEquals(io.grpc.Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // CLI plain-text output tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testServerInfoCliPlainText() {
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(outBuf, true, StandardCharsets.UTF_8);
+        PrintStream err = new PrintStream(errBuf, true, StandardCharsets.UTF_8);
+
+        FileServerAdminCli cli = new FileServerAdminCli(out, err);
+        int rc = cli.run(new String[]{"server-info", "--server", serverAddress});
+
+        assertEquals("CLI should exit 0", 0, rc);
+        String output = outBuf.toString(StandardCharsets.UTF_8);
+        assertTrue("Output should contain 'Server info'", output.contains("Server info:"));
+        assertTrue("Output should contain 'storage_mode'", output.contains("storage_mode"));
+        assertTrue("Output should contain 'local'", output.contains("local"));
+        assertTrue("Output should contain 'Block cache'", output.contains("Block cache"));
+    }
+
+    @Test
+    public void testServerInfoCliJson() {
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(outBuf, true, StandardCharsets.UTF_8);
+        PrintStream err = new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8);
+
+        FileServerAdminCli cli = new FileServerAdminCli(out, err);
+        int rc = cli.run(new String[]{"server-info", "--server", serverAddress, "--json"});
+
+        assertEquals("CLI should exit 0", 0, rc);
+        String json = outBuf.toString(StandardCharsets.UTF_8).trim();
+        assertTrue("JSON must start with {", json.startsWith("{"));
+        assertTrue("JSON must contain storage_mode", json.contains("\"storage_mode\""));
+        assertTrue("JSON must contain block_cache_max_bytes", json.contains("\"block_cache_max_bytes\""));
+        assertTrue("JSON must contain disk_cache_max_bytes", json.contains("\"disk_cache_max_bytes\""));
+    }
+
+    @Test
+    public void testResizeCacheCliFailsInLocalMode() {
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(outBuf, true, StandardCharsets.UTF_8);
+        PrintStream err = new PrintStream(errBuf, true, StandardCharsets.UTF_8);
+
+        FileServerAdminCli cli = new FileServerAdminCli(out, err);
+        int rc = cli.run(new String[]{
+                "resize-cache", "--server", serverAddress, "--max-bytes", "536870912"
+        });
+
+        // gRPC FAILED_PRECONDITION → CLI returns 1
+        assertEquals("CLI should exit 1 on failed precondition", 1, rc);
+        String errOutput = errBuf.toString(StandardCharsets.UTF_8);
+        assertTrue("Error output should mention 'ERROR'", errOutput.contains("ERROR"));
+    }
+
+    @Test
+    public void testCliNoArgsReturns2() {
+        FileServerAdminCli cli = new FileServerAdminCli(
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+        int rc = cli.run(new String[0]);
+        assertEquals(2, rc);
+    }
+
+    @Test
+    public void testCliUnknownCommandReturns2() {
+        FileServerAdminCli cli = new FileServerAdminCli(
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+        int rc = cli.run(new String[]{"no-such-command"});
+        assertEquals(2, rc);
+    }
+
+    // ---------------------------------------------------------------
+    // JSON serialiser unit test
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testToJsonBasic() {
+        java.util.Map<String, Object> m = new java.util.LinkedHashMap<>();
+        m.put("str", "hello");
+        m.put("num", 42L);
+        m.put("bool", true);
+        m.put("nil", null);
+        String json = FileServerAdminCli.toJson(m);
+        assertEquals("{\"str\":\"hello\",\"num\":42,\"bool\":true,\"nil\":null}", json);
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
@@ -631,6 +631,59 @@ public class CachingObjectStorageTest {
     }
 
     @Test
+    public void testSetMaxCacheBytesUpdatesPolicy() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        long initialMax = 10 * 1024 * 1024; // 10 MB
+        CachingObjectStorage cache = build(inner, initialMax);
+
+        assertEquals("getMaxCacheBytes must match construction value",
+                initialMax, cache.getMaxCacheBytes());
+
+        long newMax = 20 * 1024 * 1024; // 20 MB
+        long prev = cache.setMaxCacheBytes(newMax);
+
+        assertEquals("setMaxCacheBytes must return the previous maximum",
+                initialMax, prev);
+        assertEquals("getMaxCacheBytes must reflect the new maximum after set",
+                newMax, cache.getMaxCacheBytes());
+    }
+
+    @Test
+    public void testByteCountersAfterMissAndHit() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024);
+
+        int blockSize = 4096;
+        byte[] block = new byte[blockSize];
+        for (int i = 0; i < block.length; i++) {
+            block[i] = (byte) (i & 0xFF);
+        }
+        // Write block to inner so a readRange will go to inner on first access.
+        inner.data.put("counters.page.multipart/0", block);
+
+        // First readRange → cache MISS: missBytes must be incremented by the requested length.
+        int readLen = 128;
+        long missBefore = caching.getMissBytes();
+        long hitBefore = caching.getHitBytes();
+        ReadResult r1 = caching.readRange("counters.page", 0, readLen, blockSize).get();
+        assertEquals(ReadResult.Status.FOUND, r1.status());
+        assertEquals("missBytes must increase by the requested length on a cache miss",
+                missBefore + readLen, caching.getMissBytes());
+        assertEquals("hitBytes must not change on a cache miss",
+                hitBefore, caching.getHitBytes());
+
+        // Second readRange of same block → cache HIT: hitBytes must be incremented.
+        long missBefore2 = caching.getMissBytes();
+        long hitBefore2 = caching.getHitBytes();
+        ReadResult r2 = caching.readRange("counters.page", 0, readLen, blockSize).get();
+        assertEquals(ReadResult.Status.FOUND, r2.status());
+        assertEquals("hitBytes must increase by the requested length on a cache hit",
+                hitBefore2 + readLen, caching.getHitBytes());
+        assertEquals("missBytes must not change on a cache hit",
+                missBefore2, caching.getMissBytes());
+    }
+
+    @Test
     public void testAsyncWriteFailureDoesNotCacheData() throws Exception {
         // Create a failing inner storage
         FakeObjectStorage inner = new FakeObjectStorage() {

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/InMemoryBlockCacheObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/InMemoryBlockCacheObjectStorageTest.java
@@ -316,6 +316,43 @@ public class InMemoryBlockCacheObjectStorageTest {
     }
 
     @Test
+    public void testSetMaxBytesUpdatesPolicy() throws Exception {
+        CountingFake inner = new CountingFake();
+        long initialMax = 4 * 1024 * 1024; // 4 MB
+
+        try (InMemoryBlockCacheObjectStorage cache =
+                new InMemoryBlockCacheObjectStorage(inner, initialMax)) {
+
+            assertEquals("getMaxBytes must match construction value",
+                    initialMax, cache.getMaxBytes());
+
+            long newMax = 8 * 1024 * 1024; // 8 MB
+            long prev = cache.setMaxBytes(newMax);
+
+            assertEquals("setMaxBytes must return the previous maximum",
+                    initialMax, prev);
+            assertEquals("getMaxBytes must reflect the new maximum after set",
+                    newMax, cache.getMaxBytes());
+
+            // Shrink below current weight: subsequent cleanUp triggers eviction.
+            // Fill roughly 2 * BLOCK_SIZE of weight, then shrink to 1 * BLOCK_SIZE.
+            inner.putBlock("shrink/a", 0, makeBlock(40, BLOCK_SIZE));
+            inner.putBlock("shrink/b", 0, makeBlock(41, BLOCK_SIZE));
+            ReadResult r1 = cache.readRange("shrink/a", 0, 16, BLOCK_SIZE).get();
+            r1.release();
+            ReadResult r2 = cache.readRange("shrink/b", 0, 16, BLOCK_SIZE).get();
+            r2.release();
+
+            // Shrink to one block's worth — Caffeine evicts lazily after cleanUp.
+            cache.setMaxBytes(BLOCK_SIZE);
+            cache.cleanUp();
+
+            assertTrue("cache weight must not exceed new maximum after shrink and cleanUp",
+                    cache.estimatedBytes() <= BLOCK_SIZE);
+        }
+    }
+
+    @Test
     public void maxBytesMustBePositive() {
         CountingFake inner = new CountingFake();
         try {

--- a/herddb-services/pom.xml
+++ b/herddb-services/pom.xml
@@ -177,6 +177,13 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>herddb-remote-file-service</artifactId>
+            <version>${project.version}</version>
+            <classifier>admin-cli</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>herddb-indexing-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/herddb-services/src/main/assemble/zip-assembly.xml
+++ b/herddb-services/src/main/assemble/zip-assembly.xml
@@ -103,6 +103,16 @@
         <dependencySet>
             <useProjectArtifact>true</useProjectArtifact>
             <useStrictFiltering>true</useStrictFiltering>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.herddb:herddb-remote-file-service:jar:admin-cli</include>
+            </includes>
+            <outputDirectory>fileserver-admin</outputDirectory>
+            <outputFileNameMapping>herddb-fileserver-admin-${project.version}.jar</outputFileNameMapping>
+        </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useStrictFiltering>true</useStrictFiltering>
             <unpack>true</unpack>           
             <includes>
                 <include>org.herddb:herddb-ui:war:war-no-libs</include>                                

--- a/herddb-services/src/main/resources/bin/fileserver-admin.sh
+++ b/herddb-services/src/main/resources/bin/fileserver-admin.sh
@@ -42,7 +42,11 @@ JAVA_HEAP="${FILESERVER_ADMIN_HEAP:--Xms64m -Xmx256m}"
 # inside the k3s/GKE tools pod), auto-wire --server for sub-commands that
 # accept it unless the user already passed it.
 EXTRA_ARGS=()
-if [ -n "$HERDDB_FILESERVER_SERVER" ] && [ -n "$1" ]; then
+# Auto-wire --server when HERDDB_FILESERVER_SERVER is set, unless the user
+# already passed --server, or only asked for help (in which case the server
+# address is irrelevant and may not be reachable from the local shell).
+if [ -n "$HERDDB_FILESERVER_SERVER" ] && [ -n "$1" ] \
+        && [ "$1" != "-h" ] && [ "$1" != "--help" ]; then
     HAS_SERVER=false
     for arg in "$@"; do
         if [ "$arg" = "--server" ]; then

--- a/herddb-services/src/main/resources/bin/fileserver-admin.sh
+++ b/herddb-services/src/main/resources/bin/fileserver-admin.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+### BASE_DIR discovery
+if [ -z "$BASE_DIR" ]; then
+  BASE_DIR="`dirname \"$0\"`"
+  BASE_DIR="`( cd \"$BASE_DIR\" && pwd )`"
+fi
+BASE_DIR=$BASE_DIR/..
+BASE_DIR="`( cd \"$BASE_DIR\" && pwd )`"
+
+. $BASE_DIR/bin/setenv.sh
+
+JAVA="$JAVA_HOME/bin/java"
+JAR=$(ls "$BASE_DIR"/fileserver-admin/herddb-fileserver-admin-*.jar 2>/dev/null | head -1)
+
+if [ -z "$JAR" ]; then
+    echo "ERROR: herddb-fileserver-admin jar not found under $BASE_DIR/fileserver-admin/" >&2
+    exit 1
+fi
+
+JAVA_HEAP="${FILESERVER_ADMIN_HEAP:--Xms64m -Xmx256m}"
+
+# When HERDDB_FILESERVER_SERVER is set (typically injected by the Helm chart
+# inside the k3s/GKE tools pod), auto-wire --server for sub-commands that
+# accept it unless the user already passed it.
+EXTRA_ARGS=()
+if [ -n "$HERDDB_FILESERVER_SERVER" ] && [ -n "$1" ]; then
+    HAS_SERVER=false
+    for arg in "$@"; do
+        if [ "$arg" = "--server" ]; then
+            HAS_SERVER=true
+            break
+        fi
+    done
+    if [ "$HAS_SERVER" = false ]; then
+        EXTRA_ARGS+=("--server" "$HERDDB_FILESERVER_SERVER")
+    fi
+fi
+
+exec $JAVA $JAVA_HEAP -jar "$JAR" "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
Fixes #336.

## Changes

- **`CachingObjectStorage`**: Enabled Caffeine `recordStats()` for hit/miss/eviction counts; added manual `AtomicLong` byte-level counters (`hitBytes`, `missBytes`); added `setMaxCacheBytes(long)` for live LRU resizing via `policy().eviction()`.
- **`InMemoryBlockCacheObjectStorage`**: Added `setMaxBytes(long)` for live resizing; `getMaxBytes()` now reflects the live policy value.
- **`RemoteFileServer`**: Added public `getDiskCache()`, `getBlockCache()`, `getStorageMode()` accessors; registers 7 Prometheus gauges under `rfs_disk_cache_*` scope; adds `RemoteFileServerAdminImpl` service to the gRPC server.
- **`remote_file_service.proto`**: New `RemoteFileServerAdmin` gRPC service with `GetServerInfo` and `ResizeDiskCache` RPCs; `GetServerInfoResponse` includes JVM, disk-cache, and block-cache stats.
- **`RemoteFileServerAdminImpl`** (new): gRPC service implementation; `GetServerInfo` returns live stats from disk/block caches; `ResizeDiskCache` validates and applies the new limit, returning `FAILED_PRECONDITION` if no disk cache is present.
- **`FileServerAdminClient`** (new): Thin blocking gRPC client wrapper (`Closeable`).
- **`FileServerAdminCli`** (new): CLI with `server-info` (plain text + `--json`) and `resize-cache` (with `--max-bytes`) commands; returns 0/1/2 exit codes; minimal JSON serialiser with no extra deps.
- **`herddb-remote-file-service/pom.xml`**: `slf4j-jdk14` at compile scope (bundled in uber-jar); `commons-cli` dependency; maven-shade-plugin execution producing `*-admin-cli.jar`.
- **`herddb-services/pom.xml`**: Added `herddb-remote-file-service:admin-cli` runtime dependency.
- **`zip-assembly.xml`**: New `fileserver-admin/` output directory entry.
- **`fileserver-admin.sh`** (new): Launcher script mirroring `indexing-admin.sh`; auto-wires `--server` from `HERDDB_FILESERVER_SERVER` env var.
- **Helm templates**: `herddb.fileServerAdminAddress` helper; `fileserver-admin` script in tools ConfigMap; `HERDDB_FILESERVER_SERVER` env var and `fileserver-admin` volumeMount in tools StatefulSet.
- **Grafana dashboard**: Two new rows — "Disk Cache Rates" (hit/miss bytes rate, hit ratio) and "Disk Cache Size" (max bytes trend, evictions + entries).

## Tests

- `FileServerAdminCliTest` — 8 integration tests using an embedded `RemoteFileServer` in local-storage mode (no S3):
  - `testGetServerInfoViaClient` — verifies gRPC `GetServerInfo` returns correct storage mode, JVM heap, block cache stats, and zeroed disk-cache fields in local mode
  - `testResizeDiskCacheFailsInLocalMode` — confirms `ResizeDiskCache` returns `FAILED_PRECONDITION` when no disk cache is present
  - `testServerInfoCliPlainText` — verifies the `server-info` CLI command emits expected plain-text output
  - `testServerInfoCliJson` — verifies `--json` flag produces valid JSON with required keys
  - `testResizeCacheCliFailsInLocalMode` — confirms `resize-cache` CLI exits 1 with error output in local mode
  - `testCliNoArgsReturns2` — exit code 2 on empty args
  - `testCliUnknownCommandReturns2` — exit code 2 on unknown command
  - `testToJsonBasic` — unit test for the minimal JSON serialiser

🤖 Implemented by the `pr-worker` agent.