### PR TITLE
issue #411: detach BLink separator keys + slab-pack incremental rightseps

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/BytesBytesSizeEvaluator.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BytesBytesSizeEvaluator.java
@@ -52,4 +52,18 @@ public final class BytesBytesSizeEvaluator implements SizeEvaluator<Bytes, Bytes
     public Bytes getPosiviveInfinityKey() {
         return Bytes.POSITIVE_INFINITY;
     }
+
+    /**
+     * Issue #411: defensively detach the BLink rightsep promoted at split /
+     * half-merge time so it no longer pins the donor leaf's per-page
+     * {@link herddb.utils.IndexKeySlab}. {@link Bytes#POSITIVE_INFINITY} is a
+     * sentinel singleton with no slab anchor and goes through unchanged.
+     */
+    @Override
+    public Bytes detachSeparator(Bytes key) {
+        if (key == Bytes.POSITIVE_INFINITY) {
+            return key;
+        }
+        return key.materialiseAndDetach();
+    }
 }

--- a/herddb-core/src/main/java/herddb/index/blink/BytesLongSizeEvaluator.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BytesLongSizeEvaluator.java
@@ -70,4 +70,18 @@ public final class BytesLongSizeEvaluator implements SizeEvaluator<Bytes, Long> 
     public Bytes getPosiviveInfinityKey() {
         return Bytes.POSITIVE_INFINITY;
     }
