### PR TITLE
issue #416: validate v2 page index entries at parse time

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPage.java
@@ -156,10 +156,18 @@ public final class LazyDataPage extends DataPage {
                 return new Record(key, Bytes.EMPTY_ARRAY);
             }
             if (m.valueLength < 0) {
-                // Guard against a malformed v2 page whose index entry slipped
-                // past the parser's range checks; surface as the same
+                // Defence-in-depth (issue #416). The authoritative check now
+                // lives in {@link LazyDataPageFormat#readIndex(ByteBuf, int, long)},
+                // which rejects negative valueLength / valueOffset, long
+                // overflow on (valueOffset + valueLength), and value ranges
+                // that exceed the values section size — so under normal
+                // operation no negative valueLength can reach this point.
+                // We keep this belt-and-braces guard so that any future code
+                // path which constructs a {@link RecordMetadata} bypassing
+                // the parser still surfaces the corruption as the
                 // LazyValueFetchException callers already handle, instead of
-                // a raw NegativeArraySizeException.
+                // a raw NegativeArraySizeException leaking out of the
+                // {@code new byte[m.valueLength]} below.
                 throw new LazyValueFetchException("Negative valueLength " + m.valueLength
                         + " for key " + key + " in " + tableSpace + "/" + uuid + "#" + pageId,
                         new IllegalStateException("corrupted page index"));

--- a/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPageFormat.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/LazyDataPageFormat.java
@@ -270,8 +270,42 @@ public final class LazyDataPageFormat {
      * Reads {@code numRecords} {@link RecordMetadata} entries from the index
      * section (already positioned at the start of the index and containing at
      * least {@code indexSize} readable bytes).
+     *
+     * <p>Equivalent to {@link #readIndex(ByteBuf, int, long)} with
+     * {@code valueSize = Long.MAX_VALUE}: per-entry sanity checks (non-negative
+     * {@code valueOffset}/{@code valueLength}, no {@code long} overflow on
+     * {@code valueOffset + valueLength}) are performed, but the upper bound
+     * against the values-section size is skipped. Prefer the 3-arg overload
+     * when {@code valueSize} is known so corrupt entries are rejected even
+     * earlier.
      */
     public static List<RecordMetadata> readIndex(ByteBuf indexSection, int numRecords)
+            throws DataStorageManagerException {
+        return readIndex(indexSection, numRecords, Long.MAX_VALUE);
+    }
+
+    /**
+     * Reads {@code numRecords} {@link RecordMetadata} entries from the index
+     * section (already positioned at the start of the index and containing at
+     * least {@code indexSize} readable bytes), validating each entry against
+     * {@code valueSize} (the declared size of the values section, from the
+     * fixed header).
+     *
+     * <p>Each parsed entry must satisfy:
+     * <ul>
+     *   <li>{@code valueOffset >= 0}
+     *   <li>{@code valueLength >= 0}
+     *   <li>{@code valueOffset + valueLength} does not overflow {@code long}
+     *   <li>{@code valueOffset + valueLength <= valueSize}
+     * </ul>
+     *
+     * <p>A failure on any of these checks throws
+     * {@link DataStorageManagerException} so both the lazy and eager read
+     * paths surface a single, consistent corruption signal — never raw
+     * {@link NegativeArraySizeException} or {@link IndexOutOfBoundsException}
+     * from a downstream allocation or {@code getBytes} call.
+     */
+    public static List<RecordMetadata> readIndex(ByteBuf indexSection, int numRecords, long valueSize)
             throws DataStorageManagerException {
         final List<RecordMetadata> result = new ArrayList<>(numRecords);
         try {
@@ -279,6 +313,30 @@ public final class LazyDataPageFormat {
                 final byte[] keyBytes = ByteBufUtils.readArray(indexSection);
                 final long valueOffset = ByteBufUtils.readVLong(indexSection);
                 final int valueLength = ByteBufUtils.readVInt(indexSection);
+                if (valueOffset < 0L) {
+                    throw new DataStorageManagerException(
+                            "corrupted v2 page index: negative valueOffset " + valueOffset
+                                    + " at record " + i);
+                }
+                if (valueLength < 0) {
+                    throw new DataStorageManagerException(
+                            "corrupted v2 page index: negative valueLength " + valueLength
+                                    + " at record " + i);
+                }
+                // detect long overflow on the sum (valueOffset + valueLength); since both
+                // operands are non-negative, the sum can only be < valueOffset on wrap-around.
+                final long endOffset = valueOffset + (long) valueLength;
+                if (endOffset < valueOffset) {
+                    throw new DataStorageManagerException(
+                            "corrupted v2 page index: valueOffset+valueLength overflow ("
+                                    + valueOffset + " + " + valueLength + ") at record " + i);
+                }
+                if (endOffset > valueSize) {
+                    throw new DataStorageManagerException(
+                            "corrupted v2 page index: value range [" + valueOffset + ", "
+                                    + endOffset + ") exceeds valueSize " + valueSize
+                                    + " at record " + i);
+                }
                 result.add(new RecordMetadata(Bytes.from_array(keyBytes), valueOffset, valueLength));
             }
         } catch (IndexOutOfBoundsException e) {
@@ -317,9 +375,10 @@ public final class LazyDataPageFormat {
                 throw new DataStorageManagerException("v2 page footer hash mismatch");
             }
         }
-        // parse index
+        // parse index — pass valueSize so corrupted entries are rejected before
+        // we allocate value byte[]s based on attacker-controlled lengths.
         final ByteBuf indexSlice = wholeFile.slice(startIdx + FIXED_HEADER_SIZE, h.indexSize);
-        final List<RecordMetadata> metadata = readIndex(indexSlice, h.numRecords);
+        final List<RecordMetadata> metadata = readIndex(indexSlice, h.numRecords, h.valueSize);
         // extract values
         final int valueSectionStart = startIdx + FIXED_HEADER_SIZE + h.indexSize;
         final List<Record> result = new ArrayList<>(h.numRecords);

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -810,7 +810,11 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         }
         ByteBuf tmp = io.netty.buffer.Unpooled.wrappedBuffer(indexBytes);
         try {
-            return LazyDataPageFormat.readIndex(tmp, h.numRecords);
+            // Pass valueSize so corrupted index entries are rejected at parse
+            // time on the lazy-load path (issue #416), surfacing a single
+            // DataStorageManagerException instead of a downstream
+            // NegativeArraySizeException / IndexOutOfBoundsException.
+            return LazyDataPageFormat.readIndex(tmp, h.numRecords, h.valueSize);
         } finally {
             tmp.release();
         }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/LazyDataPageFormatCorruptionTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/LazyDataPageFormatCorruptionTest.java
@@ -1,0 +1,288 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+/**
+ * Corruption-handling unit tests for {@link LazyDataPageFormat}.
+ *
+ * <p>Verifies that a v2 page index entry with out-of-range
+ * {@code valueOffset}/{@code valueLength} values is rejected at parse time
+ * with a {@link DataStorageManagerException} (issue #416), so that:
+ * <ul>
+ *   <li>the eager read path
+ *       ({@link LazyDataPageFormat#readAllRecords(ByteBuf)} →
+ *       {@code RemoteFileDataStorageManager.readPage(...)}) never reaches
+ *       the {@code new byte[m.valueLength]} allocation with a negative
+ *       {@code valueLength} and never throws raw
+ *       {@link NegativeArraySizeException} /
+ *       {@link IndexOutOfBoundsException};
+ *   <li>the lazy read path
+ *       ({@link LazyDataPageFormat#readIndex(ByteBuf, int, long)} →
+ *       {@code RemoteFileDataStorageManager.readPageIndex(...)} →
+ *       {@code LazyDataPage.get(...)}) surfaces the same single corruption
+ *       signal, so callers' defensive catches see a consistent exception
+ *       type for both flows.
+ * </ul>
+ *
+ * <p>Note on negative {@code valueOffset}: the v2 wire format encodes
+ * {@code valueOffset} as a {@code VLong}, and the in-tree
+ * {@code readVLong(...)} parser refuses to decode 10-byte forms that wrap
+ * to negative values (it throws an {@link IllegalArgumentException}), so a
+ * legitimate-looking v2 index cannot encode a negative {@code valueOffset}.
+ * The {@code valueOffset < 0} guard inside
+ * {@link LazyDataPageFormat#readIndex(ByteBuf, int, long)} is therefore a
+ * defence-in-depth check for any future code path that might construct
+ * {@link LazyDataPageFormat.RecordMetadata} bypassing the parser, and is
+ * not exercised here.
+ */
+public class LazyDataPageFormatCorruptionTest {
+
+    /**
+     * Crafts a v2 index section containing a single entry with the supplied
+     * key/value-offset/value-length, encoded on the wire exactly the way
+     * {@link LazyDataPageFormat#write} would, except with the freedom to
+     * inject otherwise-illegal {@code valueLength} bytes (negative VInts
+     * cannot come out of {@code writeVInt} but can be hand-written).
+     *
+     * <p>Returned {@code ByteBuf} is a freshly allocated unpooled heap
+     * buffer; the caller is responsible for releasing it.
+     */
+    private static ByteBuf craftIndexSection(byte[] key, long valueOffset, byte[] rawVIntValueLength) {
+        ByteBuf b = Unpooled.buffer();
+        ByteBufUtils.writeArray(b, key);
+        ByteBufUtils.writeVLong(b, valueOffset);
+        b.writeBytes(rawVIntValueLength);
+        return b;
+    }
+
+    /**
+     * Encodes {@code n} as a 5-byte VInt, allowing negative values that
+     * {@link ByteBufUtils#writeVInt} would normally still accept (writeVInt
+     * does not refuse negative ints — it just emits the 5-byte form whose
+     * 5th byte sets bit 31). Returned bytes are exactly what
+     * {@link ByteBufUtils#readVInt} consumes.
+     */
+    private static byte[] vIntFiveByteForm(int n) {
+        byte[] out = new byte[5];
+        out[0] = (byte) ((n & 0x7F) | 0x80);
+        out[1] = (byte) (((n >>> 7) & 0x7F) | 0x80);
+        out[2] = (byte) (((n >>> 14) & 0x7F) | 0x80);
+        out[3] = (byte) (((n >>> 21) & 0x7F) | 0x80);
+        out[4] = (byte) ((n >>> 28) & 0x7F);
+        return out;
+    }
+
+    @Test
+    public void readIndex_negativeValueLength_throwsDataStorageManagerException() {
+        // Integer.MIN_VALUE encoded on the wire as a 5-byte VInt with bit 31 set.
+        ByteBuf idx = craftIndexSection("k0".getBytes(), 0L, vIntFiveByteForm(Integer.MIN_VALUE));
+        try {
+            LazyDataPageFormat.readIndex(idx, 1, /* valueSize */ 1024L);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertNotNull(e.getMessage());
+            assertTrue("message should mention valueLength: " + e.getMessage(),
+                    e.getMessage().contains("valueLength"));
+            assertTrue("message should mention corruption: " + e.getMessage(),
+                    e.getMessage().contains("corrupted"));
+        } finally {
+            idx.release();
+        }
+    }
+
+    @Test
+    public void readIndex_negativeValueLength_throwsEvenWithoutValueSizeBound() {
+        // The 2-arg overload (no valueSize bound) must still reject the
+        // negative valueLength because the per-entry guard fires first.
+        ByteBuf idx = craftIndexSection("k0".getBytes(), 0L, vIntFiveByteForm(-1));
+        try {
+            LazyDataPageFormat.readIndex(idx, 1);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertTrue("message should mention valueLength: " + e.getMessage(),
+                    e.getMessage().contains("valueLength"));
+        } finally {
+            idx.release();
+        }
+    }
+
+    @Test
+    public void readIndex_valueOffsetPlusLengthOverflow_throwsDataStorageManagerException() {
+        // valueOffset = Long.MAX_VALUE, valueLength = 1 → overflow.
+        // Use vIntFiveByteForm to force a 5-byte VInt encoding (writeVInt would
+        // shorten it but the result is the same after readVInt; using the
+        // 5-byte form keeps the test independent of writeVInt's chosen size).
+        ByteBuf idx = craftIndexSection("k0".getBytes(), Long.MAX_VALUE, vIntFiveByteForm(1));
+        try {
+            LazyDataPageFormat.readIndex(idx, 1, /* valueSize */ Long.MAX_VALUE);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertTrue("message should mention overflow: " + e.getMessage(),
+                    e.getMessage().contains("overflow"));
+        } finally {
+            idx.release();
+        }
+    }
+
+    @Test
+    public void readIndex_valueRangeBeyondValueSize_throwsDataStorageManagerException() {
+        // valueOffset=0, valueLength=100, valueSize=50 → out of bounds.
+        ByteBuf idx = craftIndexSection("k0".getBytes(), 0L, vIntFiveByteForm(100));
+        try {
+            LazyDataPageFormat.readIndex(idx, 1, /* valueSize */ 50L);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertTrue("message should mention valueSize: " + e.getMessage(),
+                    e.getMessage().contains("valueSize"));
+        } finally {
+            idx.release();
+        }
+    }
+
+    @Test
+    public void readIndex_valueRangeOnTheEdgeOfValueSize_succeeds() throws DataStorageManagerException {
+        // valueOffset=10, valueLength=40, valueSize=50 → exactly at the
+        // boundary; must NOT trigger the upper-bound check (endOffset == 50).
+        ByteBuf idx = craftIndexSection("k0".getBytes(), 10L, vIntFiveByteForm(40));
+        try {
+            assertEquals(1, LazyDataPageFormat.readIndex(idx, 1, /* valueSize */ 50L).size());
+        } finally {
+            idx.release();
+        }
+    }
+
+    @Test
+    public void readAllRecords_corruptedIndexNegativeValueLength_throwsDataStorageManagerException()
+            throws DataStorageManagerException {
+        // Build a complete v2 page where the single index entry's valueLength
+        // is hand-corrupted to Integer.MIN_VALUE while the fixed header is
+        // structurally valid. The eager path (readAllRecords → readIndex)
+        // must reject this before reaching `new byte[m.valueLength]`.
+        ByteBuf page = buildPageWithSingleCorruptIndexEntry(
+                /* valueOffset */ 0L,
+                /* rawVIntValueLength */ vIntFiveByteForm(Integer.MIN_VALUE),
+                /* valueSize */ 16L,
+                /* valueBytes */ new byte[16]);
+        try {
+            LazyDataPageFormat.readAllRecords(page);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertTrue("message should mention valueLength: " + e.getMessage(),
+                    e.getMessage().contains("valueLength"));
+        } catch (NegativeArraySizeException | IndexOutOfBoundsException e) {
+            fail("expected DataStorageManagerException but got " + e.getClass().getSimpleName()
+                    + ": " + e.getMessage());
+        } finally {
+            page.release();
+        }
+    }
+
+    @Test
+    public void readAllRecords_corruptedIndexValueRangeBeyondValueSize_throwsDataStorageManagerException()
+            throws DataStorageManagerException {
+        // Single index entry that claims valueOffset=0, valueLength=100 but
+        // the values section is only 16 bytes long.
+        ByteBuf page = buildPageWithSingleCorruptIndexEntry(
+                /* valueOffset */ 0L,
+                /* rawVIntValueLength */ vIntFiveByteForm(100),
+                /* valueSize */ 16L,
+                /* valueBytes */ new byte[16]);
+        try {
+            LazyDataPageFormat.readAllRecords(page);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertTrue("message should mention valueSize: " + e.getMessage(),
+                    e.getMessage().contains("valueSize"));
+        } catch (NegativeArraySizeException | IndexOutOfBoundsException e) {
+            fail("expected DataStorageManagerException but got " + e.getClass().getSimpleName()
+                    + ": " + e.getMessage());
+        } finally {
+            page.release();
+        }
+    }
+
+    @Test
+    public void readAllRecords_corruptedIndexValueOffsetOverflow_throwsDataStorageManagerException()
+            throws DataStorageManagerException {
+        // valueOffset=Long.MAX_VALUE, valueLength=1 → overflow on the long sum.
+        ByteBuf page = buildPageWithSingleCorruptIndexEntry(
+                /* valueOffset */ Long.MAX_VALUE,
+                /* rawVIntValueLength */ vIntFiveByteForm(1),
+                /* valueSize */ 1L,
+                /* valueBytes */ new byte[1]);
+        try {
+            LazyDataPageFormat.readAllRecords(page);
+            fail("expected DataStorageManagerException");
+        } catch (DataStorageManagerException e) {
+            assertTrue("message should mention overflow: " + e.getMessage(),
+                    e.getMessage().contains("overflow"));
+        } catch (NegativeArraySizeException | IndexOutOfBoundsException e) {
+            fail("expected DataStorageManagerException but got " + e.getClass().getSimpleName()
+                    + ": " + e.getMessage());
+        } finally {
+            page.release();
+        }
+    }
+
+    /**
+     * Hand-builds a v2 page with a single hand-crafted index entry. The
+     * fixed header's {@code numRecords=1}, {@code indexSize}, and
+     * {@code valueSize} are computed and patched after the fact so the page
+     * passes the {@link LazyDataPageFormat#readHeader} sanity checks; the
+     * footer is written as the {@code NO_HASH_PRESENT} sentinel
+     * (checksum-disabled write path).
+     */
+    private static ByteBuf buildPageWithSingleCorruptIndexEntry(
+            long valueOffset, byte[] rawVIntValueLength, long valueSize, byte[] valueBytes) {
+        ByteBuf buf = Unpooled.buffer();
+        // reserve fixed header
+        buf.writeZero(LazyDataPageFormat.FIXED_HEADER_SIZE);
+        final int indexStart = buf.writerIndex();
+        // single index entry
+        ByteBufUtils.writeArray(buf, "k0".getBytes());
+        ByteBufUtils.writeVLong(buf, valueOffset);
+        buf.writeBytes(rawVIntValueLength);
+        final int indexEnd = buf.writerIndex();
+        final int indexSize = indexEnd - indexStart;
+        // values section
+        buf.writeBytes(valueBytes);
+        // footer (NO_HASH_PRESENT sentinel)
+        buf.writeLong(0L);
+        // patch fixed header
+        buf.setInt(0, LazyDataPageFormat.MAGIC);
+        buf.setByte(4, LazyDataPageFormat.VERSION_V2);
+        buf.setByte(5, LazyDataPageFormat.FLAGS_DEFAULT);
+        buf.setInt(6, /* numRecords */ 1);
+        buf.setInt(10, indexSize);
+        buf.setLong(14, valueSize);
+        return buf;
+    }
+}


### PR DESCRIPTION
Fixes #416.

Follow-up from PR #414 review: PR #414 only guarded `LazyDataPage.get`
against negative `valueLength`, leaving the eager full-page read path
(`RemoteFileDataStorageManager.readPage` →
`LazyDataPageFormat.readAllRecords`) and any other caller of
`LazyDataPageFormat.readIndex` exposed to raw
`NegativeArraySizeException` / `IndexOutOfBoundsException` if a v2 page
index entry is corrupt.

## Changes

- `LazyDataPageFormat.readIndex(...)` now validates each parsed entry
  immediately after reading `valueOffset` and `valueLength`:
    - reject negative `valueOffset`
    - reject negative `valueLength`
    - reject `valueOffset + valueLength` long-overflow
    - reject value range that exceeds the values-section size
  All four corruption cases throw a single
  `DataStorageManagerException("corrupted v2 page index: ...")` so both
  the lazy and eager read paths surface a consistent corruption signal.
- A new 3-arg overload `readIndex(buf, numRecords, valueSize)` lets
  callers that know `valueSize` (from the fixed header) enforce the
  upper-bound check; the existing 2-arg overload delegates to it with
  `valueSize = Long.MAX_VALUE`, so external callers still get the
  per-entry sanity checks even without a values-section bound.
- `LazyDataPageFormat.readAllRecords(...)` and
  `RemoteFileDataStorageManager.readPageIndex(...)` are migrated to the
  bounded overload, so corrupted indexes are rejected before the eager
  path allocates `new byte[m.valueLength]`.
- The pre-existing `valueLength < 0` guard in `LazyDataPage.get(...)` is
  kept as defence-in-depth (with an updated comment that points to the
  authoritative parser-side check) so any future code path that
  constructs a `RecordMetadata` outside the parser still surfaces a
  `LazyValueFetchException` instead of a raw
  `NegativeArraySizeException`.

## Tests

- New `LazyDataPageFormatCorruptionTest` (8 cases) covers:
    - `readIndex` rejects negative `valueLength` (both with and without
      a `valueSize` bound)
    - `readIndex` rejects `valueOffset + valueLength` long-overflow
      (`valueOffset = Long.MAX_VALUE`, `valueLength = 1`)
    - `readIndex` rejects value range beyond `valueSize`
    - `readIndex` accepts the exact-boundary case
      (`valueOffset + valueLength == valueSize`)
    - `readAllRecords` rejects each of the three corruption cases at
      the eager path, surfacing `DataStorageManagerException` instead
      of `NegativeArraySizeException` / `IndexOutOfBoundsException`
- Existing `LazyDataPageFormatTest`, `LazyDataPageTest`,
  `LazyDataPageOffHeapValuesTest`, `LazyDataPageIntegrationTest`, and
  `LazyDataPageFailureAndComplexTest` (49 tests total) all continue to
  pass — happy-path round-trips, off-heap value paths, multi-record
  scans, transactions, and checkpoint compaction are unaffected.

🤖 Implemented by the `pr-worker` agent.