### PR TITLE
issue #396: parallel BLink node writes in incremental PK checkpoint

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -55,6 +55,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -125,6 +128,23 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
     private static final int DEFAULT_SNAPSHOT_CHUNK_SIZE =
             SystemProperties.getIntSystemProperty(PROP_SNAPSHOT_CHUNK_SIZE, 50_000);
 
+    /**
+     * Maximum number of dirty BLink node-page writes that a single
+     * {@link #checkpoint(LogSequenceNumber, boolean)} invocation will keep in
+     * flight when dispatching through
+     * {@link DataStorageManager#writeIndexPageAsync}. Matches the legacy
+     * {@link BLinkKeyToPageIndex#CHECKPOINT_FLUSH_PARALLELISM} so the two
+     * implementations expose the same checkpoint fan-out.
+     *
+     * <p>Tuned via the {@code herddb.checkpoint.flush.parallelism} system
+     * property (matches the user-facing
+     * {@code server.checkpoint.flush.parallelism} server config). Defaults to
+     * 16.
+     */
+    private static final int CHECKPOINT_FLUSH_PARALLELISM =
+            Math.max(1, SystemProperties.getIntSystemProperty(
+                    "herddb.checkpoint.flush.parallelism", 16));
+
     private final String tableSpace;
     private final String indexName;
 
@@ -161,6 +181,19 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
      * the largest known page id) are reclaimed by the standard DSM GC path.
      */
     private Set<Long> lastPreserveSet = Collections.emptySet();
+
+    /**
+     * When non-null, {@link NodePageStorageImpl#createPage} dispatches BLink
+     * node-page writes through
+     * {@link DataStorageManager#writeIndexPageAsync(String, String, long, DataStorageManager.DataWriter)}
+     * and accumulates the returned futures on this batch. Set only for the
+     * duration of {@link #checkpoint(LogSequenceNumber, boolean)} so DML-driven
+     * writes (splits) continue to go through the synchronous
+     * {@link DataStorageManager#writeIndexPage} path. Access is protected by
+     * the fact that checkpoint is serialized at the caller (the TableManager
+     * Phase-C write lock).
+     */
+    private volatile AsyncIndexWriteBatch currentBatch;
 
     public IncrementalBLinkKeyToPageIndex(String tableSpace, String tableName,
                                           MemoryManager memoryManager,
@@ -476,7 +509,32 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
                 return Collections.emptyList();
             }
 
-            BLinkMetadata<Bytes> metadata = t.checkpoint();
+            /*
+             * Install a per-checkpoint batch so BLink node-page writes go
+             * through writeIndexPageAsync and run concurrently up to
+             * CHECKPOINT_FLUSH_PARALLELISM in flight. The legacy
+             * BLinkKeyToPageIndex already does this (issue #202); replicating
+             * it here is the fix for issue #396, where Phase C duration was
+             * dominated by serial round-trips to remote storage. The BLink
+             * tree traversal itself remains sequential. All futures are joined
+             * by awaitBatch() before we persist the manifest, so the
+             * IndexStatus marker never references a page whose bytes are not
+             * yet durable.
+             */
+            AsyncIndexWriteBatch batch = new AsyncIndexWriteBatch(CHECKPOINT_FLUSH_PARALLELISM);
+            BLinkMetadata<Bytes> metadata;
+            currentBatch = batch;
+            try {
+                metadata = t.checkpoint();
+            } finally {
+                currentBatch = null;
+            }
+            // Join the BLink node-page writes BEFORE we persist any manifest
+            // bytes. The snapshot chunks / delta pages below are written
+            // synchronously via writeIndexPage and durable on return, but the
+            // BLink node-page bytes referenced by storeId fields inside the
+            // metadata must be durable before the manifest naming them is.
+            awaitBatch(batch);
 
             Map<Long, BLinkNodeMetadata<Bytes>> newByNodeId = new LinkedHashMap<>(metadata.nodes.size());
             for (BLinkNodeMetadata<Bytes> node : metadata.nodes) {
@@ -559,6 +617,56 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             return result;
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
+        }
+    }
+
+    /**
+     * Joins every async BLink node-page write submitted during checkpoint.
+     * If any future failed, surfaces the first root cause as a
+     * {@link DataStorageManagerException}; other failed futures are silently
+     * drained so that by the time we return all gRPC activity is quiesced and
+     * the checkpoint can fail cleanly without leaking work to the next phase.
+     */
+    private void awaitBatch(AsyncIndexWriteBatch batch) throws DataStorageManagerException {
+        List<CompletableFuture<Void>> futures = batch.snapshot();
+        if (futures.isEmpty()) {
+            return;
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).join();
+        } catch (CompletionException ex) {
+            Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+            if (cause instanceof DataStorageManagerException) {
+                throw (DataStorageManagerException) cause;
+            }
+            throw new DataStorageManagerException(
+                    "Error awaiting async BLink index page writes for index " + indexName, cause);
+        }
+    }
+
+    /**
+     * Per-checkpoint batch coordinating async BLink node-page writes. Holds
+     * a semaphore bounding the number of in-flight writes and a list of the
+     * submitted futures. Not thread-safe for concurrent batch creation; only
+     * one batch is active at a time because checkpoint is serialized by the
+     * TableManager Phase-C write lock.
+     */
+    private static final class AsyncIndexWriteBatch {
+        final Semaphore permits;
+        // Guarded by `this` since futures are added by the (single) traversal
+        // thread but may be completed by arbitrary gRPC callback threads.
+        private final List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        AsyncIndexWriteBatch(int parallelism) {
+            this.permits = new Semaphore(parallelism);
+        }
+
+        synchronized void add(CompletableFuture<Void> future) {
+            futures.add(future);
+        }
+
+        synchronized List<CompletableFuture<Void>> snapshot() {
+            return new ArrayList<>(futures);
         }
     }
 