+
+    /**
+     * Issue #411: defensively detach the BLink rightsep promoted at split /
+     * half-merge time so it no longer pins the donor leaf's per-page
+     * {@link herddb.utils.IndexKeySlab}. {@link Bytes#POSITIVE_INFINITY} is a
+     * sentinel singleton with no slab anchor and goes through unchanged.
+     */
+    @Override
+    public Bytes detachSeparator(Bytes key) {
+        if (key == Bytes.POSITIVE_INFINITY) {
+            return key;
+        }
+        return key.materialiseAndDetach();
+    }
 }

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
@@ -63,6 +63,17 @@ final class IncrementalBLinkPageCodec {
     private static final byte RIGHTSEP_INF = 0;
     private static final byte RIGHTSEP_BYTES = 1;
 
+    /**
+     * Defensive upper bound on the per-chunk node count read from disk.
+     * The default {@code DEFAULT_SNAPSHOT_CHUNK_SIZE} in
+     * {@link IncrementalBLinkKeyToPageIndex} is 50,000 nodes; this cap is
+     * orders of magnitude above any plausible legitimate value, so it
+     * never trips on a healthy page but blocks a corrupted {@code vint}
+     * count from triggering eight separate large-array allocations
+     * inside {@link #readNodeMetadataArray} (issue #411 review).
+     */
+    static final int MAX_NODES_PER_CHUNK = 1 << 22; // ~4.2M
+
     private IncrementalBLinkPageCodec() {
     }
 
@@ -229,6 +240,19 @@ final class IncrementalBLinkPageCodec {
      */
     private static BLinkNodeMetadata<Bytes>[] readNodeMetadataArray(ByteBufCursor in, int count)
             throws IOException {
+        if (count < 0) {
+            throw new IOException("corrupted node-metadata array: negative count " + count);
+        }
+        if (count > MAX_NODES_PER_CHUNK) {
+            // Refuse before we allocate eight scratch arrays of size `count`.
+            // A healthy chunk is bounded by DEFAULT_SNAPSHOT_CHUNK_SIZE
+            // (50,000 nodes); anything beyond MAX_NODES_PER_CHUNK is almost
+            // certainly a corrupted vint that would otherwise blow up the
+            // GC at allocation time.
+            throw new IOException("node-metadata array count " + count
+                    + " exceeds MAX_NODES_PER_CHUNK (" + MAX_NODES_PER_CHUNK
+                    + "); page is corrupted");
+        }
         if (count == 0) {
             return newArray(0);
         }

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
@@ -24,6 +24,8 @@ import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
 import herddb.utils.ByteBufCursor;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.HerdDBByteBufAllocators;
+import herddb.utils.IndexKeySlab;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,10 +99,7 @@ final class IncrementalBLinkPageCodec {
         int chunkIndex = in.readVInt();
         int totalChunks = in.readVInt();
         int count = in.readVInt();
-        BLinkNodeMetadata<Bytes>[] nodes = newArray(count);
-        for (int i = 0; i < count; i++) {
-            nodes[i] = readNodeMetadata(in);
-        }
+        BLinkNodeMetadata<Bytes>[] nodes = readNodeMetadataArray(in, count);
         return new SnapshotChunkContents(epoch, chunkIndex, totalChunks, nodes);
     }
 
@@ -161,10 +160,7 @@ final class IncrementalBLinkPageCodec {
         long epoch = in.readVLong();
 
         int upsertedCount = in.readVInt();
-        BLinkNodeMetadata<Bytes>[] upserted = newArray(upsertedCount);
-        for (int i = 0; i < upsertedCount; i++) {
-            upserted[i] = readNodeMetadata(in);
-        }
+        BLinkNodeMetadata<Bytes>[] upserted = readNodeMetadataArray(in, upsertedCount);
 
         int removedCount = in.readVInt();
         long[] removedNodeIds = new long[removedCount];
@@ -215,24 +211,83 @@ final class IncrementalBLinkPageCodec {
         }
     }
 
-    private static BLinkNodeMetadata<Bytes> readNodeMetadata(ByteBufCursor in) throws IOException {
-        boolean leaf = in.readBoolean();
-        long id = in.readVLong();
-        long storeId = in.readVLong();
-        int keys = in.readVInt();
-        long bytes = in.readVLong();
-        long outlink = in.readZLong();
-        long rightlink = in.readZLong();
-        byte sepKind = in.readByte();
-        Bytes rightsep;
-        if (sepKind == RIGHTSEP_INF) {
-            rightsep = Bytes.POSITIVE_INFINITY;
-        } else if (sepKind == RIGHTSEP_BYTES) {
-            rightsep = Bytes.from_array(in.readArray());
-        } else {
-            throw new IOException("unknown rightsep marker " + sepKind);
+    /**
+     * Two-pass node-metadata array reader (issue #411). The first pass
+     * reads each node's plain fields and the rightsep raw bytes (or
+     * INF marker) into local arrays so we can size and allocate a single
+     * off-heap {@link IndexKeySlab} that holds every rightsep across
+     * the snapshot chunk / delta. The second pass packs the rightseps
+     * into the slab (gated by {@link IndexKeySlab#OFFHEAP_KEY_BYTES_THRESHOLD},
+     * so tiny snapshots keep the on-heap fast path) and builds the
+     * {@link BLinkNodeMetadata} array. Each rightsep returned via
+     * {@link IndexKeySlab#wrap(int, int)} carries a strong reference to
+     * the slab owner, anchoring the slab against premature GC for the
+     * BLink's lifetime; long-lived split-key handoffs that promote one
+     * of these rightseps later go through
+     * {@code SizeEvaluator.detachSeparator}, copying the bytes onto the
+     * heap and breaking the anchor (see issue #411).
+     */
+    private static BLinkNodeMetadata<Bytes>[] readNodeMetadataArray(ByteBufCursor in, int count)
+            throws IOException {
+        if (count == 0) {
+            return newArray(0);
         }
-        return new BLinkNodeMetadata<>(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep);
+        boolean[] leafArr = new boolean[count];
+        long[] idArr = new long[count];
+        long[] storeIdArr = new long[count];
+        int[] keysArr = new int[count];
+        long[] bytesArr = new long[count];
+        long[] outlinkArr = new long[count];
+        long[] rightlinkArr = new long[count];
+        boolean[] rightsepInf = new boolean[count];
+        byte[][] rightsepBytes = new byte[count][];
+        long totalRightsepBytes = 0L;
+        for (int i = 0; i < count; i++) {
+            leafArr[i] = in.readBoolean();
+            idArr[i] = in.readVLong();
+            storeIdArr[i] = in.readVLong();
+            keysArr[i] = in.readVInt();
+            bytesArr[i] = in.readVLong();
+            outlinkArr[i] = in.readZLong();
+            rightlinkArr[i] = in.readZLong();
+            byte sepKind = in.readByte();
+            if (sepKind == RIGHTSEP_INF) {
+                rightsepInf[i] = true;
+            } else if (sepKind == RIGHTSEP_BYTES) {
+                byte[] rs = in.readArray();
+                if (rs == null) {
+                    // The writer never emits a null rightsep array (it always
+                    // calls writeArray on a non-null Bytes.to_array()), so a
+                    // null here means the on-disk page is corrupted. Fail
+                    // fast with an actionable message.
+                    throw new IOException("corrupted node metadata: null rightsep at index " + i);
+                }
+                rightsepBytes[i] = rs;
+                totalRightsepBytes += (long) rs.length;
+            } else {
+                throw new IOException("unknown rightsep marker " + sepKind);
+            }
+        }
+        IndexKeySlab slabOwner = (totalRightsepBytes >= IndexKeySlab.OFFHEAP_KEY_BYTES_THRESHOLD
+                && totalRightsepBytes <= (long) Integer.MAX_VALUE)
+                ? new IndexKeySlab(totalRightsepBytes,
+                        HerdDBByteBufAllocators.indexPagesAllocator())
+                : null;
+        BLinkNodeMetadata<Bytes>[] result = newArray(count);
+        for (int i = 0; i < count; i++) {
+            Bytes rightsep;
+            if (rightsepInf[i]) {
+                rightsep = Bytes.POSITIVE_INFINITY;
+            } else if (slabOwner != null) {
+                int off = slabOwner.append(rightsepBytes[i]);
+                rightsep = slabOwner.wrap(off, rightsepBytes[i].length);
+            } else {
+                rightsep = Bytes.from_array(rightsepBytes[i]);
+            }
+            result[i] = new BLinkNodeMetadata<>(leafArr[i], idArr[i], storeIdArr[i],
+                    keysArr[i], bytesArr[i], outlinkArr[i], rightlinkArr[i], rightsep);
+        }
+        return result;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/herddb-core/src/test/java/herddb/index/blink/BLinkSeparatorDetachTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BLinkSeparatorDetachTest.java
@@ -68,12 +68,19 @@ public class BLinkSeparatorDetachTest {
 
     @Test
     public void noRightsepStaysOffHeapAfterSplits() throws Exception {
-        // 1024 keys × ~24 bytes each = ~24 KiB → many leaf splits. Each split
-        // promotes the donor leaf's lastKey to rightsep; without the detach
-        // hook, those rightseps would all be off-heap-backed (slab-anchored
-        // to the donor's page slab).
+        // To exercise the issue #411 detach hook against an off-heap lastKey
+        // we need (a) multiple leaves (so splits actually fire) and (b) each
+        // leaf's aggregate key bytes ≥ IndexKeySlab.OFFHEAP_KEY_BYTES_THRESHOLD
+        // (so BLinkIndexDataStorageImpl.loadPage slab-packs the keys, making
+        // lastKey off-heap at split time). 64-byte keys + 32 KiB pages ⇒
+        // ~178 entries/leaf; after a leaf split each half holds ~89 entries
+        // × 64 B = ~5.7 KiB worth of keys, well above the 4 KiB slab
+        // threshold ⇒ slab-pack fires per leaf on reload. With 1024 initial
+        // keys we get ~6 leaves; after reload we add 512 more keys so
+        // post-reload splits fire on leaves already populated with off-heap
+        // shared-slab keys, exercising detachSeparator's off-heap branch.
         final int n = 1024;
-        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), 32L * 1024L);
         ds = new MemoryDataStorageManager();
         idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
         idx.init();
@@ -87,12 +94,13 @@ public class BLinkSeparatorDetachTest {
         }
         idx.close();
 
-        // Reload — disk-load path repopulates rightseps via metadata. The
-        // detach hook fires later only on subsequent splits; on a fresh load
-        // rightseps come straight off the metadata which (with this build)
-        // does NOT slab-pack them (BLinkMetadata.MetadataSerializer emits
-        // each rightsep as its own on-heap byte[]). They stay on-heap
-        // throughout this test, which is exactly what we assert.
+        // Reload — disk-load path repopulates rightseps via the legacy
+        // BLinkMetadata.MetadataSerializer (which emits each rightsep as
+        // an on-heap byte[]). LEAF KEYS, however, come back off-heap from
+        // BLinkIndexDataStorageImpl.loadPage when the per-page key bytes
+        // exceed the slab threshold — so post-reload splits will see an
+        // off-heap lastKey at the rightsep handoff site, exercising
+        // detachSeparator's off-heap branch.
         idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
         idx.init();
         idx.start(new LogSequenceNumber(1L, 1L), false);
@@ -112,9 +120,20 @@ public class BLinkSeparatorDetachTest {
         for (int i = n; i < n + n / 2; i++) {
             idx.put(Bytes.from_array(makeKey(i)), (long) i);
         }
+
+        // The test's invariant only means anything if splits actually fired
+        // — guard against a too-generous future page size silently making
+        // this test vacuous (one leaf ⇒ no rightseps ⇒ -1 trivially passes).
+        int loadedNodes = BLinkTestReflection.nodeCount(idx);
+        assertTrue("test setup must produce splits so detachSeparator runs (got "
+                + loadedNodes + " loaded nodes; need ≥ 2)",
+                loadedNodes >= 2);
+
         // Sanity: at least one Bytes key in the tree is off-heap (the keys
         // themselves still live in their per-page slabs — we are NOT
-        // detaching every key, only the separators).
+        // detaching every key, only the separators). This also confirms
+        // the lastKey at split time was off-heap, which is the only
+        // configuration where detachSeparator's branch is meaningful.
         assertTrue("expected some leaf key to remain off-heap-backed",
                 BLinkTestReflection.anyKeyOffHeap(idx));
 
@@ -128,9 +147,12 @@ public class BLinkSeparatorDetachTest {
     }
 
     private static byte[] makeKey(int i) {
-        // Deterministic 24-byte key matching BLinkOffHeapKeysTest's helper
-        // so we share the same ~6 KiB-per-page slab profile.
-        byte[] out = new byte[24];
+        // Deterministic 64-byte key. The 4-byte big-endian int prefix
+        // controls sort order; the trailing bytes pad each key out so a
+        // 32 KiB leaf fills with enough raw key bytes (~89 keys × 64 B
+        // ≈ 5.7 KiB) for BLinkIndexDataStorageImpl.loadPage to slab-pack
+        // on reload.
+        byte[] out = new byte[64];
         out[0] = (byte) (i >>> 24);
         out[1] = (byte) (i >>> 16);
         out[2] = (byte) (i >>> 8);

--- a/herddb-core/src/test/java/herddb/index/blink/BLinkSeparatorDetachTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BLinkSeparatorDetachTest.java
@@ -1,0 +1,143 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Verifies issue #411: at every BLink split / half-merge, the separator
+ * promoted to {@code rightsep} is detached from the donor's per-page
+ * {@link herddb.utils.IndexKeySlab} via
+ * {@link herddb.utils.Bytes#materialiseAndDetach()}, so a single separator
+ * never pins the slab indefinitely.
+ *
+ * <p>The test inserts enough keys to force splits, reloads the BLink
+ * (which exercises {@code half_merge} during page eviction churn under
+ * load), and asserts that no live node's rightsep is off-heap-backed —
+ * meaning every separator went through the detach hook.
+ */
+public class BLinkSeparatorDetachTest {
+
+    private BLinkKeyToPageIndex idx;
+    private MemoryDataStorageManager ds;
+
+    @After
+    public void closeResources() {
+        try {
+            if (idx != null) {
+                idx.close();
+            }
+        } finally {
+            if (ds != null) {
+                try {
+                    ds.close();
+                } catch (Exception ignored) {
+                    // not actionable in test teardown
+                }
+            }
+        }
+    }
+
+    @Test
+    public void noRightsepStaysOffHeapAfterSplits() throws Exception {
+        // 1024 keys × ~24 bytes each = ~24 KiB → many leaf splits. Each split
+        // promotes the donor leaf's lastKey to rightsep; without the detach
+        // hook, those rightseps would all be off-heap-backed (slab-anchored
+        // to the donor's page slab).
+        final int n = 1024;
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        ds = new MemoryDataStorageManager();
+        idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.init();
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+        for (int i = 0; i < n; i++) {
+            idx.put(Bytes.from_array(makeKey(i)), (long) i);
+        }
+        List<PostCheckpointAction> actions = idx.checkpoint(new LogSequenceNumber(1L, 1L), false);
+        for (PostCheckpointAction a : actions) {
+            a.run();
+        }
+        idx.close();
+
+        // Reload — disk-load path repopulates rightseps via metadata. The
+        // detach hook fires later only on subsequent splits; on a fresh load
+        // rightseps come straight off the metadata which (with this build)
+        // does NOT slab-pack them (BLinkMetadata.MetadataSerializer emits
+        // each rightsep as its own on-heap byte[]). They stay on-heap
+        // throughout this test, which is exactly what we assert.
+        idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.init();
+        idx.start(new LogSequenceNumber(1L, 1L), false);
+
+        // Round-trip lookup correctness sanity-check: detach must not
+        // change comparison semantics.
+        for (int i = 0; i < n; i++) {
+            Long v = idx.get(Bytes.from_array(makeKey(i)));
+            assertNotNull("missing key " + i, v);
+            assertEquals(Long.valueOf(i), v);
+        }
+        assertEquals((long) n, idx.size());
+
+        // Force more splits / merges by inserting an interleaved batch so
+        // detachSeparator must fire on the live tree (not just on metadata
+        // load). Without the hook a multi-byte rightsep would be off-heap.
+        for (int i = n; i < n + n / 2; i++) {
+            idx.put(Bytes.from_array(makeKey(i)), (long) i);
+        }
+        // Sanity: at least one Bytes key in the tree is off-heap (the keys
+        // themselves still live in their per-page slabs — we are NOT
+        // detaching every key, only the separators).
+        assertTrue("expected some leaf key to remain off-heap-backed",
+                BLinkTestReflection.anyKeyOffHeap(idx));
+
+        // Core invariant: no live rightsep is off-heap-backed. The detach
+        // hook must have fired at every split / half-merge promotion.
+        int offHeapRightSepIdx = BLinkTestReflection.firstOffHeapRightSep(idx);
+        assertEquals(
+                "issue #411: every BLink rightsep must be on-heap after detach (offending node index="
+                        + offHeapRightSepIdx + ")",
+                -1, offHeapRightSepIdx);
+    }
+
+    private static byte[] makeKey(int i) {
+        // Deterministic 24-byte key matching BLinkOffHeapKeysTest's helper
+        // so we share the same ~6 KiB-per-page slab profile.
+        byte[] out = new byte[24];
+        out[0] = (byte) (i >>> 24);
+        out[1] = (byte) (i >>> 16);
+        out[2] = (byte) (i >>> 8);
+        out[3] = (byte) i;
+        for (int j = 4; j < out.length; j++) {
+            out[j] = (byte) ((i * 31 + j) & 0xff);
+        }
+        return out;
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/blink/BLinkTestReflection.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BLinkTestReflection.java
@@ -69,4 +69,64 @@ final class BLinkTestReflection {
         }
         return false;
     }
+
+    /**
+     * Iterates every loaded BLink node and returns {@code true} as soon as
+     * any non-INFINITY {@code rightsep} satisfies {@link Bytes#isOffHeap()}.
+     * Used by the issue #411 codec slab-pack test to assert rightseps loaded
+     * from the on-disk snapshot do live off-heap when the aggregate exceeds
+     * the {@link herddb.utils.IndexKeySlab#OFFHEAP_KEY_BYTES_THRESHOLD}.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static boolean anyRightSepOffHeap(Object indexInstance) throws Exception {
+        for (Object node : nodeIterable(indexInstance)) {
+            Bytes rs = rightSepOf(node);
+            if (rs != null && rs != Bytes.POSITIVE_INFINITY && rs.isOffHeap()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Asserts the issue #411 invariant that no BLink {@code rightsep} is
+     * off-heap-backed. After {@code SizeEvaluator.detachSeparator} fires at
+     * every split / half-merge, every promoted separator should be on-heap
+     * (the only off-heap rightseps left would come straight off the
+     * {@code IncrementalBLinkPageCodec} load path, which carries its own
+     * dedicated slab and is intentionally separate from per-page slabs).
+     *
+     * @return the index of the first off-heap rightsep encountered, or -1
+     *         if every rightsep is on-heap (or POSITIVE_INFINITY).
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static int firstOffHeapRightSep(Object indexInstance) throws Exception {
+        int idx = 0;
+        for (Object node : nodeIterable(indexInstance)) {
+            Bytes rs = rightSepOf(node);
+            if (rs != null && rs != Bytes.POSITIVE_INFINITY && rs.isOffHeap()) {
+                return idx;
+            }
+            idx++;
+        }
+        return -1;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Iterable<?> nodeIterable(Object indexInstance) throws Exception {
+        Field treeField = indexInstance.getClass().getDeclaredField("tree");
+        treeField.setAccessible(true);
+        BLink<Bytes, Long> blink = (BLink<Bytes, Long>) treeField.get(indexInstance);
+        Field nodes = BLink.class.getDeclaredField("nodes");
+        nodes.setAccessible(true);
+        ConcurrentMap<Long, ?> nodeMap = (ConcurrentMap<Long, ?>) nodes.get(blink);
+        return nodeMap.values();
+    }
+
+    private static Bytes rightSepOf(Object node) throws Exception {
+        Field rs = node.getClass().getDeclaredField("rightsep");
+        rs.setAccessible(true);
+        Object v = rs.get(node);
+        return (v instanceof Bytes) ? (Bytes) v : null;
+    }
 }

--- a/herddb-core/src/test/java/herddb/index/blink/BLinkTestReflection.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BLinkTestReflection.java
@@ -129,4 +129,59 @@ final class BLinkTestReflection {
         Object v = rs.get(node);
         return (v instanceof Bytes) ? (Bytes) v : null;
     }
+
+    /**
+     * Returns the number of live nodes in the BLink. Used by the
+     * {@code BLinkSeparatorDetachTest} to fail loudly if the test's page
+     * size is so generous that no splits actually fired (in which case
+     * the rightsep invariant is vacuous).
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static int nodeCount(Object indexInstance) throws Exception {
+        Field treeField = indexInstance.getClass().getDeclaredField("tree");
+        treeField.setAccessible(true);
+        BLink<Bytes, Long> blink = (BLink<Bytes, Long>) treeField.get(indexInstance);
+        Field nodes = BLink.class.getDeclaredField("nodes");
+        nodes.setAccessible(true);
+        ConcurrentMap<Long, ?> nodeMap = (ConcurrentMap<Long, ?>) nodes.get(blink);
+        return nodeMap.size();
+    }
+
+    /**
+     * Iterates every loaded BLink node and returns the index of the first
+     * non-INFINITY rightsep that satisfies {@code !isOffHeap()}, or -1 if
+     * every non-INF rightsep is off-heap. Used by the issue #411 codec
+     * slab-pack test to assert that a partial regression where only a
+     * fraction of rightseps go off-heap is caught.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static int firstOnHeapNonInfRightSep(Object indexInstance) throws Exception {
+        int idx = 0;
+        for (Object node : nodeIterable(indexInstance)) {
+            Bytes rs = rightSepOf(node);
+            if (rs != null && rs != Bytes.POSITIVE_INFINITY && !rs.isOffHeap()) {
+                return idx;
+            }
+            idx++;
+        }
+        return -1;
+    }
+
+    /**
+     * Counts loaded BLink nodes whose rightsep is a non-INFINITY
+     * {@link Bytes}. Used to make the issue #411 below-threshold codec
+     * test verify that a non-trivial number of real separators were
+     * exercised (not just the root's POSITIVE_INFINITY).
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static int countNonInfRightSeps(Object indexInstance) throws Exception {
+        int n = 0;
+        for (Object node : nodeIterable(indexInstance)) {
+            Bytes rs = rightSepOf(node);
+            if (rs != null && rs != Bytes.POSITIVE_INFINITY) {
+                n++;
+            }
+        }
+        return n;
+    }
 }

--- a/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkRightSepOffHeapTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkRightSepOffHeapTest.java
@@ -1,0 +1,156 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Issue #411: when {@link IncrementalBLinkPageCodec} loads a snapshot
+ * chunk / delta whose aggregate rightsep bytes exceed
+ * {@link herddb.utils.IndexKeySlab#OFFHEAP_KEY_BYTES_THRESHOLD}, every
+ * non-INFINITY rightsep must come back as off-heap-backed
+ * ({@link Bytes#isOffHeap()} returns {@code true}). Below the threshold
+ * the codec must transparently fall back to on-heap allocations.
+ *
+ * <p>Round-trip lookup correctness is also verified at every reload:
+ * the slab-pack must not change comparison semantics.
+ */
+public class IncrementalBLinkRightSepOffHeapTest {
+
+    private IncrementalBLinkKeyToPageIndex idx;
+    private MemoryDataStorageManager ds;
+
+    @After
+    public void closeResources() {
+        try {
+            if (idx != null) {
+                idx.close();
+            }
+        } finally {
+            if (ds != null) {
+                try {
+                    ds.close();
+                } catch (Exception ignored) {
+                    // not actionable in test teardown
+                }
+            }
+        }
+    }
+
+    @Test
+    public void rightsepsLoadedFromSnapshotAreOffHeapWhenAggregateExceedsThreshold() throws Exception {
+        // We need MANY leaves so that aggregate rightsep bytes exceed the
+        // 4 KiB IndexKeySlab threshold. With the per-entry overhead (~120 B
+        // for 24-B keys + Long values) and a 2 KiB page, each leaf holds
+        // ~14 entries. 4096 keys ⇒ ~290 leaves ⇒ ~290 × 24 B ≈ 7 KiB of
+        // rightsep bytes — well above the threshold.
+        final int n = 4096;
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), 2048L);
+        ds = new MemoryDataStorageManager();
+        idx = new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.init();
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+        for (int i = 0; i < n; i++) {
+            idx.put(Bytes.from_array(makeKey(i)), (long) i);
+        }
+        List<PostCheckpointAction> actions = idx.checkpoint(new LogSequenceNumber(1L, 1L), false);
+        for (PostCheckpointAction a : actions) {
+            a.run();
+        }
+        idx.close();
+
+        // Reload via the incremental codec: this exercises
+        // IncrementalBLinkPageCodec.readSnapshotChunk (and possibly readDelta),
+        // which is the path migrated by issue #411.
+        idx = new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.init();
+        idx.start(new LogSequenceNumber(1L, 1L), false);
+
+        // Round-trip lookup: bytes survive the slab-pack round-trip.
+        for (int i = 0; i < n; i++) {
+            Long v = idx.get(Bytes.from_array(makeKey(i)));
+            assertNotNull("missing key " + i, v);
+            assertEquals(Long.valueOf(i), v);
+        }
+        assertEquals((long) n, idx.size());
+
+        // Strong invariant: at least one rightsep loaded from the snapshot
+        // chunk is off-heap-backed. Without issue #411's slab-pack at
+        // IncrementalBLinkPageCodec, every rightsep would arrive on-heap.
+        assertTrue(
+                "issue #411: at least one rightsep loaded from the incremental codec must be off-heap",
+                BLinkTestReflection.anyRightSepOffHeap(idx));
+    }
+
+    @Test
+    public void smallSnapshotFallsBackToHeap() throws Exception {
+        // 4 tiny keys, well below the 4 KiB rightsep slab threshold.
+        // The slab-pack path must NOT fire; rightseps come back on-heap.
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        ds = new MemoryDataStorageManager();
+        idx = new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.init();
+        idx.start(LogSequenceNumber.START_OF_TIME, true);
+        for (int i = 0; i < 4; i++) {
+            idx.put(Bytes.from_int(i), (long) i);
+        }
+        List<PostCheckpointAction> actions = idx.checkpoint(new LogSequenceNumber(1L, 1L), false);
+        for (PostCheckpointAction a : actions) {
+            a.run();
+        }
+        idx.close();
+
+        idx = new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+        idx.init();
+        idx.start(new LogSequenceNumber(1L, 1L), false);
+        for (int i = 0; i < 4; i++) {
+            assertEquals(Long.valueOf(i), idx.get(Bytes.from_int(i)));
+        }
+        assertEquals(4L, idx.size());
+
+        // No off-heap rightseps under the threshold (the only rightsep is
+        // the root's POSITIVE_INFINITY anyway, but the helper handles that).
+        assertEquals("below-threshold codec must not pack rightseps off-heap",
+                -1, BLinkTestReflection.firstOffHeapRightSep(idx));
+    }
+
+    private static byte[] makeKey(int i) {
+        byte[] out = new byte[24];
+        out[0] = (byte) (i >>> 24);
+        out[1] = (byte) (i >>> 16);
+        out[2] = (byte) (i >>> 8);
+        out[3] = (byte) i;
+        for (int j = 4; j < out.length; j++) {
+            out[j] = (byte) ((i * 31 + j) & 0xff);
+        }
+        return out;
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkRightSepOffHeapTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/IncrementalBLinkRightSepOffHeapTest.java
@@ -102,24 +102,37 @@ public class IncrementalBLinkRightSepOffHeapTest {
         }
         assertEquals((long) n, idx.size());
 
-        // Strong invariant: at least one rightsep loaded from the snapshot
-        // chunk is off-heap-backed. Without issue #411's slab-pack at
-        // IncrementalBLinkPageCodec, every rightsep would arrive on-heap.
-        assertTrue(
-                "issue #411: at least one rightsep loaded from the incremental codec must be off-heap",
-                BLinkTestReflection.anyRightSepOffHeap(idx));
+        // Stronger invariant: EVERY non-INFINITY rightsep loaded from the
+        // snapshot must be off-heap-backed. A regression where the second
+        // pass slab-packed only a fraction of rightseps (e.g. an off-by-one
+        // or partial loop) would still satisfy "at least one off-heap" but
+        // be caught here.
+        int onHeapNonInfIdx = BLinkTestReflection.firstOnHeapNonInfRightSep(idx);
+        assertEquals(
+                "issue #411: every non-INFINITY rightsep loaded from the codec must be"
+                        + " off-heap-backed when the aggregate exceeds the slab threshold"
+                        + " (offending node index=" + onHeapNonInfIdx + ")",
+                -1, onHeapNonInfIdx);
+        // Also assert at least one was non-INF, otherwise the test is vacuous.
+        assertTrue("test must observe ≥ 1 non-INF rightsep to be meaningful",
+                BLinkTestReflection.countNonInfRightSeps(idx) >= 1);
     }
 
     @Test
     public void smallSnapshotFallsBackToHeap() throws Exception {
-        // 4 tiny keys, well below the 4 KiB rightsep slab threshold.
-        // The slab-pack path must NOT fire; rightseps come back on-heap.
-        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
+        // We need a non-trivial number of leaves (so several non-INF
+        // rightseps are persisted) but the aggregate rightsep bytes must
+        // stay BELOW the 4 KiB slab threshold. With 4-byte keys (~96 B
+        // per BLink entry) and a 1 KiB page (~7 entries/leaf) we can fit
+        // ~7 leaves with 50 keys total ⇒ ~6 non-INF rightseps × 4 B ≈
+        // 24 B aggregate ≪ 4 KiB. The codec must take the on-heap path.
+        final int n = 50;
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), 1024L);
         ds = new MemoryDataStorageManager();
         idx = new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
         idx.init();
         idx.start(LogSequenceNumber.START_OF_TIME, true);
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < n; i++) {
             idx.put(Bytes.from_int(i), (long) i);
         }
         List<PostCheckpointAction> actions = idx.checkpoint(new LogSequenceNumber(1L, 1L), false);
@@ -131,13 +144,21 @@ public class IncrementalBLinkRightSepOffHeapTest {
         idx = new IncrementalBLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
         idx.init();
         idx.start(new LogSequenceNumber(1L, 1L), false);
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < n; i++) {
             assertEquals(Long.valueOf(i), idx.get(Bytes.from_int(i)));
         }
-        assertEquals(4L, idx.size());
+        assertEquals((long) n, idx.size());
 
-        // No off-heap rightseps under the threshold (the only rightsep is
-        // the root's POSITIVE_INFINITY anyway, but the helper handles that).
+        // Pre-condition: the test setup must produce real (non-INF) rightseps,
+        // otherwise the assertion below is vacuous (a single-leaf tree has
+        // only POSITIVE_INFINITY, which the on-heap helper skips).
+        int nonInf = BLinkTestReflection.countNonInfRightSeps(idx);
+        assertTrue("test setup must produce ≥ 1 non-INF rightsep so the on-heap"
+                + " fallback assertion is meaningful (got " + nonInf + ")",
+                nonInf >= 1);
+
+        // Below-threshold invariant: NO non-INFINITY rightsep is off-heap;
+        // the codec must have taken the on-heap fallback path.
         assertEquals("below-threshold codec must not pack rightseps off-heap",
                 -1, BLinkTestReflection.firstOffHeapRightSep(idx));
     }

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -2359,8 +2359,11 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
             owner.usedMemory.add(NODE_CONSTANT_SIZE);
 
             // if n and new are leaves, their separators are set equal to the largest keys in them.
-            // The pre-existing rightsep is already detached (see invariant note below); just
-            // transfer the reference to the new right node.
+            // No detach needed for this transfer: the pre-existing rightsep is either heap-detached
+            // (split / half_merge previously ran on it, or it came from the legacy on-heap codec
+            // BLinkKeyToPageIndex.MetadataSerializer), or it anchors the IncrementalBLink codec's
+            // shared snapshot slab. In neither case does it pin a per-page IndexKeySlab, so
+            // forwarding the reference to the new right node is safe.
             right.rightsep = rightsep;
 
             // Issue #411: lastKey came from THIS node's per-page IndexKeySlab. Promoting it

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -229,6 +229,29 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
          */
         X getPosiviveInfinityKey();
 
+        /**
+         * Hook invoked at every BLink split / half-merge handoff that
+         * promotes a node-local key to a separator slot which may outlive
+         * the donor node (e.g. a leaf's last key becoming the right
+         * sibling's {@code rightsep}). The default implementation returns
+         * the input key unchanged.
+         *
+         * <p>Issue #411: {@code Bytes}-keyed BLink trees override this to
+         * call {@link herddb.utils.Bytes#materialiseAndDetach()} so a
+         * separator backed by the donor's per-page
+         * {@link herddb.utils.IndexKeySlab} no longer pins the slab once
+         * the donor is unloaded. Implementations must return a value that
+         * compares (and hashes) identically to the input — typically the
+         * same instance after an in-place detach.</p>
+         *
+         * @param key the key being promoted to a long-lived separator slot
+         * @return a key with identical comparison semantics, possibly the
+         *         same instance, with any soon-to-be-stale slab anchor cleared
+         */
+        default X detachSeparator(X key) {
+            return key;
+        }
+
     }
 
     public BLink(
@@ -2240,8 +2263,10 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
             // its outlink pointing to l
             right.outlink = this;
 
-            // If l is a leaf, its separator is set to the largest key in it
-            rightsep = right.rightsep;
+            // If l is a leaf, its separator is set to the largest key in it.
+            // Issue #411: detach any stale slab anchor — the right node is about
+            // to be unloaded, so its rightsep would otherwise pin its IndexKeySlab.
+            rightsep = owner.evaluator.detachSeparator(right.rightsep);
 
             /*
              * Right data page not needed anymore, unload it NOW. Removing from policy now has 2 benefits:
@@ -2333,10 +2358,18 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
             /* We need to count the added node constant size into used memory */
             owner.usedMemory.add(NODE_CONSTANT_SIZE);
 
-            // if n and new are leaves, their separators are set equal to the largest keys in them
+            // if n and new are leaves, their separators are set equal to the largest keys in them.
+            // The pre-existing rightsep is already detached (see invariant note below); just
+            // transfer the reference to the new right node.
             right.rightsep = rightsep;
 
-            rightsep = lastKey;
+            // Issue #411: lastKey came from THIS node's per-page IndexKeySlab. Promoting it
+            // to rightsep makes it outlive every eviction/refresh of this node's keys, which
+            // would otherwise pin the slab indefinitely. detachSeparator copies the bytes onto
+            // the heap and clears the slab anchor; downstream readers see identical comparison
+            // semantics. Invariant: every rightsep ever stored on a Node has been through this
+            // detach (or is POSITIVE_INFINITY / pre-detached metadata).
+            rightsep = owner.evaluator.detachSeparator(lastKey);
 
             // the return value is the new rightmost separator in n
             // Cast to K, is K for sure because it has a right sibling

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -596,12 +596,23 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     /**
-     * Eagerly copies the off-heap bytes into a private on-heap {@code byte[]}
-     * and breaks every link to the underlying slab. After this call the
-     * {@code Bytes} behaves exactly like an instance built via
-     * {@link #from_array(byte[])}: {@link #isOffHeap()} returns {@code false},
-     * {@link #isShared()} returns {@code false}, no {@link IndexKeySlab} is
-     * pinned, and equality / hashing semantics are unchanged.
+     * <b>Restricted-use API.</b> This method is intended <em>only</em> for
+     * the BLink split / half-merge separator-handoff sites in
+     * {@code herddb-utils}'s {@code BLink} (via the
+     * {@code SizeEvaluator.detachSeparator} hook). Do not call it from
+     * request-serving code or anywhere a sibling thread might be inside
+     * a read path on this {@code Bytes}: the same quiescence contract
+     * documented on {@link #release()} applies, and a violating concurrent
+     * reader can observe an {@link IllegalStateException} or — for owned
+     * slices — a use-after-free.
+     *
+     * <p>Eagerly copies the off-heap bytes into a private on-heap
+     * {@code byte[]} and breaks every link to the underlying slab. After
+     * this call the {@code Bytes} behaves exactly like an instance built
+     * via {@link #from_array(byte[])}: {@link #isOffHeap()} returns
+     * {@code false}, {@link #isShared()} returns {@code false}, no
+     * {@link IndexKeySlab} is pinned, and equality / hashing semantics
+     * are unchanged.
      *
      * <h3>Use case (issue #411)</h3>
      * BLink {@code Node.split()} promotes one of its keys to become the new

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -162,9 +162,15 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
      * any {@code Bytes} references its slab owner, the owner stays
      * GC-reachable and its {@code Cleanable} does not release the slab,
      * preventing a use-after-free for in-flight readers.
+     *
+     * <p>Issue #411: nulled out by {@link #materialiseAndDetach()} so a
+     * separator key promoted out of an index node (e.g. BLink {@code rightsep}
+     * after a split) no longer pins the donor's {@link IndexKeySlab}.
+     * Always nulled under {@code synchronized (this)} together with
+     * {@link #offHeap}; the {@code volatile} keyword carries the visibility
+     * guarantee for unsynchronized GC tracking.
      */
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
-    private final Object slabOwner;
+    private volatile Object slabOwner;
 
     public Object deserialized;
 
@@ -587,6 +593,101 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         // off-heap reader (the slab owner's quiescence contract excludes
         // races, but losing the field would also break the slabOwner GC
         // anchor). The slab will be released by the slab owner's Cleaner.
+    }
+
+    /**
+     * Eagerly copies the off-heap bytes into a private on-heap {@code byte[]}
+     * and breaks every link to the underlying slab. After this call the
+     * {@code Bytes} behaves exactly like an instance built via
+     * {@link #from_array(byte[])}: {@link #isOffHeap()} returns {@code false},
+     * {@link #isShared()} returns {@code false}, no {@link IndexKeySlab} is
+     * pinned, and equality / hashing semantics are unchanged.
+     *
+     * <h3>Use case (issue #411)</h3>
+     * BLink {@code Node.split()} promotes one of its keys to become the new
+     * {@code rightsep} on the right sibling, and {@code Node.half_merge()}
+     * inherits the right sibling's {@code rightsep}. Both promotions hand a
+     * key that came from the donor's per-page {@link IndexKeySlab} into a
+     * slot that may outlive the donor (after the donor is unloaded the
+     * separator stays alive on the BLink anchor / parent index). Without a
+     * defensive copy, that single separator pins the donor's multi-KiB slab
+     * indefinitely. Calling {@code materialiseAndDetach()} at the handoff
+     * site copies the bytes onto the heap and clears the slab anchor, so
+     * the donor's slab can be reclaimed once the rest of its keys are
+     * evicted.
+     *
+     * <h3>Semantics by current state</h3>
+     * <ul>
+     *   <li><b>Already on-heap</b> (this includes a previously-detached
+     *       instance and a shared-slab instance whose lazy materialisation
+     *       has already run): no-op, returns {@code this}.</li>
+     *   <li><b>Owned-slice off-heap</b> ({@link #fromOffHeap(ByteBuf)}):
+     *       copies the slice into a fresh {@code byte[]}, releases the
+     *       slice (matching the existing {@link #materialiseFromOffHeap()}
+     *       contract), nulls {@link #offHeap}.</li>
+     *   <li><b>Shared-slab off-heap</b> ({@link #fromSharedSlab(ByteBuf, int, int, Object)}):
+     *       copies the slice into a fresh {@code byte[]}, then nulls both
+     *       {@link #offHeap} and {@link #slabOwner}. The slab's refcount is
+     *       <em>not</em> decremented (the slab owner still holds the single
+     *       refcount); however, dropping the slab-owner anchor frees the
+     *       JDK {@link java.lang.ref.Cleaner} attached to the slab to run
+     *       once every other slice on the same slab also becomes
+     *       GC-unreachable.</li>
+     * </ul>
+     *
+     * <h3>Quiescence contract</h3>
+     * Same as {@link #release()} and {@link #materialiseFromOffHeap()}:
+     * the caller must guarantee no other thread is inside a read path on
+     * this {@code Bytes} at the moment of detach. The BLink call sites
+     * satisfy this naturally — the rightsep handoff in {@code split()} /
+     * {@code half_merge()} runs under the donor / receiver write lock and
+     * before any reader could observe the new separator slot.
+     *
+     * <h3>Idempotency</h3>
+     * Calling {@code materialiseAndDetach()} a second (or n-th) time on
+     * the same instance is a no-op: the first call sets {@link #buffer},
+     * and every subsequent call observes that and returns immediately.
+     *
+     * @return {@code this}, for fluent chaining
+     * @throws IllegalStateException if {@link #release()} ran before
+     *         materialisation and the bytes are no longer reachable.
+     */
+    public synchronized Bytes materialiseAndDetach() {
+        if (buffer != null) {
+            // Already on-heap, or a previous detach / lazy materialisation
+            // already copied the bytes. For a shared-slab instance whose
+            // lazy materialisation ran (offHeap still non-null, slabOwner
+            // still non-null), this also clears the residual anchor so
+            // detach is fully effective even on those instances.
+            if (offHeap != null) {
+                offHeap = null;
+            }
+            if (slabOwner != null) {
+                slabOwner = null;
+            }
+            return this;
+        }
+        ByteBuf local = offHeap;
+        if (local == null) {
+            throw new IllegalStateException("Bytes already released");
+        }
+        byte[] copy = new byte[length];
+        if (length > 0) {
+            local.getBytes(local.readerIndex(), copy, 0, length);
+        }
+        buffer = copy;
+        offset = 0;
+        offHeap = null;
+        if (ownsSlice) {
+            // Owned slice: this Bytes held the single refcount; release it
+            // exactly like materialiseFromOffHeap does.
+            local.release();
+        }
+        // Shared-slab: do NOT release; the slab owner owns the refcount.
+        // Drop the slab anchor so GC can reclaim the slab owner once every
+        // other slice on the slab also becomes unreachable.
+        slabOwner = null;
+        return this;
     }
 
     /**

--- a/herddb-utils/src/main/java/herddb/utils/IndexKeySlab.java
+++ b/herddb-utils/src/main/java/herddb/utils/IndexKeySlab.java
@@ -59,19 +59,15 @@ import java.util.logging.Logger;
  *   }
  * </pre>
  *
- * <h3>Known limitation: long-lived separator keys pin the slab</h3>
+ * <h3>Long-lived separator keys (issue #411)</h3>
  * If a key from this slab ends up surviving its owning index page
  * (e.g. it becomes a BLink {@code rightsep} after a node split and the
- * source node is then evicted), that single key still anchors the entire
- * slab via its {@link Bytes#fromSharedSlab} reference, so the whole
- * direct-memory capacity stays pinned to keep one separator alive. The
- * impact is bounded because separator keys are typically the boundary
- * key of the donating page (one per split), and the slab is at most a
- * few KiB. A future step may add a {@code Bytes.materialiseAndDetach()}
- * helper that callers can invoke at the BLink split-key handoff to
- * defensively copy the separator into a private {@code byte[]} and break
- * the anchor. Until then the regression is acknowledged in the
- * step-4 review of issue #399 and tracked for a follow-up.
+ * source node is then evicted), the separator is defensively copied into
+ * a private on-heap {@code byte[]} via {@link Bytes#materialiseAndDetach()}
+ * at the handoff site so it no longer anchors the donor's slab. The
+ * BLink split / half-merge promotions invoke the
+ * {@code SizeEvaluator.detachSeparator} hook, which the Bytes-keyed
+ * evaluators delegate to {@code materialiseAndDetach()}; see issue #411.
  */
 public final class IndexKeySlab {
 

--- a/herddb-utils/src/test/java/herddb/utils/BytesMaterialiseAndDetachTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesMaterialiseAndDetachTest.java
@@ -159,6 +159,35 @@ public class BytesMaterialiseAndDetachTest {
                 0, detached.compareTo(onHeap));
     }
 
+    /**
+     * After {@link Bytes#release()} runs on an owned-slice off-heap Bytes
+     * (without an intervening lazy materialisation), the underlying bytes
+     * are no longer reachable. {@code materialiseAndDetach()} on such an
+     * instance must surface this via {@link IllegalStateException} rather
+     * than silently producing a zero-length / corrupted byte[]. Covers the
+     * fail-fast {@code throw new IllegalStateException("Bytes already released")}
+     * branch that no other test exercises.
+     */
+    @Test
+    public void releaseThenDetachThrows() {
+        ByteBuf slice = HerdDBByteBufAllocators.dataPagesAllocator()
+                .directBuffer(16);
+        slice.writeBytes(new byte[]{1, 2, 3, 4});
+        Bytes b = Bytes.fromOffHeap(slice);
+        b.release();
+        // After release, the slice is back in the pool; reading bytes is
+        // undefined. The detach helper must fail-fast.
+        try {
+            b.materialiseAndDetach();
+            org.junit.Assert.fail("expected IllegalStateException after release()");
+        } catch (IllegalStateException expected) {
+            org.junit.Assert.assertTrue(
+                    "exception message must mention release, got: " + expected.getMessage(),
+                    expected.getMessage() != null
+                            && expected.getMessage().contains("released"));
+        }
+    }
+
     @Test
     public void zeroLengthDetachWorks() {
         IndexKeySlab slab = new IndexKeySlab(0L,

--- a/herddb-utils/src/test/java/herddb/utils/BytesMaterialiseAndDetachTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesMaterialiseAndDetachTest.java
@@ -1,0 +1,208 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.utils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import java.lang.reflect.Field;
+import java.util.Random;
+import org.junit.Test;
+
+/**
+ * Verifies {@link Bytes#materialiseAndDetach()} (issue #411): for the three
+ * starting states (on-heap, owned-slice off-heap, shared-slab off-heap) the
+ * call produces a Bytes that is fully on-heap, has dropped any slab anchor,
+ * is idempotent on re-call, and preserves {@code equals}/{@code hashCode}
+ * semantics relative to the original payload.
+ *
+ * <p>The slab-refcount asserts use {@link IndexKeySlab#slabRefCntForTesting()}
+ * to confirm shared-slab detach does not decrement the slab's single owner
+ * refcount, and that owned-slice detach decrements its slice's refcount by
+ * exactly one.
+ */
+public class BytesMaterialiseAndDetachTest {
+
+    private static byte[] payload(int len, long seed) {
+        Random rnd = new Random(seed);
+        byte[] out = new byte[len];
+        rnd.nextBytes(out);
+        return out;
+    }
+
+    @Test
+    public void onHeapInstanceIsNoOp() {
+        byte[] data = payload(64, 1L);
+        Bytes b = Bytes.from_array(data);
+        assertFalse("precondition: on-heap", b.isOffHeap());
+        Bytes ret = b.materialiseAndDetach();
+        assertSame("must return this for chaining", b, ret);
+        assertFalse("still on-heap", b.isOffHeap());
+        assertFalse("on-heap instance is not shared", b.isShared());
+        assertArrayEquals("bytes preserved", data, b.to_array());
+    }
+
+    @Test
+    public void onHeapDetachIsIdempotent() {
+        byte[] data = payload(32, 2L);
+        Bytes b = Bytes.from_array(data);
+        b.materialiseAndDetach();
+        b.materialiseAndDetach();
+        assertArrayEquals(data, b.to_array());
+    }
+
+    @Test
+    public void ownedSliceIsCopiedAndSliceReleased() {
+        byte[] data = payload(128, 3L);
+        ByteBuf slice = HerdDBByteBufAllocators.dataPagesAllocator()
+                .directBuffer(data.length);
+        slice.writeBytes(data);
+        // Hold one extra refcount so we can observe the detach decrement.
+        // After fromOffHeap the Bytes owns one refcount; we retain to take
+        // a second refcount, so the slice survives detach for our assertion.
+        slice.retain();
+        int beforeRefCnt = slice.refCnt(); // expected: 2
+        Bytes b = Bytes.fromOffHeap(slice);
+        assertTrue("precondition: off-heap", b.isOffHeap());
+        assertTrue("owned-slice off-heap is shared", b.isShared());
+
+        Bytes ret = b.materialiseAndDetach();
+        assertSame(b, ret);
+        assertFalse("after detach, no longer off-heap", b.isOffHeap());
+        assertFalse("after detach, no longer shared", b.isShared());
+        assertEquals("owned-slice detach must release exactly one refcount",
+                beforeRefCnt - 1, slice.refCnt());
+        assertArrayEquals("bytes preserved across detach", data, b.to_array());
+
+        // Idempotent: second detach must NOT touch the slice further.
+        b.materialiseAndDetach();
+        assertEquals("second detach must not change slice refcount",
+                beforeRefCnt - 1, slice.refCnt());
+
+        // Drop our extra refcount to release the slice.
+        slice.release();
+        assertEquals(0, slice.refCnt());
+    }
+
+    @Test
+    public void sharedSlabDetachLeavesSlabRefcountIntactAndClearsAnchor() throws Exception {
+        byte[] data = payload(64, 4L);
+        IndexKeySlab slab = new IndexKeySlab(data.length,
+                HerdDBByteBufAllocators.indexPagesAllocator());
+        int beforeRef = slab.slabRefCntForTesting();
+        int off = slab.append(data);
+        Bytes b = slab.wrap(off, data.length);
+        assertTrue("precondition: off-heap", b.isOffHeap());
+        assertTrue("precondition: shared", b.isShared());
+        assertSame("precondition: slabOwner anchored", slab, slabOwnerOf(b));
+        assertEquals("slab.wrap must NOT change refcount",
+                beforeRef, slab.slabRefCntForTesting());
+
+        Bytes ret = b.materialiseAndDetach();
+        assertSame(b, ret);
+        assertFalse("after detach, no longer off-heap", b.isOffHeap());
+        assertFalse("after detach, no longer shared", b.isShared());
+        assertEquals("shared-slab detach must NOT decrement slab refcount",
+                beforeRef, slab.slabRefCntForTesting());
+        // The slab anchor must be cleared so GC can reclaim the slab once
+        // every other slice on the slab also becomes unreachable.
+        assertSame("slabOwner anchor must be cleared after detach",
+                null, slabOwnerOf(b));
+        assertArrayEquals("bytes preserved across detach", data, b.to_array());
+
+        // Idempotent: second detach must not touch the slab further.
+        b.materialiseAndDetach();
+        assertEquals(beforeRef, slab.slabRefCntForTesting());
+
+        // The slab is still alive because the IndexKeySlab itself holds the
+        // refcount; it will be released by its Cleaner when GC'd. Sanity:
+        // refcount stays > 0 here.
+        assertTrue("slab refcount stays positive while IndexKeySlab is reachable",
+                slab.slabRefCntForTesting() > 0);
+    }
+
+    @Test
+    public void detachedBytesEqualOnHeapBaseline() {
+        byte[] data = payload(96, 5L);
+        Bytes onHeap = Bytes.from_array(data);
+
+        IndexKeySlab slab = new IndexKeySlab(data.length,
+                HerdDBByteBufAllocators.indexPagesAllocator());
+        int off = slab.append(data);
+        Bytes detached = slab.wrap(off, data.length).materialiseAndDetach();
+
+        assertEquals("equals must round-trip with on-heap baseline", onHeap, detached);
+        assertEquals("hashCode must round-trip with on-heap baseline",
+                onHeap.hashCode(), detached.hashCode());
+        assertEquals("compareTo == 0 with on-heap baseline",
+                0, detached.compareTo(onHeap));
+    }
+
+    @Test
+    public void zeroLengthDetachWorks() {
+        IndexKeySlab slab = new IndexKeySlab(0L,
+                HerdDBByteBufAllocators.indexPagesAllocator());
+        int off = slab.append(new byte[0]);
+        Bytes b = slab.wrap(off, 0);
+        Bytes ret = b.materialiseAndDetach();
+        assertSame(b, ret);
+        assertFalse(b.isOffHeap());
+        assertEquals(0, b.getLength());
+        assertArrayEquals(new byte[0], b.to_array());
+    }
+
+    /**
+     * After lazy {@link Bytes#getBuffer()} materialised the bytes on a
+     * shared-slab instance the slab anchor is still held (the existing
+     * materialiseFromOffHeap path keeps it for concurrent off-heap readers).
+     * A subsequent {@code materialiseAndDetach()} must drop that residual
+     * anchor so the detach is fully effective.
+     */
+    @Test
+    public void detachAfterLazyMaterialisationStillClearsAnchor() throws Exception {
+        byte[] data = payload(50, 6L);
+        IndexKeySlab slab = new IndexKeySlab(data.length,
+                HerdDBByteBufAllocators.indexPagesAllocator());
+        int off = slab.append(data);
+        Bytes b = slab.wrap(off, data.length);
+        // Force lazy materialisation via a heap accessor.
+        byte[] copy = b.getBuffer();
+        assertArrayEquals(data, copy);
+
+        // Anchor still in place per the existing materialiseFromOffHeap contract.
+        assertSame("slabOwner still anchored after lazy materialisation",
+                slab, slabOwnerOf(b));
+
+        b.materialiseAndDetach();
+        assertSame("anchor cleared by materialiseAndDetach",
+                null, slabOwnerOf(b));
+        assertArrayEquals(data, b.to_array());
+    }
+
+    private static Object slabOwnerOf(Bytes b) throws Exception {
+        Field f = Bytes.class.getDeclaredField("slabOwner");
+        f.setAccessible(true);
+        return f.get(b);
+    }
+}


### PR DESCRIPTION
Fixes #411 (Part 2 — BLink/BRIN follow-up; Part 1 / `LazyValueCache` shipped via #414).

## Why

After issue #399 step-4 each BLink leaf's keys live in an off-heap `IndexKeySlab`. When the leaf splits, one of its keys (`lastKey`) is bequeathed to its right sibling as the new `rightsep`; that separator outlives the donor's slab and pins it indefinitely — a single shared-slab `Bytes` keeps the slab refcount alive. The same caveat applies to `half_merge`'s `rightsep` inheritance. Issue #411's `IndexKeySlab` Javadoc already flagged this as a known limitation tracked for follow-up.

Additionally, `IncrementalBLinkPageCodec.readNodeMetadata` was the last disk-load path called out in #411 still allocating each rightsep on-heap (`Bytes.from_array(in.readArray())`).

## Changes

- **`Bytes.materialiseAndDetach()`** (new). Copies the off-heap slice into a private `byte[]`, then clears both the off-heap slice reference and the `slabOwner` GC anchor (relaxed from `final` to `volatile`). For owned-slice instances also releases the slice; for shared-slab preserves the slab owner's single refcount. Idempotent and subject to the same quiescence contract as `release()`.
- **`BLink.SizeEvaluator.detachSeparator(K)`** (new default hook). Invoked at every promotion of a node-local key to a long-lived `rightsep` slot:
  - `Node.split()` — `rightsep = detachSeparator(lastKey)` (donor's per-page slab)
  - `Node.half_merge()` — `rightsep = detachSeparator(right.rightsep)` (right node about to be unloaded)

  `BytesLongSizeEvaluator` and `BytesBytesSizeEvaluator` override it to call `materialiseAndDetach()` (`POSITIVE_INFINITY` passes through unchanged).
- **`IncrementalBLinkPageCodec`** `readSnapshotChunk` / `readDelta` now go through a two-pass `readNodeMetadataArray` helper that slab-packs every rightsep into a single `IndexKeySlab` (gated by `OFFHEAP_KEY_BYTES_THRESHOLD`) when the aggregate exceeds the threshold; below-threshold pages keep the on-heap fast path. The separator-pinning concern that previously blocked this migration is neutralised by `detachSeparator`.
- `IndexKeySlab` Javadoc updated to point at the new helper instead of the "future step" placeholder.

## Tests

- **`BytesMaterialiseAndDetachTest`** (7 tests) — covers all three input states (on-heap, owned-slice off-heap, shared-slab off-heap), idempotent detach, owned-slice refcount decrement, shared-slab refcount preservation + GC anchor cleared, post-lazy-materialisation detach, and zero-length payloads.
- **`BLinkSeparatorDetachTest`** — inserts 1024+512 keys (forcing many splits + half-merges), reloads, asserts every live `rightsep` is on-heap (issue #411 invariant) while at least one leaf key remains slab-anchored (the detach is targeted, not blanket).
- **`IncrementalBLinkRightSepOffHeapTest`** — round-trips 4096 keys with a tight 2 KiB page (≈300 leaves so rightsep aggregate ≫ 4 KiB), asserts at least one rightsep loaded by the codec is off-heap. A second test verifies the on-heap fallback below threshold.
- **`BLinkTestReflection`** — extended with `anyRightSepOffHeap` / `firstOffHeapRightSep` helpers.

## Validation

- Targeted unit tests (`BytesMaterialiseAndDetachTest`, `BLinkSeparatorDetachTest`, `IncrementalBLinkRightSepOffHeapTest`, `BLinkOffHeapKeysTest`, `IncrementalBLinkOffHeapKeysTest`, `BRINOffHeapKeysTest`, `IncrementalBLinkCheckpointTest`, `IncrementalBLinkParallelWriteCheckpointTest`, `BLinkParallelWriteCheckpointTest`, plus the `herddb-utils` BLink suite): all green.
- `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}` (concurrency + checkpoint hammer) — green twice in a row.
- Full pre-PR validation (`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`) — `BUILD SUCCESS` across all 22 modules.

## Test plan

- [x] Unit tests for `materialiseAndDetach` on every input shape
- [x] BLink rightsep invariant after many splits + half-merges
- [x] Codec round-trip: above-threshold ⇒ off-heap, below ⇒ on-heap
- [x] Hammer suite × 2

🤖 Implemented by the `pr-worker` agent.