### PR TITLE
issue #409: slab-pack DataPage values on toImmutable()

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -271,6 +271,88 @@ public class DataPage extends Page<TableManager> {
     }
 
     /**
+     * Issue #409: rebuild a mutable page's {@link Record} map onto a
+     * dedicated off-heap value slab as part of {@link #toImmutable()}.
+     *
+     * <p>Returns a slab-packed immutable {@code DataPage} when the records'
+     * aggregate value bytes meet {@link #OFFHEAP_VALUE_BYTES_THRESHOLD} and
+     * fit a 32-bit {@code ByteBuf} capacity. Returns {@code null} otherwise
+     * to signal that the caller should keep the on-heap representation.
+     *
+     * <p>The {@code Record}s in the new page are fresh objects whose values
+     * are non-owning {@link Bytes#fromSharedSlab} views into the slab,
+     * anchored against the new {@link DataPageHolder} so the JDK
+     * {@link Cleaner} releases the slab once the page (and every shared-slab
+     * {@code Bytes} extracted from it) becomes GC-unreachable. The original
+     * mutable page's on-heap {@code byte[]}-backed {@code Record}s remain
+     * untouched and are eligible for GC as soon as the caller drops its
+     * references to them — exactly the same lifecycle invariant that
+     * already held for the legacy on-heap {@code toImmutable()}.
+     *
+     * <p>Key {@code Bytes} are reused as-is (unchanged identity, unchanged
+     * representation) — only the value bytes are repacked onto the slab.
+     *
+     * @param owner       the {@link TableManager} that will own the new page.
+     * @param pageId      page id to copy onto the new immutable page.
+     * @param maxSize     {@code maxSize} of the source mutable page.
+     * @param sourceData  the source mutable page's record map; iterated once
+     *                    to size the slab and once to pack values.
+     * @return a new immutable, slab-packed {@code DataPage}, or {@code null}
+     *         when the records do not warrant a slab (tiny aggregate bytes
+     *         or pathological size).
+     */
+    static DataPage buildSlabPackedFromMutableData(TableManager owner, long pageId, long maxSize,
+                                                    Map<Bytes, Record> sourceData) {
+        long totalValueBytes = 0L;
+        for (Record r : sourceData.values()) {
+            totalValueBytes += r.value.getLength();
+        }
+        if (totalValueBytes < OFFHEAP_VALUE_BYTES_THRESHOLD || totalValueBytes > Integer.MAX_VALUE) {
+            // Stay on-heap when the slab overhead would dominate (tiny pages)
+            // or when a 32-bit ByteBuf cannot hold the aggregate (pathological).
+            return null;
+        }
+
+        PooledByteBufAllocator allocator = HerdDBByteBufAllocators.dataPagesAllocator();
+        // The slab's refcount is 1 here; the Cleanable in the constructor below
+        // releases it exactly once when the page (and every shared-slab Bytes
+        // anchored to it) becomes GC-unreachable.
+        ByteBuf slab = allocator.directBuffer((int) totalValueBytes);
+        try {
+            Map<Bytes, Record> map = new HashMap<>(sourceData.size());
+            DataPageHolder holder = new DataPageHolder();
+            int writePos = 0;
+            long estimatedPageSize = 0L;
+            for (Record r : sourceData.values()) {
+                int valueLen = r.value.getLength();
+                if (valueLen > 0) {
+                    // Reading from the source value triggers lazy materialisation
+                    // for off-heap-backed sources, but on the toImmutable() path
+                    // sources are mutable on-heap pages so this is a plain
+                    // byte[] read.
+                    slab.writeBytes(r.value.getBuffer(), r.value.getOffset(), valueLen);
+                }
+                Bytes offHeapValue = Bytes.fromSharedSlab(slab, writePos, valueLen, holder);
+                Record packed = new Record(r.key, offHeapValue);
+                map.put(packed.key, packed);
+                estimatedPageSize += DataPage.estimateEntrySize(packed);
+                writePos += valueLen;
+            }
+            DataPage page = new DataPage(owner, pageId, maxSize, estimatedPageSize, map, true, slab);
+            holder.page = page;
+            return page;
+        } catch (RuntimeException t) {
+            // Narrow catch (per CLAUDE.md): everything inside the try can only
+            // throw unchecked exceptions — slab.writeBytes (IOOBE on capacity
+            // miscalculation), Bytes.fromSharedSlab (NPE on bad arguments),
+            // HashMap.put (none expected). Allocation succeeded; subsequent
+            // failure must release the slab so we don't leak pooled memory.
+            slab.release();
+            throw t;
+        }
+    }
+
+    /**
      * Holder that lets {@link #buildSlabPackedImmutable} hand each
      * shared-slab {@code Bytes} a reference that resolves to the
      * {@code DataPage} once construction completes. The {@code Bytes} only
@@ -322,6 +404,13 @@ public class DataPage extends Page<TableManager> {
      * before checking).
      * </p>
      *
+     * <p><b>Issue #409 — off-heap value slab</b>: when the aggregate
+     * {@code Record.value} bytes meet {@link #OFFHEAP_VALUE_BYTES_THRESHOLD}
+     * the converter rebuilds the records onto a dedicated off-heap slab via
+     * {@link #buildSlabPackedFromMutableData}, so ingest-resident immutable
+     * pages stop pinning their value bytes on the JVM heap. Tiny / pathological
+     * pages keep the legacy on-heap layout.
+     *
      * @return immutable data page version
      */
     DataPage toImmutable() {
@@ -334,6 +423,15 @@ public class DataPage extends Page<TableManager> {
             throw new IllegalStateException("page " + pageId + " cannot be converted to immutable because still writable!");
         }
 
+        // Issue #409: pack value bytes into a dedicated DATA_PAGES off-heap
+        // slab when the aggregate exceeds the slab threshold. Falls back to
+        // the legacy on-heap layout for tiny / pathological pages so we keep
+        // the pre-#409 behaviour where the slab's per-record overhead would
+        // outweigh the savings.
+        DataPage slabPacked = buildSlabPackedFromMutableData(owner, pageId, maxSize, data);
+        if (slabPacked != null) {
+            return slabPacked;
+        }
         return new DataPage(owner, pageId, maxSize, usedMemory.get(), data, true);
 
     }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1081,6 +1081,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                  * (page.metadata == null). Pages that were added by allocateLivePage when they filled up
                  * already have metadata set; adding the immutable copy again would throw "Added a page twice".
                  */
