### PR TITLE
issue #377: avoid float[] allocation in validateIndexableValue and serializeIndexKey

### DIFF
--- a/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
+++ b/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
@@ -189,30 +189,45 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
     }
 
     /**
-     * Returns the raw index-key bytes for a non-PK column directly from the record value
-     * bytes, without materialising a Java object.  The returned {@link Bytes} is a
-     * zero-copy view into the underlying record value buffer.
+     * Fast null-check for a column without materialising a Java object (issue #377).
      *
-     * <p>Returns {@code null} when:
-     * <ul>
-     *   <li>the column is a primary-key column (its bytes live in the key buffer, not
-     *       the value buffer — the caller must use {@link #get(String)} in that case),
-     *   <li>the column value is absent / null in the serialised record, or
-     *   <li>the column type is not directly optimisable (e.g. INTEGER, LONG, TIMESTAMP
-     *       whose key encoding differs from the value encoding due to sign-flip masking).
-     *       In that case the caller must fall back to {@link #get(String)} +
-     *       {@link RecordSerializer#serialize(Object, int)}.
-     * </ul>
+     * <p>Used by {@link RecordSerializer#validateIndexableValue} to avoid a full
+     * deserialise + box + unbox round-trip when the only thing the validate path
+     * needs to know is whether the column is null.
      *
-     * <p>Package-private: used exclusively by {@link RecordSerializer} as a performance
-     * optimisation (issue #377).
+     * <p>For primary-key columns we always return {@code false} because PK columns
+     * cannot be NULL by construction.
      */