@@ -779,7 +887,7 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
 
         private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             long pid = (pageId == NEW_PAGE) ? allocatePageId() : pageId;
-            dataStorageManager.writeIndexPage(tableSpace, indexName, pid, out -> {
+            DataStorageManager.DataWriter writer = out -> {
                 out.writeVLong(1);
                 out.writeVLong(0);
                 out.writeByte(type);
@@ -799,7 +907,38 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
                     }
                 });
                 out.writeByte(NODE_PAGE_END_BLOCK);
-            });
+            };
+
+            /*
+             * When a checkpoint is in progress (currentBatch != null) dispatch
+             * the write asynchronously and record the future on the batch; the
+             * outer checkpoint() joins every future before persisting the
+             * manifest. Outside of checkpoint (DML splits or recovery
+             * rebuilds), keep the synchronous path so callers observe the
+             * write is durable before returning. Mirrors
+             * {@link BLinkKeyToPageIndex#createPage} so both PK index modes
+             * expose the same checkpoint fan-out (issue #396).
+             */
+            AsyncIndexWriteBatch batch = currentBatch;
+            if (batch != null) {
+                try {
+                    batch.permits.acquire();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while acquiring BLink async-write permit", ex);
+                }
+                CompletableFuture<Void> future;
+                try {
+                    future = dataStorageManager.writeIndexPageAsync(
+                            tableSpace, indexName, pid, writer);
+                } catch (RuntimeException ex) {
+                    batch.permits.release();
+                    throw ex;
+                }
+                batch.add(future.whenComplete((v, t) -> batch.permits.release()));
+            } else {
+                dataStorageManager.writeIndexPage(tableSpace, indexName, pid, writer);
+            }
             return pid;
         }
     }

