### PR TITLE
issue #386: replace BLink Node/Anchor RW lock with StampedLock

### DIFF
--- a/.claude/agents/pr-worker.md
+++ b/.claude/agents/pr-worker.md
@@ -175,6 +175,9 @@ mvn -pl <module> -Dtest='<TestClass>' \
 mvn -pl herddb-core \
     -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' \
     -Dmaven.repo.local=$MAVEN_REPO test
+mvn -pl herddb-utils \
+    -Dtest='BLinkConcurrentSearchInsertTest' \
+    -Dmaven.repo.local=$MAVEN_REPO test
 ```
 
 **Pre-PR validation:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,21 @@ This matches what `.github/workflows/pr-validation.yml` runs in CI (checkstyle, 
 
 For any change related to indexes, checkpoints, or concurrency, also run every
 subclass of `DirectMultipleConcurrentUpdatesSuite` (in
-`herddb-core/src/test/java/herddb/server/hammer/`) and make sure they all pass:
+`herddb-core/src/test/java/herddb/server/hammer/`) plus the BLink-level
+concurrent search/insert hammer (`BLinkConcurrentSearchInsertTest` in
+`herddb-utils/src/test/java/herddb/index/blink/`), and make sure they all pass:
 ```
 mvn -pl herddb-core -Dtest='DirectMultipleConcurrentUpdatesSuiteNoIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest,DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest' test