-    Bytes getColumnBytesNoCopy(String property) {
+    @Override
+    public boolean isNull(String property) {
+        if (table.isPrimaryKeyColumn(property)) {
+            // PK columns cannot be NULL by construction
+            return false;
+        }
+        try {
+            return RecordSerializer.isNullValueForColumn(property, record.value, table);
+        } catch (IOException err) {
+            throw new IllegalStateException("bad data: " + err, err);
+        }
+    }
+
+    /**
+     * Returns the FLOATARRAY index-key bytes for a non-PK column as a freshly-allocated
+     * {@code byte[]} — never a slice of the record value buffer (issue #377).
+     *
+     * <p>The fresh allocation is intentional: the returned bytes are stored long-term
+     * by the index manager, and a slice would pin the record's entire value buffer
+     * (and potentially a multi-MB DataPage backing array), causing a memory leak.
+     *
+     * <p>Returns {@code null} when the column is a primary key, is absent, or is NULL
+     * in the record.  Package-private — used exclusively by {@link RecordSerializer}.
+     */
+    byte[] extractFloatArrayIndexKeyBytes(String property) {
         if (table.isPrimaryKeyColumn(property)) {
             return null;
         }
         try {
-            return RecordSerializer.extractRawIndexBytesNoCopy(property, record.value, table);
+            return RecordSerializer.extractFloatArrayIndexKeyBytes(property, record.value, table);
         } catch (IOException err) {
             throw new IllegalStateException("bad data: " + err, err);
         }

--- a/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
+++ b/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
@@ -189,23 +189,30 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
     }
 
     /**
-     * Returns the raw IEEE 754 big-endian float bytes for a FLOATARRAY column from the
-     * record value bytes without allocating a {@code float[]}.  The returned {@link Bytes}
-     * is a zero-copy view into the underlying record value buffer.
-     * Returns {@code null} if the column value is null/absent or if the column is a
-     * primary-key column (whose bytes live in the key, not the value).
-     * <p>
-     * Package-private: used exclusively by {@link RecordSerializer} as a performance
+     * Returns the raw index-key bytes for a non-PK column directly from the record value
+     * bytes, without materialising a Java object.  The returned {@link Bytes} is a
+     * zero-copy view into the underlying record value buffer.
+     *
+     * <p>Returns {@code null} when:
+     * <ul>
+     *   <li>the column is a primary-key column (its bytes live in the key buffer, not
+     *       the value buffer — the caller must use {@link #get(String)} in that case),
+     *   <li>the column value is absent / null in the serialised record, or
+     *   <li>the column type is not directly optimisable (e.g. INTEGER, LONG, TIMESTAMP
+     *       whose key encoding differs from the value encoding due to sign-flip masking).
+     *       In that case the caller must fall back to {@link #get(String)} +
+     *       {@link RecordSerializer#serialize(Object, int)}.
+     * </ul>
+     *
+     * <p>Package-private: used exclusively by {@link RecordSerializer} as a performance
      * optimisation (issue #377).
      */
-    Bytes getFloatArrayColumnBytesNoCopy(String property) {
+    Bytes getColumnBytesNoCopy(String property) {
         if (table.isPrimaryKeyColumn(property)) {
-            // PK columns are stored in the key buffer, not in the value bytes;
-            // fall back to the general path via get().
             return null;
         }
         try {
-            return RecordSerializer.extractFloatArrayBytesNoCopy(property, record.value, table);
+            return RecordSerializer.extractRawIndexBytesNoCopy(property, record.value, table);
         } catch (IOException err) {
             throw new IllegalStateException("bad data: " + err, err);
         }

--- a/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
+++ b/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
@@ -188,4 +188,27 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
         return record;
     }
 
+    /**
+     * Returns the raw IEEE 754 big-endian float bytes for a FLOATARRAY column from the
+     * record value bytes without allocating a {@code float[]}.  The returned {@link Bytes}
+     * is a zero-copy view into the underlying record value buffer.
+     * Returns {@code null} if the column value is null/absent or if the column is a
+     * primary-key column (whose bytes live in the key, not the value).
+     * <p>
+     * Package-private: used exclusively by {@link RecordSerializer} as a performance
+     * optimisation (issue #377).
+     */
+    Bytes getFloatArrayColumnBytesNoCopy(String property) {
+        if (table.isPrimaryKeyColumn(property)) {
+            // PK columns are stored in the key buffer, not in the value bytes;
+            // fall back to the general path via get().
+            return null;
+        }
+        try {
+            return RecordSerializer.extractFloatArrayBytesNoCopy(property, record.value, table);
+        } catch (IOException err) {
+            throw new IllegalStateException("bad data: " + err, err);
+        }
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -888,6 +888,21 @@ public final class RecordSerializer {
                 throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(pkColumn));
             }
             Column c = index.getColumn(pkColumn);
+            // Optimisation (issue #377): for FLOATARRAY columns backed by a
+            // DataAccessorForFullRecord extract the raw float bytes directly from the
+            // serialised record value — avoids the float[] decode + re-encode round trip.
+            if ((c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)
+                    && record instanceof DataAccessorForFullRecord) {
+                Bytes rawFloatBytes = ((DataAccessorForFullRecord) record).getFloatArrayColumnBytesNoCopy(c.name);
+                if (rawFloatBytes != null) {
+                    return rawFloatBytes;
+                }
+                // rawFloatBytes == null: column is absent (null value)
+                if (index.allowNullsForIndexedValues()) {
+                    return null;
+                }
+                throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
+            }
             Object v = record.get(c.name);
             if (v == null) {
                 if (index.allowNullsForIndexedValues()) {
@@ -931,6 +946,48 @@ public final class RecordSerializer {
     }
 
     /**
+     * Extracts the raw IEEE 754 big-endian float bytes for a FLOATARRAY column from
+     * the record value bytes without allocating a {@code float[]}.
+     * The returned {@link Bytes} is a zero-copy view into the original value buffer.
+     * Returns {@code null} if the column is absent (null value) or if the stored type
+     * tag does not match a FLOATARRAY type.
+     */
+    static Bytes extractFloatArrayBytesNoCopy(
+            String property, Bytes value, Table table) throws IOException {
+        Column column = table.getColumn(property);
+        if (column == null) {
+            return null;
+        }
+        try (ByteArrayCursor din = value.newCursor()) {
+            while (!din.isEof()) {
+                int serialPosition = din.readVIntNoEOFException();
+                if (din.isEof()) {
+                    return null;
+                }
+                Column col = table.getColumnBySerialPosition(serialPosition);
+                if (col != null && col.name.equals(property)) {
+                    int type = din.readVInt();
+                    if (type == ColumnTypes.FLOATARRAY || type == ColumnTypes.NOTNULL_FLOATARRAY) {
+                        int len = din.readVInt();
+                        if (len == -1) {
+                            return null; // explicit NULL marker
+                        }
+                        if (len == 0) {
+                            return Bytes.EMPTY_ARRAY;
+                        }
+                        // Zero-copy: return a view into the underlying byte array
+                        return Bytes.from_array(din.getArray(), din.getPosition(), len * 4);
+                    }
+                    return null; // unexpected type for this column
+                } else {
+                    skipTypeAndValue(din);
+                }
+            }
+        }
+        return null; // column not found → null value
+    }
+
+    /**
      * Like {@link #serializeIndexKey(herddb.utils.DataAccessor, herddb.model.ColumnsList, java.lang.String[])
      * } but without return a value and/or creating temporary byte[]
      *
@@ -946,6 +1003,19 @@ public final class RecordSerializer {
                 throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(pkColumn));
             }
             Column c = indexDefinition.getColumn(pkColumn);
+            // Optimisation (issue #377): for FLOATARRAY columns the type is always correct
+            // when the value comes from serialised bytes, so the instanceof check in validate()
+            // is a guaranteed no-op.  Avoid materialising a float[] entirely.
+            if (c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY) {
+                if (!indexDefinition.allowNullsForIndexedValues()) {
+                    Object v = record.get(c.name);
+                    if (v == null) {
+                        throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
+                    }
+                }
+                // nulls allowed (common case for secondary indexes): nothing to validate
+                return;
+            }
             Object v = record.get(c.name);
             if (v == null && !indexDefinition.allowNullsForIndexedValues()) {
                 throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
@@ -959,6 +1029,17 @@ public final class RecordSerializer {
                     throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(columnListForIndex));
                 }
                 Column c = indexDefinition.getColumn(pkColumn);
+                // Optimisation (issue #377): same as single-column case above
+                if (c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY) {
+                    if (!indexDefinition.allowNullsForIndexedValues()) {
+                        Object v = record.get(c.name);
+                        if (v == null) {
+                            throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
+                        }
+                    }
+                    i++;
+                    continue;
+                }
                 Object v = record.get(c.name);
                 if (v == null && !indexDefinition.allowNullsForIndexedValues()) {
                     throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -748,7 +748,12 @@ public final class RecordSerializer {
                 }
                 Column col = table.getColumnBySerialPosition(serialPosition);
                 if (col != null && col.name.equals(property)) {
-                    // peek the type marker; -1 indicates an explicit NULL
+                    // The column was found in the buffer, so it is non-null.  A NULL
+                    // column is omitted from the value buffer entirely (see
+                    // serializeValueRaw); we never see {@code ColumnTypes.NULL} as the
+                    // type byte in the record-value format.  The defensive check below
+                    // is kept so a future writer that emits an explicit NULL marker
+                    // (e.g. for a column added without a default value) is handled.
                     int type = din.readVInt();
                     return type == ColumnTypes.NULL;
                 } else {
@@ -1014,7 +1019,10 @@ public final class RecordSerializer {
                     }
                     int len = din.readVInt();
                     if (len == -1) {
-                        return null; // explicit NULL marker
+                        // Defensive: writer omits NULL FLOATARRAY columns from the buffer,
+                        // so the -1 length marker is unreachable in practice — but mirror
+                        // the readFloatArray semantics in case a future writer emits it.
+                        return null;
                     }
                     int byteLen = len * 4;
                     byte[] copy = new byte[byteLen];

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -980,8 +980,8 @@ public final class RecordSerializer {
      */
     static Bytes extractRawIndexBytesNoCopy(
             String property, Bytes value, Table table) throws IOException {
-        Column column = table.getColumn(property);
-        if (column == null) {
+        // Fast-path: if the column is not in the schema, no need to scan the value buffer.
+        if (table.getColumn(property) == null) {
             return null;
         }
         try (ByteArrayCursor din = value.newCursor()) {

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -888,20 +888,21 @@ public final class RecordSerializer {
                 throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(pkColumn));
             }
             Column c = index.getColumn(pkColumn);
-            // Optimisation (issue #377): for FLOATARRAY columns backed by a
-            // DataAccessorForFullRecord extract the raw float bytes directly from the
-            // serialised record value — avoids the float[] decode + re-encode round trip.
-            if ((c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)
-                    && record instanceof DataAccessorForFullRecord) {
-                Bytes rawFloatBytes = ((DataAccessorForFullRecord) record).getFloatArrayColumnBytesNoCopy(c.name);
-                if (rawFloatBytes != null) {
-                    return rawFloatBytes;
+            // Optimisation (issue #377): for columns backed by a DataAccessorForFullRecord
+            // extract the raw index-key bytes directly from the serialised record value —
+            // avoids the decode + re-encode round trip for FLOATARRAY, STRING, BYTEARRAY,
+            // DOUBLE, and BOOLEAN.  INTEGER, LONG, and TIMESTAMP are NOT optimised here
+            // because their index-key encoding XORs a sign-flip mask that is absent from
+            // the record value encoding.
+            if (record instanceof DataAccessorForFullRecord) {
+                Bytes rawBytes = ((DataAccessorForFullRecord) record).getColumnBytesNoCopy(c.name);
+                if (rawBytes != null) {
+                    return rawBytes;
                 }
-                // rawFloatBytes == null: column is absent (null value)
-                if (index.allowNullsForIndexedValues()) {
-                    return null;
-                }
-                throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
+                // rawBytes == null: either the column is absent (null value) for a type
+                // that is optimisable, or the type is non-optimisable (INTEGER/LONG/
+                // TIMESTAMP).  Fall through to the general get() + serialize() path,
+                // which handles both cases correctly.
             }
             Object v = record.get(c.name);
             if (v == null) {
@@ -946,13 +947,38 @@ public final class RecordSerializer {
     }
 
     /**
-     * Extracts the raw IEEE 754 big-endian float bytes for a FLOATARRAY column from
-     * the record value bytes without allocating a {@code float[]}.
-     * The returned {@link Bytes} is a zero-copy view into the original value buffer.
-     * Returns {@code null} if the column is absent (null value) or if the stored type
-     * tag does not match a FLOATARRAY type.
+     * Extracts the raw index-key bytes for a single-column non-PK index column directly
+     * from the serialised record value without materialising a Java object.
+     *
+     * <p>The returned {@link Bytes} is a zero-copy view into the original value buffer —
+     * no heap allocation beyond the thin {@code Bytes} wrapper itself.
+     *
+     * <p>This optimisation is applicable to the types listed below, where the
+     * serialised form in the record value uses the <em>same</em> byte encoding as the
+     * single-column index key produced by {@link #serialize(Object, int)}:
+     * <ul>
+     *   <li>{@code FLOATARRAY} / {@code NOTNULL_FLOATARRAY}: strip the leading
+     *       {@code vint(numFloats)} prefix, return the raw IEEE 754 float bytes.
+     *   <li>{@code STRING} / {@code NOTNULL_STRING}: strip the leading {@code vint(len)}
+     *       prefix, return the raw UTF-8 bytes.
+     *   <li>{@code BYTEARRAY} / {@code NOTNULL_BYTEARRAY}: strip the leading
+     *       {@code vint(len)} prefix, return the raw bytes.
+     *   <li>{@code DOUBLE} / {@code NOTNULL_DOUBLE}: return the 8 raw big-endian bytes
+     *       (no prefix).
+     *   <li>{@code BOOLEAN} / {@code NOTNULL_BOOLEAN}: return the single raw byte
+     *       (no prefix).
+     * </ul>
+     *
+     * <p>{@code INTEGER}, {@code LONG}, and {@code TIMESTAMP} are <em>not</em> optimisable
+     * here because their index-key encoding XORs a sign-flip mask (see
+     * {@link Bytes#putInt}/{@link Bytes#putLong}) that is absent from the record value
+     * encoding ({@code DataOutputStream.writeInt/writeLong}).
+     *
+     * @return a zero-copy {@link Bytes} view of the raw index-key bytes, or {@code null}
+     *         if the column is absent / null in the record, or the column type is not
+     *         optimisable (caller should fall back to {@link #serialize(Object, int)}).
      */
-    static Bytes extractFloatArrayBytesNoCopy(
+    static Bytes extractRawIndexBytesNoCopy(
             String property, Bytes value, Table table) throws IOException {
         Column column = table.getColumn(property);
         if (column == null) {
@@ -967,18 +993,45 @@ public final class RecordSerializer {
                 Column col = table.getColumnBySerialPosition(serialPosition);
                 if (col != null && col.name.equals(property)) {
                     int type = din.readVInt();
-                    if (type == ColumnTypes.FLOATARRAY || type == ColumnTypes.NOTNULL_FLOATARRAY) {
-                        int len = din.readVInt();
-                        if (len == -1) {
-                            return null; // explicit NULL marker
+                    switch (type) {
+                        case ColumnTypes.FLOATARRAY:
+                        case ColumnTypes.NOTNULL_FLOATARRAY: {
+                            // vint(numFloats) prefix in value; index key = raw float bytes
+                            int len = din.readVInt();
+                            if (len == -1) {
+                                return null; // explicit NULL marker
+                            }
+                            if (len == 0) {
+                                return Bytes.EMPTY_ARRAY;
+                            }
+                            return Bytes.from_array(din.getArray(), din.getPosition(), len * 4);
                         }
-                        if (len == 0) {
-                            return Bytes.EMPTY_ARRAY;
+                        case ColumnTypes.STRING:
+                        case ColumnTypes.NOTNULL_STRING:
+                        case ColumnTypes.BYTEARRAY:
+                        case ColumnTypes.NOTNULL_BYTEARRAY: {
+                            // vint(len) prefix in value; index key = raw bytes only
+                            int len = din.readVInt();
+                            if (len == -1) {
+                                return null; // explicit NULL marker
+                            }
+                            if (len == 0) {
+                                return Bytes.EMPTY_ARRAY;
+                            }
+                            return Bytes.from_array(din.getArray(), din.getPosition(), len);
                         }
-                        // Zero-copy: return a view into the underlying byte array
-                        return Bytes.from_array(din.getArray(), din.getPosition(), len * 4);
+                        case ColumnTypes.DOUBLE:
+                        case ColumnTypes.NOTNULL_DOUBLE:
+                            // 8 raw big-endian bytes, no prefix; same encoding in value and key
+                            return Bytes.from_array(din.getArray(), din.getPosition(), 8);
+                        case ColumnTypes.BOOLEAN:
+                        case ColumnTypes.NOTNULL_BOOLEAN:
+                            // 1 raw byte, no prefix; same encoding in value and key
+                            return Bytes.from_array(din.getArray(), din.getPosition(), 1);
+                        default:
+                            // INTEGER, LONG, TIMESTAMP: sign-flipped key encoding; cannot copy raw bytes
+                            return null;
                     }
-                    return null; // unexpected type for this column
                 } else {
                     skipTypeAndValue(din);
                 }
@@ -1003,10 +1056,14 @@ public final class RecordSerializer {
                 throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(pkColumn));
             }
             Column c = indexDefinition.getColumn(pkColumn);
-            // Optimisation (issue #377): for FLOATARRAY columns the type is always correct
-            // when the value comes from serialised bytes, so the instanceof check in validate()
-            // is a guaranteed no-op.  Avoid materialising a float[] entirely.
-            if (c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY) {
+            // Optimisation (issue #377): for FLOATARRAY columns backed by
+            // DataAccessorForFullRecord the type is always correct (enforced by the
+            // serialised format), so the instanceof check inside validate() is a
+            // guaranteed no-op.  Other DataAccessor implementations (e.g. MapDataAccessor)
+            // may carry user-supplied values of unexpected types (List<Number>, String, …)
+            // so we must still run validate() for them.
+            if ((c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)
+                    && record instanceof DataAccessorForFullRecord) {
                 if (!indexDefinition.allowNullsForIndexedValues()) {
                     Object v = record.get(c.name);
                     if (v == null) {
@@ -1029,8 +1086,9 @@ public final class RecordSerializer {
                     throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(columnListForIndex));
                 }
                 Column c = indexDefinition.getColumn(pkColumn);
-                // Optimisation (issue #377): same as single-column case above
-                if (c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY) {
+                // Optimisation (issue #377): same gating as the single-column path above
+                if ((c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)
+                        && record instanceof DataAccessorForFullRecord) {
                     if (!indexDefinition.allowNullsForIndexedValues()) {
                         Object v = record.get(c.name);
                         if (v == null) {

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -727,6 +727,38 @@ public final class RecordSerializer {
         }
     }
 
+    /**
+     * Returns {@code true} if the column {@code property} has a NULL value (or is absent)
+     * in the record value buffer, without materialising a Java object.
+     *
+     * <p>Used by {@link DataAccessorForFullRecord#isNull(String)} as a fast path for
+     * {@link #validateIndexableValue(DataAccessor, ColumnsList, String[])} (issue #377):
+     * the only thing the validate path needs to know is whether the column is null,
+     * so we can skip the deserialise + box + unbox cycle entirely.
+     */
+    static boolean isNullValueForColumn(String property, Bytes value, Table table) throws IOException {
+        if (table.getColumn(property) == null) {
+            return true;
+        }
+        try (ByteArrayCursor din = value.newCursor()) {
+            while (!din.isEof()) {
+                int serialPosition = din.readVIntNoEOFException();
+                if (din.isEof()) {
+                    return true;
+                }
+                Column col = table.getColumnBySerialPosition(serialPosition);
+                if (col != null && col.name.equals(property)) {
+                    // peek the type marker; -1 indicates an explicit NULL
+                    int type = din.readVInt();
+                    return type == ColumnTypes.NULL;
+                } else {
+                    skipTypeAndValue(din);
+                }
+            }
+            return true;
+        }
+    }
+
     static Object accessRawDataFromValue(int index, Bytes value, Table table) throws IOException {
         Column column = table.getColumn(index);
         try (ByteArrayCursor din = value.newCursor()) {
@@ -888,21 +920,20 @@ public final class RecordSerializer {
                 throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(pkColumn));
             }
             Column c = index.getColumn(pkColumn);
-            // Optimisation (issue #377): for columns backed by a DataAccessorForFullRecord
-            // extract the raw index-key bytes directly from the serialised record value —
-            // avoids the decode + re-encode round trip for FLOATARRAY, STRING, BYTEARRAY,
-            // DOUBLE, and BOOLEAN.  INTEGER, LONG, and TIMESTAMP are NOT optimised here
-            // because their index-key encoding XORs a sign-flip mask that is absent from
-            // the record value encoding.
-            if (record instanceof DataAccessorForFullRecord) {
-                Bytes rawBytes = ((DataAccessorForFullRecord) record).getColumnBytesNoCopy(c.name);
-                if (rawBytes != null) {
-                    return rawBytes;
+            // Optimisation (issue #377): for FLOATARRAY columns backed by
+            // DataAccessorForFullRecord, copy the raw IEEE 754 float bytes directly from
+            // the serialised record value into a fresh byte[].  This avoids the
+            // float[N] intermediate that record.get() + serialize() would allocate.
+            // We deliberately COPY (rather than zero-copy slice) so the index does not
+            // retain a reference to the record's value buffer (which could pin a whole
+            // DataPage byte array — a memory leak).
+            if (record instanceof DataAccessorForFullRecord
+                    && (c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)) {
+                byte[] keyBytes = ((DataAccessorForFullRecord) record).extractFloatArrayIndexKeyBytes(c.name);
+                if (keyBytes != null) {
+                    return Bytes.from_array(keyBytes);
                 }
-                // rawBytes == null: either the column is absent (null value) for a type
-                // that is optimisable, or the type is non-optimisable (INTEGER/LONG/
-                // TIMESTAMP).  Fall through to the general get() + serialize() path,
-                // which handles both cases correctly.
+                // keyBytes == null: column is NULL — fall through to the general null-handling code
             }
             Object v = record.get(c.name);
             if (v == null) {
@@ -947,38 +978,22 @@ public final class RecordSerializer {
     }
 
     /**
-     * Extracts the raw index-key bytes for a single-column non-PK index column directly
-     * from the serialised record value without materialising a Java object.
+     * Extracts the index-key bytes for a single-column FLOATARRAY index, copying the raw
+     * IEEE 754 float bytes from the serialised record value into a fresh {@code byte[]}
+     * without going through a {@code float[]} intermediate (issue #377).
      *
-     * <p>The returned {@link Bytes} is a zero-copy view into the original value buffer —
-     * no heap allocation beyond the thin {@code Bytes} wrapper itself.
+     * <p>The record value format for FLOATARRAY is {@code vint(N) | 4N raw bytes}; the
+     * single-column index-key format is just the raw 4N bytes.  We strip the vint
+     * prefix and copy the payload into a freshly-allocated {@code byte[4N]} — never a
+     * slice of the record buffer — so the resulting index key does not retain a
+     * reference to the record's value buffer (which would pin the whole DataPage byte
+     * array, a memory-leak vector).
      *
-     * <p>This optimisation is applicable to the types listed below, where the
-     * serialised form in the record value uses the <em>same</em> byte encoding as the
-     * single-column index key produced by {@link #serialize(Object, int)}:
-     * <ul>
-     *   <li>{@code FLOATARRAY} / {@code NOTNULL_FLOATARRAY}: strip the leading
-     *       {@code vint(numFloats)} prefix, return the raw IEEE 754 float bytes.
-     *   <li>{@code STRING} / {@code NOTNULL_STRING}: strip the leading {@code vint(len)}
-     *       prefix, return the raw UTF-8 bytes.
-     *   <li>{@code BYTEARRAY} / {@code NOTNULL_BYTEARRAY}: strip the leading
-     *       {@code vint(len)} prefix, return the raw bytes.
-     *   <li>{@code DOUBLE} / {@code NOTNULL_DOUBLE}: return the 8 raw big-endian bytes
-     *       (no prefix).
-     *   <li>{@code BOOLEAN} / {@code NOTNULL_BOOLEAN}: return the single raw byte
-     *       (no prefix).
-     * </ul>
-     *
-     * <p>{@code INTEGER}, {@code LONG}, and {@code TIMESTAMP} are <em>not</em> optimisable
-     * here because their index-key encoding XORs a sign-flip mask (see
-     * {@link Bytes#putInt}/{@link Bytes#putLong}) that is absent from the record value
-     * encoding ({@code DataOutputStream.writeInt/writeLong}).
-     *
-     * @return a zero-copy {@link Bytes} view of the raw index-key bytes, or {@code null}
-     *         if the column is absent / null in the record, or the column type is not
-     *         optimisable (caller should fall back to {@link #serialize(Object, int)}).
+     * @return a fresh {@code byte[]} holding the index-key bytes, or {@code null} if
+     *         the column is absent / NULL in the record (caller must fall through to
+     *         the general null-handling path).
      */
-    static Bytes extractRawIndexBytesNoCopy(
+    static byte[] extractFloatArrayIndexKeyBytes(
             String property, Bytes value, Table table) throws IOException {
         // Fast-path: if the column is not in the schema, no need to scan the value buffer.
         if (table.getColumn(property) == null) {
@@ -993,45 +1008,20 @@ public final class RecordSerializer {
                 Column col = table.getColumnBySerialPosition(serialPosition);
                 if (col != null && col.name.equals(property)) {
                     int type = din.readVInt();
-                    switch (type) {
-                        case ColumnTypes.FLOATARRAY:
-                        case ColumnTypes.NOTNULL_FLOATARRAY: {
-                            // vint(numFloats) prefix in value; index key = raw float bytes
-                            int len = din.readVInt();
-                            if (len == -1) {
-                                return null; // explicit NULL marker
-                            }
-                            if (len == 0) {
-                                return Bytes.EMPTY_ARRAY;
-                            }
-                            return Bytes.from_array(din.getArray(), din.getPosition(), len * 4);
-                        }
-                        case ColumnTypes.STRING:
-                        case ColumnTypes.NOTNULL_STRING:
-                        case ColumnTypes.BYTEARRAY:
-                        case ColumnTypes.NOTNULL_BYTEARRAY: {
-                            // vint(len) prefix in value; index key = raw bytes only
-                            int len = din.readVInt();
-                            if (len == -1) {
-                                return null; // explicit NULL marker
-                            }
-                            if (len == 0) {
-                                return Bytes.EMPTY_ARRAY;
-                            }
-                            return Bytes.from_array(din.getArray(), din.getPosition(), len);
-                        }
-                        case ColumnTypes.DOUBLE:
-                        case ColumnTypes.NOTNULL_DOUBLE:
-                            // 8 raw big-endian bytes, no prefix; same encoding in value and key
-                            return Bytes.from_array(din.getArray(), din.getPosition(), 8);
-                        case ColumnTypes.BOOLEAN:
-                        case ColumnTypes.NOTNULL_BOOLEAN:
-                            // 1 raw byte, no prefix; same encoding in value and key
-                            return Bytes.from_array(din.getArray(), din.getPosition(), 1);
-                        default:
-                            // INTEGER, LONG, TIMESTAMP: sign-flipped key encoding; cannot copy raw bytes
-                            return null;
+                    if (type != ColumnTypes.FLOATARRAY && type != ColumnTypes.NOTNULL_FLOATARRAY) {
+                        // Defensive: should never happen for FLOATARRAY columns.
+                        return null;
                     }
+                    int len = din.readVInt();
+                    if (len == -1) {
+                        return null; // explicit NULL marker
+                    }
+                    int byteLen = len * 4;
+                    byte[] copy = new byte[byteLen];
+                    if (byteLen > 0) {
+                        System.arraycopy(din.getArray(), din.getPosition(), copy, 0, byteLen);
+                    }
+                    return copy;
                 } else {
                     skipTypeAndValue(din);
                 }
@@ -1050,27 +1040,25 @@ public final class RecordSerializer {
      */
     public static void validateIndexableValue(DataAccessor record, ColumnsList indexDefinition, String[] columns) {
         String[] columnListForIndex = indexDefinition.getPrimaryKey();
+        // Optimisation (issue #377): for records backed by serialised bytes
+        // (DataAccessorForFullRecord) the column type is guaranteed correct by the
+        // serialised format itself, so we can skip the type-check inside validate()
+        // and only need to confirm whether the value is null.  DataAccessor.isNull()
+        // avoids materialising the (potentially large) Java object — this eliminates
+        // the float[] / byte[] / String allocation that would otherwise dominate this
+        // hot path on every insert / update touching a secondary index.
+        boolean rawRecord = record instanceof DataAccessorForFullRecord;
         if (columnListForIndex.length == 1) {
             String pkColumn = columnListForIndex[0];
             if (columns.length != 1 && !columns[0].equals(pkColumn)) {
                 throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(pkColumn));
             }
             Column c = indexDefinition.getColumn(pkColumn);
-            // Optimisation (issue #377): for FLOATARRAY columns backed by
-            // DataAccessorForFullRecord the type is always correct (enforced by the
-            // serialised format), so the instanceof check inside validate() is a
-            // guaranteed no-op.  Other DataAccessor implementations (e.g. MapDataAccessor)
-            // may carry user-supplied values of unexpected types (List<Number>, String, …)
-            // so we must still run validate() for them.
-            if ((c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)
-                    && record instanceof DataAccessorForFullRecord) {
-                if (!indexDefinition.allowNullsForIndexedValues()) {
-                    Object v = record.get(c.name);
-                    if (v == null) {
-                        throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
-                    }
+            if (rawRecord) {
+                if (!indexDefinition.allowNullsForIndexedValues() && record.isNull(c.name)) {
+                    throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
                 }
-                // nulls allowed (common case for secondary indexes): nothing to validate
+                // nulls allowed or non-null: format guarantees type correctness, no validate() needed
                 return;
             }
             Object v = record.get(c.name);
@@ -1086,14 +1074,9 @@ public final class RecordSerializer {
                     throw new IllegalArgumentException("SQLTranslator error, " + Arrays.toString(columns) + " != " + Arrays.asList(columnListForIndex));
                 }
                 Column c = indexDefinition.getColumn(pkColumn);
-                // Optimisation (issue #377): same gating as the single-column path above
-                if ((c.type == ColumnTypes.FLOATARRAY || c.type == ColumnTypes.NOTNULL_FLOATARRAY)
-                        && record instanceof DataAccessorForFullRecord) {
-                    if (!indexDefinition.allowNullsForIndexedValues()) {
-                        Object v = record.get(c.name);
-                        if (v == null) {
-                            throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
-                        }
+                if (rawRecord) {
+                    if (!indexDefinition.allowNullsForIndexedValues() && record.isNull(c.name)) {
+                        throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
                     }
                     i++;
                     continue;

--- a/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
+++ b/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
@@ -21,6 +21,7 @@ package herddb.codec;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import herddb.model.Column;
@@ -215,6 +216,20 @@ public class RecordSerializerTest {
     }
 
     // ── issue #377 optimisation tests ──────────────────────────────────────────
+    //
+    // The optimisation has two distinct components:
+    //   (1) `validateIndexableValue` uses the new `DataAccessor.isNull(name)` method to
+    //       avoid materialising a Java object when the only thing it needs to know is
+    //       whether the column is null.  This applies to ALL types when the accessor
+    //       is a `DataAccessorForFullRecord` (the serialised format guarantees type
+    //       correctness, so `validate()` is a no-op).
+    //   (2) `serializeIndexKey` has a FLOATARRAY-specific fast path that copies the
+    //       raw IEEE 754 bytes from the record value buffer into a fresh `byte[]`
+    //       without going through a `float[]` intermediate.  The bytes are COPIED
+    //       (not sliced) so the index does not retain a reference to the record's
+    //       value buffer (which would pin a multi-MB DataPage backing array).
+    //
+    // These tests cover both components and the equivalence with the general path.
 
     /**
      * Helper: build a cache-free {@link Record} (ensures {@link Record#getDataAccessor}
@@ -249,15 +264,68 @@ public class RecordSerializerTest {
         assertEquals("Index key mismatch for type " + columnType, expectedKey, actualKey);
     }
 
-    // ── FLOATARRAY ─────────────────────────────────────────────────────────────
+    // ── DataAccessor.isNull() — used by validateIndexableValue ─────────────────
+
+    /** Default {@link DataAccessor#isNull} implementation: get() == null. */
+    @Test
+    public void testIsNullDefaultImplementationOnMapDataAccessor() {
+        Map<String, Object> mapData = new HashMap<>();
+        mapData.put("a", "hello");
+        mapData.put("b", null);
+        DataAccessor m = new MapDataAccessor(mapData, new String[]{"a", "b", "c"});
+
+        assertFalse("'a' has a non-null value", m.isNull("a"));
+        assertTrue("'b' is explicitly null", m.isNull("b"));
+        assertTrue("'c' is absent → null", m.isNull("c"));
+    }
+
+    /** {@link DataAccessorForFullRecord#isNull} for non-null and null columns of every type. */
+    @Test
+    public void testIsNullOnDataAccessorForFullRecord() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("s", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .column("d", ColumnTypes.DOUBLE)
+                .column("n", ColumnTypes.LONG)
+                .primaryKey("pk")
+                .build();
+
+        // Record with all columns populated
+        Record full = makeCacheFreeRecord(table, "pk", 1,
+                "s", RawString.of("foo"),
+                "vec", new float[]{1f, 2f},
+                "d", 3.14,
+                "n", 42L);
+        DataAccessor fullA = full.getDataAccessor(table);
+        assertTrue("DataAccessorForFullRecord expected", fullA instanceof DataAccessorForFullRecord);
+        assertFalse("PK is never null", fullA.isNull("pk"));
+        assertFalse("'s' is non-null", fullA.isNull("s"));
+        assertFalse("'vec' is non-null", fullA.isNull("vec"));
+        assertFalse("'d' is non-null", fullA.isNull("d"));
+        assertFalse("'n' is non-null", fullA.isNull("n"));
+
+        // Record with only PK and one column populated
+        Record sparse = makeCacheFreeRecord(table, "pk", 2, "s", RawString.of("only-s"));
+        DataAccessor sparseA = sparse.getDataAccessor(table);
+        assertFalse("PK is never null", sparseA.isNull("pk"));
+        assertFalse("'s' is populated", sparseA.isNull("s"));
+        assertTrue("'vec' is absent → null", sparseA.isNull("vec"));
+        assertTrue("'d' is absent → null", sparseA.isNull("d"));
+        assertTrue("'n' is absent → null", sparseA.isNull("n"));
+    }
+
+    // ── serializeIndexKey FLOATARRAY fast path ─────────────────────────────────
 
     /**
      * Happy path: DataAccessorForFullRecord with a FLOATARRAY column produces the same
-     * index key as MapDataAccessor.  Also asserts {@link Bytes#isShared()} == true so
-     * a regression to the allocating slow path is detected.
+     * index key as MapDataAccessor.  Asserts {@link Bytes#isShared()} == false to
+     * confirm the fast path COPIES the bytes (rather than slicing the record value
+     * buffer, which would retain a reference to the whole DataPage and leak memory).
      */
     @Test
-    public void testSerializeIndexKeyFloatArrayNoCopy() {
+    public void testSerializeIndexKeyFloatArrayCopies() {
         Table table = Table.builder()
                 .name("t1")
                 .column("pk", ColumnTypes.INTEGER)
@@ -284,10 +352,11 @@ public class RecordSerializerTest {
         Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
 
         assertEquals(expectedKey, actualKey);
-        // The no-copy path returns a slice into the record value buffer; isShared()
-        // returns true whenever offset > 0 or length < buffer.length.  If this
-        // assertion fails the optimisation has silently regressed to the allocating path.
-        assertTrue("No-copy path should return a shared (sliced) Bytes", actualKey.isShared());
+        // Critical: the returned Bytes must wrap a freshly-allocated byte[], NOT a
+        // slice of the record value buffer.  A slice would retain a reference to the
+        // entire DataPage backing array and create a memory leak when the index
+        // stores the key long-term.
+        assertFalse("FLOATARRAY fast path must COPY bytes (isShared=false)", actualKey.isShared());
     }
 
     /** Null FLOATARRAY value is absent from the record bytes → serializeIndexKey returns null. */
@@ -346,7 +415,7 @@ public class RecordSerializerTest {
         assertIndexKeyEquivalence(table, record, "vec", ColumnTypes.FLOATARRAY, empty);
     }
 
-    /** Large vector (4 096 floats) confirms the len*4 arithmetic and slice size. */
+    /** Large vector (4 096 floats) confirms the len*4 arithmetic and copy size. */
     @Test
     public void testSerializeIndexKeyFloatArrayLargeVector() {
         Table table = Table.builder()
@@ -365,9 +434,147 @@ public class RecordSerializerTest {
         assertIndexKeyEquivalence(table, record, "vec", ColumnTypes.FLOATARRAY, bigVec);
     }
 
-    /** validateIndexableValue must not throw for a valid non-null FLOATARRAY column. */
+    /**
+     * FLOATARRAY column at a non-zero serial position (preceded by another non-PK
+     * column in the value buffer): exercises the {@code skipTypeAndValue} branch
+     * inside {@code extractFloatArrayIndexKeyBytes}.
+     */
     @Test
-    public void testValidateIndexableValueFloatArrayNoCopy() {
+    public void testSerializeIndexKeyFloatArrayAtLaterSerialPosition() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("prev", ColumnTypes.STRING)         // serialised before vec
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] vector = {0.5f, -0.25f, 1.5f};
+        Record record = makeCacheFreeRecord(table, "pk", 1, "prev", RawString.of("skip-me"), "vec", vector);
+        assertIndexKeyEquivalence(table, record, "vec", ColumnTypes.FLOATARRAY, vector);
+
+        // Also confirm the result is COPIED (isShared == false)
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+        assertFalse("FLOATARRAY fast path must COPY bytes (isShared=false)", actualKey.isShared());
+    }
+
+    // ── Equivalence tests for non-FLOATARRAY types (verifies general path correctness) ──
+    //
+    // The serializeIndexKey fast path applies ONLY to FLOATARRAY.  These tests confirm
+    // that the general (record.get() + serialize()) path still produces the correct
+    // result for every other type.
+
+    /** STRING single-column index produces the correct key via the general path. */
+    @Test
+    public void testSerializeIndexKeyStringGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("name", ColumnTypes.STRING)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "name", RawString.of("hello"));
+        assertIndexKeyEquivalence(table, record, "name", ColumnTypes.STRING, RawString.of("hello"));
+    }
+
+    /** BYTEARRAY single-column index produces the correct key via the general path. */
+    @Test
+    public void testSerializeIndexKeyByteArrayGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("data", ColumnTypes.BYTEARRAY)
+                .primaryKey("pk")
+                .build();
+
+        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        Record record = makeCacheFreeRecord(table, "pk", 1, "data", payload);
+        assertIndexKeyEquivalence(table, record, "data", ColumnTypes.BYTEARRAY, payload);
+    }
+
+    /** DOUBLE single-column index produces the correct key via the general path. */
+    @Test
+    public void testSerializeIndexKeyDoubleGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("score", ColumnTypes.DOUBLE)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "score", 3.14);
+        assertIndexKeyEquivalence(table, record, "score", ColumnTypes.DOUBLE, 3.14);
+    }
+
+    /** BOOLEAN single-column index produces the correct key via the general path. */
+    @Test
+    public void testSerializeIndexKeyBooleanGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("flag", ColumnTypes.BOOLEAN)
+                .primaryKey("pk")
+                .build();
+
+        Record trueRec = makeCacheFreeRecord(table, "pk", 1, "flag", Boolean.TRUE);
+        assertIndexKeyEquivalence(table, trueRec, "flag", ColumnTypes.BOOLEAN, Boolean.TRUE);
+
+        Record falseRec = makeCacheFreeRecord(table, "pk", 2, "flag", Boolean.FALSE);
+        assertIndexKeyEquivalence(table, falseRec, "flag", ColumnTypes.BOOLEAN, Boolean.FALSE);
+    }
+
+    /** INTEGER single-column index produces the correct key via the general path (sign-flip applied). */
+    @Test
+    public void testSerializeIndexKeyIntegerGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("num", ColumnTypes.INTEGER)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "num", 42);
+        assertIndexKeyEquivalence(table, record, "num", ColumnTypes.INTEGER, 42);
+    }
+
+    /** LONG single-column index produces the correct key via the general path (sign-flip applied). */
+    @Test
+    public void testSerializeIndexKeyLongGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("ts", ColumnTypes.LONG)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "ts", 123456789L);
+        assertIndexKeyEquivalence(table, record, "ts", ColumnTypes.LONG, 123456789L);
+    }
+
+    /** TIMESTAMP single-column index produces the correct key via the general path (sign-flip applied). */
+    @Test
+    public void testSerializeIndexKeyTimestampGeneralPath() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("created", ColumnTypes.TIMESTAMP)
+                .primaryKey("pk")
+                .build();
+
+        Timestamp ts = new Timestamp(1_609_459_200_000L); // 2021-01-01 00:00:00 UTC
+        Record record = makeCacheFreeRecord(table, "pk", 1, "created", ts);
+        assertIndexKeyEquivalence(table, record, "created", ColumnTypes.TIMESTAMP, ts);
+    }
+
+    // ── validateIndexableValue ─────────────────────────────────────────────────
+
+    /** validateIndexableValue must not throw for a non-null FLOATARRAY column. */
+    @Test
+    public void testValidateIndexableValueFloatArrayNonNull() {
         Table table = Table.builder()
                 .name("t1")
                 .column("pk", ColumnTypes.INTEGER)
@@ -423,9 +630,60 @@ public class RecordSerializerTest {
         RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
     }
 
+    /**
+     * Validates the optimisation applies to ALL types (not just FLOATARRAY): for
+     * DataAccessorForFullRecord the type is guaranteed correct by the format, so the
+     * generic isNull-only path must accept any column type without throwing.
+     */
+    @Test
+    public void testValidateIndexableValueAllTypesOnDataAccessorForFullRecord() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("s", ColumnTypes.STRING)
+                .column("d", ColumnTypes.DOUBLE)
+                .column("n", ColumnTypes.LONG)
+                .column("b", ColumnTypes.BOOLEAN)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1,
+                "s", RawString.of("hello"), "d", 3.14, "n", 42L, "b", Boolean.TRUE);
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue(rawAccessor instanceof DataAccessorForFullRecord);
+
+        // Single-column index for each type
+        for (Column col : new Column[]{
+                Column.column("s", ColumnTypes.STRING),
+                Column.column("d", ColumnTypes.DOUBLE),
+                Column.column("n", ColumnTypes.LONG),
+                Column.column("b", ColumnTypes.BOOLEAN)}) {
+            ColumnsList idx = new ColumnsListImpl(new Column[]{col});
+            RecordSerializer.validateIndexableValue(rawAccessor, idx, idx.getPrimaryKey());
+        }
+    }
+
+    /** STRING null with nulls forbidden → validateIndexableValue must throw (not just FLOATARRAY). */
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateIndexableValueStringNullForbidden() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("s", ColumnTypes.STRING)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1); // s is null
+        Column sColumn = Column.column("s", ColumnTypes.STRING);
+        ColumnsList index = new ColumnsListImplNoNulls(new Column[]{sColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
+    }
+
     /** Multi-column index (STRING + FLOATARRAY): validates the multi-column branch. */
     @Test
-    public void testValidateIndexableValueFloatArrayMultiColumnIndex() {
+    public void testValidateIndexableValueMultiColumnIndex() {
         Table table = Table.builder()
                 .name("t1")
                 .column("pk", ColumnTypes.INTEGER)
@@ -453,155 +711,23 @@ public class RecordSerializerTest {
         RecordSerializer.validateIndexableValue(rawNullVec, index, index.getPrimaryKey()); // must not throw
     }
 
-    // ── Other index types — equivalence tests (verifies INTEGER/LONG fall through) ──
-
-    /** STRING single-column index: optimised and reference paths must agree. */
-    @Test
-    public void testSerializeIndexKeyStringNoCopy() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("name", ColumnTypes.STRING)
-                .primaryKey("pk")
-                .build();
-
-        Record record = makeCacheFreeRecord(table, "pk", 1, "name", RawString.of("hello"));
-        assertIndexKeyEquivalence(table, record, "name", ColumnTypes.STRING, RawString.of("hello"));
-    }
-
-    /** DOUBLE single-column index: optimised and reference paths must agree. */
-    @Test
-    public void testSerializeIndexKeyDoubleNoCopy() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("score", ColumnTypes.DOUBLE)
-                .primaryKey("pk")
-                .build();
-
-        Record record = makeCacheFreeRecord(table, "pk", 1, "score", 3.14);
-        assertIndexKeyEquivalence(table, record, "score", ColumnTypes.DOUBLE, 3.14);
-    }
-
     /**
-     * INTEGER single-column index: sign-flip means the optimisation is intentionally
-     * skipped; the general path must still produce the correct result.
+     * MapDataAccessor (non-DataAccessorForFullRecord) callers MUST still go through the
+     * full validate() path to catch user-supplied values of the wrong type.  Verify by
+     * supplying a String where a FLOATARRAY is expected and asserting that validate()
+     * rejects it.
      */
-    @Test
-    public void testSerializeIndexKeyIntegerFallsThrough() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("num", ColumnTypes.INTEGER)
-                .primaryKey("pk")
-                .build();
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateIndexableValueMapDataAccessorStillValidatesType() {
+        Map<String, Object> mapData = new HashMap<>();
+        mapData.put("vec", "not a float array");
+        DataAccessor m = new MapDataAccessor(mapData, new String[]{"vec"});
 
-        Record record = makeCacheFreeRecord(table, "pk", 1, "num", 42);
-        assertIndexKeyEquivalence(table, record, "num", ColumnTypes.INTEGER, 42);
-    }
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
 
-    /**
-     * LONG single-column index: sign-flip means the optimisation is intentionally
-     * skipped; the general path must still produce the correct result.
-     */
-    @Test
-    public void testSerializeIndexKeyLongFallsThrough() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("ts", ColumnTypes.LONG)
-                .primaryKey("pk")
-                .build();
-
-        Record record = makeCacheFreeRecord(table, "pk", 1, "ts", 123456789L);
-        assertIndexKeyEquivalence(table, record, "ts", ColumnTypes.LONG, 123456789L);
-    }
-
-    /**
-     * TIMESTAMP single-column index: sign-flip (via Bytes.putLong) means the optimisation
-     * is intentionally skipped; the general path must still produce the correct result.
-     */
-    @Test
-    public void testSerializeIndexKeyTimestampFallsThrough() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("created", ColumnTypes.TIMESTAMP)
-                .primaryKey("pk")
-                .build();
-
-        Timestamp ts = new Timestamp(1_609_459_200_000L); // 2021-01-01 00:00:00 UTC
-        Record record = makeCacheFreeRecord(table, "pk", 1, "created", ts);
-        assertIndexKeyEquivalence(table, record, "created", ColumnTypes.TIMESTAMP, ts);
-    }
-
-    /** BYTEARRAY single-column index: optimised and reference paths must agree,
-     *  and the result must be a zero-copy slice (isShared == true). */
-    @Test
-    public void testSerializeIndexKeyByteArrayNoCopy() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("data", ColumnTypes.BYTEARRAY)
-                .primaryKey("pk")
-                .build();
-
-        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
-        Record record = makeCacheFreeRecord(table, "pk", 1, "data", payload);
-
-        assertIndexKeyEquivalence(table, record, "data", ColumnTypes.BYTEARRAY, payload);
-
-        // Verify the no-copy path returns a shared slice, not a newly-allocated buffer
-        Column dataColumn = Column.column("data", ColumnTypes.BYTEARRAY);
-        ColumnsList index = new ColumnsListImpl(new Column[]{dataColumn});
-        DataAccessor rawAccessor = record.getDataAccessor(table);
-        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
-        assertTrue("No-copy path should return a shared (sliced) Bytes", actualKey.isShared());
-    }
-
-    /** BOOLEAN single-column index: optimised and reference paths must agree for both true and false. */
-    @Test
-    public void testSerializeIndexKeyBooleanNoCopy() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("flag", ColumnTypes.BOOLEAN)
-                .primaryKey("pk")
-                .build();
-
-        // true
-        Record trueRecord = makeCacheFreeRecord(table, "pk", 1, "flag", Boolean.TRUE);
-        assertIndexKeyEquivalence(table, trueRecord, "flag", ColumnTypes.BOOLEAN, Boolean.TRUE);
-
-        // false
-        Record falseRecord = makeCacheFreeRecord(table, "pk", 2, "flag", Boolean.FALSE);
-        assertIndexKeyEquivalence(table, falseRecord, "flag", ColumnTypes.BOOLEAN, Boolean.FALSE);
-    }
-
-    /**
-     * Exercises the {@code skipTypeAndValue} branch inside {@code extractRawIndexBytesNoCopy}:
-     * the indexed column (DOUBLE) is preceded by another non-PK column (STRING) in the record
-     * value buffer, so the scan loop must skip it before reaching the target.
-     */
-    @Test
-    public void testSerializeIndexKeyDoubleNoCopyAtLaterSerialPosition() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("prev", ColumnTypes.STRING)    // serialised before target
-                .column("target", ColumnTypes.DOUBLE)  // the indexed column
-                .primaryKey("pk")
-                .build();
-
-        Record record = makeCacheFreeRecord(table, "pk", 1, "prev", RawString.of("skip-me"), "target", 2.718281828);
-        assertIndexKeyEquivalence(table, record, "target", ColumnTypes.DOUBLE, 2.718281828);
-
-        // Confirm isShared() == true (no-copy slice, not a fresh allocation)
-        Column targetColumn = Column.column("target", ColumnTypes.DOUBLE);
-        ColumnsList index = new ColumnsListImpl(new Column[]{targetColumn});
-        DataAccessor rawAccessor = record.getDataAccessor(table);
-        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
-        assertTrue("No-copy path should return a shared (sliced) Bytes", actualKey.isShared());
+        // MapDataAccessor → validate() must run → reject the String
+        RecordSerializer.validateIndexableValue(m, index, index.getPrimaryKey());
     }
 
     // ── Inner helpers ───────────────────────────────────────────────────────────

--- a/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
+++ b/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
@@ -517,6 +517,93 @@ public class RecordSerializerTest {
         assertIndexKeyEquivalence(table, record, "ts", ColumnTypes.LONG, 123456789L);
     }
 
+    /**
+     * TIMESTAMP single-column index: sign-flip (via Bytes.putLong) means the optimisation
+     * is intentionally skipped; the general path must still produce the correct result.
+     */
+    @Test
+    public void testSerializeIndexKeyTimestampFallsThrough() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("created", ColumnTypes.TIMESTAMP)
+                .primaryKey("pk")
+                .build();
+
+        Timestamp ts = new Timestamp(1_609_459_200_000L); // 2021-01-01 00:00:00 UTC
+        Record record = makeCacheFreeRecord(table, "pk", 1, "created", ts);
+        assertIndexKeyEquivalence(table, record, "created", ColumnTypes.TIMESTAMP, ts);
+    }
+
+    /** BYTEARRAY single-column index: optimised and reference paths must agree,
+     *  and the result must be a zero-copy slice (isShared == true). */
+    @Test
+    public void testSerializeIndexKeyByteArrayNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("data", ColumnTypes.BYTEARRAY)
+                .primaryKey("pk")
+                .build();
+
+        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        Record record = makeCacheFreeRecord(table, "pk", 1, "data", payload);
+
+        assertIndexKeyEquivalence(table, record, "data", ColumnTypes.BYTEARRAY, payload);
+
+        // Verify the no-copy path returns a shared slice, not a newly-allocated buffer
+        Column dataColumn = Column.column("data", ColumnTypes.BYTEARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{dataColumn});
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+        assertTrue("No-copy path should return a shared (sliced) Bytes", actualKey.isShared());
+    }
+
+    /** BOOLEAN single-column index: optimised and reference paths must agree for both true and false. */
+    @Test
+    public void testSerializeIndexKeyBooleanNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("flag", ColumnTypes.BOOLEAN)
+                .primaryKey("pk")
+                .build();
+
+        // true
+        Record trueRecord = makeCacheFreeRecord(table, "pk", 1, "flag", Boolean.TRUE);
+        assertIndexKeyEquivalence(table, trueRecord, "flag", ColumnTypes.BOOLEAN, Boolean.TRUE);
+
+        // false
+        Record falseRecord = makeCacheFreeRecord(table, "pk", 2, "flag", Boolean.FALSE);
+        assertIndexKeyEquivalence(table, falseRecord, "flag", ColumnTypes.BOOLEAN, Boolean.FALSE);
+    }
+
+    /**
+     * Exercises the {@code skipTypeAndValue} branch inside {@code extractRawIndexBytesNoCopy}:
+     * the indexed column (DOUBLE) is preceded by another non-PK column (STRING) in the record
+     * value buffer, so the scan loop must skip it before reaching the target.
+     */
+    @Test
+    public void testSerializeIndexKeyDoubleNoCopyAtLaterSerialPosition() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("prev", ColumnTypes.STRING)    // serialised before target
+                .column("target", ColumnTypes.DOUBLE)  // the indexed column
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "prev", RawString.of("skip-me"), "target", 2.718281828);
+        assertIndexKeyEquivalence(table, record, "target", ColumnTypes.DOUBLE, 2.718281828);
+
+        // Confirm isShared() == true (no-copy slice, not a fresh allocation)
+        Column targetColumn = Column.column("target", ColumnTypes.DOUBLE);
+        ColumnsList index = new ColumnsListImpl(new Column[]{targetColumn});
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+        assertTrue("No-copy path should return a shared (sliced) Bytes", actualKey.isShared());
+    }
+
     // ── Inner helpers ───────────────────────────────────────────────────────────
 
     private static Bytes varInt(int i) throws Exception {

--- a/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
+++ b/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
@@ -22,6 +22,7 @@ package herddb.codec;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import herddb.model.Column;
 import herddb.model.ColumnTypes;
 import herddb.model.ColumnsList;
@@ -272,6 +273,126 @@ public class RecordSerializerTest {
         public boolean allowNullsForIndexedValues() {
             return true;
         }
+    }
+
+    /**
+     * Verifies that {@link RecordSerializer#serializeIndexKey} on a
+     * {@link DataAccessorForFullRecord} with a FLOATARRAY column produces the same
+     * {@link Bytes} key as the general path that goes through a {@link MapDataAccessor}.
+     * This exercises the no-copy optimisation introduced in issue #377.
+     */
+    @Test
+    public void testSerializeIndexKeyFloatArrayNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] vector = {1.0f, 2.0f, 3.0f, 4.0f};
+        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1, "vec", vector);
+        // Use a cache-free record so getDataAccessor() returns DataAccessorForFullRecord
+        Record record = new Record(baseRecord.key, baseRecord.value);
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+
+        // Reference result via MapDataAccessor (original path)
+        Map<String, Object> mapData = new HashMap<>();
+        mapData.put("pk", 1);
+        mapData.put("vec", vector);
+        DataAccessor mapAccessor = new MapDataAccessor(mapData, table.columnNames);
+        Bytes expectedKey = RecordSerializer.serializeIndexKey(mapAccessor, index, index.getPrimaryKey());
+
+        // Optimised path: DataAccessorForFullRecord
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+
+        assertEquals(expectedKey, actualKey);
+    }
+
+    /**
+     * Verifies that {@link RecordSerializer#serializeIndexKey} returns {@code null}
+     * when the FLOATARRAY column is absent from the record value bytes (null value),
+     * and that the index allows nulls.
+     */
+    @Test
+    public void testSerializeIndexKeyFloatArrayNullValue() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        // Record with no "vec" value → vec is null
+        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1);
+        Record record = new Record(baseRecord.key, baseRecord.value);
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+
+        Bytes result = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+        assertNull("Expected null for absent FLOATARRAY column", result);
+    }
+
+    /**
+     * Verifies that {@link RecordSerializer#validateIndexableValue} does not throw
+     * for a FLOATARRAY column with a valid value on a {@link DataAccessorForFullRecord}
+     * (the no-materialise optimisation must not break validation).
+     */
+    @Test
+    public void testValidateIndexableValueFloatArrayNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] vector = {0.5f, 1.5f, -3.0f};
+        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1, "vec", vector);
+        Record record = new Record(baseRecord.key, baseRecord.value);
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+
+        // Must not throw
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
+    }
+
+    /**
+     * Verifies that {@link RecordSerializer#validateIndexableValue} does not throw
+     * when the FLOATARRAY column is null and nulls are allowed
+     * (common case for secondary indexes: {@link Index#allowNullsForIndexedValues()} = true).
+     */
+    @Test
+    public void testValidateIndexableValueFloatArrayNullAllowed() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        // No "vec" value → null
+        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1);
+        Record record = new Record(baseRecord.key, baseRecord.value);
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn}); // allowNulls = true
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        // Must not throw even though vec is null, because allowNullsForIndexedValues() = true
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
     }
 
 }

--- a/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
+++ b/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
@@ -214,6 +214,311 @@ public class RecordSerializerTest {
 
     }
 
+    // ── issue #377 optimisation tests ──────────────────────────────────────────
+
+    /**
+     * Helper: build a cache-free {@link Record} (ensures {@link Record#getDataAccessor}
+     * returns {@link DataAccessorForFullRecord}, not {@link MapDataAccessor}).
+     */
+    private static Record makeCacheFreeRecord(Table table, Object... kv) {
+        Record r = RecordSerializer.makeRecord(table, kv);
+        return new Record(r.key, r.value);
+    }
+
+    /**
+     * Helper: assert that the optimised (DataAccessorForFullRecord) and reference
+     * (MapDataAccessor) paths produce identical index keys for the given column.
+     */
+    private void assertIndexKeyEquivalence(Table table, Record record,
+            String columnName, int columnType, Object columnValue) {
+        Column col = Column.column(columnName, columnType);
+        ColumnsList index = new ColumnsListImpl(new Column[]{col});
+
+        Map<String, Object> mapData = new HashMap<>();
+        mapData.put("pk", record.key.to_int()); // works for INTEGER PK used in these tests
+        if (columnValue != null) {
+            mapData.put(columnName, columnValue);
+        }
+        DataAccessor mapAccessor = new MapDataAccessor(mapData, table.columnNames);
+        Bytes expectedKey = RecordSerializer.serializeIndexKey(mapAccessor, index, index.getPrimaryKey());
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+
+        assertEquals("Index key mismatch for type " + columnType, expectedKey, actualKey);
+    }
+
+    // ── FLOATARRAY ─────────────────────────────────────────────────────────────
+
+    /**
+     * Happy path: DataAccessorForFullRecord with a FLOATARRAY column produces the same
+     * index key as MapDataAccessor.  Also asserts {@link Bytes#isShared()} == true so
+     * a regression to the allocating slow path is detected.
+     */
+    @Test
+    public void testSerializeIndexKeyFloatArrayNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] vector = {1.0f, 2.0f, 3.0f, 4.0f};
+        Record record = makeCacheFreeRecord(table, "pk", 1, "vec", vector);
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+
+        // Reference result via MapDataAccessor (general path)
+        Map<String, Object> mapData = new HashMap<>();
+        mapData.put("pk", 1);
+        mapData.put("vec", vector);
+        DataAccessor mapAccessor = new MapDataAccessor(mapData, table.columnNames);
+        Bytes expectedKey = RecordSerializer.serializeIndexKey(mapAccessor, index, index.getPrimaryKey());
+
+        // Optimised path: DataAccessorForFullRecord
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+
+        assertEquals(expectedKey, actualKey);
+        // The no-copy path returns a slice into the record value buffer; isShared()
+        // returns true whenever offset > 0 or length < buffer.length.  If this
+        // assertion fails the optimisation has silently regressed to the allocating path.
+        assertTrue("No-copy path should return a shared (sliced) Bytes", actualKey.isShared());
+    }
+
+    /** Null FLOATARRAY value is absent from the record bytes → serializeIndexKey returns null. */
+    @Test
+    public void testSerializeIndexKeyFloatArrayNullValue() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1); // no vec → null
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+
+        assertNull("Expected null for absent FLOATARRAY column",
+                RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey()));
+    }
+
+    /** Null FLOATARRAY column with nulls forbidden → serializeIndexKey must throw. */
+    @Test(expected = IllegalArgumentException.class)
+    public void testSerializeIndexKeyFloatArrayNullValueThrowsWhenNullsForbidden() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1); // vec is null
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImplNoNulls(new Column[]{vecColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
+    }
+
+    /** Empty float[0] → both paths must produce equal (empty) Bytes. */
+    @Test
+    public void testSerializeIndexKeyFloatArrayEmpty() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] empty = new float[0];
+        Record record = makeCacheFreeRecord(table, "pk", 1, "vec", empty);
+
+        assertIndexKeyEquivalence(table, record, "vec", ColumnTypes.FLOATARRAY, empty);
+    }
+
+    /** Large vector (4 096 floats) confirms the len*4 arithmetic and slice size. */
+    @Test
+    public void testSerializeIndexKeyFloatArrayLargeVector() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] bigVec = new float[4096];
+        for (int i = 0; i < bigVec.length; i++) {
+            bigVec[i] = i * 0.001f;
+        }
+        Record record = makeCacheFreeRecord(table, "pk", 1, "vec", bigVec);
+
+        assertIndexKeyEquivalence(table, record, "vec", ColumnTypes.FLOATARRAY, bigVec);
+    }
+
+    /** validateIndexableValue must not throw for a valid non-null FLOATARRAY column. */
+    @Test
+    public void testValidateIndexableValueFloatArrayNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "vec", new float[]{0.5f, 1.5f, -3.0f});
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey()); // must not throw
+    }
+
+    /** Null FLOATARRAY with nulls allowed → validateIndexableValue must not throw. */
+    @Test
+    public void testValidateIndexableValueFloatArrayNullAllowed() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1); // no vec → null
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn}); // allowNulls = true
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey()); // must not throw
+    }
+
+    /** Null FLOATARRAY with nulls forbidden → validateIndexableValue must throw. */
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateIndexableValueFloatArrayNullForbidden() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1); // vec is null
+
+        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
+        ColumnsList index = new ColumnsListImplNoNulls(new Column[]{vecColumn});
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
+    }
+
+    /** Multi-column index (STRING + FLOATARRAY): validates the multi-column branch. */
+    @Test
+    public void testValidateIndexableValueFloatArrayMultiColumnIndex() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("tag", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+
+        float[] vector = {1.0f, 2.0f};
+        Record record = makeCacheFreeRecord(table, "pk", 1, "tag", RawString.of("a"), "vec", vector);
+
+        // Multi-column index: [tag, vec]
+        ColumnsList index = new ColumnsListImpl(new Column[]{
+            Column.column("tag", ColumnTypes.STRING),
+            Column.column("vec", ColumnTypes.FLOATARRAY)
+        });
+
+        DataAccessor rawAccessor = record.getDataAccessor(table);
+        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
+        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey()); // must not throw
+
+        // Also verify with null vec (nulls allowed)
+        Record recordNullVec = makeCacheFreeRecord(table, "pk", 2, "tag", RawString.of("b"));
+        DataAccessor rawNullVec = recordNullVec.getDataAccessor(table);
+        RecordSerializer.validateIndexableValue(rawNullVec, index, index.getPrimaryKey()); // must not throw
+    }
+
+    // ── Other index types — equivalence tests (verifies INTEGER/LONG fall through) ──
+
+    /** STRING single-column index: optimised and reference paths must agree. */
+    @Test
+    public void testSerializeIndexKeyStringNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("name", ColumnTypes.STRING)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "name", RawString.of("hello"));
+        assertIndexKeyEquivalence(table, record, "name", ColumnTypes.STRING, RawString.of("hello"));
+    }
+
+    /** DOUBLE single-column index: optimised and reference paths must agree. */
+    @Test
+    public void testSerializeIndexKeyDoubleNoCopy() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("score", ColumnTypes.DOUBLE)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "score", 3.14);
+        assertIndexKeyEquivalence(table, record, "score", ColumnTypes.DOUBLE, 3.14);
+    }
+
+    /**
+     * INTEGER single-column index: sign-flip means the optimisation is intentionally
+     * skipped; the general path must still produce the correct result.
+     */
+    @Test
+    public void testSerializeIndexKeyIntegerFallsThrough() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("num", ColumnTypes.INTEGER)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "num", 42);
+        assertIndexKeyEquivalence(table, record, "num", ColumnTypes.INTEGER, 42);
+    }
+
+    /**
+     * LONG single-column index: sign-flip means the optimisation is intentionally
+     * skipped; the general path must still produce the correct result.
+     */
+    @Test
+    public void testSerializeIndexKeyLongFallsThrough() {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.INTEGER)
+                .column("ts", ColumnTypes.LONG)
+                .primaryKey("pk")
+                .build();
+
+        Record record = makeCacheFreeRecord(table, "pk", 1, "ts", 123456789L);
+        assertIndexKeyEquivalence(table, record, "ts", ColumnTypes.LONG, 123456789L);
+    }
+
+    // ── Inner helpers ───────────────────────────────────────────────────────────
+
     private static Bytes varInt(int i) throws Exception {
         VisibleByteArrayOutputStream res = new VisibleByteArrayOutputStream(1);
         ExtendedDataOutputStream oo = new ExtendedDataOutputStream(res);
@@ -275,124 +580,17 @@ public class RecordSerializerTest {
         }
     }
 
