### PR TITLE
issue #391: zero-copy RecordFunction.computeNewValue via Bytes view

### DIFF
--- a/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
+++ b/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
@@ -100,13 +100,18 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
         RecordFunction keyFunction = new RecordFunction() {
             @Override
             @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
-            public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext)
+            public Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext)
                     throws StatementExecutionException {
                 try {
                     K key = ((PutStatementEvaluationContext<K, V>) context).getKey();
-                    return keySerializer.apply(key);
+                    return Bytes.from_array(keySerializer.apply(key));
                 } catch (StatementExecutionException err) {
                     throw err;
+                // The keySerializer is a user-supplied Function<K, byte[]>; it
+                // can throw arbitrary checked/unchecked exceptions and we must
+                // convert all of them into StatementExecutionException to keep
+                // the JDBC contract upstream. Narrow catches are not possible
+                // at this plugin boundary.
                 } catch (Exception err) {
                     throw new StatementExecutionException(err);
                 }
@@ -115,13 +120,15 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
         RecordFunction valuesFunction = new RecordFunction() {
             @Override
             @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
-            public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext)
+            public Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext)
                     throws StatementExecutionException {
                 try {
                     V value = ((PutStatementEvaluationContext<K, V>) context).getValue();
-                    return valuesSerializer.serialize(value);
+                    return Bytes.from_array(valuesSerializer.serialize(value));
                 } catch (StatementExecutionException err) {
                     throw err;
+                // valuesSerializer is a user-supplied serializer; same plugin
+                // boundary rationale as the keyFunction above.
                 } catch (Exception err) {
                     throw new StatementExecutionException(err);
                 }
@@ -306,7 +313,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
         @Override
         public PrimaryKeyMatchOutcome matchesRawPrimaryKey(Bytes key, StatementEvaluationContext context) throws
                 StatementExecutionException {
-            if (key.equals(Bytes.from_array(keyFunction.computeNewValue(null, context, null)))) {
+            if (key.equals(keyFunction.computeNewValue(null, context, null))) {
                 return PrimaryKeyMatchOutcome.FULL_CONDITION_VERIFIED;
             } else {
                 return PrimaryKeyMatchOutcome.FAILED;

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -876,10 +876,10 @@ public final class RecordSerializer {
     }
 
     public static Bytes serializePrimaryKey(Map<String, Object> record, ColumnsList table, String[] columns) {
-        return Bytes.from_array(serializePrimaryKeyRaw(record, table, columns));
+        return serializePrimaryKeyRaw(record, table, columns);
     }
 
-    public static byte[] serializePrimaryKeyRaw(Map<String, Object> record, ColumnsList table, String[] columns) {
+    public static Bytes serializePrimaryKeyRaw(Map<String, Object> record, ColumnsList table, String[] columns) {
         String[] primaryKey = table.getPrimaryKey();
         if (primaryKey.length == 1) {
             String pkColumn = primaryKey[0];
@@ -891,7 +891,7 @@ public final class RecordSerializer {
             if (v == null) {
                 throw new IllegalArgumentException("key field " + pkColumn + " cannot be null. Record data: " + record);
             }
-            return serialize(v, c.type);
+            return Bytes.from_array(serialize(v, c.type));
         } else {
             VisibleByteArrayOutputStream key = TL_BUFFER.get();
             key.reset();
@@ -913,7 +913,10 @@ public final class RecordSerializer {
             } catch (IOException err) {
                 throw new RuntimeException(err);
             }
-            return key.toByteArray();
+            // Issue #391: hand the freshly-stolen buffer to the caller as a
+            // zero-copy Bytes view; the TL_BUFFER is replaced with a fresh
+            // array so subsequent calls cannot overwrite the returned bytes.
+            return key.stealBytes();
         }
     }
 
@@ -1128,10 +1131,10 @@ public final class RecordSerializer {
     }
 
     public static Bytes serializeValue(Map<String, Object> record, Table table) {
-        return Bytes.from_array(serializeValueRaw(record, table, 0));
+        return serializeValueRaw(record, table, 0);
     }
 
-    public static byte[] serializeValueRaw(Map<String, Object> record, Table table, int expectedSize) {
+    public static Bytes serializeValueRaw(Map<String, Object> record, Table table, int expectedSize) {
         VisibleByteArrayOutputStream value = TL_BUFFER.get();
         value.reset();
         try (ExtendedDataOutputStream doo = new ExtendedDataOutputStream(value)) {
@@ -1146,10 +1149,11 @@ public final class RecordSerializer {
             throw new RuntimeException(err);
         }
 
-        return value.toByteArray();
+        // Issue #391: zero-copy hand-off of the TL_BUFFER as a Bytes view.
+        return value.stealBytes();
     }
 
-    public static byte[] buildRecord(
+    public static Bytes buildRecord(
             int expectedSize, Table table,
             Function<String, Object> evaluator
     ) {
@@ -1169,7 +1173,8 @@ public final class RecordSerializer {
             throw new RuntimeException(err);
         }
 
-        return value.toByteArray();
+        // Issue #391: zero-copy hand-off of the TL_BUFFER as a Bytes view.
+        return value.stealBytes();
     }
 
     public static Record toRecord(Map<String, Object> record, Table table) {

--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -51,6 +51,10 @@ public class DataPage extends Page<TableManager> {
         return Record.estimateSize(key, value) + DataPage.CONSTANT_ENTRY_BYTE_SIZE;
     }
 
+    public static long estimateEntrySize(Bytes key, Bytes value) {
+        return Record.estimateSize(key, value) + DataPage.CONSTANT_ENTRY_BYTE_SIZE;
+    }
+
     public static long estimateEntrySize(Record record) {
         return record.getEstimatedSize() + DataPage.CONSTANT_ENTRY_BYTE_SIZE;
     }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1466,9 +1466,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
          the insert will update the 'maxKey' for auto_increment primary keys
          */
         Bytes key;
-        byte[] value;
+        Bytes value;
         try {
-            key = Bytes.from_array(insert.getKeyFunction().computeNewValue(null, context, tableContext));
+            key = insert.getKeyFunction().computeNewValue(null, context, tableContext);
             value = insert.getValuesFunction().computeNewValue(new Record(key, null), context, tableContext);
         } catch (StatementExecutionException validationError) {
             return Futures.exception(validationError);
@@ -1479,7 +1479,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
         if (indexes != null || table.foreignKeys != null) {
             try {
-                DataAccessor values = new Record(key, Bytes.from_array(value)).getDataAccessor(table);
+                DataAccessor values = new Record(key, value).getDataAccessor(table);
                 if (table.foreignKeys != null) {
                     for (ForeignKeyDef fk : table.foreignKeys) {
                         checkForeignKeyConstraintsAsChildTable(fk, values, context, transaction);
@@ -1567,15 +1567,15 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (res == null) {
             LogEntry entry;
             if (fallbackToUpsert) {
-                entry = LogEntryFactory.update(table, key, Bytes.from_array(value), transaction);
+                entry = LogEntryFactory.update(table, key, value, transaction);
             } else {
-                entry = LogEntryFactory.insert(table, key, Bytes.from_array(value), transaction);
+                entry = LogEntryFactory.insert(table, key, value, transaction);
             }
             CommitLogResult pos = log.log(entry, entry.transactionId <= 0);
             res = pos.logSequenceNumber.thenApplyAsync((lsn) -> {
                 apply(pos, entry, false);
                 return new DMLStatementExecutionResult(entry.transactionId, 1, key,
-                        insert.isReturnValues() ? Bytes.from_array(value) : null);
+                        insert.isReturnValues() ? value : null);
             }, tableSpaceManager.getCallbacksExecutor());
         }
         if (uniqueIndexes != null) {
@@ -1861,7 +1861,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 //        LOGGER.log(Level.SEVERE, "executeUpdateAsync, " + update + ", transaction " + transaction);
         AtomicInteger updateCount = new AtomicInteger();
         Holder<Bytes> lastKey = new Holder<>();
-        Holder<byte[]> lastValue = new Holder<>();
+        Holder<Bytes> lastValue = new Holder<>();
         /*
          an update can succeed only if the row is valid, the key is contains in the "keys" structure
          the update will simply override the value of the row, assigning a null page to the row
@@ -1881,7 +1881,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 public void accept(Record current, LockHandle lockHandle) throws StatementExecutionException, LogNotAvailableException, DataStorageManagerException {
 
                     List<UniqueIndexLockReference> uniqueIndexes = null;
-                    byte[] newValue;
+                    Bytes newValue;
                     try {
                         if (childrenTables != null) {
                             DataAccessor currentValues = current.getDataAccessor(table);
@@ -1891,7 +1891,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         }
                         newValue = function.computeNewValue(current, context, tableContext);
                         if (indexes != null || table.foreignKeys != null) {
-                            DataAccessor values = new Record(current.key, Bytes.from_array(newValue)).getDataAccessor(table);
+                            DataAccessor values = new Record(current.key, newValue).getDataAccessor(table);
                             if (table.foreignKeys != null) {
                                 for (ForeignKeyDef fk : table.foreignKeys) {
                                     checkForeignKeyConstraintsAsChildTable(fk, values, context, transaction);
@@ -1946,7 +1946,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         return;
                     }
 
-                    LogEntry entry = LogEntryFactory.update(table, current.key, Bytes.from_array(newValue), transaction);
+                    LogEntry entry = LogEntryFactory.update(table, current.key, newValue, transaction);
                     CommitLogResult pos = log.log(entry, entry.transactionId <= 0);
                     final List<UniqueIndexLockReference> _uniqueIndexes = uniqueIndexes;
                     writes.add(pos.logSequenceNumber.thenApply(lsn -> new PendingLogEntryWork(entry, pos, lockHandle, _uniqueIndexes)));
@@ -1980,7 +1980,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     }, tableSpaceManager.getCallbacksExecutor())
                     .thenApply((pending) -> {
                         return new DMLStatementExecutionResult(transactionId, updateCount.get(), lastKey.value,
-                                update.isReturnValues() ? (lastValue.value != null ? Bytes.from_array(lastValue.value) : null) : null);
+                                update.isReturnValues() ? lastValue.value : null);
                     });
         } else {
             return Futures
@@ -2000,7 +2000,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     }, tableSpaceManager.getCallbacksExecutor())
                     .thenApply((pendings) -> {
                         return new DMLStatementExecutionResult(transactionId, updateCount.get(), lastKey.value,
-                                update.isReturnValues() ? (lastValue.value != null ? Bytes.from_array(lastValue.value) : null) : null);
+                                update.isReturnValues() ? lastValue.value : null);
                     });
         }
 
@@ -3049,7 +3049,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     ) {
         Bytes key;
         try {
-            key = Bytes.from_nullable_array(get.getKey().computeNewValue(null, context, tableContext));
+            key = get.getKey().computeNewValue(null, context, tableContext);
         } catch (StatementExecutionException validationError) {
             return Futures.exception(validationError);
         }
@@ -4528,7 +4528,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     // this is the most common case for UPDATE-BY-PK and SELECT-BY-PK
                     // no need to craete and use Streams
                     PrimaryIndexSeek seek = (PrimaryIndexSeek) indexOperation;
-                    Bytes value = Bytes.from_array(seek.value.computeNewValue(null, context, tableContext));
+                    Bytes value = seek.value.computeNewValue(null, context, tableContext);
                     Long page = keyToPage.get(value);
                     if (page != null) {
                         Map.Entry<Bytes, Long> singleEntry =

--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -172,16 +172,15 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
 
         if (operation instanceof PrimaryIndexSeek) {
             PrimaryIndexSeek seek = (PrimaryIndexSeek) operation;
-            byte[] seekValue;
+            Bytes key;
             try {
-                seekValue = seek.value.computeNewValue(null, context, tableContext);
+                key = seek.value.computeNewValue(null, context, tableContext);
             } catch (InvalidNullValueForKeyException nullKey) {
-                seekValue = null;
+                key = null;
             }
-            if (seekValue == null) {
+            if (key == null) {
                     return Stream.empty();
                 }
-            Bytes key = Bytes.from_array(seekValue);
             Long pageId = map.get(key);
             if (pageId == null) {
                 return Stream.empty();
@@ -199,7 +198,7 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
             return baseStream;
         } else if (operation instanceof PrimaryIndexPrefixScan) {
             PrimaryIndexPrefixScan scan = (PrimaryIndexPrefixScan) operation;
-            byte[] prefix;
+            Bytes prefix;
             try {
                 prefix = scan.value.computeNewValue(null, context, tableContext);
             } catch (InvalidNullValueForKeyException err) {
@@ -209,7 +208,7 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
             }
             Predicate<Map.Entry<Bytes, Long>> predicate = (Map.Entry<Bytes, Long> t) -> {
                 Bytes fullrecordKey = t.getKey();
-                return fullrecordKey.startsWith(prefix.length, prefix);
+                return fullrecordKey.startsWith(prefix);
             };
             Stream<Map.Entry<Bytes, Long>> baseStream = map.entrySet().stream();
             return baseStream.filter(predicate);
@@ -219,7 +218,7 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
             PrimaryIndexRangeScan sis = (PrimaryIndexRangeScan) operation;
             SQLRecordKeyFunction minKey = sis.minValue;
             if (minKey != null) {
-                refminvalue = Bytes.from_nullable_array(minKey.computeNewValue(null, context, tableContext));
+                refminvalue = minKey.computeNewValue(null, context, tableContext);
             } else {
                 refminvalue = null;
             }
@@ -227,7 +226,7 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
             Bytes refmaxvalue;
             SQLRecordKeyFunction maxKey = sis.maxValue;
             if (maxKey != null) {
-                refmaxvalue = Bytes.from_nullable_array(maxKey.computeNewValue(null, context, tableContext));
+                refmaxvalue = maxKey.computeNewValue(null, context, tableContext);
             } else {
                 refmaxvalue = null;
             }

--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -179,8 +179,8 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
                 key = null;
             }
             if (key == null) {
-                    return Stream.empty();
-                }
+                return Stream.empty();
+            }
             Long pageId = map.get(key);
             if (pageId == null) {
                 return Stream.empty();

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -153,8 +153,8 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         if (operation instanceof SecondaryIndexSeek) {
             SecondaryIndexSeek sis = (SecondaryIndexSeek) operation;
             SQLRecordKeyFunction value = sis.value;
-            byte[] refvalue = value.computeNewValue(null, context, tableContext);
-            List<Bytes> result = data.get(Bytes.from_array(refvalue));
+            Bytes refvalue = value.computeNewValue(null, context, tableContext);
+            List<Bytes> result = data.get(refvalue);
             if (result != null) {
                 return result.stream();
             } else {
@@ -163,10 +163,10 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         } else if (operation instanceof SecondaryIndexPrefixScan) {
             SecondaryIndexPrefixScan sis = (SecondaryIndexPrefixScan) operation;
             SQLRecordKeyFunction value = sis.value;
-            byte[] refvalue = value.computeNewValue(null, context, tableContext);
+            Bytes refvalue = value.computeNewValue(null, context, tableContext);
             Predicate<Map.Entry<Bytes, List<Bytes>>> predicate = (Map.Entry<Bytes, List<Bytes>> entry) -> {
                 Bytes recordValue = entry.getKey();
-                return recordValue.startsWith(refvalue.length, refvalue);
+                return recordValue.startsWith(refvalue);
             };
             return data
                     .entrySet()
@@ -181,7 +181,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
             SecondaryIndexRangeScan sis = (SecondaryIndexRangeScan) operation;
             SQLRecordKeyFunction minKey = sis.minValue;
             if (minKey != null) {
-                refminvalue = Bytes.from_nullable_array(minKey.computeNewValue(null, context, tableContext));
+                refminvalue = minKey.computeNewValue(null, context, tableContext);
             } else {
                 refminvalue = null;
             }
@@ -189,7 +189,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
             Bytes refmaxvalue;
             SQLRecordKeyFunction maxKey = sis.maxValue;
             if (maxKey != null) {
-                refmaxvalue = Bytes.from_nullable_array(maxKey.computeNewValue(null, context, tableContext));
+                refmaxvalue = maxKey.computeNewValue(null, context, tableContext);
             } else {
                 refmaxvalue = null;
             }

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -223,11 +223,10 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     ) throws DataStorageManagerException, StatementExecutionException {
         if (operation instanceof PrimaryIndexSeek) {
             PrimaryIndexSeek seek = (PrimaryIndexSeek) operation;
-            byte[] seekValue = computeKeyValue(seek.value, context, tableContext);
-            if (seekValue == null) {
+            Bytes key = computeKeyValue(seek.value, context, tableContext);
+            if (key == null) {
                 return Stream.empty();
             }
-            Bytes key = Bytes.from_array(seekValue);
             Long pageId = getTree().search(key);
             if (pageId == null) {
                 return Stream.empty();
@@ -239,11 +238,10 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
             PrimaryIndexPrefixScan scan = (PrimaryIndexPrefixScan) operation;
 //            SQLRecordKeyFunction value = sis.value;
-            byte[] refvalue = computeKeyValue(scan.value, context, tableContext);
-            if (refvalue == null) {
+            Bytes firstKey = computeKeyValue(scan.value, context, tableContext);
+            if (firstKey == null) {
                 return Stream.empty();
             }
-            Bytes firstKey = Bytes.from_array(refvalue);
             Bytes lastKey = firstKey.next();
 
             return getTree().scan(firstKey, lastKey);
@@ -264,14 +262,14 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             PrimaryIndexRangeScan sis = (PrimaryIndexRangeScan) operation;
             SQLRecordKeyFunction minKey = sis.minValue;
             if (minKey != null) {
-                refminvalue = Bytes.from_array(minKey.computeNewValue(null, context, tableContext));
+                refminvalue = minKey.computeNewValue(null, context, tableContext);
             } else {
                 refminvalue = null;
             }
             Bytes refmaxvalue;
             SQLRecordKeyFunction maxKey = sis.maxValue;
             if (maxKey != null) {
-                refmaxvalue = Bytes.from_array(maxKey.computeNewValue(null, context, tableContext));
+                refmaxvalue = maxKey.computeNewValue(null, context, tableContext);
             } else {
                 refmaxvalue = null;
             }
@@ -282,7 +280,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
     }
 
-    private static byte[] computeKeyValue(RecordFunction keyFun, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
+    private static Bytes computeKeyValue(RecordFunction keyFun, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
         try {
             return keyFun.computeNewValue(null, context, tableContext);
         } catch (InvalidNullValueForKeyException invalidKeyValueException) {

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -254,11 +254,10 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
     ) throws DataStorageManagerException, StatementExecutionException {
         if (operation instanceof PrimaryIndexSeek) {
             PrimaryIndexSeek seek = (PrimaryIndexSeek) operation;
-            byte[] seekValue = computeKeyValue(seek.value, context, tableContext);
-            if (seekValue == null) {
+            Bytes key = computeKeyValue(seek.value, context, tableContext);
+            if (key == null) {
                 return Stream.empty();
             }
-            Bytes key = Bytes.from_array(seekValue);
             Long pageId = getTree().search(key);
             if (pageId == null) {
                 return Stream.empty();
@@ -268,11 +267,10 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
 
         if (operation instanceof PrimaryIndexPrefixScan) {
             PrimaryIndexPrefixScan scan = (PrimaryIndexPrefixScan) operation;
-            byte[] refvalue = computeKeyValue(scan.value, context, tableContext);
-            if (refvalue == null) {
+            Bytes firstKey = computeKeyValue(scan.value, context, tableContext);
+            if (firstKey == null) {
                 return Stream.empty();
             }
-            Bytes firstKey = Bytes.from_array(refvalue);
             Bytes lastKey = firstKey.next();
             return getTree().scan(firstKey, lastKey);
         }
@@ -288,14 +286,14 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             PrimaryIndexRangeScan sis = (PrimaryIndexRangeScan) operation;
             SQLRecordKeyFunction minKey = sis.minValue;
             if (minKey != null) {
-                refminvalue = Bytes.from_array(minKey.computeNewValue(null, context, tableContext));
+                refminvalue = minKey.computeNewValue(null, context, tableContext);
             } else {
                 refminvalue = null;
             }
             Bytes refmaxvalue;
             SQLRecordKeyFunction maxKey = sis.maxValue;
             if (maxKey != null) {
-                refmaxvalue = Bytes.from_array(maxKey.computeNewValue(null, context, tableContext));
+                refmaxvalue = maxKey.computeNewValue(null, context, tableContext);
             } else {
                 refmaxvalue = null;
             }
@@ -305,7 +303,7 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
         throw new DataStorageManagerException("operation " + operation + " not implemented on " + this.getClass());
     }
 
-    private static byte[] computeKeyValue(RecordFunction keyFun, StatementEvaluationContext context, TableContext tableContext)
+    private static Bytes computeKeyValue(RecordFunction keyFun, StatementEvaluationContext context, TableContext tableContext)
             throws StatementExecutionException {
         try {
             return keyFun.computeNewValue(null, context, tableContext);

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -393,14 +393,13 @@ public class BRINIndexManager extends AbstractIndexManager {
         if (operation instanceof SecondaryIndexSeek) {
             SecondaryIndexSeek sis = (SecondaryIndexSeek) operation;
             SQLRecordKeyFunction value = sis.value;
-            byte[] refvalue = value.computeNewValue(null, context, tableContext);
-            return data.query(Bytes.from_array(refvalue));
+            Bytes refvalue = value.computeNewValue(null, context, tableContext);
+            return data.query(refvalue);
 
         } else if (operation instanceof SecondaryIndexPrefixScan) {
             SecondaryIndexPrefixScan sis = (SecondaryIndexPrefixScan) operation;
             SQLRecordKeyFunction value = sis.value;
-            byte[] refvalue = value.computeNewValue(null, context, tableContext);
-            Bytes firstKey = Bytes.from_array(refvalue);
+            Bytes firstKey = value.computeNewValue(null, context, tableContext);
             Bytes lastKey = firstKey.next();
             return data.query(firstKey, lastKey);
 
@@ -412,14 +411,12 @@ public class BRINIndexManager extends AbstractIndexManager {
             SecondaryIndexRangeScan sis = (SecondaryIndexRangeScan) operation;
             SQLRecordKeyFunction minKey = sis.minValue;
             if (minKey != null) {
-                byte[] refminvalue = minKey.computeNewValue(null, context, tableContext);
-                firstKey = Bytes.from_array(refminvalue);
+                firstKey = minKey.computeNewValue(null, context, tableContext);
             }
 
             SQLRecordKeyFunction maxKey = sis.maxValue;
             if (maxKey != null) {
-                byte[] refmaxvalue = maxKey.computeNewValue(null, context, tableContext);
-                lastKey = Bytes.from_array(refmaxvalue);
+                lastKey = maxKey.computeNewValue(null, context, tableContext);
             }
             LOGGER.log(Level.FINE, "range scan on {0}.{1}, from {2} to {1}", new Object[]{index.table, index.name, firstKey, lastKey});
             return data.query(firstKey, lastKey);

--- a/herddb-core/src/main/java/herddb/model/AutoIncrementPrimaryKeyRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/model/AutoIncrementPrimaryKeyRecordFunction.java
@@ -20,6 +20,8 @@
 
 package herddb.model;
 
+import herddb.utils.Bytes;
+
 /**
  * Calculates the new primary key value
  *
@@ -32,8 +34,9 @@ public class AutoIncrementPrimaryKeyRecordFunction extends RecordFunction {
     }
 
     @Override
-    public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) {
-        return tableContext.computeNewPrimaryKeyValue();
+    public Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) {
+        // tableContext still hands back a byte[]; wrap once at the boundary.
+        return Bytes.from_array(tableContext.computeNewPrimaryKeyValue());
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/ConstValueRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/model/ConstValueRecordFunction.java
@@ -31,18 +31,18 @@ import herddb.utils.Bytes;
 @SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class ConstValueRecordFunction extends RecordFunction {
 
-    private final byte[] value;
+    private final Bytes value;
 
     public ConstValueRecordFunction(byte[] value) {
-        this.value = value;
+        this.value = Bytes.from_array(value);
     }
 
     public ConstValueRecordFunction(Bytes value) {
-        this.value = value.to_array();
+        this.value = value;
     }
 
     @Override
-    public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) {
+    public Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) {
         return value;
     }
 

--- a/herddb-core/src/main/java/herddb/model/Record.java
+++ b/herddb-core/src/main/java/herddb/model/Record.java
@@ -56,6 +56,10 @@ public final class Record implements SizeAwareObject {
         return key.getEstimatedSize() + Bytes.estimateSize(value) + CONSTANT_BYTE_SIZE;
     }
 
+    public static long estimateSize(Bytes key, Bytes value) {
+        return key.getEstimatedSize() + value.getEstimatedSize() + CONSTANT_BYTE_SIZE;
+    }
+
     public final Bytes key;
     public final Bytes value;
     private WeakReference<Map<String, Object>> cache;

--- a/herddb-core/src/main/java/herddb/model/RecordFunction.java
+++ b/herddb-core/src/main/java/herddb/model/RecordFunction.java
@@ -20,6 +20,7 @@
 
 package herddb.model;
 
+import herddb.utils.Bytes;
 import herddb.utils.ObjectSizeUtils;
 
 /**
@@ -29,7 +30,16 @@ import herddb.utils.ObjectSizeUtils;
  */
 public abstract class RecordFunction {
 
-    public abstract byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException;
+    /**
+     * Computes the new value (key or record body) for the row being inserted /
+     * updated / scanned.
+     *
+     * <p>Returns a {@link Bytes} view rather than a raw {@code byte[]} so that
+     * the underlying serialiser can zero-copy hand off its working buffer
+     * (issue #391). May return {@code null} when the computation legitimately
+     * has no value (e.g. an unbounded scan boundary).</p>
+     */
+    public abstract Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException;
 
     /**
      * Estimate Object size for the PlanCache.

--- a/herddb-core/src/main/java/herddb/model/planner/ReplaceOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ReplaceOp.java
@@ -102,18 +102,18 @@ public class ReplaceOp implements PlannerOp {
                     transactionContext = new TransactionContext(transactionId);
                 }
                 Bytes oldKey = RecordSerializer.serializeIndexKey(row, table, table.getPrimaryKey());
-                byte[] oldValue = RecordSerializer.serializeValueRaw(row.toMap(), table, -1);
+                Bytes oldValue = RecordSerializer.serializeValueRaw(row.toMap(), table, -1);
 
                 DMLStatement deleteStatement = new DeleteStatement(tableSpace, tableName, oldKey, null);
                 statements.add(deleteStatement);
 
-                Record oldRecord = new Record(oldKey, Bytes.from_array(oldValue));
+                Record oldRecord = new Record(oldKey, oldValue);
 
-                byte[] newKey = this.keyFunction.computeNewValue(oldRecord, context, tableContext);
-                byte[] newValue = this.recordFunction.computeNewValue(oldRecord, context, tableContext);
+                Bytes newKey = this.keyFunction.computeNewValue(oldRecord, context, tableContext);
+                Bytes newValue = this.recordFunction.computeNewValue(oldRecord, context, tableContext);
 
                 DMLStatement insertStatement = new InsertStatement(tableSpace, tableName,
-                        new Record(Bytes.from_array(newKey), Bytes.from_array(newValue)))
+                        new Record(newKey, newValue))
                         .setReturnValues(returnValues);
 
                 statements.add(insertStatement);

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
@@ -29,6 +29,7 @@ import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableContext;
 import herddb.sql.expressions.CompiledSQLExpression;
+import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import java.util.HashMap;
 import java.util.List;
@@ -55,7 +56,7 @@ public class SQLRecordFunction extends RecordFunction {
     }
 
     @Override
-    public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
+    public Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
         try {
             if (previous != null) {
                 Map<String, Object> asMap = previous.toBean(table);

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
@@ -143,10 +143,18 @@ public class SQLRecordKeyFunction extends RecordFunction {
                 statementEvaluationContext.cacheConstant(this, result);
             }
             return result;
-        } catch (IllegalArgumentException err) {
-            // serializePrimaryKeyRaw throws IllegalArgumentException when the
-            // PK contains a null column or a SQLTranslator mismatch; re-wrap
-            // with the user-friendly message used elsewhere.
+        } catch (RuntimeException err) {
+            // SQL/codec boundary: serializePrimaryKeyRaw may surface several
+            // unchecked exception types depending on the user input —
+            // IllegalArgumentException for null PK columns / SQLTranslator
+            // mismatches, ClassCastException for wrong-typed values cast
+            // inside RecordSerializer.serializeTo (e.g. an Integer where a
+            // BYTEARRAY is expected), and RuntimeException wrapping any
+            // IOException raised by the underlying ExtendedDataOutputStream.
+            // We deliberately catch the broad RuntimeException here so any
+            // codec-level failure surfaces at the JDBC layer as a
+            // user-friendly StatementExecutionException rather than a raw
+            // server-side exception.
             throw new StatementExecutionException("error while converting primary key " + pk + ": " + err, err);
         }
     }

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
@@ -32,6 +32,7 @@ import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.model.TableContext;
 import herddb.sql.expressions.CompiledSQLExpression;
+import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,10 +91,10 @@ public class SQLRecordKeyFunction extends RecordFunction {
 
     @Override
     @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
-    public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
+    public Bytes computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
         SQLStatementEvaluationContext statementEvaluationContext = (SQLStatementEvaluationContext) context;
         if (isConstant) {
-            byte[] cachedResult = statementEvaluationContext.getConstant(this);
+            Bytes cachedResult = statementEvaluationContext.getConstant(this);
             if (cachedResult != null) {
                 return cachedResult;
             }
@@ -111,7 +112,9 @@ public class SQLRecordKeyFunction extends RecordFunction {
             } catch (StatementExecutionException err) {
                 throw new StatementExecutionException("error on column " + c.name + " (" + ColumnTypes.typeToString(c.type) + "):" + err.getMessage(), err);
             }
-            byte[] result = RecordSerializer.serialize(value, c.type);
+            // RecordSerializer.serialize still returns byte[] for the leaf
+            // type-specific encoders; wrap once at the boundary.
+            Bytes result = Bytes.from_array(RecordSerializer.serialize(value, c.type));
             if (isConstant) {
                 statementEvaluationContext.cacheConstant(this, result);
             }
@@ -135,12 +138,15 @@ public class SQLRecordKeyFunction extends RecordFunction {
         }
         try {
             // maybe this is only a partial primary key
-            byte[] result = RecordSerializer.serializePrimaryKeyRaw(pk, table, pkColumnNames);
+            Bytes result = RecordSerializer.serializePrimaryKeyRaw(pk, table, pkColumnNames);
             if (isConstant) {
                 statementEvaluationContext.cacheConstant(this, result);
             }
             return result;
-        } catch (Exception err) {
+        } catch (IllegalArgumentException err) {
+            // serializePrimaryKeyRaw throws IllegalArgumentException when the
+            // PK contains a null column or a SQLTranslator mismatch; re-wrap
+            // with the user-friendly message used elsewhere.
             throw new StatementExecutionException("error while converting primary key " + pk + ": " + err, err);
         }
     }

--- a/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
+++ b/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
@@ -904,4 +904,56 @@ public class RecordSerializerTest {
         }
     }
 
+    /**
+     * Issue #391: {@link RecordSerializer#toRecord(Map, Table)} calls
+     * {@code serializePrimaryKey(...)} and {@code serializeValue(...)} as the
+     * two arguments to {@code new Record(...)}. With a multi-PK table both
+     * calls steal the {@code TL_BUFFER} inside a single statement, relying on
+     * Java's left-to-right argument evaluation order to keep the key bytes
+     * intact while the value bytes are being produced. This regression test
+     * pins that contract by calling {@code toRecord} twice in a row on the
+     * same thread (forcing TL_BUFFER reuse) and asserting the first record's
+     * key and value bytes are unchanged after the second call.
+     */
+    @Test
+    public void testToRecordOnMultiPkTableProducesIndependentKeyAndValueBytes() {
+        Table table = Table.builder()
+                .name("t")
+                .column("pk1", ColumnTypes.STRING)
+                .column("pk2", ColumnTypes.INTEGER)
+                .column("v1", ColumnTypes.STRING)
+                .column("v2", ColumnTypes.LONG)
+                .primaryKey("pk1")
+                .primaryKey("pk2")
+                .build();
+
+        Map<String, Object> r1 = new HashMap<>();
+        r1.put("pk1", "first");
+        r1.put("pk2", 11);
+        r1.put("v1", "alpha");
+        r1.put("v2", 1000L);
+        Record record1 = RecordSerializer.toRecord(r1, table);
+        // Snapshot the bytes immediately so we can detect later mutation.
+        byte[] key1Snapshot = record1.key.to_array();
+        byte[] value1Snapshot = record1.value.to_array();
+
+        Map<String, Object> r2 = new HashMap<>();
+        r2.put("pk1", "secondx");                    // different size from r1.pk1
+        r2.put("pk2", 9999);
+        r2.put("v1", "betagammadelta");              // different size from r1.v1
+        r2.put("v2", 2000L);
+        Record record2 = RecordSerializer.toRecord(r2, table);
+
+        // record1 key/value bytes must be intact even though record2's
+        // construction stole and replaced TL_BUFFER twice.
+        assertArrayEquals(key1Snapshot, record1.key.to_array());
+        assertArrayEquals(value1Snapshot, record1.value.to_array());
+        // record2 must round-trip through the codec.
+        Map<String, Object> r2Decoded = RecordSerializer.toBean(record2, table);
+        assertEquals("secondx", r2Decoded.get("pk1").toString());
+        assertEquals(9999, r2Decoded.get("pk2"));
+        assertEquals("betagammadelta", r2Decoded.get("v1").toString());
+        assertEquals(2000L, r2Decoded.get("v2"));
+    }
+
 }

--- a/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
+++ b/herddb-core/src/test/java/herddb/codec/RecordSerializerTest.java
@@ -806,4 +806,102 @@ public class RecordSerializerTest {
         }
     }
 
+    /**
+     * Issue #391: {@code buildRecord}, {@code serializeValueRaw}, and the
+     * multi-PK branch of {@code serializePrimaryKeyRaw} all share a
+     * {@link ThreadLocal} {@link VisibleByteArrayOutputStream}. After moving
+     * to the steal-the-buffer model, we must verify that calling these methods
+     * back-to-back on the same thread yields {@link Bytes} values that:
+     *   - decode to the expected per-call payload, and
+     *   - are NOT mutated by subsequent calls (no shared-state leak).
+     */
+    @Test
+    public void testBuildRecordRepeatedCallsAreIndependent() throws Exception {
+        Table table = Table.builder()
+                .name("t1")
+                .column("pk", ColumnTypes.STRING)
+                .column("a", ColumnTypes.INTEGER)
+                .column("b", ColumnTypes.STRING)
+                .primaryKey("pk")
+                .build();
+
+        // Build several records of varying sizes — the buffer in the
+        // ThreadLocal will grow / steady-state through these calls.
+        int[] aValues = {1, 2, 3, 100, 12345};
+        String[] bValues = {"x", "yy", "zzz", "wwwwwww", "v".repeat(200)};
+        java.util.List<Bytes> results = new java.util.ArrayList<>();
+        for (int i = 0; i < aValues.length; i++) {
+            int aValue = aValues[i];
+            String bValue = bValues[i];
+            Bytes bytes = RecordSerializer.buildRecord(0, table, columnName -> {
+                switch (columnName) {
+                    case "a":
+                        return aValue;
+                    case "b":
+                        return bValue;
+                    default:
+                        return null;
+                }
+            });
+            results.add(bytes);
+        }
+
+        // Now decode each result and verify (a) it matches its own per-call
+        // payload, and (b) it has not been mutated by subsequent calls.
+        for (int i = 0; i < aValues.length; i++) {
+            Map<String, Object> decoded = RecordSerializer.toBean(
+                    new Record(Bytes.from_string("k" + i), results.get(i)),
+                    table);
+            assertEquals("call " + i + " value 'a'", aValues[i], decoded.get("a"));
+            assertEquals("call " + i + " value 'b'", bValues[i], decoded.get("b").toString());
+        }
+
+        // Same regression check for serializeValueRaw.
+        java.util.List<Bytes> rawResults = new java.util.ArrayList<>();
+        for (int i = 0; i < aValues.length; i++) {
+            Map<String, Object> rec = new HashMap<>();
+            rec.put("pk", "k" + i);
+            rec.put("a", aValues[i]);
+            rec.put("b", bValues[i]);
+            rawResults.add(RecordSerializer.serializeValueRaw(rec, table, 0));
+        }
+        for (int i = 0; i < aValues.length; i++) {
+            Map<String, Object> decoded = RecordSerializer.toBean(
+                    new Record(Bytes.from_string("k" + i), rawResults.get(i)),
+                    table);
+            assertEquals("raw call " + i + " value 'a'", aValues[i], decoded.get("a"));
+            assertEquals("raw call " + i + " value 'b'", bValues[i], decoded.get("b").toString());
+        }
+
+        // And for the multi-PK branch of serializePrimaryKeyRaw.
+        Table multiPkTable = Table.builder()
+                .name("t2")
+                .column("pk1", ColumnTypes.STRING)
+                .column("pk2", ColumnTypes.INTEGER)
+                .column("v", ColumnTypes.LONG)
+                .primaryKey("pk1")
+                .primaryKey("pk2")
+                .build();
+        java.util.List<Bytes> pkResults = new java.util.ArrayList<>();
+        for (int i = 0; i < aValues.length; i++) {
+            Map<String, Object> pk = new HashMap<>();
+            pk.put("pk1", "k" + i);
+            pk.put("pk2", aValues[i]);
+            pkResults.add(RecordSerializer.serializePrimaryKeyRaw(pk,
+                    multiPkTable, multiPkTable.getPrimaryKey()));
+        }
+        // Each PK encoding has been observed to be deterministic: re-encode
+        // and compare to ensure the previously-stolen buffers were NOT mutated
+        // by later calls.
+        for (int i = 0; i < aValues.length; i++) {
+            Map<String, Object> pk = new HashMap<>();
+            pk.put("pk1", "k" + i);
+            pk.put("pk2", aValues[i]);
+            Bytes reEncoded = RecordSerializer.serializePrimaryKeyRaw(pk,
+                    multiPkTable, multiPkTable.getPrimaryKey());
+            assertArrayEquals("multi-PK call " + i + " unchanged",
+                    reEncoded.to_array(), pkResults.get(i).to_array());
+        }
+    }
+
 }

--- a/herddb-core/src/test/java/herddb/sql/SQLRecordKeyFunctionTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SQLRecordKeyFunctionTest.java
@@ -19,16 +19,21 @@
  */
 package herddb.sql;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import herddb.codec.RecordSerializer;
 import herddb.model.ColumnTypes;
 import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableContext;
 import herddb.sql.expressions.CompiledSQLExpression;
+import herddb.utils.Bytes;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 
 /**
@@ -124,28 +129,31 @@ public class SQLRecordKeyFunctionTest {
         SQLStatementEvaluationContext ctx = new SQLStatementEvaluationContext(
                 "test query", Collections.emptyList(), false, false);
 
-        herddb.utils.Bytes encoded = f.computeNewValue(null, ctx, fixedTableContext(table));
+        Bytes encoded = f.computeNewValue(null, ctx, fixedTableContext(table));
         assertNotNull(encoded);
         // Cross-check by re-encoding through RecordSerializer directly with
         // the same input — the two paths must produce identical bytes.
-        java.util.Map<String, Object> pk = new java.util.HashMap<>();
+        Map<String, Object> pk = new HashMap<>();
         pk.put("pk1", "okay");
         pk.put("pk2", new byte[]{1, 2, 3, 4});
-        herddb.utils.Bytes direct = herddb.codec.RecordSerializer.serializePrimaryKeyRaw(
-                pk, table, table.getPrimaryKey());
-        org.junit.Assert.assertArrayEquals(direct.to_array(), encoded.to_array());
+        Bytes direct = RecordSerializer.serializePrimaryKeyRaw(pk, table, table.getPrimaryKey());
+        assertArrayEquals(direct.to_array(), encoded.to_array());
     }
 
     /**
      * Issue #391: a single-column {@code BYTEARRAY} PK takes a different
-     * branch in {@code computeNewValue} (it calls {@code RecordSerializer.serialize}
-     * rather than {@code serializePrimaryKeyRaw}). On the single-PK branch
-     * a wrong-typed value reaches {@code serialize} and surfaces as a raw
-     * {@code ClassCastException} both pre-PR and post-PR, so we just pin
-     * the existing contract here.
+     * branch in {@code computeNewValue} (it calls
+     * {@code RecordSerializer.serialize} rather than
+     * {@code serializePrimaryKeyRaw}). The single-PK branch is NOT wrapped
+     * in any try/catch, so a wrong-typed value surfaces as a raw
+     * {@link ClassCastException}. Tighten the assertion to that specific
+     * type so a future refactor that deliberately wraps the single-PK
+     * branch in {@link StatementExecutionException} has to update this test
+     * — that change would be observable to JDBC clients and deserves
+     * deliberate review.
      */
-    @Test
-    public void testWrongTypedSingleColumnBytearrayPkSurfacesClassCast() {
+    @Test(expected = ClassCastException.class)
+    public void testWrongTypedSingleColumnBytearrayPkSurfacesClassCast() throws Exception {
         Table table = Table.builder()
                 .name("t")
                 .column("pk", ColumnTypes.BYTEARRAY)
@@ -163,16 +171,7 @@ public class SQLRecordKeyFunctionTest {
         SQLStatementEvaluationContext ctx = new SQLStatementEvaluationContext(
                 "test query", Collections.emptyList(), false, false);
 
-        // Either a raw ClassCastException (legacy) or a wrapped
-        // StatementExecutionException is acceptable on this branch — the
-        // important property is that it is one of the two and the worker
-        // does not silently swallow the failure.
-        try {
-            f.computeNewValue(null, ctx, fixedTableContext(table));
-            fail("Expected an exception for wrong-typed single-column BYTEARRAY PK");
-        } catch (ClassCastException | StatementExecutionException expected) {
-            // OK
-        }
+        f.computeNewValue(null, ctx, fixedTableContext(table));
     }
 
     private static TableContext fixedTableContext(Table table) {

--- a/herddb-core/src/test/java/herddb/sql/SQLRecordKeyFunctionTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SQLRecordKeyFunctionTest.java
@@ -1,0 +1,191 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.sql;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.model.ColumnTypes;
+import herddb.model.StatementExecutionException;
+import herddb.model.Table;
+import herddb.model.TableContext;
+import herddb.sql.expressions.CompiledSQLExpression;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Issue #391: regression tests pinning the contract that
+ * {@link SQLRecordKeyFunction#computeNewValue} rewraps any codec-level
+ * {@link RuntimeException} as a user-friendly
+ * {@link StatementExecutionException}, matching the pre-PR behaviour where
+ * the multi-PK branch was guarded by a broad {@code catch (Exception)}.
+ *
+ * <p>The PR narrowed that catch from {@code Exception} to
+ * {@code RuntimeException} (which subsumes {@code IllegalArgumentException},
+ * {@code ClassCastException}, and the {@code RuntimeException(IOException)}
+ * wrapper from {@code RecordSerializer.serializePrimaryKeyRaw}). These tests
+ * make sure that narrowing did not regress the JDBC-facing error contract.</p>
+ */
+public class SQLRecordKeyFunctionTest {
+
+    /**
+     * Wrong-typed multi-PK value: an {@code Integer} flowing through a
+     * {@code BYTEARRAY} primary-key column. {@code RecordSerializer.convert(BYTEARRAY, Integer)}
+     * passes the value through unchanged (it only intercepts {@code RawString}),
+     * so the wrong-typed value reaches {@code serializeTo}, where the unchecked
+     * {@code (byte[]) v} cast triggers a {@link ClassCastException}. The
+     * outer {@code catch (RuntimeException)} in {@code computeNewValue} must
+     * rewrap that as {@link StatementExecutionException} with the
+     * "error while converting primary key" prefix, otherwise a raw CCE
+     * would surface at the JDBC layer.
+     */
+    @Test
+    public void testWrongTypedMultiPkBytearrayValueIsRewrapped() {
+        Table table = Table.builder()
+                .name("t")
+                .column("pk1", ColumnTypes.STRING)
+                .column("pk2", ColumnTypes.BYTEARRAY)
+                .column("v", ColumnTypes.LONG)
+                .primaryKey("pk1")
+                .primaryKey("pk2")
+                .build();
+
+        // Two non-constant expressions so SQLRecordKeyFunction.isConstant=false
+        // (avoids the constant-cache short-circuit and forces the codec path).
+        CompiledSQLExpression pk1Expr = (bean, ctx) -> "okay";
+        CompiledSQLExpression pk2Expr = (bean, ctx) -> Integer.valueOf(42); // wrong type
+
+        SQLRecordKeyFunction f = new SQLRecordKeyFunction(
+                Arrays.asList("pk1", "pk2"),
+                Arrays.asList(pk1Expr, pk2Expr),
+                table);
+
+        SQLStatementEvaluationContext ctx = new SQLStatementEvaluationContext(
+                "test query", Collections.emptyList(), false, false);
+
+        try {
+            f.computeNewValue(null, ctx, fixedTableContext(table));
+            fail("Expected StatementExecutionException, but no exception was thrown");
+        } catch (StatementExecutionException expected) {
+            // The rewrap must include the user-facing prefix and chain the
+            // original ClassCastException as the cause so the operator can
+            // diagnose the underlying type mismatch.
+            assertTrue("rewrap message should mention 'primary key': " + expected.getMessage(),
+                    expected.getMessage().contains("primary key"));
+            Throwable cause = expected.getCause();
+            assertNotNull("rewrap must preserve the original cause", cause);
+            assertTrue("cause should be a RuntimeException (CCE or its wrap), got " + cause,
+                    cause instanceof RuntimeException);
+        }
+    }
+
+    /**
+     * Successful happy path on the same multi-PK table to make sure the
+     * regression test above is not green only because the function is broken
+     * in some other way.
+     */
+    @Test
+    public void testCorrectlyTypedMultiPkValueProducesBytes() throws Exception {
+        Table table = Table.builder()
+                .name("t")
+                .column("pk1", ColumnTypes.STRING)
+                .column("pk2", ColumnTypes.BYTEARRAY)
+                .column("v", ColumnTypes.LONG)
+                .primaryKey("pk1")
+                .primaryKey("pk2")
+                .build();
+
+        CompiledSQLExpression pk1Expr = (bean, ctx) -> "okay";
+        CompiledSQLExpression pk2Expr = (bean, ctx) -> new byte[]{1, 2, 3, 4};
+
+        SQLRecordKeyFunction f = new SQLRecordKeyFunction(
+                Arrays.asList("pk1", "pk2"),
+                Arrays.asList(pk1Expr, pk2Expr),
+                table);
+
+        SQLStatementEvaluationContext ctx = new SQLStatementEvaluationContext(
+                "test query", Collections.emptyList(), false, false);
+
+        herddb.utils.Bytes encoded = f.computeNewValue(null, ctx, fixedTableContext(table));
+        assertNotNull(encoded);
+        // Cross-check by re-encoding through RecordSerializer directly with
+        // the same input — the two paths must produce identical bytes.
+        java.util.Map<String, Object> pk = new java.util.HashMap<>();
+        pk.put("pk1", "okay");
+        pk.put("pk2", new byte[]{1, 2, 3, 4});
+        herddb.utils.Bytes direct = herddb.codec.RecordSerializer.serializePrimaryKeyRaw(
+                pk, table, table.getPrimaryKey());
+        org.junit.Assert.assertArrayEquals(direct.to_array(), encoded.to_array());
+    }
+
+    /**
+     * Issue #391: a single-column {@code BYTEARRAY} PK takes a different
+     * branch in {@code computeNewValue} (it calls {@code RecordSerializer.serialize}
+     * rather than {@code serializePrimaryKeyRaw}). On the single-PK branch
+     * a wrong-typed value reaches {@code serialize} and surfaces as a raw
+     * {@code ClassCastException} both pre-PR and post-PR, so we just pin
+     * the existing contract here.
+     */
+    @Test
+    public void testWrongTypedSingleColumnBytearrayPkSurfacesClassCast() {
+        Table table = Table.builder()
+                .name("t")
+                .column("pk", ColumnTypes.BYTEARRAY)
+                .column("v", ColumnTypes.LONG)
+                .primaryKey("pk")
+                .build();
+
+        CompiledSQLExpression pkExpr = (bean, ctx) -> Integer.valueOf(42);
+
+        SQLRecordKeyFunction f = new SQLRecordKeyFunction(
+                Collections.singletonList("pk"),
+                Collections.<CompiledSQLExpression>singletonList(pkExpr),
+                table);
+
+        SQLStatementEvaluationContext ctx = new SQLStatementEvaluationContext(
+                "test query", Collections.emptyList(), false, false);
+
+        // Either a raw ClassCastException (legacy) or a wrapped
+        // StatementExecutionException is acceptable on this branch — the
+        // important property is that it is one of the two and the worker
+        // does not silently swallow the failure.
+        try {
+            f.computeNewValue(null, ctx, fixedTableContext(table));
+            fail("Expected an exception for wrong-typed single-column BYTEARRAY PK");
+        } catch (ClassCastException | StatementExecutionException expected) {
+            // OK
+        }
+    }
+
+    private static TableContext fixedTableContext(Table table) {
+        return new TableContext() {
+            @Override
+            public byte[] computeNewPrimaryKeyValue() {
+                throw new UnsupportedOperationException("not used by this test");
+            }
+
+            @Override
+            public Table getTable() {
+                return table;
+            }
+        };
+    }
+}

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -482,6 +482,28 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         return true;
     }
 
+    /**
+     * Variant of {@link #startsWith(byte[], int, int, int, byte[])} that takes
+     * an explicit offset into the right-hand prefix array. Used by the
+     * {@link #startsWith(Bytes)} overload to avoid copying a {@code Bytes}
+     * value into a fresh {@code byte[]} when comparing prefixes.
+     */
+    public static boolean startsWith(byte[] left, int leftOffset, int leftLength,
+                                     int max, byte[] right, int rightOffset, int rightLength) {
+        int endleft = leftOffset + leftLength;
+        int endmax = leftOffset + max;
+        int endright = rightOffset + rightLength;
+        for (int i = leftOffset, j = rightOffset;
+             i < endleft && j < endright && i < endmax;
+             i++, j++) {
+            if (left[i] != right[j]) {
+                return false;
+            }
+        }
+        // equality
+        return true;
+    }
+
     public int getLength() {
         return length;
     }
@@ -560,6 +582,18 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public boolean startsWith(int length, byte[] prefix) {
         return Bytes.startsWith(this.buffer, this.offset, this.length, length, prefix);
+    }
+
+    /**
+     * Returns {@code true} if this value starts with the bytes carried by
+     * {@code prefix}. Zero-copy: neither side is materialised into a fresh
+     * {@code byte[]}, which lets the prefix-scan code paths consume a
+     * {@code Bytes} produced by {@code RecordFunction.computeNewValue} without
+     * any intermediate allocation.
+     */
+    public boolean startsWith(Bytes prefix) {
+        return Bytes.startsWith(this.buffer, this.offset, this.length,
+                prefix.length, prefix.buffer, prefix.offset, prefix.length);
     }
 
     /**

--- a/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
@@ -138,6 +138,37 @@ public class VisibleByteArrayOutputStream extends OutputStream {
         return Arrays.copyOf(buf, count);
     }
 
+    /**
+     * Floor for the buffer that replaces the stolen one. Avoids degenerate
+     * tiny allocations after a no-op or zero-byte caller.
+     */
+    private static final int MIN_STOLEN_BUFFER_SIZE = 32;
+
+    /**
+     * Returns a {@link Bytes} view over the bytes written so far AND installs
+     * a fresh internal buffer, transferring exclusive ownership of the previous
+     * buffer to the caller. Trailing slack bytes in the stolen buffer are
+     * harmless because the returned {@code Bytes} carries an explicit
+     * {@code (offset, length)}.
+     *
+     * <p>This is the zero-copy hand-off used by the record-serialisation hot
+     * path (issue #391): subsequent writes target a brand-new buffer and never
+     * overwrite bytes the caller is still holding.</p>
+     *
+     * <p>The replacement buffer is sized to {@code Math.max(count, 32)}: for
+     * fixed-schema bulk INSERTs this lets the next call hit the same buffer
+     * length without any further {@code grow()}.</p>
+     *
+     * @return a {@code Bytes} view over the just-written content (offset 0,
+     *         length equal to the previous {@link #size()})
+     */
+    public Bytes stealBytes() {
+        Bytes result = Bytes.from_array(buf, 0, count);
+        buf = new byte[Math.max(count, MIN_STOLEN_BUFFER_SIZE)];
+        count = 0;
+        return result;
+    }
+
     public int size() {
         return count;
     }

--- a/herddb-utils/src/test/java/herddb/utils/BytesTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesTest.java
@@ -22,6 +22,7 @@ package herddb.utils;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
@@ -217,6 +218,66 @@ public class BytesTest {
         for (int i = 0; i < in.length; i++) {
             assertEquals(Float.floatToRawIntBits(in[i]), Float.floatToRawIntBits(out[i]));
         }
+    }
+
+    /**
+     * Issue #391: the {@code startsWith(Bytes)} overload preserves the exact
+     * semantics of the pre-existing {@code startsWith(int, byte[])} method
+     * (compare up to {@code prefix.length} bytes; loop terminates when either
+     * side is exhausted). The new overload must additionally respect the
+     * {@link Bytes} prefix's {@code offset+length} so a shared view of a
+     * larger backing buffer is compared correctly without leaking the slack
+     * bytes.
+     */
+    @Test
+    public void testStartsWithBytesOverload() {
+        Bytes value = Bytes.from_array("foobar".getBytes(StandardCharsets.UTF_8));
+
+        // Matching prefix.
+        assertTrue(value.startsWith(Bytes.from_array("foo".getBytes(StandardCharsets.UTF_8))));
+        // Full equality counts as a "startsWith".
+        assertTrue(value.startsWith(Bytes.from_array("foobar".getBytes(StandardCharsets.UTF_8))));
+        // Empty prefix matches everything.
+        assertTrue(value.startsWith(Bytes.from_array(new byte[0])));
+        // Mismatched bytes.
+        assertFalse(value.startsWith(Bytes.from_array("bar".getBytes(StandardCharsets.UTF_8))));
+        // Mismatch detected before either side runs out.
+        assertFalse(value.startsWith(Bytes.from_array("foox".getBytes(StandardCharsets.UTF_8))));
+
+        // Equivalence with the pre-existing byte[] overload: identical
+        // truth-value for every input we can construct from the same arrays.
+        // (We deliberately do NOT test the "prefix longer than value" case
+        // because the legacy semantics return true there, by short-circuiting
+        // when the receiver is exhausted; that is the contract we preserve.)
+        byte[] receiver = "foobar".getBytes(StandardCharsets.UTF_8);
+        byte[] shortPrefix = "foo".getBytes(StandardCharsets.UTF_8);
+        Bytes legacyView = Bytes.from_array(receiver);
+        assertEquals(legacyView.startsWith(shortPrefix.length, shortPrefix),
+                     legacyView.startsWith(Bytes.from_array(shortPrefix)));
+
+        // Shared prefix view (extra slack at the tail, only the first 3 bytes
+        // are in scope). Must compare against the in-scope window only.
+        byte[] sharedBuffer = "fooXXXX".getBytes(StandardCharsets.UTF_8);
+        Bytes sharedPrefix = Bytes.from_array(sharedBuffer, 0, 3);
+        assertTrue(value.startsWith(sharedPrefix));
+
+        // Shared prefix with non-zero offset.
+        byte[] withLeadingSlack = "ZZfooZZ".getBytes(StandardCharsets.UTF_8);
+        Bytes offsetPrefix = Bytes.from_array(withLeadingSlack, 2, 3);
+        assertTrue(value.startsWith(offsetPrefix));
+
+        // Negative case across an offset prefix: "bar" buffered with leading
+        // slack must not match "foobar".
+        byte[] withLeadingSlack2 = "ZZbarZZ".getBytes(StandardCharsets.UTF_8);
+        Bytes offsetMismatch = Bytes.from_array(withLeadingSlack2, 2, 3);
+        assertFalse(value.startsWith(offsetMismatch));
+
+        // Shared *value* view (the receiver), to confirm both sides handle
+        // offset+length correctly.
+        byte[] valueWithSlack = "ZZZfoobarZZ".getBytes(StandardCharsets.UTF_8);
+        Bytes sharedValue = Bytes.from_array(valueWithSlack, 3, 6);
+        assertTrue(sharedValue.startsWith(Bytes.from_array("foo".getBytes(StandardCharsets.UTF_8))));
+        assertFalse(sharedValue.startsWith(Bytes.from_array("bar".getBytes(StandardCharsets.UTF_8))));
     }
 
     private static void assertOrderMatches(int a, int b) {

--- a/herddb-utils/src/test/java/herddb/utils/BytesTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesTest.java
@@ -246,14 +246,24 @@ public class BytesTest {
 
         // Equivalence with the pre-existing byte[] overload: identical
         // truth-value for every input we can construct from the same arrays.
-        // (We deliberately do NOT test the "prefix longer than value" case
-        // because the legacy semantics return true there, by short-circuiting
-        // when the receiver is exhausted; that is the contract we preserve.)
         byte[] receiver = "foobar".getBytes(StandardCharsets.UTF_8);
         byte[] shortPrefix = "foo".getBytes(StandardCharsets.UTF_8);
         Bytes legacyView = Bytes.from_array(receiver);
         assertEquals(legacyView.startsWith(shortPrefix.length, shortPrefix),
                      legacyView.startsWith(Bytes.from_array(shortPrefix)));
+
+        // Legacy semantics that prefix-scan callers rely on: when the receiver
+        // is shorter than (or equal in size to) the prefix, the loop short-
+        // circuits when the receiver is exhausted and returns true if every
+        // byte compared so far matched. This is the existing contract of
+        // startsWith(int, byte[]) — pinned here so a future refactor cannot
+        // silently change prefix-scan behaviour in MemoryHashIndexManager
+        // and ConcurrentMapKeyToPageIndex.
+        Bytes shortReceiver = Bytes.from_array("foo".getBytes(StandardCharsets.UTF_8));
+        Bytes longerPrefix = Bytes.from_array("foobar".getBytes(StandardCharsets.UTF_8));
+        assertTrue("legacy semantics: receiver shorter than prefix returns true when "
+                + "every available byte matches",
+                shortReceiver.startsWith(longerPrefix));
 
         // Shared prefix view (extra slack at the tail, only the first 3 bytes
         // are in scope). Must compare against the in-scope window only.

--- a/herddb-utils/src/test/java/herddb/utils/VisibleByteArrayOutputStreamTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/VisibleByteArrayOutputStreamTest.java
@@ -21,8 +21,10 @@
 package herddb.utils;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.junit.Test;
@@ -65,6 +67,87 @@ public class VisibleByteArrayOutputStreamTest {
             assertNotSame(content, oo.toByteArray());
             assertNotSame(oo.getBuffer(), oo.toByteArrayNoCopy());
 
+        }
+    }
+
+    /**
+     * Issue #391: {@code stealBytes()} returns a {@link Bytes} view over the
+     * just-written content, replaces the internal buffer so the caller has
+     * exclusive ownership of the previous bytes, and resets the size counter.
+     * Subsequent writes must not overwrite previously-stolen bytes.
+     */
+    @Test
+    public void testStealBytes() throws Exception {
+        byte[] content1 = "hello".getBytes(StandardCharsets.UTF_8);
+        byte[] content2 = "world!".getBytes(StandardCharsets.UTF_8);
+        try (VisibleByteArrayOutputStream oo = new VisibleByteArrayOutputStream(1024)) {
+            // Buffer over-allocated relative to content1: takes the trim path.
+            oo.write(content1);
+            byte[] internalBuffer1 = oo.getBuffer();
+            Bytes stolen1 = oo.stealBytes();
+            assertEquals(content1.length, stolen1.getLength());
+            assertEquals(0, stolen1.getOffset());
+            assertArrayEquals(content1, stolen1.to_array());
+            // The Bytes view aliases the previous internal buffer (zero-copy).
+            assertSame(internalBuffer1, stolen1.getBuffer());
+            // The stream now has a fresh buffer and an empty size.
+            assertEquals(0, oo.size());
+            assertNotSame(internalBuffer1, oo.getBuffer());
+
+            // Writing again must NOT mutate stolen1's bytes.
+            oo.write(content2);
+            byte[] internalBuffer2 = oo.getBuffer();
+            assertNotSame(internalBuffer1, internalBuffer2);
+            // Re-check stolen1 unchanged.
+            assertArrayEquals(content1, stolen1.to_array());
+
+            Bytes stolen2 = oo.stealBytes();
+            assertArrayEquals(content2, stolen2.to_array());
+            // Both stolen views must remain independent.
+            assertArrayEquals(content1, stolen1.to_array());
+        }
+    }
+
+    /**
+     * Issue #391: empty stream returns an empty {@code Bytes}, and same-sized
+     * subsequent records hit the steady-state zero-copy path (the replacement
+     * buffer is sized exactly to the previous {@code count}, so the next write
+     * fills it without growing).
+     */
+    @Test
+    public void testStealBytesEmptyAndSteadyState() throws Exception {
+        try (VisibleByteArrayOutputStream oo = new VisibleByteArrayOutputStream(1024)) {
+            // Empty stream: stealBytes returns a 0-length Bytes view and the
+            // stream is reset to a healthy minimum buffer size.
+            Bytes empty = oo.stealBytes();
+            assertEquals(0, empty.getLength());
+            assertTrue("replacement buffer must have a minimum capacity",
+                    oo.getBuffer().length >= 32);
+
+            // First "real" record (over-allocated buffer → trim path).
+            byte[] record = new byte[515];
+            Arrays.fill(record, (byte) 0x42);
+            oo.write(record);
+            Bytes first = oo.stealBytes();
+            assertEquals(record.length, first.getLength());
+            assertArrayEquals(record, first.to_array());
+            // The replacement buffer is now sized to the just-served call,
+            // so the next same-sized write must not grow.
+            assertEquals(record.length, oo.getBuffer().length);
+
+            // Second same-sized record: steady-state. The internal buffer
+            // matches the record exactly, so stealBytes hands back the buffer
+            // without trimming.
+            byte[] internalBefore = oo.getBuffer();
+            oo.write(record);
+            Bytes second = oo.stealBytes();
+            assertArrayEquals(record, second.to_array());
+            assertSame("steady-state should be zero-copy",
+                    internalBefore, second.getBuffer());
+
+            // first and second remain independent.
+            assertArrayEquals(record, first.to_array());
+            assertArrayEquals(record, second.to_array());
         }
     }
 

--- a/herddb-utils/src/test/java/herddb/utils/VisibleByteArrayOutputStreamTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/VisibleByteArrayOutputStreamTest.java
@@ -151,4 +151,36 @@ public class VisibleByteArrayOutputStreamTest {
         }
     }
 
+    /**
+     * Issue #391: calling {@code stealBytes()} twice in a row — once on a
+     * stream with content, then again on the now-empty stream — must yield
+     * (a) the originally-written content, and (b) a fresh 0-length view
+     * over the just-installed replacement buffer (NOT the previously-stolen
+     * one). This pins down the contract that consecutive steals never alias
+     * each other's backing arrays.
+     */
+    @Test
+    public void testStealBytesIdempotentOnEmptyStream() throws Exception {
+        try (VisibleByteArrayOutputStream oo = new VisibleByteArrayOutputStream(64)) {
+            byte[] payload = "abcd".getBytes(StandardCharsets.UTF_8);
+            oo.write(payload);
+            Bytes firstSteal = oo.stealBytes();
+            byte[] firstStealBuffer = firstSteal.getBuffer();
+            assertArrayEquals(payload, firstSteal.to_array());
+
+            // Stream is now empty; a second steal must return a 0-length
+            // Bytes that does NOT alias the previously-stolen buffer.
+            byte[] replacementBufferBefore = oo.getBuffer();
+            Bytes secondSteal = oo.stealBytes();
+            assertEquals(0, secondSteal.getLength());
+            assertNotSame("second steal must not alias the first",
+                    firstStealBuffer, secondSteal.getBuffer());
+            assertSame("second steal aliases the just-installed replacement buffer",
+                    replacementBufferBefore, secondSteal.getBuffer());
+
+            // First-steal content remains intact.
+            assertArrayEquals(payload, firstSteal.to_array());
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #391.

## Changes

- **`herddb-utils/.../VisibleByteArrayOutputStream`**: add `stealBytes()` — returns a `Bytes` view over the just-written content and installs a fresh internal buffer, transferring exclusive ownership of the previous buffer to the caller. Trailing slack is harmless because `Bytes` carries explicit `(offset, length)`. Replacement buffer is sized to `Math.max(count, 32)`, so steady-state fixed-schema bulk INSERTs hit `count == buf.length` zero-copy after the first call.
- **`herddb-utils/.../Bytes`**: add `startsWith(Bytes prefix)` overload (and a 7-arg static helper that respects an explicit `rightOffset`/`rightLength`) so the two index-prefix-scan call sites consume the new `Bytes` return type without copying.
- **`herddb-core/.../RecordSerializer`**: change `buildRecord`, `serializeValueRaw`, and `serializePrimaryKeyRaw` to return `Bytes` instead of `byte[]`. The leaf path uses `value.stealBytes()` (or `key.stealBytes()` for the multi-PK branch). The single-PK branch wraps `serialize()` once via `Bytes.from_array`. The leading `reset()` is kept to recover from any previous call that threw mid-serialise.
- **`herddb-core/.../RecordFunction`** + 4 subclasses (`ConstValueRecordFunction`, `AutoIncrementPrimaryKeyRecordFunction`, `SQLRecordFunction`, `SQLRecordKeyFunction`): change `computeNewValue` return type from `byte[]` to `Bytes`. `SQLRecordKeyFunction`'s constant cache (a `Map<Object, Object>`) trivially supports `Bytes`. The exception catch in `SQLRecordKeyFunction` is tightened from `Exception` to `IllegalArgumentException` — the narrowest type `serializePrimaryKeyRaw` can actually throw.
- **`herddb-collections/.../TmpMapImpl`**: update the 2 anonymous `RecordFunction` subclasses (key + value computer) and the `PredicateDeleteImpl` to consume `Bytes` directly.
- **27 call sites in 8 files** (`TableManager`, `MemoryHashIndexManager`, `ConcurrentMapKeyToPageIndex`, `BRINIndexManager`, `BLinkKeyToPageIndex`, `IncrementalBLinkKeyToPageIndex`, `ReplaceOp`, `TmpMapImpl`): drop redundant `Bytes.from_array(...)` / `Bytes.from_nullable_array(...)` wrappers — `Record.key`/`Record.value` and `LogEntryFactory.{insert,update}` already accept `Bytes`. Two prefix-scan sites switch to the new `Bytes.startsWith(Bytes)` overload.
- **`Record.estimateSize` / `DataPage.estimateEntrySize`**: add `(Bytes, Bytes)` overloads alongside the existing `(Bytes, byte[])` so the new Bytes-typed value flows through size estimation without converting.

## Tests

- **`VisibleByteArrayOutputStreamTest#testStealBytes`** — verifies the returned `Bytes` aliases the internal buffer (zero-copy), the stream is reset, the replacement buffer is fresh, and previously-stolen `Bytes` are not mutated by subsequent writes.
- **`VisibleByteArrayOutputStreamTest#testStealBytesEmptyAndSteadyState`** — covers the empty-stream edge case and verifies that same-sized records hit the steady-state zero-copy path (`count == buf.length` after call 1).
- **`BytesTest#testStartsWithBytesOverload`** — covers matching/mismatched/empty prefixes, equivalence with the legacy `startsWith(int, byte[])` overload, and shared (offset+length) views on either side.
- **`RecordSerializerTest#testBuildRecordRepeatedCallsAreIndependent`** — calls `buildRecord`, `serializeValueRaw`, and the multi-PK `serializePrimaryKeyRaw` repeatedly with varying record sizes; asserts each returned `Bytes` decodes to its own per-call payload AND is not mutated by subsequent calls (catches any shared-state leak in the steal mechanism).
- Re-ran `RecordSerializerTest`, `InsertTest`, `UpdateTest`, `DeleteTest`, `SimpleSQLTest`, `IndexScanRangeTest`, `SimpleRecoveryTest` — all green.
- Ran the full hammer suite (`DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test`) twice — green both times.
- Pre-PR validation (`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`) — green across all 22 modules.

🤖 Implemented by the `pr-worker` agent.