--- a/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkParallelWriteCheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkParallelWriteCheckpointTest.java
@@ -1,0 +1,205 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Exercises the parallel BLink node-write path added for issue #396 in
+ * {@link IncrementalBLinkKeyToPageIndex}. The legacy
+ * {@link BLinkKeyToPageIndex} already used
+ * {@code DataStorageManager.writeIndexPageAsync} during checkpoint (issue
+ * #202) but the incremental implementation kept writing each node-page
+ * synchronously, which on remote storage made Phase C duration grow linearly
+ * with the page count.
+ *
+ * <p>Both tests wrap a {@link MemoryDataStorageManager} with a spy that
+ * dispatches each async write onto a real executor so the futures actually
+ * run off-thread, and check (1) that DML uses the sync path and checkpoint
+ * uses the async path on both the snapshot and delta legs of the incremental
+ * format, and (2) that an injected async-write failure surfaces a
+ * {@link DataStorageManagerException} rather than persisting a half-baked
+ * manifest.</p>
+ */
+public class IncrementalBLinkParallelWriteCheckpointTest {
+
+    private static IncrementalBLinkKeyToPageIndex newIndex(DataStorageManager ds) {
+        MemoryManager mem = new MemoryManager(
+                5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        IncrementalBLinkKeyToPageIndex idx =
+                new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+        return idx;
+    }
+
+    @Test
+    public void checkpointDispatchesEachNodeViaWriteIndexPageAsync() throws Exception {
+        // Populate enough keys to produce many dirty BLink leaves and inner nodes,
+        // then run the snapshot leg of the incremental format. After mutating
+        // a smaller batch run a second checkpoint that produces a delta. Both
+        // legs must dispatch node writes through writeIndexPageAsync.
+        CountingAsyncStorage ds = new CountingAsyncStorage();
+        try (IncrementalBLinkKeyToPageIndex idx = newIndex(ds)) {
+            for (int i = 0; i < 2000; i++) {
+                idx.put(Bytes.from_int(i), (long) i);
+            }
+            assertEquals("Population (DML splits) should go through sync path only",
+                    0, ds.asyncCalls.get());
+
+            // Snapshot leg.
+            int asyncBefore = ds.asyncCalls.get();
+            idx.checkpoint(new LogSequenceNumber(1, 1), false);
+            int asyncAfterSnapshot = ds.asyncCalls.get();
+            assertNotNull("manifest must be persisted after first checkpoint",
+                    idx.getCurrentManifest());
+            assertTrue("expected writeIndexPageAsync calls during snapshot checkpoint, got "
+                            + (asyncAfterSnapshot - asyncBefore),
+                    asyncAfterSnapshot > asyncBefore);
+
+            // Mutate enough to dirty several leaves but not so many that it
+            // triggers a full snapshot rewrite.
+            for (int i = 2000; i < 3000; i++) {
+                idx.put(Bytes.from_int(i), (long) i);
+            }
+            assertEquals("Post-checkpoint DML must continue to use sync path",
+                    asyncAfterSnapshot, ds.asyncCalls.get());
+
+            // Delta leg.
+            idx.checkpoint(new LogSequenceNumber(1, 2), false);
+            assertTrue("expected writeIndexPageAsync calls during delta checkpoint, got "
+                            + (ds.asyncCalls.get() - asyncAfterSnapshot),
+                    ds.asyncCalls.get() > asyncAfterSnapshot);
+        } finally {
+            ds.shutdown();
+        }
+    }
+
+    @Test
+    public void failingAsyncWriteFailsCheckpointCleanly() throws Exception {
+        // Inject a failure in one writeIndexPageAsync call; the checkpoint must
+        // surface a DataStorageManagerException rather than silently completing
+        // with a half-published manifest.
+        CountingAsyncStorage ds = new CountingAsyncStorage();
+        ds.failNthAsyncWrite(3);
+        try (IncrementalBLinkKeyToPageIndex idx = newIndex(ds)) {
+            for (int i = 0; i < 2000; i++) {
+                idx.put(Bytes.from_int(i), (long) i);
+            }
+            try {
+                idx.checkpoint(new LogSequenceNumber(1, 1), false);
+                fail("checkpoint must fail when an async index write fails");
+            } catch (DataStorageManagerException expected) {
+                String chain = chainMessages(expected);
+                assertTrue("unexpected cause chain: " + chain,
+                        chain.contains("injected"));
+            }
+            // The previous failed checkpoint must NOT have published a manifest:
+            // the join in awaitBatch happens before indexCheckpoint persists the
+            // IndexStatus, so currentManifest stays null on the failure path.
+            assertEquals("failed checkpoint must not advance manifest state",
+                    null, idx.getCurrentManifest());
+        } finally {
+            ds.shutdown();
+        }
+    }
+
+    private static String chainMessages(Throwable t) {
+        StringBuilder b = new StringBuilder();
+        Throwable cur = t;
+        while (cur != null) {
+            if (b.length() > 0) {
+                b.append(" <- ");
+            }
+            b.append(cur.getClass().getSimpleName()).append(": ").append(cur.getMessage());
+            cur = cur.getCause();
+        }
+        return b.toString();
+    }
+
+    /**
+     * {@link MemoryDataStorageManager} subclass that:
+     * <ul>
+     *   <li>Dispatches {@code writeIndexPageAsync} onto a real executor so
+     *       the futures actually complete off-thread (the default
+     *       implementation runs synchronously).</li>
+     *   <li>Counts async and sync writes so the test can assert the correct
+     *       path was taken.</li>
+     *   <li>Can inject a failure on the N-th async write for the error path.</li>
+     * </ul>
+     */
+    private static final class CountingAsyncStorage extends MemoryDataStorageManager {
+        final AtomicInteger asyncCalls = new AtomicInteger();
+        private final AtomicInteger asyncSeq = new AtomicInteger();
+        volatile int failAt = -1;
+        private final ExecutorService exec = Executors.newFixedThreadPool(4, r -> {
+            Thread t = new Thread(r, "incremental-blink-parallel-test-writer");
+            t.setDaemon(true);
+            return t;
+        });
+
+        void failNthAsyncWrite(int n) {
+            this.failAt = n;
+        }
+
+        void shutdown() throws InterruptedException {
+            exec.shutdown();
+            exec.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public CompletableFuture<Void> writeIndexPageAsync(String tableSpace, String indexName,
+                long pageId, DataWriter writer) {
+            asyncCalls.incrementAndGet();
+            int seq = asyncSeq.incrementAndGet();
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            exec.submit(() -> {
+                if (failAt > 0 && seq == failAt) {
+                    future.completeExceptionally(new RuntimeException(
+                            "injected failure on async write #" + seq));
+                    return;
+                }
+                try {
+                    // Delegate the actual byte storage to the synchronous base impl.
+                    super.writeIndexPage(tableSpace, indexName, pageId, writer);
+                    future.complete(null);
+                } catch (RuntimeException ex) {
+                    future.completeExceptionally(ex);
+                }
+            });
+            return future;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #396.

## Root cause

`IncrementalBLinkKeyToPageIndex` is the default PK index implementation
(`herddb.index.pk.mode=incremental`). Its `checkpoint()` calls the BLink
tree traversal which writes every dirty node-page through
`dataStorageManager.writeIndexPage(...)` — the **synchronous** path.

The legacy `BLinkKeyToPageIndex` already fixed this in issue #202 by
installing a per-checkpoint `AsyncIndexWriteBatch` that dispatches each
node write through `writeIndexPageAsync` with up to
`server.checkpoint.flush.parallelism` (default 16) writes in flight. The
incremental implementation never picked up that optimisation.

The math matches the GKE bench measurement exactly:
`51,235 pages × 5.32 ms/page` (synchronous round-trip latency to remote
storage) `= 272,605 ms`, matching the observed Phase C duration of
272,765 ms. With 16× parallelism on a latency-bound remote store this
collapses by an order of magnitude — enough that a 1 B-row run becomes
feasible without changing the lock semantics.

## Changes

- `IncrementalBLinkKeyToPageIndex.java`: add `AsyncIndexWriteBatch` field
  + `CHECKPOINT_FLUSH_PARALLELISM` constant (same `herddb.checkpoint.flush.parallelism`
  system property as the legacy class). Install the batch around
  `t.checkpoint()`, join all submitted futures via `awaitBatch(...)` BEFORE
  persisting the manifest (so `IndexStatus` never references a page whose
  bytes are not yet durable). In `NodePageStorageImpl.createPage`, when a
  batch is active dispatch through `writeIndexPageAsync` using the same
  permit-acquire / future-add / permit-release pattern as the legacy
  class. Outside checkpoint (DML splits) keep the synchronous path so
  callers still observe durability before returning.

## Tests

- `IncrementalBLinkParallelWriteCheckpointTest` (new): mirrors
  `BLinkParallelWriteCheckpointTest`. Two cases:
  - `checkpointDispatchesEachNodeViaWriteIndexPageAsync` — populate
    ~2000 keys (DML split path, sync only), run a snapshot checkpoint,
    mutate a smaller batch (sync only), run a delta checkpoint. Asserts
    the spy's async-write counter is 0 during DML and strictly > 0
    during BOTH the snapshot and delta checkpoints.
  - `failingAsyncWriteFailsCheckpointCleanly` — inject a failure on the
    N-th async write and assert `checkpoint()` surfaces a
    `DataStorageManagerException` AND does not advance
    `currentManifest`, verifying the join is ordered before
    `indexCheckpoint`.
- Hammer suite (`DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`,
  `DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest`,
  `DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest`) — green
  on two consecutive runs (CLAUDE.md gate for index/checkpoint/
  concurrency changes).

## Out of scope (follow-ups for separate issues)

1. Releasing the Phase-C write lock during PK page I/O — architectural,
   touches issue #46 and #157 LSN-dance invariants and deserves its own
   design discussion.
2. Avoiding rewrites of non-dirty pages on random-PK workloads — the
   current logic in `BLink.Node.checkpoint()` already skips writes for
   clean pages; the GKE bench just dirties most pages because the
   BIGANN PK distribution touches most leaves.
3. Increasing the BLink page size or moving the PK index off the local
   data PVC.

🤖 Implemented by the `pr-worker` agent.