### PR TITLE
issue #415: enable Netty paranoid leak detection in herddb-remote-file-service

### DIFF
--- a/herddb-remote-file-service/pom.xml
+++ b/herddb-remote-file-service/pom.xml
@@ -192,6 +192,21 @@
                     <environmentVariables>
                         <DOCKER_API_VERSION>1.43</DOCKER_API_VERSION>
                     </environmentVariables>
+                    <!--
+                      Enable Netty paranoid resource-leak detection for every
+                      forked JVM in this module. This is the canonical
+                      regression gate for ByteBuf refcount discipline (see
+                      issue #415): any test that drops a pooled direct
+                      ByteBuf without releasing it will be flagged with a
+                      LEAK: warning and a stack trace pointing at the
+                      allocation site. We use systemPropertyVariables (rather
+                      than overriding the parent <argLine>) so the JVM flags
+                      and JaCoCo @{argLine} from the parent's ci/default
+                      profiles are preserved.
+                    -->
+                    <systemPropertyVariables>
+                        <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <!--

--- a/herddb-remote-file-service/src/test/java/herddb/remote/LazyValueCacheOffHeapTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/LazyValueCacheOffHeapTest.java
@@ -517,8 +517,9 @@ public class LazyValueCacheOffHeapTest {
             cache.cleanUp();
 
             AtomicInteger loaderCalls = new AtomicInteger();
+            ByteBuf returned = null;
             try {
-                cache.getOrFetch(k, () -> {
+                returned = cache.getOrFetch(k, () -> {
                     int call = loaderCalls.incrementAndGet();
                     if (call == 1) {
                         // First call: succeed. Caffeine stores the buffer;
@@ -538,6 +539,13 @@ public class LazyValueCacheOffHeapTest {
                 // Recovery loader was invoked and threw — the public API
                 // must surface it as-is.
                 assertEquals("transient remote failure", expected.getMessage());
+            } finally {
+                // When the recovery path was NOT triggered, getOrFetch returned
+                // a retained slice that the caller owns and must release —
+                // otherwise paranoid leak detection flags it.
+                if (returned != null) {
+                    returned.release();
+                }
             }
             // Whether or not the race fired, the cache must not retain a
             // dangling entry referencing a failed load.

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderCacheAndMetricsTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderCacheAndMetricsTest.java
@@ -90,13 +90,13 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
         byte[] data = seqBytes(BLOCK_SIZE * 3);
         client.writeMultipartFile("ts/idx/one", new ByteArrayInputStream(data), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+        try (RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
                 client, "ts/idx/one", data.length, BLOCK_SIZE, BLOCK_SIZE,
-                statsLogger, SegmentBlockCache.disabled());
-        // Sequential read over 3 blocks — should trigger exactly 3 RPCs.
-        byte[] buf = new byte[BLOCK_SIZE * 3];
-        reader.readFully(buf);
-        reader.close();
+                statsLogger, SegmentBlockCache.disabled())) {
+            // Sequential read over 3 blocks — should trigger exactly 3 RPCs.
+            byte[] buf = new byte[BLOCK_SIZE * 3];
+            reader.readFully(buf);
+        }
 
         long requests = counter("rfs.client", "read_requests");
         long bytes = counter("rfs.client", "read_bytes");
@@ -110,15 +110,13 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
         byte[] data = seqBytes(BLOCK_SIZE * 2);
         client.writeMultipartFile("ts/idx/ctx", new ByteArrayInputStream(data), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+        VectorSearchRequestContext ctx;
+        try (RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
                 client, "ts/idx/ctx", data.length, BLOCK_SIZE, BLOCK_SIZE,
-                statsLogger, SegmentBlockCache.disabled());
-        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
-        try {
+                statsLogger, SegmentBlockCache.disabled())) {
+            ctx = VectorSearchRequestContext.begin();
             byte[] buf = new byte[BLOCK_SIZE * 2];
             reader.readFully(buf);
-        } finally {
-            reader.close();
         }
         assertEquals(2L, ctx.getReadFileRangeCalls());
         assertEquals((long) BLOCK_SIZE * 2, ctx.getReadFileRangeBytes());
@@ -134,12 +132,12 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
         byte[] data = seqBytes(BLOCK_SIZE);
         client.writeMultipartFile("ts/idx/no-ctx", new ByteArrayInputStream(data), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
+        try (RemoteRandomAccessReader reader = new RemoteRandomAccessReader(
                 client, "ts/idx/no-ctx", data.length, BLOCK_SIZE, BLOCK_SIZE,
-                statsLogger, SegmentBlockCache.disabled());
-        byte[] buf = new byte[BLOCK_SIZE];
-        reader.readFully(buf);
-        reader.close();
+                statsLogger, SegmentBlockCache.disabled())) {
+            byte[] buf = new byte[BLOCK_SIZE];
+            reader.readFully(buf);
+        }
         // No exception means ensureBlockLoaded safely handles a null context.
     }
 
@@ -155,19 +153,19 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
                 statsLogger, cache);
 
         // Warm the cache on reader #1 — 3 misses → 3 RPCs.
-        RemoteRandomAccessReader r1 = (RemoteRandomAccessReader) supplier.get();
         byte[] buf = new byte[BLOCK_SIZE * 3];
-        r1.readFully(buf);
-        r1.close();
+        try (RemoteRandomAccessReader r1 = (RemoteRandomAccessReader) supplier.get()) {
+            r1.readFully(buf);
+        }
         long requestsAfterFirstReader = counter("rfs.client", "read_requests");
         assertEquals(3L, requestsAfterFirstReader);
 
         // Reader #2: same segment, same byte ranges. All reads should be hits.
-        RemoteRandomAccessReader r2 = (RemoteRandomAccessReader) supplier.get();
         VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
         byte[] buf2 = new byte[BLOCK_SIZE * 3];
-        r2.readFully(buf2);
-        r2.close();
+        try (RemoteRandomAccessReader r2 = (RemoteRandomAccessReader) supplier.get()) {
+            r2.readFully(buf2);
+        }
         long requestsAfterSecondReader = counter("rfs.client", "read_requests");
         assertEquals("no additional RPCs — all served from cache",
                 requestsAfterFirstReader, requestsAfterSecondReader);
@@ -192,20 +190,20 @@ public class RemoteRandomAccessReaderCacheAndMetricsTest {
                 client, "ts/idx/inv", data.length, BLOCK_SIZE, BLOCK_SIZE,
                 statsLogger, cache);
 
-        RemoteRandomAccessReader r1 = (RemoteRandomAccessReader) supplier.get();
         byte[] buf = new byte[BLOCK_SIZE * 2];
-        r1.readFully(buf);
-        r1.close();
+        try (RemoteRandomAccessReader r1 = (RemoteRandomAccessReader) supplier.get()) {
+            r1.readFully(buf);
+        }
         long requestsAfterWarm = counter("rfs.client", "read_requests");
         assertEquals(2L, requestsAfterWarm);
 
         cache.invalidatePath("ts/idx/inv");
 
         // After invalidation, next read must refetch from remote.
-        RemoteRandomAccessReader r2 = (RemoteRandomAccessReader) supplier.get();
         byte[] buf2 = new byte[BLOCK_SIZE * 2];
-        r2.readFully(buf2);
-        r2.close();
+        try (RemoteRandomAccessReader r2 = (RemoteRandomAccessReader) supplier.get()) {
+            r2.readFully(buf2);
+        }
         long requestsAfterInvalidate = counter("rfs.client", "read_requests");
         assertEquals("invalidation forced 2 more RPCs",
                 requestsAfterWarm + 2, requestsAfterInvalidate);

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderTest.java
@@ -75,16 +75,18 @@ public class RemoteRandomAccessReaderTest {
         byte[] data = seqBytes(BLOCK_SIZE * 2 + 20);
         client.writeMultipartFile("ts/idx/graph", new ByteArrayInputStream(data), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(client, "ts/idx/graph", data.length, BLOCK_SIZE);
-        reader.seek(10);
-        assertEquals(10, reader.getPosition());
+        try (RemoteRandomAccessReader reader =
+                new RemoteRandomAccessReader(client, "ts/idx/graph", data.length, BLOCK_SIZE)) {
+            reader.seek(10);
+            assertEquals(10, reader.getPosition());
 
-        byte[] buf = new byte[5];
-        reader.readFully(buf);
-        for (int i = 0; i < 5; i++) {
-            assertEquals((byte) (10 + i), buf[i]);
+            byte[] buf = new byte[5];
+            reader.readFully(buf);
+            for (int i = 0; i < 5; i++) {
+                assertEquals((byte) (10 + i), buf[i]);
+            }
+            assertEquals(15, reader.getPosition());
         }
-        assertEquals(15, reader.getPosition());
     }
 
     @Test
@@ -92,13 +94,15 @@ public class RemoteRandomAccessReaderTest {
         byte[] data = seqBytes(BLOCK_SIZE * 2 + 10);
         client.writeMultipartFile("ts/idx/cross", new ByteArrayInputStream(data), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(client, "ts/idx/cross", data.length, BLOCK_SIZE);
-        // Seek to 4 bytes before end of first block
-        reader.seek(BLOCK_SIZE - 4);
-        byte[] buf = new byte[8]; // crosses block boundary
-        reader.readFully(buf);
-        for (int i = 0; i < 8; i++) {
-            assertEquals((byte) (BLOCK_SIZE - 4 + i), buf[i]);
+        try (RemoteRandomAccessReader reader =
+                new RemoteRandomAccessReader(client, "ts/idx/cross", data.length, BLOCK_SIZE)) {
+            // Seek to 4 bytes before end of first block
+            reader.seek(BLOCK_SIZE - 4);
+            byte[] buf = new byte[8]; // crosses block boundary
+            reader.readFully(buf);
+            for (int i = 0; i < 8; i++) {
+                assertEquals((byte) (BLOCK_SIZE - 4 + i), buf[i]);
+            }
         }
     }
 
@@ -110,9 +114,11 @@ public class RemoteRandomAccessReaderTest {
         block[0] = 0x01; block[1] = 0x02; block[2] = 0x03; block[3] = 0x04;
         client.writeMultipartFile("ts/idx/int", new ByteArrayInputStream(block), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(client, "ts/idx/int", BLOCK_SIZE, BLOCK_SIZE);
-        reader.seek(0);
-        assertEquals(value, reader.readInt());
+        try (RemoteRandomAccessReader reader =
+                new RemoteRandomAccessReader(client, "ts/idx/int", BLOCK_SIZE, BLOCK_SIZE)) {
+            reader.seek(0);
+            assertEquals(value, reader.readInt());
+        }
     }
 
     @Test
@@ -126,9 +132,11 @@ public class RemoteRandomAccessReaderTest {
         block[3] = (byte) bits;
         client.writeMultipartFile("ts/idx/float", new ByteArrayInputStream(block), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(client, "ts/idx/float", BLOCK_SIZE, BLOCK_SIZE);
-        reader.seek(0);
-        assertEquals(expected, reader.readFloat(), 0.0f);
+        try (RemoteRandomAccessReader reader =
+                new RemoteRandomAccessReader(client, "ts/idx/float", BLOCK_SIZE, BLOCK_SIZE)) {
+            reader.seek(0);
+            assertEquals(expected, reader.readFloat(), 0.0f);
+        }
     }
 
     @Test
@@ -140,9 +148,11 @@ public class RemoteRandomAccessReaderTest {
         }
         client.writeMultipartFile("ts/idx/long", new ByteArrayInputStream(block), BLOCK_SIZE);
 
-        RemoteRandomAccessReader reader = new RemoteRandomAccessReader(client, "ts/idx/long", BLOCK_SIZE, BLOCK_SIZE);
-        reader.seek(0);
-        assertEquals(expected, reader.readLong());
+        try (RemoteRandomAccessReader reader =
+                new RemoteRandomAccessReader(client, "ts/idx/long", BLOCK_SIZE, BLOCK_SIZE)) {
+            reader.seek(0);
+            assertEquals(expected, reader.readLong());
+        }
     }
 
     @Test

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
@@ -180,10 +180,14 @@ public class CachingObjectStorageTest {
 
         int readsBefore = inner.readCalls.get();
         ReadResult result = cache.read("a/b.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
-        // inner.read must NOT have been called (served from cache)
-        assertEquals(readsBefore, inner.readCalls.get());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+            // inner.read must NOT have been called (served from cache)
+            assertEquals(readsBefore, inner.readCalls.get());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -192,7 +196,11 @@ public class CachingObjectStorageTest {
         CachingObjectStorage cache = build(inner, 10 * 1024 * 1024);
 
         ReadResult result = cache.read("nonexistent.page").get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -205,9 +213,13 @@ public class CachingObjectStorageTest {
         inner.data.put("ts1/x.page", data);
 
         ReadResult result = caching.read("ts1/x.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
-        assertEquals(1, inner.readCalls.get());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+            assertEquals(1, inner.readCalls.get());
+        } finally {
+            result.release();
+        }
 
         // Local cache file should have been written
         Path cacheFile = caching.cacheFilePath("ts1/x.page");
@@ -239,7 +251,11 @@ public class CachingObjectStorageTest {
         caching.delete("del/1.page").get();
 
         ReadResult result = caching.read("del/1.page").get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
 
         Path cacheFile = caching.cacheFilePath("del/1.page");
         assertFalse("local cache file should be gone", Files.exists(cacheFile));
@@ -258,10 +274,25 @@ public class CachingObjectStorageTest {
         assertEquals(2, deleted);
 
         // pfx entries gone from cache
-        assertEquals(ReadResult.Status.NOT_FOUND, caching.read("pfx/a.page").get().status());
-        assertEquals(ReadResult.Status.NOT_FOUND, caching.read("pfx/b.page").get().status());
+        ReadResult ra = caching.read("pfx/a.page").get();
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, ra.status());
+        } finally {
+            ra.release();
+        }
+        ReadResult rb = caching.read("pfx/b.page").get();
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, rb.status());
+        } finally {
+            rb.release();
+        }
         // other entry still accessible via inner
-        assertEquals(ReadResult.Status.FOUND, caching.read("other/c.page").get().status());
+        ReadResult rc = caching.read("other/c.page").get();
+        try {
+            assertEquals(ReadResult.Status.FOUND, rc.status());
+        } finally {
+            rc.release();
+        }
 
         assertFalse(Files.exists(caching.cacheFilePath("pfx/a.page")));
         assertFalse(Files.exists(caching.cacheFilePath("pfx/b.page")));
@@ -322,12 +353,17 @@ public class CachingObjectStorageTest {
 
         int readsBefore = inner.readCalls.get();
         ReadResult result = caching.readRange("big.page", 1000, 16, 4096).get();
-        // inner.read must NOT fire: slice must be served from the disk cache via FileChannel.
-        assertEquals(readsBefore, inner.readCalls.get());
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertEquals(16, result.content().length);
-        byte[] expected = Arrays.copyOfRange(block, 1000, 1016);
-        assertArrayEquals(expected, result.content());
+        try {
+            // inner.read must NOT fire: slice must be served from the disk cache via FileChannel.
+            assertEquals(readsBefore, inner.readCalls.get());
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            byte[] resultBytes = result.content();
+            assertEquals(16, resultBytes.length);
+            byte[] expected = Arrays.copyOfRange(block, 1000, 1016);
+            assertArrayEquals(expected, resultBytes);
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -363,7 +399,12 @@ public class CachingObjectStorageTest {
             futures.add(caching.read("hot.page"));
         }
         for (CompletableFuture<ReadResult> f : futures) {
-            assertEquals(ReadResult.Status.FOUND, f.get().status());
+            ReadResult res = f.get();
+            try {
+                assertEquals(ReadResult.Status.FOUND, res.status());
+            } finally {
+                res.release();
+            }
         }
         assertEquals("concurrent misses must collapse to a single inner read",
                 1, inner.readCalls.get());
@@ -385,8 +426,12 @@ public class CachingObjectStorageTest {
         // Cache LRU still reports the entry present; the next read must not throw and must
         // fall through to inner.read on NoSuchFileException.
         ReadResult result = caching.read("race/1.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(content, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(content, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     /** Ensures any async task (removal listener, supplyAsync) scheduled on {@code executor} completes. */
@@ -416,8 +461,12 @@ public class CachingObjectStorageTest {
 
         // Verify data is cached
         ReadResult result = caching.read("concurrent/file.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -439,8 +488,12 @@ public class CachingObjectStorageTest {
 
         // Read should recover from the eviction and fall through to inner.read
         ReadResult result = caching.read("race/1.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -464,8 +517,12 @@ public class CachingObjectStorageTest {
 
         // readRange should recover and fall through to inner
         ReadResult result = caching.readRange("big.page", 1000, 16, 4096).get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertEquals(16, result.content().length);
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertEquals(16, result.content().length);
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -494,8 +551,12 @@ public class CachingObjectStorageTest {
 
         // Verify reads work
         ReadResult r0 = caching.readRange("multi.page", 0, 100, 1024).get();
-        assertEquals(ReadResult.Status.FOUND, r0.status());
-        assertEquals(100, r0.content().length);
+        try {
+            assertEquals(ReadResult.Status.FOUND, r0.status());
+            assertEquals(100, r0.content().length);
+        } finally {
+            r0.release();
+        }
     }
 
     @Test
@@ -533,7 +594,11 @@ public class CachingObjectStorageTest {
         }
         for (CompletableFuture<ReadResult> f : futures) {
             ReadResult res = f.get();
-            assertEquals(ReadResult.Status.FOUND, res.status());
+            try {
+                assertEquals(ReadResult.Status.FOUND, res.status());
+            } finally {
+                res.release();
+            }
         }
         assertEquals("concurrent misses must collapse to a single inner read",
                 1, inner.readCalls.get());
@@ -566,8 +631,18 @@ public class CachingObjectStorageTest {
         assertTrue("c should remain", Files.exists(fileC));
 
         // Verify reads still work (newer entries remain accessible)
-        assertEquals(ReadResult.Status.FOUND, caching.read("blobs/b").get().status());
-        assertEquals(ReadResult.Status.FOUND, caching.read("blobs/c").get().status());
+        ReadResult rb = caching.read("blobs/b").get();
+        try {
+            assertEquals(ReadResult.Status.FOUND, rb.status());
+        } finally {
+            rb.release();
+        }
+        ReadResult rc = caching.read("blobs/c").get();
+        try {
+            assertEquals(ReadResult.Status.FOUND, rc.status());
+        } finally {
+            rc.release();
+        }
     }
 
     @Test
@@ -590,13 +665,24 @@ public class CachingObjectStorageTest {
             futures.add(caching.read("concurrent/file.page"));
         }
 
-        // Wait for all to complete
+        // Wait for all to complete; release any ReadResults returned by the
+        // concurrent reads so the pooled buffers don't leak.
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+        for (CompletableFuture<?> f : futures) {
+            Object v = f.get();
+            if (v instanceof ReadResult) {
+                ((ReadResult) v).release();
+            }
+        }
 
         // Verify final state is correct
         ReadResult result = caching.read("concurrent/file.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -621,13 +707,21 @@ public class CachingObjectStorageTest {
         // Read from cached block 0 (should not call inner)
         int innerReadsBefore = inner.readCalls.get();
         ReadResult r0 = caching.readRange("big.page", 1000, 16, 4096).get();
-        assertEquals(ReadResult.Status.FOUND, r0.status());
-        assertEquals(innerReadsBefore, inner.readCalls.get()); // No new inner calls
+        try {
+            assertEquals(ReadResult.Status.FOUND, r0.status());
+            assertEquals(innerReadsBefore, inner.readCalls.get()); // No new inner calls
+        } finally {
+            r0.release();
+        }
 
         // Read from uncached block 1 (should call inner)
         ReadResult r1 = caching.readRange("big.page", 5000, 16, 4096).get();
-        assertEquals(ReadResult.Status.FOUND, r1.status());
-        assertTrue("should have called inner for uncached block", inner.readCalls.get() > innerReadsBefore);
+        try {
+            assertEquals(ReadResult.Status.FOUND, r1.status());
+            assertTrue("should have called inner for uncached block", inner.readCalls.get() > innerReadsBefore);
+        } finally {
+            r1.release();
+        }
     }
 
     @Test
@@ -666,21 +760,29 @@ public class CachingObjectStorageTest {
         long missBefore = caching.getMissBytes();
         long hitBefore = caching.getHitBytes();
         ReadResult r1 = caching.readRange("counters.page", 0, readLen, blockSize).get();
-        assertEquals(ReadResult.Status.FOUND, r1.status());
-        assertEquals("missBytes must increase by the requested length on a cache miss",
-                missBefore + readLen, caching.getMissBytes());
-        assertEquals("hitBytes must not change on a cache miss",
-                hitBefore, caching.getHitBytes());
+        try {
+            assertEquals(ReadResult.Status.FOUND, r1.status());
+            assertEquals("missBytes must increase by the requested length on a cache miss",
+                    missBefore + readLen, caching.getMissBytes());
+            assertEquals("hitBytes must not change on a cache miss",
+                    hitBefore, caching.getHitBytes());
+        } finally {
+            r1.release();
+        }
 
         // Second readRange of same block → cache HIT: hitBytes must be incremented.
         long missBefore2 = caching.getMissBytes();
         long hitBefore2 = caching.getHitBytes();
         ReadResult r2 = caching.readRange("counters.page", 0, readLen, blockSize).get();
-        assertEquals(ReadResult.Status.FOUND, r2.status());
-        assertEquals("hitBytes must increase by the requested length on a cache hit",
-                hitBefore2 + readLen, caching.getHitBytes());
-        assertEquals("missBytes must not change on a cache hit",
-                missBefore2, caching.getMissBytes());
+        try {
+            assertEquals(ReadResult.Status.FOUND, r2.status());
+            assertEquals("hitBytes must increase by the requested length on a cache hit",
+                    hitBefore2 + readLen, caching.getHitBytes());
+            assertEquals("missBytes must not change on a cache hit",
+                    missBefore2, caching.getMissBytes());
+        } finally {
+            r2.release();
+        }
     }
 
     @Test

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/LocalObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/LocalObjectStorageTest.java
@@ -61,14 +61,22 @@ public class LocalObjectStorageTest {
         storage.write("ts1/uuid1/1.page", data).get();
 
         ReadResult result = storage.read("ts1/uuid1/1.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
     public void testReadMissing() throws Exception {
         ReadResult result = storage.read("nonexistent/path.page").get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -78,7 +86,12 @@ public class LocalObjectStorageTest {
 
         assertTrue(storage.delete("ts1/uuid2/1.page").get());
         assertFalse(storage.delete("ts1/uuid2/1.page").get());
-        assertEquals(ReadResult.Status.NOT_FOUND, storage.read("ts1/uuid2/1.page").get().status());
+        ReadResult missing = storage.read("ts1/uuid2/1.page").get();
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, missing.status());
+        } finally {
+            missing.release();
+        }
     }
 
     @Test
@@ -122,23 +135,37 @@ public class LocalObjectStorageTest {
 
         // Read a range within block 0
         ReadResult r0 = storage.readRange("ts1/uuid1/graph", 10, 20, 100).get();
-        assertEquals(ReadResult.Status.FOUND, r0.status());
-        assertEquals(20, r0.content().length);
-        for (int i = 0; i < 20; i++) {
-            assertEquals((byte) (10 + i), r0.content()[i]);
+        try {
+            assertEquals(ReadResult.Status.FOUND, r0.status());
+            byte[] r0Bytes = r0.content();
+            assertEquals(20, r0Bytes.length);
+            for (int i = 0; i < 20; i++) {
+                assertEquals((byte) (10 + i), r0Bytes[i]);
+            }
+        } finally {
+            r0.release();
         }
 
         // Read first 5 bytes of block 1
         ReadResult r1 = storage.readRange("ts1/uuid1/graph", 100, 5, 100).get();
-        assertEquals(ReadResult.Status.FOUND, r1.status());
-        assertEquals(5, r1.content().length);
-        for (int i = 0; i < 5; i++) {
-            assertEquals((byte) (100 + i), r1.content()[i]);
+        try {
+            assertEquals(ReadResult.Status.FOUND, r1.status());
+            byte[] r1Bytes = r1.content();
+            assertEquals(5, r1Bytes.length);
+            for (int i = 0; i < 5; i++) {
+                assertEquals((byte) (100 + i), r1Bytes[i]);
+            }
+        } finally {
+            r1.release();
         }
 
         // Read missing block
         ReadResult missing = storage.readRange("ts1/uuid1/graph", 200, 10, 100).get();
-        assertEquals(ReadResult.Status.NOT_FOUND, missing.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, missing.status());
+        } finally {
+            missing.release();
+        }
     }
 
     @Test
@@ -152,7 +179,11 @@ public class LocalObjectStorageTest {
 
         // plain file unaffected
         ReadResult r = storage.read("ts1/uuid1/plain.page").get();
-        assertEquals(ReadResult.Status.FOUND, r.status());
+        try {
+            assertEquals(ReadResult.Status.FOUND, r.status());
+        } finally {
+            r.release();
+        }
     }
 
     @Test
@@ -181,8 +212,12 @@ public class LocalObjectStorageTest {
 
         for (CompletableFuture<ReadResult> f : futures) {
             ReadResult result = f.get();
-            assertEquals(ReadResult.Status.FOUND, result.status());
-            assertArrayEquals(data, result.content());
+            try {
+                assertEquals(ReadResult.Status.FOUND, result.status());
+                assertArrayEquals(data, result.content());
+            } finally {
+                result.release();
+            }
         }
     }
 
@@ -201,8 +236,12 @@ public class LocalObjectStorageTest {
         // Verify all writes succeeded
         for (int i = 0; i < 4; i++) {
             ReadResult result = storage.read("ts1/page" + i).get();
-            assertEquals(ReadResult.Status.FOUND, result.status());
-            assertArrayEquals(("data" + i).getBytes(), result.content());
+            try {
+                assertEquals(ReadResult.Status.FOUND, result.status());
+                assertArrayEquals(("data" + i).getBytes(), result.content());
+            } finally {
+                result.release();
+            }
         }
     }
 
@@ -215,8 +254,12 @@ public class LocalObjectStorageTest {
 
         storage.write("ts1/uuid1/large.page", largeData).get();
         ReadResult result = storage.read("ts1/uuid1/large.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(largeData, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(largeData, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -229,7 +272,11 @@ public class LocalObjectStorageTest {
 
         // Request beyond file size
         ReadResult result = storage.readRange("ts1/uuid1/graph", 150, 10, 100).get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -239,7 +286,11 @@ public class LocalObjectStorageTest {
 
         // Try to read from a block that doesn't exist
         ReadResult result = storage.readRange("ts1/uuid1/graph", 200, 10, 100).get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -251,7 +302,11 @@ public class LocalObjectStorageTest {
 
         // Normal read should work fine
         ReadResult result = storage.read("ts1/test.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -261,7 +316,11 @@ public class LocalObjectStorageTest {
         storage.write("ts1/uuid1/nested/deep/path/1.page", data).get();
 
         ReadResult result = storage.read("ts1/uuid1/nested/deep/path/1.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+        } finally {
+            result.release();
+        }
     }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/S3ObjectStorageIT.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/S3ObjectStorageIT.java
@@ -98,14 +98,22 @@ public class S3ObjectStorageIT {
         storage.write("ts1/uuid1/1.page", data).get();
 
         ReadResult result = storage.read("ts1/uuid1/1.page").get();
-        assertEquals(ReadResult.Status.FOUND, result.status());
-        assertArrayEquals(data, result.content());
+        try {
+            assertEquals(ReadResult.Status.FOUND, result.status());
+            assertArrayEquals(data, result.content());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
     public void testReadMissing() throws Exception {
         ReadResult result = storage.read("nonexistent/key.page").get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test
@@ -117,7 +125,11 @@ public class S3ObjectStorageIT {
         assertTrue(storage.delete("del/1.page").get());
 
         ReadResult result = storage.read("del/1.page").get();
-        assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        try {
+            assertEquals(ReadResult.Status.NOT_FOUND, result.status());
+        } finally {
+            result.release();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #415.

## Why

PR #414 deferred enabling `-Dio.netty.leakDetection.level=paranoid` in the
`herddb-remote-file-service` test suite because the flag had exposed
multiple **pre-existing** ByteBuf-refcount leaks unrelated to that PR. This
PR lands the flag as the canonical regression gate for refcount discipline:
from now on, any test that drops a pooled direct `ByteBuf` without
releasing it produces a `LEAK: ByteBuf.release() was not called before
it's garbage-collected` warning with a stack trace in the surefire
output.

## What

### Surefire wiring

`herddb-remote-file-service/pom.xml` adds:

```xml
<systemPropertyVariables>
    <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
</systemPropertyVariables>
```

We use `<systemPropertyVariables>` rather than overriding `<argLine>` so
the parent pom's JVM flags (`@{argLine}` JaCoCo prefix, `--add-opens=...`,
`--add-modules=jdk.incubator.vector`, `-Xmx2G`, etc., from both the
`default` and `ci` profiles) are preserved unchanged.

### Pre-existing leaks fixed before flipping the flag

A 327-test full-module run under `-Pci` (JaCoCo + paranoid) surfaced **7
LEAK warnings** from 6 distinct test methods. All are fixed in this PR:

- **`RemoteRandomAccessReaderTest`** — 5 tests (`testSeekAndReadFully`,
  `testCrossBlockRead`, `testReadInt`, `testReadFloat`, `testReadLong`)
  leaked the reader's cached pooled `blockBuffer` because the reader was
  never closed. Each is now wrapped in `try-with-resources`, matching the
  rest of the file (the `testReadFully_*` family, `testEveryAccessor`,
  `testCloseIsIdempotent`, etc. already used `try-with-resources`).
- **`LazyValueCacheOffHeapTest.raceLossWithFailingSecondLoaderSurfacesException`** —
  the second `cache.getOrFetch` returns a `retainedSlice` that the test
  discarded when the recovery path was NOT triggered. The fix captures
  the result and releases it in a `try/finally`; the existing
  `try { ... } catch (RuntimeException expected)` pattern continues to
  cover the recovery throw path.

### Hygiene fixes (the file the issue body specifically calls out)

`LocalObjectStorageTest`, `CachingObjectStorageTest`, and `S3ObjectStorageIT`
now pair every `ReadResult.content()` use with a `try/finally` that calls
`result.release()`. These weren't reproducing leak warnings on master under
my reproducer, but the issue body explicitly names `LocalObjectStorageTest`
as the primary audit target and the code is technically incorrect — every
`ReadResult` returned from a backing store with a pooled `ByteBuf` must be
released by the consumer.

### What I did NOT change

The issue body also flagged a *suspected* `RemoteFileServiceClient`
gRPC-startup leak ("a candidate is one of the gRPC client init buffers;
needs a closer audit"). My 327-test full-module run under
`-Pci`+JaCoCo+paranoid produced **zero** such leak. I did not chase a
phantom: if a real one ever resurfaces, the new flag will pin it
to the offending PR.

## Validation

- 3 consecutive full-module runs under `-Pci`: **0 `LEAK:` warnings each**
  (the run 2 BUILD FAILURE was a flake in
  `LazyValueCacheConcurrentUpdatesSuiteNoIndexesTest.testWithTransactionsWithCheckpoints`,
  unrelated to leaks — `Inconsistency! Table mytable no record in memory`,
  same flavour as the herddb-core hammer-suite flakes tracked elsewhere).
- Pre-PR validation green: `mvn -B checkstyle:check apache-rat:check
  spotbugs:check install -DskipTests -Pci` builds successfully.
- Targeted: `RemoteRandomAccessReaderTest`, `LazyValueCacheOffHeapTest`,
  `LocalObjectStorageTest`, `CachingObjectStorageTest`,
  `ReadResultTest` — all green under the flag.

## Tests

| File | Tests | Effect |
|---|---|---|
| `RemoteRandomAccessReaderTest.java` | 5 modified | Wrap reader in `try-with-resources`; closes the cached pooled `blockBuffer`. |
| `LazyValueCacheOffHeapTest.java` | 1 modified | Capture and release the `retainedSlice` from `getOrFetch` in a `try/finally`. |
| `LocalObjectStorageTest.java` | 11 modified | Wrap `ReadResult` consumption in `try/finally` with `result.release()`. |
| `CachingObjectStorageTest.java` | 14 modified | Same. |
| `S3ObjectStorageIT.java` | 3 modified | Same. |

🤖 Implemented by the `pr-worker` agent.