-    /**
-     * Verifies that {@link RecordSerializer#serializeIndexKey} on a
-     * {@link DataAccessorForFullRecord} with a FLOATARRAY column produces the same
-     * {@link Bytes} key as the general path that goes through a {@link MapDataAccessor}.
-     * This exercises the no-copy optimisation introduced in issue #377.
-     */
-    @Test
-    public void testSerializeIndexKeyFloatArrayNoCopy() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("vec", ColumnTypes.FLOATARRAY)
-                .primaryKey("pk")
-                .build();
+    /** {@link ColumnsListImpl} variant with {@code allowNullsForIndexedValues() = false}. */
+    private class ColumnsListImplNoNulls extends ColumnsListImpl {
 
-        float[] vector = {1.0f, 2.0f, 3.0f, 4.0f};
-        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1, "vec", vector);
-        // Use a cache-free record so getDataAccessor() returns DataAccessorForFullRecord
-        Record record = new Record(baseRecord.key, baseRecord.value);
+        public ColumnsListImplNoNulls(Column[] indexedColumns) {
+            super(indexedColumns);
+        }
 
-        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
-        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
-
-        // Reference result via MapDataAccessor (original path)
-        Map<String, Object> mapData = new HashMap<>();
-        mapData.put("pk", 1);
-        mapData.put("vec", vector);
-        DataAccessor mapAccessor = new MapDataAccessor(mapData, table.columnNames);
-        Bytes expectedKey = RecordSerializer.serializeIndexKey(mapAccessor, index, index.getPrimaryKey());
-
-        // Optimised path: DataAccessorForFullRecord
-        DataAccessor rawAccessor = record.getDataAccessor(table);
-        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
-        Bytes actualKey = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
-
-        assertEquals(expectedKey, actualKey);
-    }
-
-    /**
-     * Verifies that {@link RecordSerializer#serializeIndexKey} returns {@code null}
-     * when the FLOATARRAY column is absent from the record value bytes (null value),
-     * and that the index allows nulls.
-     */
-    @Test
-    public void testSerializeIndexKeyFloatArrayNullValue() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("vec", ColumnTypes.FLOATARRAY)
-                .primaryKey("pk")
-                .build();
-
-        // Record with no "vec" value → vec is null
-        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1);
-        Record record = new Record(baseRecord.key, baseRecord.value);
-
-        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
-        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
-
-        DataAccessor rawAccessor = record.getDataAccessor(table);
-        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
-
-        Bytes result = RecordSerializer.serializeIndexKey(rawAccessor, index, index.getPrimaryKey());
-        assertNull("Expected null for absent FLOATARRAY column", result);
-    }
-
-    /**
-     * Verifies that {@link RecordSerializer#validateIndexableValue} does not throw
-     * for a FLOATARRAY column with a valid value on a {@link DataAccessorForFullRecord}
-     * (the no-materialise optimisation must not break validation).
-     */
-    @Test
-    public void testValidateIndexableValueFloatArrayNoCopy() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("vec", ColumnTypes.FLOATARRAY)
-                .primaryKey("pk")
-                .build();
-
-        float[] vector = {0.5f, 1.5f, -3.0f};
-        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1, "vec", vector);
-        Record record = new Record(baseRecord.key, baseRecord.value);
-
-        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
-        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn});
-
-        DataAccessor rawAccessor = record.getDataAccessor(table);
-        assertTrue("Expected DataAccessorForFullRecord", rawAccessor instanceof DataAccessorForFullRecord);
-
-        // Must not throw
-        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
-    }
-
-    /**
-     * Verifies that {@link RecordSerializer#validateIndexableValue} does not throw
-     * when the FLOATARRAY column is null and nulls are allowed
-     * (common case for secondary indexes: {@link Index#allowNullsForIndexedValues()} = true).
-     */
-    @Test
-    public void testValidateIndexableValueFloatArrayNullAllowed() {
-        Table table = Table.builder()
-                .name("t1")
-                .column("pk", ColumnTypes.INTEGER)
-                .column("vec", ColumnTypes.FLOATARRAY)
-                .primaryKey("pk")
-                .build();
-
-        // No "vec" value → null
-        Record baseRecord = RecordSerializer.makeRecord(table, "pk", 1);
-        Record record = new Record(baseRecord.key, baseRecord.value);
-
-        Column vecColumn = Column.column("vec", ColumnTypes.FLOATARRAY);
-        ColumnsList index = new ColumnsListImpl(new Column[]{vecColumn}); // allowNulls = true
-
-        DataAccessor rawAccessor = record.getDataAccessor(table);
-        // Must not throw even though vec is null, because allowNullsForIndexedValues() = true
-        RecordSerializer.validateIndexableValue(rawAccessor, index, index.getPrimaryKey());
+        @Override
+        public boolean allowNullsForIndexedValues() {
+            return false;
+        }
     }
 
 }