+mvn -pl herddb-utils -Dtest='BLinkConcurrentSearchInsertTest' test
 ```
-These hammer tests exercise concurrent DML with periodic checkpoints and
-recovery, so they are the main regression gate for the primary-key index, the
-checkpoint pipeline, and transaction isolation. Run them multiple times when
-the first pass is green to reduce the chance of a flake masking a real bug.
+The `DirectMultipleConcurrentUpdatesSuite` tests exercise concurrent DML with
+periodic checkpoints and recovery, so they are the main regression gate for
+the primary-key index, the checkpoint pipeline, and transaction isolation.
+`BLinkConcurrentSearchInsertTest` hammers the lower-level BLink with many
+concurrent searches against fewer concurrent writers on overlapping keys,
+catching regressions in the per-node and anchor lock primitives that drive
+every primary-key lookup. Run them multiple times when the first pass is
+green to reduce the chance of a flake masking a real bug.
 
 ## Test Categories
 Tests that require ZooKeeper/BookKeeper infrastructure (cluster mode) must be annotated with

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -1741,6 +1741,17 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
      * the same observable behaviour as {@link StampedLock#unlockRead(long)} called
      * with an invalid stamp.
      * </p>
+     * <p>
+     * <b>Important:</b> the unstamped {@code tryUnlockRead/Write} primitives do
+     * <i>not</i> verify that the releasing thread is the one that originally
+     * acquired the lock. This helper therefore relies on BLink's strict
+     * same-thread acquire/release pairing — every operation that locks a node
+     * or the anchor must release that same lock on the same thread. Any future
+     * caller that hands a held lock off to another thread for release would
+     * silently corrupt the lock state and must instead use the stamped
+     * {@link StampedLock#unlockRead(long)} / {@link StampedLock#unlockWrite(long)}
+     * primitives directly.
+     * </p>
      */
     private void unlock(StampedLock lock, int locktype) {
         if (locktype == READ_LOCK) {

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.StampedLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -1710,19 +1711,46 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         unlock(n.lock, locktype);
     }
 
-    private void lock(ReadWriteLock lock, int locktype) {
+    /**
+     * Acquire {@code lock} in the requested mode.
+     * <p>
+     * The {@link StampedLock#readLock()} / {@link StampedLock#writeLock()} stamps are
+     * intentionally discarded: BLink's per-node and anchor locks always follow a strict
+     * acquire-then-release pattern within the same operation, with no same-thread
+     * re-entrancy on the same lock instance and no read→write upgrade. The companion
+     * {@link #unlock(StampedLock, int)} releases via {@link StampedLock#tryUnlockRead()} /
+     * {@link StampedLock#tryUnlockWrite()}, which do not require the stamp.
+     * </p>
+     */
+    private void lock(StampedLock lock, int locktype) {
         if (locktype == READ_LOCK) {
-            lock.readLock().lock();
+            lock.readLock();
         } else {
-            lock.writeLock().lock();
+            lock.writeLock();
         }
     }
 
-    private void unlock(ReadWriteLock lock, int locktype) {
+    /**
+     * Release one hold of {@code lock} in the requested mode.
+     * <p>
+     * Uses the unstamped {@link StampedLock#tryUnlockRead()} /
+     * {@link StampedLock#tryUnlockWrite()} primitives so we don't have to thread
+     * stamps through every BLink call site. They release exactly one hold of the
+     * matching mode and return {@code false} if no such hold exists; we promote that
+     * to {@link IllegalMonitorStateException} so misuse is caught at the call site —
+     * the same observable behaviour as {@link StampedLock#unlockRead(long)} called
+     * with an invalid stamp.
+     * </p>
+     */
+    private void unlock(StampedLock lock, int locktype) {
         if (locktype == READ_LOCK) {
-            lock.readLock().unlock();
+            if (!lock.tryUnlockRead()) {
+                throw new IllegalMonitorStateException("read lock not held");
+            }
         } else {
-            lock.writeLock().unlock();
+            if (!lock.tryUnlockWrite()) {
+                throw new IllegalMonitorStateException("write lock not held");
+            }
         }
     }
 
@@ -1868,7 +1896,14 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 //  end;
     private static class Anchor<X extends Comparable<X>, Y> {
 
-        final ReadWriteLock lock;
+        /**
+         * Anchor access lock. {@link StampedLock} is used instead of
+         * {@link ReentrantReadWriteLock} to drop the AQS {@code HoldCounter}
+         * {@link ThreadLocal} and shrink per-acquisition state transitions on
+         * the very hot anchor read path (every BLink {@code search} /
+         * {@code locate_leaf} reads the anchor).
+         */
+        final StampedLock lock;
 
         /*
          * Next fields won't need to be volatile. They are written only during write lock AND no other thread
@@ -1898,7 +1933,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
             this.topheight = topheight;
             this.first = first;
 
-            lock = new ReentrantReadWriteLock(false);
+            lock = new StampedLock();
         }
 
         public void reset(Node<X, Y> root) {
@@ -1925,15 +1960,19 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         /**
          * Estimated constant memory overhead for a BLink Node object.
          * <p>
-         * Includes the Node instance itself, one TreeMap, and two ReentrantReadWriteLocks.
+         * Includes the Node instance itself, one TreeMap, one {@link StampedLock}
+         * (the per-node access lock) and one {@link ReentrantReadWriteLock}
+         * (the per-node load lock).
          * <p>
          * With compressed oops:
-         *   Node instance: 88 bytes, TreeMap: 48 bytes, 2x ReadWriteLock: 240 bytes = 376 bytes
+         *   Node instance: 88 bytes, TreeMap: 48 bytes,
+         *   StampedLock: ~64 bytes, ReentrantReadWriteLock: ~120 bytes = 320 bytes
          * <p>
          * Without compressed oops:
-         *   Node instance: 136 bytes, TreeMap: 64 bytes, 2x ReadWriteLock: 384 bytes = 584 bytes
+         *   Node instance: 136 bytes, TreeMap: 64 bytes,
+         *   StampedLock: ~96 bytes, ReentrantReadWriteLock: ~192 bytes = 488 bytes
          */
-        static final long NODE_CONSTANT_SIZE = ObjectSizeUtils.COMPRESSED_OOPS ? 376L : 584L;
+        static final long NODE_CONSTANT_SIZE = ObjectSizeUtils.COMPRESSED_OOPS ? 320L : 488L;
 
         /**
          * Estimated size of a single TreeMap.Entry (Red-Black tree node).
@@ -1957,9 +1996,18 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         final boolean leaf;
 
         /**
-         * Node access lock
+         * Node access lock.
+         * <p>
+         * {@link StampedLock} is used instead of {@link ReentrantReadWriteLock}
+         * to drop the AQS {@code HoldCounter} {@link ThreadLocal} and shrink
+         * per-acquisition state transitions on the BLink search path, which
+         * acquires this read lock on every node along the descent. BLink locks
+         * each node with a strict acquire/release pattern (no same-thread
+         * re-entrancy on the same node), so the non-reentrant
+         * {@link StampedLock} is a safe drop-in.
+         * </p>
          */
-        final ReadWriteLock lock;
+        final StampedLock lock;
 
         /**
          * Node data load/unload lock ({@link #map})
@@ -2006,7 +2054,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 
             this.rightsep = rightsep;
 
-            this.lock = new ReentrantReadWriteLock(false);
+            this.lock = new StampedLock();
             this.loadLock = new ReentrantReadWriteLock(false);
 
             this.map = newNodeMap();
@@ -2044,7 +2092,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 
             this.rightsep = metadata.rightsep;
 
-            this.lock = new ReentrantReadWriteLock(false);
+            this.lock = new StampedLock();
             this.loadLock = new ReentrantReadWriteLock(false);
 
             this.map = newNodeMap();

--- a/herddb-utils/src/test/java/herddb/index/blink/BLinkConcurrentSearchInsertTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/BLinkConcurrentSearchInsertTest.java
@@ -1,0 +1,235 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.ClockProPolicy;
+import herddb.utils.Sized;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * Targeted regression test for the {@code Node.lock} / {@code Anchor.lock}
+ * swap from {@link java.util.concurrent.locks.ReentrantReadWriteLock} to
+ * {@link java.util.concurrent.locks.StampedLock} (issue #386).
+ *
+ * <p>Reproduces the exact lock-contention shape from the issue: many concurrent
+ * search threads exercising the read-lock path against a smaller set of insert
+ * threads exercising the write-lock path on overlapping keys, plus a snapshot
+ * of pre-populated keys that must remain visible throughout the run. Asserts:
+ * <ul>
+ *   <li>no exception thrown by any worker thread,</li>
+ *   <li>every pre-populated key is found by the search threads on every
+ *       iteration (the snapshot stays visible while writers churn around it),</li>
+ *   <li>after the writers complete, every newly-inserted key is findable and
+ *       every newly-deleted key is gone,</li>
+ *   <li>the tree's reported {@code size()} matches the expected count.</li>
+ * </ul>
+ *
+ * <p>The non-reentrancy of {@link java.util.concurrent.locks.StampedLock} would
+ * surface here as deadlock or {@link IllegalMonitorStateException}; mismatched
+ * stamps would surface as cross-key visibility errors.
+ */
+public class BLinkConcurrentSearchInsertTest {
+
+    @Test
+    public void searchHeavyConcurrentLoad() throws Exception {
+
+        final int snapshotKeys = 4000;
+        final int writerKeys = 4000;
+        final int searchThreads = 12;
+        final int writerThreads = 4;
+        final int searchIterations = 200;
+        final int writerIterations = 1500;
+        final long timeoutSeconds = 120;
+
+        BLinkTest.DummyBLinkIndexDataStorage<Sized<Long>, Long> storage =
+                new BLinkTest.DummyBLinkIndexDataStorage<>();
+
+        try (BLink<Sized<Long>, Long> blink = new BLink<>(
+                4096L,
+                new BLinkTest.LongSizeEvaluator(),
+                new ClockProPolicy(50),
+                storage)) {
+
+            // Snapshot: pre-populated keys that must remain visible for the
+            // entire run. They never overlap with the writer key range so a
+            // search for any of them must always succeed.
+            final ConcurrentHashMap<Long, Long> snapshot = new ConcurrentHashMap<>();
+            for (long k = 0; k < snapshotKeys; k++) {
+                long value = k * 31L + 7L; // arbitrary non-zero value
+                blink.insert(Sized.valueOf(k), value);
+                snapshot.put(k, value);
+            }
+            assertEquals(snapshotKeys, blink.size());
+
+            // Writer key range starts above the snapshot range.
+            final long writerKeyBase = snapshotKeys;
+            final ConcurrentHashMap<Long, Long> writerExpected = new ConcurrentHashMap<>();
+
+            final List<Long> snapshotKeysList = new ArrayList<>(snapshot.keySet());
+            Collections.shuffle(snapshotKeysList, new Random(42));
+            final List<Long> snapshotKeysReadOnly = Collections.unmodifiableList(snapshotKeysList);
+
+            final ExecutorService pool = Executors.newFixedThreadPool(searchThreads + writerThreads);
+            final CountDownLatch ready = new CountDownLatch(searchThreads + writerThreads);
+            final CountDownLatch start = new CountDownLatch(1);
+            final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+            final AtomicLong searches = new AtomicLong();
+            final AtomicLong writes = new AtomicLong();
+            final AtomicLong deletes = new AtomicLong();
+
+            final List<Future<?>> futures = new ArrayList<>();
+
+            for (int t = 0; t < searchThreads; t++) {
+                final long seed = 1_000L + t;
+                futures.add(pool.submit(() -> {
+                    Random rnd = new Random(seed);
+                    ready.countDown();
+                    try {
+                        start.await();
+                        for (int i = 0; i < searchIterations; i++) {
+                            // Spot-check a random subset of snapshot keys per iteration:
+                            // keep the work per iteration bounded so the writer threads
+                            // get plenty of overlap rather than spending all their time
+                            // queued behind a single long search round.
+                            int probes = 32;
+                            for (int p = 0; p < probes; p++) {
+                                long k = snapshotKeysReadOnly.get(
+                                        rnd.nextInt(snapshotKeysReadOnly.size()));
+                                Long expected = snapshot.get(k);
+                                Long actual = blink.search(Sized.valueOf(k));
+                                assertNotNull("snapshot key " + k + " disappeared during run",
+                                        actual);
+                                assertEquals("snapshot key " + k + " value drift",
+                                        expected, actual);
+                                searches.incrementAndGet();
+                            }
+                            // Also probe writer-range keys to exercise the read path
+                            // against keys that may or may not exist concurrently with
+                            // writers; result is allowed to be null but must not throw.
+                            long wk = writerKeyBase + rnd.nextInt(writerKeys);
+                            blink.search(Sized.valueOf(wk));
+                            searches.incrementAndGet();
+                        }
+                    } catch (Throwable err) {
+                        firstFailure.compareAndSet(null, err);
+                    }
+                }));
+            }
+
+            for (int t = 0; t < writerThreads; t++) {
+                final long seed = 2_000L + t;
+                futures.add(pool.submit(() -> {
+                    Random rnd = new Random(seed);
+                    ready.countDown();
+                    try {
+                        start.await();
+                        for (int i = 0; i < writerIterations; i++) {
+                            long k = writerKeyBase + rnd.nextInt(writerKeys);
+                            int op = rnd.nextInt(10);
+                            if (op < 8) {
+                                // 80 % insert/update
+                                long v = rnd.nextLong();
+                                if (v == 0L) {
+                                    v = 1L; // reserve 0 as "deleted" sentinel
+                                }
+                                blink.insert(Sized.valueOf(k), v);
+                                writerExpected.put(k, v);
+                                writes.incrementAndGet();
+                            } else {
+                                // 20 % delete
+                                blink.delete(Sized.valueOf(k));
+                                writerExpected.put(k, 0L);
+                                deletes.incrementAndGet();
+                            }
+                        }
+                    } catch (Throwable err) {
+                        firstFailure.compareAndSet(null, err);
+                    }
+                }));
+            }
+
+            // Synchronize start so all threads contend together.
+            assertTrue("workers never reached the start barrier",
+                    ready.await(30, TimeUnit.SECONDS));
+            start.countDown();
+
+            for (Future<?> f : futures) {
+                f.get(timeoutSeconds, TimeUnit.SECONDS);
+            }
+            pool.shutdown();
+            assertTrue("thread pool did not shut down cleanly",
+                    pool.awaitTermination(30, TimeUnit.SECONDS));
+
+            if (firstFailure.get() != null) {
+                fail("worker thread failed: " + firstFailure.get());
+            }
+
+            // Re-verify the snapshot keys: every one of them must still be present
+            // with the original value.
+            for (long k = 0; k < snapshotKeys; k++) {
+                Long actual = blink.search(Sized.valueOf(k));
+                assertNotNull("post-run: snapshot key " + k + " missing", actual);
+                assertEquals("post-run: snapshot key " + k + " drifted",
+                        snapshot.get(k), actual);
+            }
+
+            // Verify writer-range keys match the latest writer expectation.
+            int finalLiveWriterKeys = 0;
+            for (long k = writerKeyBase; k < writerKeyBase + writerKeys; k++) {
+                Long expected = writerExpected.get(k);
+                Long actual = blink.search(Sized.valueOf(k));
+                if (expected == null || expected == 0L) {
+                    assertNull("post-run: writer key " + k + " should be absent but found "
+                            + actual, actual);
+                } else {
+                    assertEquals("post-run: writer key " + k + " value mismatch",
+                            expected, actual);
+                    finalLiveWriterKeys++;
+                }
+            }
+
+            assertEquals("tree size mismatch after concurrent run",
+                    snapshotKeys + finalLiveWriterKeys, blink.size());
+
+            System.out.println("BLinkConcurrentSearchInsertTest done — searches="
+                    + searches.get() + " writes=" + writes.get()
+                    + " deletes=" + deletes.get()
+                    + " liveWriterKeys=" + finalLiveWriterKeys);
+        }
+    }
+}

--- a/herddb-utils/src/test/java/herddb/index/blink/BLinkConcurrentSearchInsertTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/BLinkConcurrentSearchInsertTest.java
@@ -39,6 +39,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Test;
 
 /**
@@ -62,16 +64,24 @@ import org.junit.Test;
  * <p>The non-reentrancy of {@link java.util.concurrent.locks.StampedLock} would
  * surface here as deadlock or {@link IllegalMonitorStateException}; mismatched
  * stamps would surface as cross-key visibility errors.
+ *
+ * <p>Each writer thread owns a disjoint shard of the writer key range so two
+ * writers never touch the same key — that keeps the in-test bookkeeping race
+ * free from "T1 inserts then T2 inserts then T2 records then T1 records"
+ * inversions and lets the post-run reconciliation be deterministic.
  */
 public class BLinkConcurrentSearchInsertTest {
+
+    private static final Logger LOGGER = Logger.getLogger(BLinkConcurrentSearchInsertTest.class.getName());
 
     @Test
     public void searchHeavyConcurrentLoad() throws Exception {
 
         final int snapshotKeys = 4000;
-        final int writerKeys = 4000;
-        final int searchThreads = 12;
         final int writerThreads = 4;
+        final int writerKeysPerThread = 1000; // disjoint shards
+        final int writerKeys = writerThreads * writerKeysPerThread;
+        final int searchThreads = 12;
         final int searchIterations = 200;
         final int writerIterations = 1500;
         final long timeoutSeconds = 120;
@@ -96,7 +106,8 @@ public class BLinkConcurrentSearchInsertTest {
             }
             assertEquals(snapshotKeys, blink.size());
 
-            // Writer key range starts above the snapshot range.
+            // Writer key range starts above the snapshot range and is sharded
+            // across writer threads so two writers never touch the same key.
             final long writerKeyBase = snapshotKeys;
             final ConcurrentHashMap<Long, Long> writerExpected = new ConcurrentHashMap<>();
 
@@ -105,131 +116,155 @@ public class BLinkConcurrentSearchInsertTest {
             final List<Long> snapshotKeysReadOnly = Collections.unmodifiableList(snapshotKeysList);
 
             final ExecutorService pool = Executors.newFixedThreadPool(searchThreads + writerThreads);
-            final CountDownLatch ready = new CountDownLatch(searchThreads + writerThreads);
-            final CountDownLatch start = new CountDownLatch(1);
-            final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
-            final AtomicLong searches = new AtomicLong();
-            final AtomicLong writes = new AtomicLong();
-            final AtomicLong deletes = new AtomicLong();
+            try {
+                final CountDownLatch ready = new CountDownLatch(searchThreads + writerThreads);
+                final CountDownLatch start = new CountDownLatch(1);
+                final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+                final AtomicLong searches = new AtomicLong();
+                final AtomicLong writes = new AtomicLong();
+                final AtomicLong deletes = new AtomicLong();
 
-            final List<Future<?>> futures = new ArrayList<>();
+                final List<Future<?>> futures = new ArrayList<>();
 
-            for (int t = 0; t < searchThreads; t++) {
-                final long seed = 1_000L + t;
-                futures.add(pool.submit(() -> {
-                    Random rnd = new Random(seed);
-                    ready.countDown();
-                    try {
-                        start.await();
-                        for (int i = 0; i < searchIterations; i++) {
-                            // Spot-check a random subset of snapshot keys per iteration:
-                            // keep the work per iteration bounded so the writer threads
-                            // get plenty of overlap rather than spending all their time
-                            // queued behind a single long search round.
-                            int probes = 32;
-                            for (int p = 0; p < probes; p++) {
-                                long k = snapshotKeysReadOnly.get(
-                                        rnd.nextInt(snapshotKeysReadOnly.size()));
-                                Long expected = snapshot.get(k);
-                                Long actual = blink.search(Sized.valueOf(k));
-                                assertNotNull("snapshot key " + k + " disappeared during run",
-                                        actual);
-                                assertEquals("snapshot key " + k + " value drift",
-                                        expected, actual);
+                for (int t = 0; t < searchThreads; t++) {
+                    final long seed = 1_000L + t;
+                    futures.add(pool.submit(() -> {
+                        Random rnd = new Random(seed);
+                        ready.countDown();
+                        try {
+                            start.await();
+                            for (int i = 0; i < searchIterations; i++) {
+                                // Spot-check a random subset of snapshot keys per iteration:
+                                // keep the work per iteration bounded so the writer threads
+                                // get plenty of overlap rather than spending all their time
+                                // queued behind a single long search round.
+                                int probes = 32;
+                                for (int p = 0; p < probes; p++) {
+                                    long k = snapshotKeysReadOnly.get(
+                                            rnd.nextInt(snapshotKeysReadOnly.size()));
+                                    Long expected = snapshot.get(k);
+                                    Long actual = blink.search(Sized.valueOf(k));
+                                    assertNotNull("snapshot key " + k + " disappeared during run",
+                                            actual);
+                                    assertEquals("snapshot key " + k + " value drift",
+                                            expected, actual);
+                                    searches.incrementAndGet();
+                                }
+                                // Also probe writer-range keys to exercise the read path
+                                // against keys that may or may not exist concurrently with
+                                // writers; result is allowed to be null but must not throw.
+                                long wk = writerKeyBase + rnd.nextInt(writerKeys);
+                                blink.search(Sized.valueOf(wk));
                                 searches.incrementAndGet();
                             }
-                            // Also probe writer-range keys to exercise the read path
-                            // against keys that may or may not exist concurrently with
-                            // writers; result is allowed to be null but must not throw.
-                            long wk = writerKeyBase + rnd.nextInt(writerKeys);
-                            blink.search(Sized.valueOf(wk));
-                            searches.incrementAndGet();
+                            // Broad catch: this is a top-level executor worker. We have to
+                            // surface every Throwable (including AssertionError raised by the
+                            // assertNotNull/assertEquals above and any unchecked exception
+                            // thrown by BLink) to the main thread, otherwise the executor
+                            // would silently swallow it and the test would falsely pass.
+                        } catch (Throwable err) {
+                            firstFailure.compareAndSet(null, err);
                         }
-                    } catch (Throwable err) {
-                        firstFailure.compareAndSet(null, err);
-                    }
-                }));
-            }
-
-            for (int t = 0; t < writerThreads; t++) {
-                final long seed = 2_000L + t;
-                futures.add(pool.submit(() -> {
-                    Random rnd = new Random(seed);
-                    ready.countDown();
-                    try {
-                        start.await();
-                        for (int i = 0; i < writerIterations; i++) {
-                            long k = writerKeyBase + rnd.nextInt(writerKeys);
-                            int op = rnd.nextInt(10);
-                            if (op < 8) {
-                                // 80 % insert/update
-                                long v = rnd.nextLong();
-                                if (v == 0L) {
-                                    v = 1L; // reserve 0 as "deleted" sentinel
-                                }
-                                blink.insert(Sized.valueOf(k), v);
-                                writerExpected.put(k, v);
-                                writes.incrementAndGet();
-                            } else {
-                                // 20 % delete
-                                blink.delete(Sized.valueOf(k));
-                                writerExpected.put(k, 0L);
-                                deletes.incrementAndGet();
-                            }
-                        }
-                    } catch (Throwable err) {
-                        firstFailure.compareAndSet(null, err);
-                    }
-                }));
-            }
-
-            // Synchronize start so all threads contend together.
-            assertTrue("workers never reached the start barrier",
-                    ready.await(30, TimeUnit.SECONDS));
-            start.countDown();
-
-            for (Future<?> f : futures) {
-                f.get(timeoutSeconds, TimeUnit.SECONDS);
-            }
-            pool.shutdown();
-            assertTrue("thread pool did not shut down cleanly",
-                    pool.awaitTermination(30, TimeUnit.SECONDS));
-
-            if (firstFailure.get() != null) {
-                fail("worker thread failed: " + firstFailure.get());
-            }
-
-            // Re-verify the snapshot keys: every one of them must still be present
-            // with the original value.
-            for (long k = 0; k < snapshotKeys; k++) {
-                Long actual = blink.search(Sized.valueOf(k));
-                assertNotNull("post-run: snapshot key " + k + " missing", actual);
-                assertEquals("post-run: snapshot key " + k + " drifted",
-                        snapshot.get(k), actual);
-            }
-
-            // Verify writer-range keys match the latest writer expectation.
-            int finalLiveWriterKeys = 0;
-            for (long k = writerKeyBase; k < writerKeyBase + writerKeys; k++) {
-                Long expected = writerExpected.get(k);
-                Long actual = blink.search(Sized.valueOf(k));
-                if (expected == null || expected == 0L) {
-                    assertNull("post-run: writer key " + k + " should be absent but found "
-                            + actual, actual);
-                } else {
-                    assertEquals("post-run: writer key " + k + " value mismatch",
-                            expected, actual);
-                    finalLiveWriterKeys++;
+                    }));
                 }
+
+                for (int t = 0; t < writerThreads; t++) {
+                    final long seed = 2_000L + t;
+                    final long shardBase = writerKeyBase + (long) t * writerKeysPerThread;
+                    final int shardSize = writerKeysPerThread;
+                    futures.add(pool.submit(() -> {
+                        Random rnd = new Random(seed);
+                        ready.countDown();
+                        try {
+                            start.await();
+                            for (int i = 0; i < writerIterations; i++) {
+                                long k = shardBase + rnd.nextInt(shardSize);
+                                int op = rnd.nextInt(10);
+                                if (op < 8) {
+                                    // 80 % insert/update
+                                    long v = rnd.nextLong();
+                                    if (v == 0L) {
+                                        v = 1L; // reserve 0 as "deleted" sentinel
+                                    }
+                                    blink.insert(Sized.valueOf(k), v);
+                                    writerExpected.put(k, v);
+                                    writes.incrementAndGet();
+                                } else {
+                                    // 20 % delete
+                                    blink.delete(Sized.valueOf(k));
+                                    writerExpected.put(k, 0L);
+                                    deletes.incrementAndGet();
+                                }
+                            }
+                            // Broad catch: top-level executor worker boundary, see the
+                            // search-thread block above for the rationale.
+                        } catch (Throwable err) {
+                            firstFailure.compareAndSet(null, err);
+                        }
+                    }));
+                }
+
+                // Synchronize start so all threads contend together.
+                assertTrue("workers never reached the start barrier",
+                        ready.await(30, TimeUnit.SECONDS));
+                start.countDown();
+
+                for (Future<?> f : futures) {
+                    f.get(timeoutSeconds, TimeUnit.SECONDS);
+                }
+
+                if (firstFailure.get() != null) {
+                    fail("worker thread failed: " + firstFailure.get());
+                }
+
+                // Re-verify the snapshot keys: every one of them must still be present
+                // with the original value.
+                for (long k = 0; k < snapshotKeys; k++) {
+                    Long actual = blink.search(Sized.valueOf(k));
+                    assertNotNull("post-run: snapshot key " + k + " missing", actual);
+                    assertEquals("post-run: snapshot key " + k + " drifted",
+                            snapshot.get(k), actual);
+                }
+
+                // Verify writer-range keys match the latest writer expectation.
+                // Because each writer owns a disjoint shard, writerExpected has the
+                // last-write-wins value for each key with no inter-thread races.
+                int finalLiveWriterKeys = 0;
+                for (long k = writerKeyBase; k < writerKeyBase + writerKeys; k++) {
+                    Long expected = writerExpected.get(k);
+                    Long actual = blink.search(Sized.valueOf(k));
+                    if (expected == null || expected == 0L) {
+                        assertNull("post-run: writer key " + k + " should be absent but found "
+                                + actual, actual);
+                    } else {
+                        assertEquals("post-run: writer key " + k + " value mismatch",
+                                expected, actual);
+                        finalLiveWriterKeys++;
+                    }
+                }
+
+                assertEquals("tree size mismatch after concurrent run",
+                        snapshotKeys + finalLiveWriterKeys, blink.size());
+
+                if (LOGGER.isLoggable(Level.INFO)) {
+                    LOGGER.log(Level.INFO,
+                            "BLinkConcurrentSearchInsertTest done - searches={0} writes={1}"
+                                    + " deletes={2} liveWriterKeys={3}",
+                            new Object[]{
+                                searches.get(),
+                                writes.get(),
+                                deletes.get(),
+                                finalLiveWriterKeys
+                            });
+                }
+            } finally {
+                // Shut down aggressively: if any worker is still alive (e.g. a deadlock
+                // we're meant to detect) this surfaces it as a clean test failure
+                // rather than a leaked non-daemon thread polluting the surefire fork.
+                pool.shutdownNow();
+                assertTrue("thread pool did not shut down cleanly",
+                        pool.awaitTermination(30, TimeUnit.SECONDS));
             }
-
-            assertEquals("tree size mismatch after concurrent run",
-                    snapshotKeys + finalLiveWriterKeys, blink.size());
-
-            System.out.println("BLinkConcurrentSearchInsertTest done — searches="
-                    + searches.get() + " writes=" + writes.get()
-                    + " deletes=" + deletes.get()
-                    + " liveWriterKeys=" + finalLiveWriterKeys);
         }
     }
 }


### PR DESCRIPTION
Fixes #386.

## Changes
- `herddb-utils/src/main/java/herddb/index/blink/BLink.java`:
  - `Anchor.lock` and `Node.lock` switched from `ReentrantReadWriteLock(false)` to `StampedLock`. Drops the AQS `HoldCounter` `ThreadLocal` and shrinks per-acquisition state transitions on the hot search path (every `BLink.search()` / `locate_leaf` traversal).
  - The two private `lock(.., int)` / `unlock(.., int)` helpers keep the same call-site signature; internally they acquire via `StampedLock.readLock()` / `writeLock()` (stamp discarded) and release via `tryUnlockRead()` / `tryUnlockWrite()` — these do not require a stamp and throw `IllegalMonitorStateException` on the `false` return, matching the observable behaviour of `unlockRead(invalidStamp)`.
  - `Node.loadLock` is intentionally **left as `ReentrantReadWriteLock`** — its read→write upgrade pattern in `loadAndLock()` and the `isWriteLockedByCurrentThread` debug check in `flush()` are unrelated to the search path and are deliberately out of scope for this perf-on-search change.
  - `NODE_CONSTANT_SIZE` updated to reflect that one of the two per-node locks is now a smaller `StampedLock`.

## Why this is safe
`StampedLock` is non-reentrant. I audited every caller of `lock(node, *)`, `unlock(node, *)`, `lock_anchor`, `unlock_anchor` (~27 call sites): the BLink algorithm uses a strict acquire-then-release pattern, every read→write upgrade is done by explicit release-and-reacquire (`lock_anchor` at line 1435 is the canonical case), and the `move_right` traversal unlocks each node before locking the next. No same-thread re-entrancy on the same lock instance exists.

This matches the issue's "intermediate improvement with less refactoring risk" path; optimistic reads in `search()` are deferred to a follow-up because they would change the move-right protocol's correctness contract.

## Tests
- New `herddb.index.blink.BLinkConcurrentSearchInsertTest`: hammers the exact lock-contention shape from the issue — 12 search threads + 4 writer threads on overlapping keys, plus a 4 K-key snapshot that must stay visible throughout. Asserts no thread errors, snapshot keys remain consistent across the run, post-run writer keys match latest expectations, and `tree.size()` matches.
- Re-ran `ConcurrentUpdatesBLinkTest`, `ConcurrentCheckpointBLinkTest`, `BLinkTest`, `BLinkConstantSizeTest` — all green.
- Hammer suite (`DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`, `DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest`, `DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest`) ran **twice end-to-end**, both passes green (12/12 each, ~28 s).
- Pre-PR validation (`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`) green.

🤖 Implemented by the `pr-worker` agent.