+                // Issue #409: toImmutable() repacks values into an off-heap
+                // slab (HerdDBByteBufAllocators.dataPagesAllocator()) when the
+                // aggregate value bytes exceed OFFHEAP_VALUE_BYTES_THRESHOLD,
+                // so the new immutablePage no longer pins record byte[]s on
+                // the JVM heap.
                 final DataPage immutablePage = pages.computeIfPresent(page.pageId, (i, p) -> p.toImmutable());
                 if (immutablePage != null && page.metadata == null) {
                     final Page.Metadata unloadMeta = pageReplacementPolicy.add(immutablePage);
@@ -1392,6 +1397,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             if (keepPageInMemory) {
                 /* If we must keep the page in memory we "covert" the page to immutable */
+                // Issue #409: see DataPage.toImmutable() — value bytes are
+                // now repacked into an off-heap slab when the page is large
+                // enough to warrant the per-record slice overhead. The flush
+                // above (writePage at line ~1386) already consumed the
+                // mutable page's records, so swapping in a slab-packed copy
+                // here doesn't affect persistence.
                 pages.put(page.pageId, page.toImmutable());
 
                 /*

--- a/herddb-core/src/test/java/herddb/core/DataPageToImmutableSlabPackTest.java
+++ b/herddb-core/src/test/java/herddb/core/DataPageToImmutableSlabPackTest.java
@@ -1,0 +1,278 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.model.Record;
+import herddb.utils.Bytes;
+import herddb.utils.HerdDBByteBufAllocators;
+import io.netty.buffer.ByteBuf;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.Test;
+
+/**
+ * Issue #409 — verifies that {@link DataPage#toImmutable()} repacks
+ * {@code Record.value} bytes into a dedicated off-heap slab allocated from
+ * {@link HerdDBByteBufAllocators#dataPagesAllocator()} when the aggregate
+ * value bytes meet the slab threshold, and that the slab is released by the
+ * JDK {@link java.lang.ref.Cleaner} once the resulting immutable page (and
+ * every shared-slab {@link Bytes} extracted from it) becomes GC-unreachable.
+ *
+ * <p>These tests are intentionally narrow: they exercise the
+ * mutable→immutable transition directly (no full {@code TableManager}), so
+ * they don't need cluster infrastructure and remain in the core test
+ * workflow.
+ */
+public class DataPageToImmutableSlabPackTest {
+
+    private static List<Record> sampleRecords(int count, int valueLen) {
+        List<Record> out = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            byte[] value = new byte[valueLen];
+            for (int j = 0; j < valueLen; j++) {
+                value[j] = (byte) ((i * 31 + j) & 0xff);
+            }
+            out.add(new Record(Bytes.from_long(i), Bytes.from_array(value)));
+        }
+        return out;
+    }
+
+    /**
+     * Build a mutable {@link DataPage} populated with the given records, mark
+     * it non-writable, and return it ready for {@link DataPage#toImmutable()}.
+     */
+    private static DataPage makeMutablePage(long pageId, long maxSize, List<Record> records) {
+        Map<Bytes, Record> map = new ConcurrentHashMap<>(records.size());
+        long estimated = 0L;
+        for (Record r : records) {
+            map.put(r.key, r);
+            estimated += DataPage.estimateEntrySize(r);
+        }
+        DataPage mutable = new DataPage(null, pageId, maxSize, estimated, map, false);
+        // toImmutable() requires writable == false (the mutable page must
+        // already be sealed by the caller before conversion); replicate that.
+        mutable.writable = false;
+        return mutable;
+    }
+
+    @Test
+    public void toImmutableSlabPacksValuesWhenAboveThreshold() throws Exception {
+        // 64 × 512 = 32 KiB total > 4 KiB threshold.
+        List<Record> records = sampleRecords(64, 512);
+        DataPage mutable = makeMutablePage(7L, 1024L * 1024L, records);
+        DataPage immutable = mutable.toImmutable();
+        try {
+            assertTrue("immutable page must be slab-packed",
+                    immutable.hasOffHeapValueSlab());
+
+            // Reflect the slab and verify it really lives in direct memory
+            // and was created by the data-pages allocator.
+            Field f = DataPage.class.getDeclaredField("valueSlab");
+            f.setAccessible(true);
+            ByteBuf slab = (ByteBuf) f.get(immutable);
+            assertNotNull(slab);
+            assertTrue("slab must be direct memory", slab.isDirect());
+            assertTrue("slab must be allocated by the data-pages allocator (not DEFAULT)",
+                    slab.alloc() == HerdDBByteBufAllocators.dataPagesAllocator());
+            assertEquals("slab must hold exactly one initial refcount",
+                    1, immutable.slabRefCntForTesting());
+
+            // Every value is now shared-slab Bytes, anchored against the new
+            // immutable page.
+            for (Record original : records) {
+                Record packed = immutable.get(original.key);
+                assertNotNull("missing key " + original.key, packed);
+                assertTrue("value must be off-heap after toImmutable()",
+                        packed.value.isOffHeap());
+                assertEquals("value length round-trip",
+                        original.value.getLength(), packed.value.getLength());
+                assertEquals("value bytes round-trip",
+                        original.value, packed.value);
+            }
+        } finally {
+            // Drop the strong reference; subsequent GC will return the slab to the pool.
+            immutable = null;
+        }
+    }
+
+    @Test
+    public void toImmutableFallsBackToOnHeapWhenBelowThreshold() {
+        // 16 × 16 = 256 bytes < 4 KiB threshold.
+        List<Record> records = sampleRecords(16, 16);
+        DataPage mutable = makeMutablePage(8L, 1024L * 1024L, records);
+        DataPage immutable = mutable.toImmutable();
+        assertFalse("tiny pages must keep on-heap values after toImmutable()",
+                immutable.hasOffHeapValueSlab());
+        assertEquals(0, immutable.slabRefCntForTesting());
+        for (Record original : records) {
+            Record passed = immutable.get(original.key);
+            assertNotNull("missing key " + original.key, passed);
+            assertFalse("value must remain on-heap (no slab)",
+                    passed.value.isOffHeap());
+            assertEquals(original.value, passed.value);
+        }
+    }
+
+    /**
+     * Mixed zero-length and non-zero-length values inside the same mutable
+     * page — the slab-pack writer must emit no bytes for empty values and
+     * slice the next non-empty value at the right offset, just like the
+     * existing {@link DataPage#buildSlabPackedImmutable} read-path factory.
+     */
+    @Test
+    public void toImmutableHandlesMixedZeroAndNonZeroLengthValues() {
+        List<Record> records = new ArrayList<>();
+        records.add(new Record(Bytes.from_long(0), Bytes.from_array(payloadOf(512, 0xa))));
+        records.add(new Record(Bytes.from_long(1), Bytes.EMPTY_ARRAY));
+        records.add(new Record(Bytes.from_long(2), Bytes.from_array(payloadOf(512, 0xb))));
+        records.add(new Record(Bytes.from_long(3), Bytes.EMPTY_ARRAY));
+        records.add(new Record(Bytes.from_long(4), Bytes.from_array(payloadOf(3 * 1024, 0xc))));
+
+        DataPage mutable = makeMutablePage(9L, 1024L * 1024L, records);
+        DataPage immutable = mutable.toImmutable();
+        assertTrue("aggregate values exceed the 4 KiB threshold",
+                immutable.hasOffHeapValueSlab());
+
+        for (Record original : records) {
+            Record packed = immutable.get(original.key);
+            assertNotNull("missing key " + original.key, packed);
+            assertEquals("value length round-trip for key " + original.key,
+                    original.value.getLength(), packed.value.getLength());
+            assertEquals("value bytes round-trip for key " + original.key,
+                    original.value, packed.value);
+            if (original.value.getLength() == 0) {
+                assertTrue(packed.value.isOffHeap());
+                assertEquals(Bytes.EMPTY_ARRAY, packed.value);
+            }
+        }
+        assertEquals(1, immutable.slabRefCntForTesting());
+    }
+
+    /**
+     * Verifies that the page's tracked {@link DataPage#getUsedMemory()} after
+     * toImmutable() stays within ±1 % of the mutable page's accounting.
+     * Guards against the eviction budget silently drifting after the change.
+     */
+    @Test
+    public void toImmutableEstimatedSizeStableAcrossPack() {
+        List<Record> records = sampleRecords(64, 512); // 32 KiB > threshold
+        DataPage mutable = makeMutablePage(10L, 1024L * 1024L, records);
+        long mutableUsed = mutable.getUsedMemory();
+        DataPage immutable = mutable.toImmutable();
+        long immutableUsed = immutable.getUsedMemory();
+        assertTrue("immutable page must be slab-packed for this test to be meaningful",
+                immutable.hasOffHeapValueSlab());
+        // Allow at most 1 % drift in either direction. The shared-slab
+        // Bytes wrappers carry a slightly larger CONSTANT_BYTE_SIZE than the
+        // on-heap variants; with 64 records and ~512-byte values the delta
+        // is below 1 % even in the worst case.
+        long drift = Math.abs(immutableUsed - mutableUsed);
+        long onePercent = Math.max(1L, mutableUsed / 100L);
+        assertTrue("usedMemory drift must stay within 1 % "
+                        + "(mutable=" + mutableUsed + ", immutable=" + immutableUsed
+                        + ", drift=" + drift + ", 1%=" + onePercent + ")",
+                drift <= onePercent);
+    }
+
+    /**
+     * The Cleaner-anchored slab returns to the pool after the new immutable
+     * page (and every shared-slab {@code Bytes} extracted from it) becomes
+     * GC-unreachable. Mirrors the pattern used by the existing
+     * {@code DataPageOffHeapValueSlabTest#cleanerReleasesSlabWhenPageBecomesUnreachable}.
+     */
+    @Test
+    public void cleanerReleasesSlabAfterToImmutable() throws Exception {
+        List<Record> records = sampleRecords(64, 512); // 32 KiB > threshold
+        DataPage mutable = makeMutablePage(11L, 1024L * 1024L, records);
+        DataPage immutable = mutable.toImmutable();
+        assertTrue(immutable.hasOffHeapValueSlab());
+
+        // Snapshot the slab without pinning the page.
+        Field f = DataPage.class.getDeclaredField("valueSlab");
+        f.setAccessible(true);
+        ByteBuf slab = (ByteBuf) f.get(immutable);
+        assertNotNull(slab);
+        assertEquals(1, slab.refCnt());
+
+        // Drop every strong reference to the page and the records that the
+        // shared-slab Bytes anchor against.
+        immutable = null;
+        records = null;
+        mutable = null;
+
+        long deadline = System.currentTimeMillis() + 10_000L;
+        while (slab.refCnt() > 0 && System.currentTimeMillis() < deadline) {
+            System.gc();
+            // Give the Cleaner thread a moment to drain.
+            Thread.sleep(50);
+        }
+        assertEquals("slab must be released by the Cleaner once the new"
+                        + " immutable page is unreachable",
+                0, slab.refCnt());
+    }
+
+    /**
+     * The legacy mutable-page records (the ones still backed by on-heap
+     * {@code byte[]}) stay readable after {@code toImmutable()} returns the
+     * new slab-packed copy. This guards against any accidental side-effect
+     * on the source page's contents.
+     */
+    @Test
+    public void mutablePageContentsUnchangedAfterToImmutable() {
+        List<Record> records = sampleRecords(64, 512); // 32 KiB > threshold
+        DataPage mutable = makeMutablePage(12L, 1024L * 1024L, records);
+        // Snapshot the mutable map's records before conversion.
+        Map<Bytes, Record> snapshot = new HashMap<>();
+        for (Record original : records) {
+            snapshot.put(original.key, mutable.get(original.key));
+        }
+
+        DataPage immutable = mutable.toImmutable();
+        assertTrue(immutable.hasOffHeapValueSlab());
+
+        for (Record original : records) {
+            Record stillMutable = mutable.get(original.key);
+            assertNotNull(stillMutable);
+            assertFalse("mutable-page records must remain on-heap-backed",
+                    stillMutable.value.isOffHeap());
+            // Identity preserved on the source page (no swap-in-place).
+            assertTrue("toImmutable must not mutate the source page records",
+                    snapshot.get(original.key) == stillMutable);
+            assertEquals(original.value, stillMutable.value);
+        }
+    }
+
+    private static byte[] payloadOf(int length, int seed) {
+        byte[] out = new byte[length];
+        for (int i = 0; i < length; i++) {
+            out[i] = (byte) ((i * 31 + seed) & 0xff);
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
Fixes #409.

Issue #399 landed all the off-heap infrastructure (`HerdDBByteBufAllocators.dataPagesAllocator()`,
`Bytes.fromOffHeap` / `fromSharedSlab`, `DataPage.buildSlabPackedImmutable`, `IndexKeySlab`) and
wired it into the eager **disk-read** path. But the **mutable→immutable** transition that runs at
checkpoint flush time still copied the `Map<Bytes, Record>` reference as-is, so every record's
`byte[]`-backed value stayed pinned on the JVM heap for the lifetime of the resident immutable
page. On the GKE bigann-1B run that translates to 9.2 GiB of `byte[]` and 42.7 M live `Bytes`
wrappers at 40 M rows — the dominant ingest-time on-heap consumer reported in the issue.

This PR closes that hole. A new package-private factory
`DataPage.buildSlabPackedFromMutableData(...)` rebuilds the source page's records onto a
dedicated off-heap slab from `HerdDBByteBufAllocators.dataPagesAllocator()`, anchored by the same
`DataPageHolder` / `Cleaner` lifecycle that issue #399 already uses for slab-packed disk reads.
`DataPage.toImmutable()` now calls the new factory and falls back to the legacy on-heap layout
only for tiny pages (below `OFFHEAP_VALUE_BYTES_THRESHOLD`) or pathological pages whose aggregate
exceeds a 32-bit `ByteBuf` capacity. The two `toImmutable()` call sites in `TableManager` are
unchanged structurally — the relevant flush write happens **before** the swap, so no persistence
path is affected — and each gains a one-line cross-reference comment.

A focused follow-up issue (#411) tracks the remaining on-heap consumers identified during the
audit (`LazyValueCache` and BLink/BRIN internal key copies) so each migration can be reviewed and
benchmarked independently.

## Changes

- `herddb-core/src/main/java/herddb/core/DataPage.java`
  - New package-private static factory `buildSlabPackedFromMutableData(owner, pageId, maxSize, sourceData)`.
    Returns a slab-packed immutable `DataPage` when the records' aggregate value bytes meet
    `OFFHEAP_VALUE_BYTES_THRESHOLD` (4 KiB) and fit a 32-bit `ByteBuf`; returns `null` to signal
    the on-heap fallback. Reuses the `DataPageHolder` GC-anchor pattern and the narrow
    `slab.release()` recovery branch already used by `buildSlabPackedImmutable`.
  - `toImmutable()` now calls the new factory and falls back to the legacy
    `new DataPage(..., true)` constructor on a `null` signal. The mutable source page's records
    are not mutated — they remain readable and eligible for GC the same way as before.
- `herddb-core/src/main/java/herddb/core/TableManager.java`
  - Comment-only updates at the two `toImmutable()` call sites (lines ~1084 and ~1395) explaining
    that the immutable copy is now slab-packed and that the swap happens after the flush write,
    so persistence is unaffected.
- `herddb-core/src/test/java/herddb/core/DataPageToImmutableSlabPackTest.java` (new)
  - 6 unit tests covering the contract end-to-end (see below).

## Tests

New test class `DataPageToImmutableSlabPackTest`:
- `toImmutableSlabPacksValuesWhenAboveThreshold` — 64×512-byte records (32 KiB > 4 KiB threshold)
  produce an immutable page with `hasOffHeapValueSlab() == true`, slab is direct memory from the
  data-pages allocator, refcount = 1, every record's value reports `isOffHeap() == true`, value
  bytes round-trip identically.
- `toImmutableFallsBackToOnHeapWhenBelowThreshold` — 16×16-byte records keep the on-heap layout;
  no slab created.
- `toImmutableHandlesMixedZeroAndNonZeroLengthValues` — empty values produce zero-length
  shared-slab `Bytes`; non-empty values round-trip at the right offsets.
- `toImmutableEstimatedSizeStableAcrossPack` — `getUsedMemory()` drift between the source mutable
  page and the slab-packed immutable copy stays within ±1 % so the eviction budget remains
  honest.
- `cleanerReleasesSlabAfterToImmutable` — JDK `Cleaner` returns the slab to the pool once the
  new immutable page (and every shared-slab `Bytes` it produced) is GC-unreachable. Mirrors the
  existing GC-driven test in `DataPageOffHeapValueSlabTest`.
- `mutablePageContentsUnchangedAfterToImmutable` — the source mutable page's records keep their
  on-heap `byte[]`-backed values and identity, guarding against any accidental in-place mutation.

Verification:
- `DataPageToImmutableSlabPackTest` (new): 6/6 ✅
- `DataPageOffHeapValueSlabTest` (existing): 6/6 ✅
- `DataPagePutOverflowTest` (existing): 5/5 ✅
- `BLinkOffHeapKeysTest` / `BRINOffHeapKeysTest` / `BLinkParallelWriteCheckpointTest` (existing):
  all green ✅
- Hammer suite (`DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test`):
  12/12 ✅, run twice per CLAUDE.md to reduce flake risk.
- Pre-PR validation (`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`):
  ✅ across all 23 modules.

## Related

- Closes #409.
- Follow-up #411 — `LazyValueCache` + BLink/BRIN internal key off-heap migration.
- Builds on #399 — original off-heap allocator infrastructure.

🤖 Implemented by the `pr-worker` agent.