--- a/herddb-utils/src/main/java/herddb/utils/DataAccessor.java
+++ b/herddb-utils/src/main/java/herddb/utils/DataAccessor.java
@@ -29,6 +29,17 @@ public interface DataAccessor {
 
     Object get(String property);
 
+    /**
+     * Returns {@code true} if the value of {@code property} is SQL NULL.
+     *
+     * <p>The default implementation calls {@link #get(String)} and checks the result —
+     * implementations backed by serialised bytes (e.g. {@code DataAccessorForFullRecord})
+     * should override to avoid materialising the Java object.
+     */
+    default boolean isNull(String property) {
+        return get(property) == null;
+    }
+
     default Map<String, Object> toMap() {
         HashMap<String, Object> res = new HashMap<>();
         forEach(res::put);


### PR DESCRIPTION
Fixes #377.

## Changes

The optimisation has two distinct components:

### 1. `validateIndexableValue` — generic `DataAccessor.isNull` fast path
- Add `DataAccessor.isNull(String)` as a default method (delegates to `get() == null`).
- Override `isNull()` on `DataAccessorForFullRecord` with a fast path that peeks the type byte in the value buffer without materialising the Java object (uses the new `RecordSerializer.isNullValueForColumn` helper).
- `validateIndexableValue`: when the accessor is a `DataAccessorForFullRecord` the serialised format already guarantees type correctness, so we only need a null check. This skips `validate()` for ALL column types (not just FLOATARRAY), eliminating the `float[]` / `byte[]` / `String` allocation that would otherwise dominate the validate hot path on every insert/update touching a secondary index.

### 2. `serializeIndexKey` — FLOATARRAY-specific copying fast path
- For FLOATARRAY columns backed by `DataAccessorForFullRecord`, copy the raw IEEE 754 float bytes directly from the record value buffer into a freshly-allocated `byte[]` via `RecordSerializer.extractFloatArrayIndexKeyBytes`. This avoids the `float[N]` intermediate that `record.get() + serialize()` would allocate.
- The bytes are **copied** (not sliced) so the index does not retain a reference to the record's value buffer (which would pin a multi-MB DataPage backing array — a memory leak).
- INTEGER, LONG, TIMESTAMP, STRING, BYTEARRAY, DOUBLE, BOOLEAN are not optimised here: the savings are marginal once a copy is mandatory, and INTEGER/LONG/TIMESTAMP additionally have a sign-flip mask difference between value and key encoding.

## Tests

29 tests in `RecordSerializerTest`, including:
- `testIsNullDefaultImplementationOnMapDataAccessor` — generic default `isNull()` impl.
- `testIsNullOnDataAccessorForFullRecord` — fast `isNull()` for STRING/FLOATARRAY/DOUBLE/LONG, populated and absent.
- `testSerializeIndexKeyFloatArrayCopies` — happy path + asserts `isShared() == false` (regression guard against a slice instead of a copy).
- `testSerializeIndexKeyFloatArrayNullValue` / `…NullValueThrowsWhenNullsForbidden` / `…Empty` / `…LargeVector` (4 096 floats) / `…AtLaterSerialPosition` (exercises `skipTypeAndValue`).
- `testSerializeIndexKeyXxxGeneralPath` — equivalence between MapDataAccessor and DataAccessorForFullRecord for STRING, BYTEARRAY, DOUBLE, BOOLEAN, INTEGER, LONG, TIMESTAMP.
- `testValidateIndexableValueXxx` — non-null, null-allowed, null-forbidden, multi-column.
- `testValidateIndexableValueAllTypesOnDataAccessorForFullRecord` — generic-isNull path applies to all types.
- `testValidateIndexableValueMapDataAccessorStillValidatesType` — guards that non-DataAccessorForFullRecord callers still run full type validation (rejects a String supplied where a FLOATARRAY is expected).

## Validation
- 29 unit tests pass.
- Pre-PR validation green: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`.
- Hammer suite green twice in a row: `DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`, `WithNonUniqueIndexesTest`, `WithUniqueIndexesTest` — 12/12 each run.

🤖 Implemented by the `pr-worker` agent.