### PR TITLE
issue #423: report LogEntry timestamps in indexing-service status

### DIFF
--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -191,7 +191,21 @@ kubectl exec herddb-tools-0 -- \
         --tablespace <UUID> --table <table> --index vidx --json
 ```
 Fields to watch: `vector_count`, `ondisk_node_count`, `segment_count`,
-`status`, `last_lsn_ledger`, `last_lsn_offset`, `ondisk_size_bytes`.
+`status`, `tailer_lsn_ledger`, `tailer_lsn_offset`, `tailer_lsn_timestamp`,
+`durable_lsn_ledger`, `durable_lsn_offset`, `durable_lsn_timestamp`,
+`ondisk_size_bytes`.
+
+The `*_timestamp` fields (issue #423) are the wall-clock (epoch ms) of the
+LogEntry at the matching LSN. Compute `tailer_lag_ms = now - tailer_lsn_timestamp`
+(and similarly for `durable_lag_ms`) to report the IS time-lag in seconds —
+the operator-friendly complement to LSN coordinates. Treat `0` as "unknown"
+(no entries processed yet, or no checkpoint yet) and skip the lag column
+in that case.
+
+For shadow replicas (role=shadow), use `indexing-admin shadow-status` and
+read `loaded_entry_timestamp_ms`. Compute `shadow_data_staleness_ms = now -
+loaded_entry_timestamp_ms` — this is how stale the data the shadow can serve
+is, and the single best signal that a shadow has fallen behind its primary.
 
 ### File-server metrics
 
@@ -420,6 +434,7 @@ Agent(
 - **rows / rate**: take `rows`, `total`, `ops_per_sec` from `GET /status`. Always show count, percentage, and rate.
 - **commits**: show `commits` and `recovered_commits`. Non-zero recovered → warn.
 - **IS-N vectors**: use `VECTORS` from `indexing-admin list-indexes`. Compute lag% = `(rows - vectors) / rows * 100`. With 2 IS replicas and `--index-num-shards 4`, steady-state target is ~50% per instance. Flag WARN if lag > 10% for 2+ consecutive ticks.
+- **IS-N time-lag (issue #423)**: from `indexing-admin status --json`, read `tailer_lag_ms` and `durable_lag_ms`. Operator-friendly time-domain measure of how far behind real time the IS is. A growing `tailer_lag_ms` indicates the tailer is not keeping up with the commit log; a growing `durable_lag_ms` (with `tailer_lag_ms` flat) indicates checkpoints are stalling. Flag WARN if `tailer_lag_ms > 30000` (30 s) or `durable_lag_ms > 300000` (5 min). Skip the column when the value is `-1` ("unknown").
 - **IS-N apply_queue**: from `engine-stats`. `FULL` = IS at max throughput, lag will grow.
 - **IS-N mem**: `total_estimated_memory_bytes` from `engine-stats`, in GiB. Warn if > 18 GiB.
 - **ServerCkpt**: last `local checkpoint finish` line from server logs — LSN + age.

--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -178,7 +178,21 @@ kubectl --kubeconfig .kubeconfig exec herddb-tools-0 -- \
         --tablespace <UUID> --table <table> --index vidx --json
 ```
 Fields to watch: `vector_count`, `ondisk_node_count`, `segment_count`,
-`status`, `last_lsn_ledger`, `last_lsn_offset`, `ondisk_size_bytes`.
+`status`, `tailer_lsn_ledger`, `tailer_lsn_offset`, `tailer_lsn_timestamp`,
+`durable_lsn_ledger`, `durable_lsn_offset`, `durable_lsn_timestamp`,
+`ondisk_size_bytes`.
+
+The `*_timestamp` fields (issue #423) are the wall-clock (epoch ms) of the
+LogEntry at the matching LSN. Compute `tailer_lag_ms = now - tailer_lsn_timestamp`
+(and similarly for `durable_lag_ms`) to report the IS time-lag in seconds —
+the operator-friendly complement to LSN coordinates. Treat `0` as "unknown"
+(no entries processed yet, or no checkpoint yet) and skip the lag column
+in that case.
+
+For shadow replicas (role=shadow), use `indexing-admin shadow-status` and
+read `loaded_entry_timestamp_ms`. Compute `shadow_data_staleness_ms = now -
+loaded_entry_timestamp_ms` — this is how stale the data the shadow can serve
+is, and the single best signal that a shadow has fallen behind its primary.
 
 Note: `indexing-admin list-instances` may return empty if ZooKeeper
 registration is not active; use the direct `--server` flag with pod DNS
@@ -399,6 +413,7 @@ Agent(
 - **rows / rate**: take `rows`, `total`, `ops_per_sec` from `GET /status`. Always show the count, percentage, and rate.
 - **commits**: show `commits` and `recovered_commits`. Non-zero recovered → warn.
 - **IS-N vectors**: use `VECTORS` from `indexing-admin list-indexes`, not watermark offsets. Compute lag% = `(rows - vectors) / rows * 100`. Flag WARN if lag > 10% sustained over ≥ 2 ticks.
+- **IS-N time-lag (issue #423)**: from `indexing-admin status --json`, read `tailer_lag_ms` and `durable_lag_ms`. These are the operator-friendly time-domain measure of how far behind real time the IS is. A growing `tailer_lag_ms` indicates the tailer is not keeping up with the commit log; a growing `durable_lag_ms` (with `tailer_lag_ms` flat) indicates checkpoints are stalling. Flag WARN if `tailer_lag_ms > 30000` (30 s) or `durable_lag_ms > 300000` (5 min). Skip the column when the value is `-1` ("unknown").
 - **IS-N apply_queue**: from `engine-stats`. `FULL` = IS at max throughput, lag will grow.
 - **IS-N mem**: `total_estimated_memory_bytes` from `engine-stats`, in GiB. Warn if > 18 GiB (limit is 20 GiB in values.yaml).
 - **ServerCkpt**: last `local checkpoint finish` line from server logs — LSN + age.

--- a/herddb-core/src/main/java/herddb/core/system/SysindexstatusTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexstatusTableManager.java
@@ -94,8 +94,14 @@ public class SysindexstatusTableManager extends AbstractSystemTableManager {
                 props.put("segmentCount", status.getSegmentCount());
                 props.put("tailerLsnLedger", status.getTailerLsnLedger());
                 props.put("tailerLsnOffset", status.getTailerLsnOffset());
+                // Wall-clock (epoch ms) of the LogEntry at the tailer LSN.
+                // 0 means "unknown" (no entries processed yet). Issue #423.
+                props.put("tailerLsnTimestamp", status.getTailerLsnTimestamp());
                 props.put("durableLsnLedger", status.getDurableLsnLedger());
                 props.put("durableLsnOffset", status.getDurableLsnOffset());
+                // Wall-clock (epoch ms) of the LogEntry at the durable LSN.
+                // 0 means "unknown" (no successful checkpoint yet). Issue #423.
+                props.put("durableLsnTimestamp", status.getDurableLsnTimestamp());
                 props.put("status", status.getStatus());
             } catch (Exception e) {
                 props.put("error", e.getMessage());

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
@@ -103,14 +103,29 @@ public interface RemoteVectorIndexService extends AutoCloseable {
      * ({@code durableLsn*}, used by the server's commit-log retention floor
      * — never advance retention past this value, otherwise an IS restart
      * cannot replay the missing entries).
+     *
+     * <p>Issue #423: also carries the wall-clock timestamps of the LogEntry
+     * at each LSN, so dashboards can report the time-lag of the IS as
+     * {@code now - timestamp} (in milliseconds) without knowing the
+     * commit-log layout.
      */
     class IndexStatusInfo {
         private final long vectorCount;
         private final int segmentCount;
         private final long tailerLsnLedger;
         private final long tailerLsnOffset;
+        /**
+         * Wall-clock timestamp (epoch ms) of the LogEntry at the tailer LSN.
+         * 0 = unknown. Issue #423.
+         */
+        private final long tailerLsnTimestamp;
         private final long durableLsnLedger;
         private final long durableLsnOffset;
+        /**
+         * Wall-clock timestamp (epoch ms) of the LogEntry at the durable LSN.
+         * 0 = unknown. Issue #423.
+         */
+        private final long durableLsnTimestamp;
         private final String status;
         /** Number of segments loaded so far during cold-start recovery (0 when not loading). */
         private final int loadingSegmentsDone;
@@ -119,23 +134,19 @@ public interface RemoteVectorIndexService extends AutoCloseable {
 
         public IndexStatusInfo(long vectorCount, int segmentCount,
                                long tailerLsnLedger, long tailerLsnOffset,
+                               long tailerLsnTimestamp,
                                long durableLsnLedger, long durableLsnOffset,
-                               String status) {
-            this(vectorCount, segmentCount, tailerLsnLedger, tailerLsnOffset,
-                    durableLsnLedger, durableLsnOffset, status, 0, 0);
-        }
-
-        public IndexStatusInfo(long vectorCount, int segmentCount,
-                               long tailerLsnLedger, long tailerLsnOffset,
-                               long durableLsnLedger, long durableLsnOffset,
+                               long durableLsnTimestamp,
                                String status,
                                int loadingSegmentsDone, int loadingSegmentsTotal) {
             this.vectorCount = vectorCount;
             this.segmentCount = segmentCount;
             this.tailerLsnLedger = tailerLsnLedger;
             this.tailerLsnOffset = tailerLsnOffset;
+            this.tailerLsnTimestamp = tailerLsnTimestamp;
             this.durableLsnLedger = durableLsnLedger;
             this.durableLsnOffset = durableLsnOffset;
+            this.durableLsnTimestamp = durableLsnTimestamp;
             this.status = status;
             this.loadingSegmentsDone = loadingSegmentsDone;
             this.loadingSegmentsTotal = loadingSegmentsTotal;
@@ -157,12 +168,32 @@ public interface RemoteVectorIndexService extends AutoCloseable {
             return tailerLsnOffset;
         }
 
+        /**
+         * Wall-clock timestamp (epoch ms) of the LogEntry at the tailer LSN.
+         * Operators compute the tailer time-lag as
+         * {@code now - getTailerLsnTimestamp()}. {@code 0} = unknown.
+         * Issue #423.
+         */
+        public long getTailerLsnTimestamp() {
+            return tailerLsnTimestamp;
+        }
+
         public long getDurableLsnLedger() {
             return durableLsnLedger;
         }
 
         public long getDurableLsnOffset() {
             return durableLsnOffset;
+        }
+
+        /**
+         * Wall-clock timestamp (epoch ms) of the LogEntry at the durable LSN.
+         * Operators compute the durable time-lag as
+         * {@code now - getDurableLsnTimestamp()}. {@code 0} = unknown.
+         * Issue #423.
+         */
+        public long getDurableLsnTimestamp() {
+            return durableLsnTimestamp;
         }
 
         public String getStatus() {

--- a/herddb-core/src/main/java/herddb/metadata/IndexingServiceCheckpointState.java
+++ b/herddb-core/src/main/java/herddb/metadata/IndexingServiceCheckpointState.java
@@ -34,6 +34,19 @@ import java.util.Objects;
  * Written at {@code /herddb/indexingServices/state/{instanceId}} after each
  * successful checkpoint so shadow replicas can observe progress and reload
  * their on-disk snapshots.
+ *
+ * <p>Carries two timestamps with very different semantics:
+ * <ul>
+ *   <li>{@link #getTimestampMillis()} — wall-clock when the primary
+ *       <em>published</em> the checkpoint state. Useful as a heartbeat ("is
+ *       the primary still alive?").</li>
+ *   <li>{@link #getLastEntryTimestampMillis()} (issue #423) — wall-clock
+ *       timestamp of the {@link herddb.log.LogEntry} at
+ *       {@code (ledgerId, offset)}. The freshness of the data the shadow
+ *       reloaded from disk: {@code now - lastEntryTimestampMillis} is the
+ *       time-lag between real-world writes and what the shadow can serve.
+ *       {@code 0} means "unknown" (no checkpoint yet).</li>
+ * </ul>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class IndexingServiceCheckpointState {
@@ -45,6 +58,7 @@ public final class IndexingServiceCheckpointState {
     private final long offset;
     private final int segmentCount;
     private final long timestampMillis;
+    private final long lastEntryTimestampMillis;
 
     @JsonCreator
     public IndexingServiceCheckpointState(
@@ -52,12 +66,14 @@ public final class IndexingServiceCheckpointState {
             @JsonProperty("ledgerId") long ledgerId,
             @JsonProperty("offset") long offset,
             @JsonProperty("segmentCount") int segmentCount,
-            @JsonProperty("timestampMillis") long timestampMillis) {
+            @JsonProperty("timestampMillis") long timestampMillis,
+            @JsonProperty("lastEntryTimestampMillis") long lastEntryTimestampMillis) {
         this.instanceId = instanceId;
         this.ledgerId = ledgerId;
         this.offset = offset;
         this.segmentCount = segmentCount;
         this.timestampMillis = timestampMillis;
+        this.lastEntryTimestampMillis = lastEntryTimestampMillis;
     }
 
     public int getInstanceId() {
@@ -78,6 +94,16 @@ public final class IndexingServiceCheckpointState {
 
     public long getTimestampMillis() {
         return timestampMillis;
+    }
+
+    /**
+     * Wall-clock timestamp (epoch ms) of the {@link herddb.log.LogEntry} at
+     * {@code (ledgerId, offset)} — i.e. the freshness of the data the shadow
+     * reloaded from disk after this checkpoint. {@code 0} means "unknown".
+     * Issue #423.
+     */
+    public long getLastEntryTimestampMillis() {
+        return lastEntryTimestampMillis;
     }
 
     @JsonIgnore
@@ -110,12 +136,14 @@ public final class IndexingServiceCheckpointState {
                 && ledgerId == that.ledgerId
                 && offset == that.offset
                 && segmentCount == that.segmentCount
-                && timestampMillis == that.timestampMillis;
+                && timestampMillis == that.timestampMillis
+                && lastEntryTimestampMillis == that.lastEntryTimestampMillis;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(instanceId, ledgerId, offset, segmentCount, timestampMillis);
+        return Objects.hash(instanceId, ledgerId, offset, segmentCount,
+                timestampMillis, lastEntryTimestampMillis);
     }
 
     @Override
@@ -126,6 +154,7 @@ public final class IndexingServiceCheckpointState {
                 + ", offset=" + offset
                 + ", segmentCount=" + segmentCount
                 + ", timestampMillis=" + timestampMillis
+                + ", lastEntryTimestampMillis=" + lastEntryTimestampMillis
                 + '}';
     }
 }

--- a/herddb-core/src/test/java/herddb/cluster/ZookeeperIndexingServiceInstancesTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ZookeeperIndexingServiceInstancesTest.java
@@ -138,7 +138,7 @@ public class ZookeeperIndexingServiceInstancesTest {
             assertNull(mgr.getIndexingServiceCheckpointState(0));
 
             IndexingServiceCheckpointState s1 = new IndexingServiceCheckpointState(
-                    0, 10L, 100L, 3, 1_700_000_000_000L);
+                    0, 10L, 100L, 3, 1_700_000_000_000L, 1_699_999_999_500L);
             mgr.publishIndexingServiceCheckpointState(s1);
 
             IndexingServiceCheckpointState read = mgr.getIndexingServiceCheckpointState(0);
@@ -156,7 +156,7 @@ public class ZookeeperIndexingServiceInstancesTest {
             });
 
             IndexingServiceCheckpointState s2 = new IndexingServiceCheckpointState(
-                    0, 10L, 200L, 4, 1_700_000_001_000L);
+                    0, 10L, 200L, 4, 1_700_000_001_000L, 1_700_000_000_500L);
             mgr.publishIndexingServiceCheckpointState(s2);
 
             assertTrue("watcher did not fire within 5s", latch.await(5, TimeUnit.SECONDS));
@@ -172,7 +172,7 @@ public class ZookeeperIndexingServiceInstancesTest {
             CountDownLatch latch = new CountDownLatch(1);
             mgr.watchIndexingServiceCheckpointState(7, state -> latch.countDown());
             mgr.publishIndexingServiceCheckpointState(
-                    new IndexingServiceCheckpointState(7, 1L, 2L, 0, 0L));
+                    new IndexingServiceCheckpointState(7, 1L, 2L, 0, 0L, 0L));
             assertTrue("watcher did not fire on first publish", latch.await(5, TimeUnit.SECONDS));
         }
     }

--- a/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
@@ -134,7 +134,10 @@ public class Issue355FrozenIsTailerLedgerRetentionTest {
                 // represents a Phase A-frozen IS that has not advanced either.
                 long l = reportedLsn.isPresent() ? reportedLsn.get().ledgerId : -1L;
                 long o = reportedLsn.isPresent() ? reportedLsn.get().offset  : -1L;
-                return new IndexStatusInfo(0, 1, l, o, l, o, "phase-a-frozen");
+                return new IndexStatusInfo(0, 1,
+                        l, o, 0L,
+                        l, o, 0L,
+                        "phase-a-frozen", 0, 0);
             }
 
             @Override

--- a/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
@@ -121,7 +121,12 @@ public class MockRemoteVectorIndexService implements RemoteVectorIndexService {
     public IndexStatusInfo getIndexStatus(String tablespace, String table, String index) {
         String key = indexKey(table, index);
         List<VectorEntry> entries = indexes.getOrDefault(key, Collections.emptyList());
-        return new IndexStatusInfo(entries.size(), 1, 0, 0, 0, 0, "mock");
+        // tailerLsnTimestamp / durableLsnTimestamp default to 0 ("unknown")
+        // since the mock has no real commit-log behind it. Issue #423.
+        return new IndexStatusInfo(entries.size(), 1,
+                0, 0, 0L,
+                0, 0, 0L,
+                "mock", 0, 0);
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
@@ -101,7 +101,10 @@ public class VectorIndexManagerSearchStreamTest {
 
         @Override
         public IndexStatusInfo getIndexStatus(String tablespace, String table, String index) {
-            return new IndexStatusInfo(population.size(), 1, 0, 0, 0, 0, "stub");
+            return new IndexStatusInfo(population.size(), 1,
+                    0, 0, 0L,
+                    0, 0, 0L,
+                    "stub", 0, 0);
         }
 
         @Override

--- a/herddb-core/src/test/java/herddb/metadata/IndexingServiceDtoTest.java
+++ b/herddb-core/src/test/java/herddb/metadata/IndexingServiceDtoTest.java
@@ -55,10 +55,37 @@ public class IndexingServiceDtoTest {
     @Test
     public void checkpointStateRoundTrip() throws Exception {
         IndexingServiceCheckpointState original =
-                new IndexingServiceCheckpointState(2, 10L, 100L, 5, 1_700_000_000_000L);
+                new IndexingServiceCheckpointState(
+                        2, 10L, 100L, 5, 1_700_000_000_000L, 1_699_999_999_500L);
         byte[] bytes = original.serialize();
         IndexingServiceCheckpointState decoded =
                 IndexingServiceCheckpointState.deserialize(bytes);
         assertEquals(original, decoded);
+        assertEquals(1_699_999_999_500L, decoded.getLastEntryTimestampMillis());
+    }
+
+    /**
+     * Issue #423: a primary running new code may publish state that an old
+     * shadow doesn't know how to consume — but Jackson's
+     * {@code @JsonIgnoreProperties(ignoreUnknown=true)} is supposed to make
+     * the reverse direction safe (old primary → new shadow), with the new
+     * field defaulting to {@code 0} ("unknown"). Verify that here.
+     */
+    @Test
+    public void checkpointStateMissingTimestampDefaultsToZero() throws Exception {
+        // Hand-craft a JSON document that omits lastEntryTimestampMillis.
+        byte[] jsonWithoutNewField =
+                ("{\"instanceId\":2,\"ledgerId\":10,\"offset\":100,\"segmentCount\":5,"
+                        + "\"timestampMillis\":1700000000000}")
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        IndexingServiceCheckpointState decoded =
+                IndexingServiceCheckpointState.deserialize(jsonWithoutNewField);
+        assertEquals(2, decoded.getInstanceId());
+        assertEquals(10L, decoded.getLedgerId());
+        assertEquals(100L, decoded.getOffset());
+        assertEquals(5, decoded.getSegmentCount());
+        assertEquals(1_700_000_000_000L, decoded.getTimestampMillis());
+        assertEquals("missing field defaults to 0 (unknown)",
+                0L, decoded.getLastEntryTimestampMillis());
     }
 }

--- a/herddb-core/src/test/java/herddb/sql/SysindexstatusTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SysindexstatusTest.java
@@ -151,6 +151,12 @@ public class SysindexstatusTest {
                 assertTrue("should contain vectorCount", props.contains("\"vectorCount\":"));
                 assertTrue("should contain segmentCount", props.contains("\"segmentCount\":"));
                 assertTrue("should contain status", props.contains("\"status\":"));
+                // Issue #423: freshness timestamps must surface in the
+                // sysindexstatus JSON for vector indexes.
+                assertTrue("should contain tailerLsnTimestamp",
+                        props.contains("\"tailerLsnTimestamp\":"));
+                assertTrue("should contain durableLsnTimestamp",
+                        props.contains("\"durableLsnTimestamp\":"));
             }
 
             // Insert more rows and verify count changes

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -547,7 +547,9 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
                 return new RemoteVectorIndexService.IndexStatusInfo(
                         resp.getVectorCount(), resp.getSegmentCount(),
                         resp.getTailerLsnLedger(), resp.getTailerLsnOffset(),
+                        resp.getTailerLsnTimestamp(),
                         resp.getDurableLsnLedger(), resp.getDurableLsnOffset(),
+                        resp.getDurableLsnTimestamp(),
                         resp.getStatus(),
                         resp.getLoadingSegmentsDone(), resp.getLoadingSegmentsTotal());
             } catch (Exception e) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -154,6 +154,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      * inside {@link #processEntry(LogSequenceNumber, LogEntry)}. {@code 0}
      * means "no entries processed yet". Issue #423: surfaced via
      * {@code GetIndexStatus.tailer_lsn_timestamp}.
+     *
+     * <p><b>Caveat:</b> {@link LogEntry#timestamp} is a wall-clock value
+     * stamped by whichever cluster writer produced the entry. Different
+     * writers may have skewed clocks, so this field can <em>regress</em>
+     * between adjacent entries when the tailer crosses a writer boundary.
+     * Use it as an indicative freshness signal for dashboards
+     * ({@code now - lastProcessedEntryTimestamp ≈ "how far behind real
+     * time the IS is"}), not as a monotonic clock.
      */
     private volatile long lastProcessedEntryTimestamp;
     /**
@@ -2234,8 +2242,9 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         if (primaryState != null) {
             this.primaryAdvertisedLsn = primaryState.toLogSequenceNumber();
             // Pre-seed the shadow freshness clock from the primary's
-            // advertised state so the very first GetShadowStatus call after
-            // boot already carries a meaningful timestamp (issue #423).
+            // advertised state so the very first GetShadowStatus call
+            // after boot already carries a meaningful timestamp, even if
+            // doShadowReload() is racing with us (issue #423).
             this.shadowLoadedEntryTimestamp = primaryState.getLastEntryTimestampMillis();
         }
         boolean initialReloadOk = doShadowReload();
@@ -2246,11 +2255,17 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             try {
                 metadataStorageManager.watchIndexingServiceCheckpointState(shadowOf, state -> {
                     this.primaryAdvertisedLsn = state.toLogSequenceNumber();
-                    // Track the primary's freshness as soon as the watch
-                    // fires; doShadowReload() will refresh it again after
-                    // the on-disk state has actually been re-loaded into
-                    // each ReadOnlyVectorStore (issue #423).
-                    this.shadowLoadedEntryTimestamp = state.getLastEntryTimestampMillis();
+                    // Issue #423: do NOT update shadowLoadedEntryTimestamp
+                    // here. The proto contract on
+                    // GetShadowStatus.loaded_entry_timestamp_ms says it is
+                    // the timestamp of the LogEntry at loaded_ledger_id /
+                    // loaded_offset. Advancing the timestamp BEFORE
+                    // doShadowReload() actually replays the new on-disk
+                    // state into each ReadOnlyVectorStore would expose an
+                    // inconsistent (LSN_old, ts_new) pair while the reload
+                    // executor is still running. The post-reload write
+                    // inside doShadowReload() is the only place the
+                    // freshness is published.
                     enqueueShadowReload();
                 });
             } catch (MetadataStorageManagerException e) {
@@ -2331,6 +2346,12 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     }
                 }
             } catch (Exception e) {
+                // Per-store failure isolation: a single ReadOnlyVectorStore
+                // failing its reload (corrupt segment file, transient I/O)
+                // must not abort the whole reload pass for the other stores
+                // this shadow holds. The failed store keeps serving its
+                // previously-loaded view; allOk=false makes the pass
+                // non-final so shadowLastReloadTimestampMs is not advanced.
                 LOGGER.log(Level.WARNING, "Shadow reload failed for index " + ro, e);
                 allOk = false;
             }
@@ -2340,9 +2361,23 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             // Capture the primary's advertised LogEntry timestamp at the
             // moment of the reload so GetShadowStatus can report the
             // freshness of the data this shadow can serve (issue #423).
-            // Read fresh from ZK rather than relying on the cached
-            // primaryAdvertisedLsn timestamp, because the watch-fired path
-            // may have updated only the LSN.
+            //
+            // Caveats:
+            //   * shadowLoadedLsn is set BEFORE this read so the visible
+            //     pair is at worst (LSN_n, timestamp_{n+1}) — never
+            //     (LSN_n, timestamp_{n-1}). The watch-callback path
+            //     deliberately does NOT touch shadowLoadedEntryTimestamp,
+            //     leaving this method as the single writer.
+            //   * IndexStatus on disk currently always carries
+            //     sequenceNumber=START_OF_TIME (PersistentVectorStore does
+            //     not yet stamp it with the real checkpoint LSN), so we do
+            //     NOT condition the timestamp write on
+            //     maxLsn.equals(primary.toLogSequenceNumber()) — that
+            //     check would never pass and shadow freshness reporting
+            //     would be permanently broken. Instead we trust that the
+            //     primary's published state is internally consistent
+            //     (LSN + timestamp written together in
+            //     publishCheckpointStateBestEffort).
             try {
                 IndexingServiceCheckpointState primary =
                         metadataStorageManager != null
@@ -2482,11 +2517,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 status = "loading";
             }
         }
-        // Snapshot both LSNs (and matching freshness timestamps) together so
-        // the response is internally consistent.
-        // Server-side retention pins on durable_lsn_*; tailer_lsn_* is exposed
-        // for diagnostics only (issue #364). Timestamps are diagnostic-only
-        // (issue #423).
+        // Snapshot both LSNs and the matching freshness timestamps together.
+        // The pair is approximately consistent: in the worst case a reader
+        // can observe (LSN_n, timestamp_{n+1}) — i.e. the timestamp is one
+        // entry newer than the LSN — because the writes in processEntry()
+        // are not atomic across the two volatile fields. Acceptable for a
+        // diagnostic measured in seconds; locking would impose hot-path
+        // cost for no operational benefit.
+        // Server-side retention pins on durable_lsn_*; tailer_lsn_* is
+        // exposed for diagnostics only (issue #364). Timestamps are
+        // diagnostic-only (issue #423).
         LogSequenceNumber tailerSnap = lastProcessedLsn;
         long tailerTsSnap = lastProcessedEntryTimestamp;
         LogSequenceNumber durableSnap = lastDurableLsn;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -148,6 +148,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
 
     private volatile LogSequenceNumber lastProcessedLsn;
     /**
+     * Wall-clock timestamp (epoch ms) of the {@link LogEntry} at
+     * {@link #lastProcessedLsn} — the freshness of the in-memory tailer.
+     * Updated atomically-with-best-effort next to {@link #lastProcessedLsn}
+     * inside {@link #processEntry(LogSequenceNumber, LogEntry)}. {@code 0}
+     * means "no entries processed yet". Issue #423: surfaced via
+     * {@code GetIndexStatus.tailer_lsn_timestamp}.
+     */
+    private volatile long lastProcessedEntryTimestamp;
+    /**
      * The LSN of the most recent checkpoint whose watermark has been
      * successfully persisted via {@link WatermarkStore#save(WatermarkSnapshot)}.
      * After a restart, the engine resumes from this LSN — so the server-side
@@ -161,6 +170,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      * {@code watermarkStore.save(...)} call. Never moves backwards.
      */
     private volatile LogSequenceNumber lastDurableLsn = LogSequenceNumber.START_OF_TIME;
+    /**
+     * Wall-clock timestamp (epoch ms) of the {@link LogEntry} at
+     * {@link #lastDurableLsn} — the freshness of the durable recovery state.
+     * Initialized at {@link #start()} from
+     * {@link WatermarkSnapshot#lastEntryTimestamp}. Advanced strictly inside
+     * {@link #checkpointAndSaveWatermark()}, immediately after a successful
+     * {@code watermarkStore.save(...)} call. Issue #423: surfaced via
+     * {@code GetIndexStatus.durable_lsn_timestamp}.
+     */
+    private volatile long lastDurableEntryTimestamp;
     private long entriesSinceLastCheckpoint;
 
     /**
@@ -204,6 +223,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     private volatile LogSequenceNumber primaryAdvertisedLsn;
     /** Loaded LSN of the shadow's current on-disk view. */
     private volatile LogSequenceNumber shadowLoadedLsn;
+    /**
+     * Wall-clock timestamp (epoch ms) of the LogEntry at {@link #shadowLoadedLsn}
+     * — the freshness of the data this shadow can serve. Picked up from the
+     * primary's advertised
+     * {@link herddb.metadata.IndexingServiceCheckpointState#getLastEntryTimestampMillis()}
+     * on every reload. {@code 0} means "unknown" (primary has not published
+     * a checkpoint yet). Issue #423: surfaced via
+     * {@code GetShadowStatus.loaded_entry_timestamp_ms}.
+     */
+    private volatile long shadowLoadedEntryTimestamp;
     /** Wall-clock of the most recent successful reload. */
     private volatile long shadowLastReloadTimestampMs;
     /** Count of successful reloads (including the initial one). */
@@ -805,6 +834,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // value is safe even if the JVM was killed mid-checkpoint after the
         // save. See lastDurableLsn JavaDoc (issue #364).
         lastDurableLsn = watermark;
+        // Re-hydrate the durable freshness timestamp from the snapshot so
+        // dashboards can compute "durable_lag_ms" immediately after a
+        // restart, without waiting for the next successful checkpoint.
+        // Stays 0 ("unknown") for START_OF_TIME. Issue #423.
+        lastDurableEntryTimestamp = snapshot.lastEntryTimestamp;
+        // The tailer freshness clock starts at the durable freshness — the
+        // engine will replay entries from `watermark` onward, but until the
+        // first replay tick advances `lastProcessedLsn` we report the same
+        // freshness as the durable state (rather than 0).
+        lastProcessedEntryTimestamp = snapshot.lastEntryTimestamp;
         if (snapshot.numInstances > 0) {
             int previous = currentNumInstances;
             currentNumInstances = snapshot.numInstances;
@@ -973,6 +1012,17 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     }
 
     /**
+     * Wall-clock timestamp (epoch ms) of the LogEntry at
+     * {@link #getLastProcessedLsn()}. {@code 0} means "unknown" (no entries
+     * processed yet on a fresh engine). Used by {@code GetIndexStatus} so
+     * dashboards can compute {@code tailer_lag_ms = now - timestamp}
+     * (issue #423).
+     */
+    public long getLastProcessedEntryTimestamp() {
+        return lastProcessedEntryTimestamp;
+    }
+
+    /**
      * Returns the LSN of the most recent checkpoint whose watermark has been
      * successfully persisted to remote storage. After a restart, the engine
      * resumes from this value. Used by {@code GetIndexStatus} so the server
@@ -981,6 +1031,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      */
     public LogSequenceNumber getLastDurableLsn() {
         return lastDurableLsn;
+    }
+
+    /**
+     * Wall-clock timestamp (epoch ms) of the LogEntry at
+     * {@link #getLastDurableLsn()}. {@code 0} means "unknown" (no successful
+     * checkpoint yet). Used by {@code GetIndexStatus} so dashboards can
+     * compute {@code durable_lag_ms = now - timestamp} (issue #423).
+     */
+    public long getLastDurableEntryTimestamp() {
+        return lastDurableEntryTimestamp;
     }
 
     /**
@@ -1030,6 +1090,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             }
 
             lastProcessedLsn = lsn;
+            // Track the LogEntry wall-clock so diagnostic tooling can report
+            // "tailer_lag_ms = now - lastProcessedEntryTimestamp" (issue #423).
+            // Note: read separately from lastProcessedLsn under no lock — a
+            // sub-microsecond race between the two volatile writes is
+            // acceptable for a diagnostic measured in seconds.
+            if (entry.timestamp > 0L) {
+                lastProcessedEntryTimestamp = entry.timestamp;
+            }
             entriesSinceLastCheckpoint++;
 
             // Periodically force a checkpoint and then persist the watermark.
@@ -1349,6 +1417,18 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     // package-private for testing
     void setLastProcessedLsnForTest(LogSequenceNumber lsn) {
         this.lastProcessedLsn = lsn;
+    }
+
+    /**
+     * Test-only sibling of {@link #setLastProcessedLsnForTest(LogSequenceNumber)}.
+     * Sets the wall-clock timestamp the engine will treat as "the LogEntry at
+     * the tailer position", used by tests that drive the engine via
+     * {@link #applyEntry(LogSequenceNumber, LogEntry)} (which bypasses
+     * {@code processEntry()}). Issue #423.
+     */
+    // package-private for testing
+    void setLastProcessedEntryTimestampForTest(long timestampMillis) {
+        this.lastProcessedEntryTimestamp = timestampMillis;
     }
 
     /**
@@ -1903,6 +1983,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             // into the in-memory store state before checkpoint captures it.
             awaitPendingWork();
             LogSequenceNumber checkpointLsn = lastProcessedLsn;
+            // Capture the LogEntry timestamp at the same instant as the LSN
+            // so the watermark we publish carries an internally-consistent
+            // (LSN, freshness) pair (issue #423). The two volatile reads are
+            // not strictly atomic, but in the worst case we observe the
+            // (LSN_n, timestamp_{n-1}) pair from two adjacent entries — fine
+            // for a freshness diagnostic measured in seconds.
+            long checkpointEntryTimestamp = lastProcessedEntryTimestamp;
             entriesSinceLastCheckpoint = 0;
 
             boolean allCheckpointsDurable = true;
@@ -2009,6 +2096,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             }
             WatermarkSnapshot snapshotToSave =
                     new WatermarkSnapshot(checkpointLsn, currentNumInstances,
+                            checkpointEntryTimestamp,
                             schemaTables, schemaVectorIndexes);
             try {
                 watermarkStore.save(snapshotToSave);
@@ -2017,6 +2105,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 // checkpointLsn on restart — this is the LSN the server's
                 // retention floor must pin against (issue #364).
                 lastDurableLsn = checkpointLsn;
+                lastDurableEntryTimestamp = checkpointEntryTimestamp;
                 LOGGER.log(Level.FINE, "Saved watermark snapshot {0}", snapshotToSave);
             } catch (IOException e) {
                 // Watermark save failed: leave lastDurableLsn unchanged.
@@ -2028,7 +2117,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             // Advertise the new durable LSN to ZK so shadow replicas can reload.
             // Primaries only; shadows never reach this code path (tailer is
             // not started for them).
-            publishCheckpointStateBestEffort(checkpointLsn);
+            publishCheckpointStateBestEffort(checkpointLsn, checkpointEntryTimestamp);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "checkpointAndSaveWatermark failed", e);
         }
@@ -2043,7 +2132,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      * watermark has already been saved, so the primary is consistent; the
      * shadow will simply observe the next successful publish.
      */
-    private void publishCheckpointStateBestEffort(LogSequenceNumber lsn) {
+    private void publishCheckpointStateBestEffort(LogSequenceNumber lsn, long entryTimestampMillis) {
         if (metadataStorageManager == null || lsn == null || config.isShadow()) {
             return;
         }
@@ -2060,7 +2149,8 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                             lsn.ledgerId,
                             lsn.offset,
                             segmentCount,
-                            System.currentTimeMillis()));
+                            System.currentTimeMillis(),
+                            entryTimestampMillis));
             LOGGER.log(Level.FINE,
                     "Published indexing-service checkpoint state: instance={0}, lsn={1}, segments={2}",
                     new Object[]{instanceId, lsn, segmentCount});
@@ -2080,7 +2170,9 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             return;
         }
         LogSequenceNumber lsn = lastProcessedLsn != null ? lastProcessedLsn : LogSequenceNumber.START_OF_TIME;
-        publishCheckpointStateBestEffort(lsn);
+        // At engine boot we only know the freshness from the loaded watermark
+        // (or 0 on a fresh install). Issue #423.
+        publishCheckpointStateBestEffort(lsn, lastDurableEntryTimestamp);
     }
 
     // -------------------------------------------------------------------------
@@ -2141,6 +2233,10 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
         if (primaryState != null) {
             this.primaryAdvertisedLsn = primaryState.toLogSequenceNumber();
+            // Pre-seed the shadow freshness clock from the primary's
+            // advertised state so the very first GetShadowStatus call after
+            // boot already carries a meaningful timestamp (issue #423).
+            this.shadowLoadedEntryTimestamp = primaryState.getLastEntryTimestampMillis();
         }
         boolean initialReloadOk = doShadowReload();
         this.shadowReady = initialReloadOk;
@@ -2150,6 +2246,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             try {
                 metadataStorageManager.watchIndexingServiceCheckpointState(shadowOf, state -> {
                     this.primaryAdvertisedLsn = state.toLogSequenceNumber();
+                    // Track the primary's freshness as soon as the watch
+                    // fires; doShadowReload() will refresh it again after
+                    // the on-disk state has actually been re-loaded into
+                    // each ReadOnlyVectorStore (issue #423).
+                    this.shadowLoadedEntryTimestamp = state.getLastEntryTimestampMillis();
                     enqueueShadowReload();
                 });
             } catch (MetadataStorageManagerException e) {
@@ -2236,6 +2337,26 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
         if (maxLsn != null) {
             this.shadowLoadedLsn = maxLsn;
+            // Capture the primary's advertised LogEntry timestamp at the
+            // moment of the reload so GetShadowStatus can report the
+            // freshness of the data this shadow can serve (issue #423).
+            // Read fresh from ZK rather than relying on the cached
+            // primaryAdvertisedLsn timestamp, because the watch-fired path
+            // may have updated only the LSN.
+            try {
+                IndexingServiceCheckpointState primary =
+                        metadataStorageManager != null
+                                ? metadataStorageManager.getIndexingServiceCheckpointState(
+                                        getShadowOfOrMinusOne())
+                                : null;
+                if (primary != null) {
+                    this.shadowLoadedEntryTimestamp = primary.getLastEntryTimestampMillis();
+                }
+            } catch (MetadataStorageManagerException e) {
+                LOGGER.log(Level.FINE,
+                        "Shadow could not refresh primary's lastEntryTimestamp after reload",
+                        e);
+            }
         }
         if (allOk) {
             this.shadowLastReloadTimestampMs = System.currentTimeMillis();
@@ -2283,6 +2404,18 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
 
     public LogSequenceNumber getShadowLoadedLsn() {
         return shadowLoadedLsn;
+    }
+
+    /**
+     * Wall-clock timestamp (epoch ms) of the LogEntry at
+     * {@link #getShadowLoadedLsn()} — the freshness of the data this shadow
+     * can serve. Picked up from the primary's advertised
+     * {@link IndexingServiceCheckpointState#getLastEntryTimestampMillis()} on
+     * every reload. {@code 0} means "unknown" (primary has not published a
+     * checkpoint yet). Issue #423.
+     */
+    public long getShadowLoadedEntryTimestamp() {
+        return shadowLoadedEntryTimestamp;
     }
 
     public LogSequenceNumber getPrimaryAdvertisedLsn() {
@@ -2349,16 +2482,22 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 status = "loading";
             }
         }
-        // Snapshot both LSNs together so the response is internally consistent.
+        // Snapshot both LSNs (and matching freshness timestamps) together so
+        // the response is internally consistent.
         // Server-side retention pins on durable_lsn_*; tailer_lsn_* is exposed
-        // for diagnostics only (issue #364).
+        // for diagnostics only (issue #364). Timestamps are diagnostic-only
+        // (issue #423).
         LogSequenceNumber tailerSnap = lastProcessedLsn;
+        long tailerTsSnap = lastProcessedEntryTimestamp;
         LogSequenceNumber durableSnap = lastDurableLsn;
+        long durableTsSnap = lastDurableEntryTimestamp;
         return new IndexStatusInfo(vectorCount, segmentCount,
                 tailerSnap != null ? tailerSnap.ledgerId : -1,
                 tailerSnap != null ? tailerSnap.offset : -1,
+                tailerTsSnap,
                 durableSnap != null ? durableSnap.ledgerId : -1,
                 durableSnap != null ? durableSnap.offset : -1,
+                durableTsSnap,
                 status,
                 loadingSegmentsDone, loadingSegmentsTotal);
     }
@@ -2494,6 +2633,10 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.tailerLsnLedger = -1L;
             d.tailerLsnOffset = -1L;
         }
+        // Capture timestamps in the same order as the LSN reads above, so the
+        // (LSN, timestamp) pairs come from the same volatile-write window.
+        // Issue #423.
+        d.tailerLsnTimestamp = lastProcessedEntryTimestamp;
         LogSequenceNumber durableSnap = lastDurableLsn;
         if (durableSnap != null) {
             d.durableLsnLedger = durableSnap.ledgerId;
@@ -2502,6 +2645,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.durableLsnLedger = -1L;
             d.durableLsnOffset = -1L;
         }
+        d.durableLsnTimestamp = lastDurableEntryTimestamp;
         return d;
     }
 
@@ -3527,23 +3671,29 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         private final int segmentCount;
         private final long tailerLsnLedger;
         private final long tailerLsnOffset;
+        private final long tailerLsnTimestamp;
         private final long durableLsnLedger;
         private final long durableLsnOffset;
+        private final long durableLsnTimestamp;
         private final String status;
         private final int loadingSegmentsDone;
         private final int loadingSegmentsTotal;
 
         public IndexStatusInfo(long vectorCount, int segmentCount,
                                long tailerLsnLedger, long tailerLsnOffset,
+                               long tailerLsnTimestamp,
                                long durableLsnLedger, long durableLsnOffset,
+                               long durableLsnTimestamp,
                                String status,
                                int loadingSegmentsDone, int loadingSegmentsTotal) {
             this.vectorCount = vectorCount;
             this.segmentCount = segmentCount;
             this.tailerLsnLedger = tailerLsnLedger;
             this.tailerLsnOffset = tailerLsnOffset;
+            this.tailerLsnTimestamp = tailerLsnTimestamp;
             this.durableLsnLedger = durableLsnLedger;
             this.durableLsnOffset = durableLsnOffset;
+            this.durableLsnTimestamp = durableLsnTimestamp;
             this.status = status;
             this.loadingSegmentsDone = loadingSegmentsDone;
             this.loadingSegmentsTotal = loadingSegmentsTotal;
@@ -3565,12 +3715,29 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             return tailerLsnOffset;
         }
 
+        /**
+         * Wall-clock timestamp (epoch ms) of the LogEntry at the tailer LSN.
+         * {@code 0} means "unknown" (no entries processed yet). Issue #423.
+         */
+        public long getTailerLsnTimestamp() {
+            return tailerLsnTimestamp;
+        }
+
         public long getDurableLsnLedger() {
             return durableLsnLedger;
         }
 
         public long getDurableLsnOffset() {
             return durableLsnOffset;
+        }
+
+        /**
+         * Wall-clock timestamp (epoch ms) of the LogEntry at the durable
+         * watermark LSN. {@code 0} means "unknown" (no successful checkpoint
+         * yet). Issue #423.
+         */
+        public long getDurableLsnTimestamp() {
+            return durableLsnTimestamp;
         }
 
         public String getStatus() {
@@ -3673,9 +3840,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // In-memory tailer position; diagnostic only. See IndexStatusInfo.
         public long tailerLsnLedger;
         public long tailerLsnOffset;
+        // Wall-clock (epoch ms) of the LogEntry at the tailer LSN; 0=unknown.
+        // Issue #423.
+        public long tailerLsnTimestamp;
         // Durable recovery LSN; the LSN the engine resumes from on restart.
         public long durableLsnLedger;
         public long durableLsnOffset;
+        // Wall-clock (epoch ms) of the LogEntry at the durable LSN; 0=unknown.
+        // Issue #423.
+        public long durableLsnTimestamp;
         public boolean fusedPQEnabled;
         public int m;
         public int beamWidth;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -239,8 +239,10 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setSegmentCount(info.getSegmentCount())
                     .setTailerLsnLedger(info.getTailerLsnLedger())
                     .setTailerLsnOffset(info.getTailerLsnOffset())
+                    .setTailerLsnTimestamp(info.getTailerLsnTimestamp())
                     .setDurableLsnLedger(info.getDurableLsnLedger())
                     .setDurableLsnOffset(info.getDurableLsnOffset())
+                    .setDurableLsnTimestamp(info.getDurableLsnTimestamp())
                     .setStatus(info.getStatus())
                     .setLoadingSegmentsDone(info.getLoadingSegmentsDone())
                     .setLoadingSegmentsTotal(info.getLoadingSegmentsTotal())
@@ -326,8 +328,10 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setDirty(details.dirty)
                     .setTailerLsnLedger(details.tailerLsnLedger)
                     .setTailerLsnOffset(details.tailerLsnOffset)
+                    .setTailerLsnTimestamp(details.tailerLsnTimestamp)
                     .setDurableLsnLedger(details.durableLsnLedger)
                     .setDurableLsnOffset(details.durableLsnOffset)
+                    .setDurableLsnTimestamp(details.durableLsnTimestamp)
                     .setFusedPqEnabled(details.fusedPQEnabled)
                     .setM(details.m)
                     .setBeamWidth(details.beamWidth)
@@ -518,7 +522,8 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setPrimaryAdvertisedOffset(advertised != null ? advertised.offset : -1L)
                     .setLastReloadTimestampMs(engine.getShadowLastReloadTimestampMs())
                     .setReloadCount(engine.getShadowReloadCount())
-                    .setAppliedIndexStatusGeneration(engine.getMinAppliedIndexStatusGeneration());
+                    .setAppliedIndexStatusGeneration(engine.getMinAppliedIndexStatusGeneration())
+                    .setLoadedEntryTimestampMs(engine.getShadowLoadedEntryTimestamp());
             responseObserver.onNext(b.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/LocalWatermarkStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/LocalWatermarkStore.java
@@ -46,6 +46,7 @@ import java.util.logging.Logger;
  *   long  ledgerId
  *   long  offset
  *   int   numInstances
+ *   long  lastEntryTimestamp   (LogEntry timestamp at lsn, ms epoch; 0=unknown)
  *   int   tableCount
  *   for each table:   int len, byte[len] serialised Table
  *   int   indexCount
@@ -91,6 +92,11 @@ public class LocalWatermarkStore implements WatermarkStore {
             long ledgerId = dis.readLong();
             long offset = dis.readLong();
             int numInstances = dis.readInt();
+            long lastEntryTimestamp = dis.readLong();
+            if (lastEntryTimestamp < 0L) {
+                throw new IOException("watermark file " + watermarkFile
+                        + " is corrupt: lastEntryTimestamp=" + lastEntryTimestamp);
+            }
 
             int tableCount = dis.readInt();
             if (tableCount < 0 || tableCount > MAX_TABLES_OR_INDEXES) {
@@ -127,6 +133,7 @@ public class LocalWatermarkStore implements WatermarkStore {
 
             WatermarkSnapshot snapshot = new WatermarkSnapshot(
                     new LogSequenceNumber(ledgerId, offset), numInstances,
+                    lastEntryTimestamp,
                     tables, vectorIndexes);
             LOGGER.info("Loaded watermark: " + snapshot);
             return snapshot;
@@ -144,6 +151,7 @@ public class LocalWatermarkStore implements WatermarkStore {
             dos.writeLong(snapshot.lsn.ledgerId);
             dos.writeLong(snapshot.lsn.offset);
             dos.writeInt(snapshot.numInstances);
+            dos.writeLong(snapshot.lastEntryTimestamp);
             // Schema snapshot: tables
             dos.writeInt(snapshot.tables.size());
             for (Table t : snapshot.tables) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/S3WatermarkStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/S3WatermarkStore.java
@@ -58,6 +58,7 @@ import java.util.logging.Logger;
  * <pre>
  *   version(VLong=1) | flags(VLong=0)
  *   ledgerId(ZLong) | offset(ZLong) | numInstances(VInt)
+ *   lastEntryTimestamp(ZLong)   (LogEntry timestamp at lsn, ms epoch; 0=unknown)
  *   tableCount(VInt)
  *   for each table:   VInt len, byte[len] serialised Table
  *   indexCount(VInt)
@@ -154,6 +155,12 @@ public class S3WatermarkStore implements WatermarkStore {
             long ledgerId = din.readZLong();
             long offset = din.readZLong();
             int numInstances = din.readVInt();
+            long lastEntryTimestamp = din.readZLong();
+            if (lastEntryTimestamp < 0L) {
+                throw new CorruptWatermarkException(
+                        "watermark object at " + path
+                                + " is corrupt: lastEntryTimestamp=" + lastEntryTimestamp);
+            }
 
             int tableCount = din.readVInt();
             if (tableCount < 0 || tableCount > MAX_TABLES_OR_INDEXES) {
@@ -192,6 +199,7 @@ public class S3WatermarkStore implements WatermarkStore {
 
             WatermarkSnapshot snapshot = new WatermarkSnapshot(
                     new LogSequenceNumber(ledgerId, offset), numInstances,
+                    lastEntryTimestamp,
                     tables, vectorIndexes);
             LOGGER.log(Level.INFO, "Loaded watermark from {0}: {1}", new Object[]{path, snapshot});
             return snapshot;
@@ -226,6 +234,7 @@ public class S3WatermarkStore implements WatermarkStore {
             dout.writeZLong(snapshot.lsn.ledgerId);
             dout.writeZLong(snapshot.lsn.offset);
             dout.writeVInt(snapshot.numInstances);
+            dout.writeZLong(snapshot.lastEntryTimestamp);
             // Schema snapshot: tables
             dout.writeVInt(snapshot.tables.size());
             for (Table t : snapshot.tables) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/WatermarkSnapshot.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/WatermarkSnapshot.java
@@ -83,6 +83,13 @@ public final class WatermarkSnapshot {
      * Issue #423: surfaced in {@code GetIndexStatus} as
      * {@code durable_lsn_timestamp} so dashboards can report
      * {@code durable_lag_ms = now - lastEntryTimestamp}.
+     *
+     * <p><b>Caveat:</b> {@link herddb.log.LogEntry#timestamp} is a
+     * wall-clock value stamped by whichever cluster writer produced the
+     * entry. Different writers may have skewed clocks, so this field is
+     * <em>not</em> guaranteed to grow monotonically between checkpoints
+     * when the tailer crosses a writer boundary. Use it as an indicative
+     * freshness signal, not as a monotonic clock.
      */
     public final long lastEntryTimestamp;
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/WatermarkSnapshot.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/WatermarkSnapshot.java
@@ -30,9 +30,10 @@ import java.util.Objects;
 /**
  * Immutable bundle of the durable indexing-service recovery state captured at
  * a successful checkpoint: the last applied {@link LogSequenceNumber}, the
- * engine's effective {@code numInstances} at that point, and a snapshot of the
- * schema ({@link Table} and vector {@link Index} definitions) tracked by the
- * engine's {@link SchemaTracker} at the time of the checkpoint.
+ * wall-clock timestamp of that {@link herddb.log.LogEntry}, the engine's
+ * effective {@code numInstances} at that point, and a snapshot of the schema
+ * ({@link Table} and vector {@link Index} definitions) tracked by the engine's
+ * {@link SchemaTracker} at the time of the checkpoint.
  *
  * <p>Persisting the schema alongside the watermark LSN ensures that a
  * restarting engine can hydrate its in-memory {@code SchemaTracker} from the
@@ -40,6 +41,12 @@ import java.util.Objects;
  * than {@code START_OF_TIME}), even when early ledgers containing the original
  * {@code CREATE_TABLE} / {@code CREATE_INDEX} entries have been trimmed from
  * BookKeeper by the server's retention policy.
+ *
+ * <p>Persisting {@link #lastEntryTimestamp} (issue #423) lets diagnostic
+ * tooling report the freshness of the durable state as
+ * {@code now - lastEntryTimestamp} (in milliseconds) — an operator-friendly
+ * complement to the LSN coordinates that does not require knowing the
+ * commit-log layout.
  *
  * @author enrico.olivelli
  */
@@ -51,9 +58,11 @@ public final class WatermarkSnapshot {
      * to fall back to its JVM-property bootstrap value. {@link #tables} and
      * {@link #vectorIndexes} are empty, telling the engine to start the tailer
      * from {@code START_OF_TIME} and rebuild its schema by replaying DDL entries.
+     * {@link #lastEntryTimestamp} is 0 ("unknown") so diagnostic consumers can
+     * treat it as "no freshness information yet".
      */
     public static final WatermarkSnapshot START_OF_TIME =
-            new WatermarkSnapshot(LogSequenceNumber.START_OF_TIME, 0,
+            new WatermarkSnapshot(LogSequenceNumber.START_OF_TIME, 0, 0L,
                     Collections.emptyList(), Collections.emptyList());
 
     public final LogSequenceNumber lsn;
@@ -67,12 +76,22 @@ public final class WatermarkSnapshot {
     public final int numInstances;
 
     /**
+     * Wall-clock timestamp (epoch ms) of the {@link herddb.log.LogEntry} at
+     * {@link #lsn} — i.e. the freshness of the durable recovery state at the
+     * moment this snapshot was published. {@code 0} means "unknown" and is
+     * used by {@link #START_OF_TIME} (no entries have been processed yet).
+     * Issue #423: surfaced in {@code GetIndexStatus} as
+     * {@code durable_lsn_timestamp} so dashboards can report
+     * {@code durable_lag_ms = now - lastEntryTimestamp}.
+     */
+    public final long lastEntryTimestamp;
+
+    /**
      * Snapshot of every {@link Table} tracked by the engine's
      * {@link SchemaTracker} at the time of the checkpoint. Empty when the
-     * snapshot was loaded from a pre-schema watermark file (old format or
-     * {@link #START_OF_TIME}). On a non-empty schema, the engine can skip
-     * replaying DDL entries from the commit log and start the tailer directly
-     * from {@link #lsn}.
+     * snapshot is {@link #START_OF_TIME}. On a non-empty schema, the engine
+     * can skip replaying DDL entries from the commit log and start the tailer
+     * directly from {@link #lsn}.
      */
     public final List<Table> tables;
 
@@ -84,29 +103,28 @@ public final class WatermarkSnapshot {
     public final List<Index> vectorIndexes;
 
     /**
-     * Legacy constructor — creates a snapshot with no schema (empty tables and
-     * vector-indexes lists). The engine will start the tailer from
-     * {@code START_OF_TIME} and rebuild its schema by replaying DDL entries.
-     */
-    public WatermarkSnapshot(LogSequenceNumber lsn, int numInstances) {
-        this(lsn, numInstances, Collections.emptyList(), Collections.emptyList());
-    }
-
-    /**
      * Full constructor — creates a snapshot with schema bundled.
      *
-     * @param lsn            last applied LSN covered by the checkpoint
-     * @param numInstances   effective routing fanout at checkpoint time
-     * @param tables         all tables tracked by {@link SchemaTracker}
-     * @param vectorIndexes  all vector indexes tracked by {@link SchemaTracker}
+     * @param lsn                last applied LSN covered by the checkpoint
+     * @param numInstances       effective routing fanout at checkpoint time
+     * @param lastEntryTimestamp wall-clock (epoch ms) of the LogEntry at {@code lsn},
+     *                           or {@code 0} when unknown
+     * @param tables             all tables tracked by {@link SchemaTracker}
+     * @param vectorIndexes      all vector indexes tracked by {@link SchemaTracker}
      */
     public WatermarkSnapshot(LogSequenceNumber lsn, int numInstances,
+                              long lastEntryTimestamp,
                               List<Table> tables, List<Index> vectorIndexes) {
         this.lsn = Objects.requireNonNull(lsn, "lsn");
         if (numInstances < 0) {
             throw new IllegalArgumentException("numInstances must be >= 0, got " + numInstances);
         }
+        if (lastEntryTimestamp < 0L) {
+            throw new IllegalArgumentException(
+                    "lastEntryTimestamp must be >= 0, got " + lastEntryTimestamp);
+        }
         this.numInstances = numInstances;
+        this.lastEntryTimestamp = lastEntryTimestamp;
         this.tables = Collections.unmodifiableList(
                 Objects.requireNonNull(tables, "tables"));
         this.vectorIndexes = Collections.unmodifiableList(
@@ -126,6 +144,7 @@ public final class WatermarkSnapshot {
     public String toString() {
         return "WatermarkSnapshot{lsn=" + lsn
                 + ", numInstances=" + numInstances
+                + ", lastEntryTimestamp=" + lastEntryTimestamp
                 + ", tables=" + tables.size()
                 + ", vectorIndexes=" + vectorIndexes.size()
                 + '}';
@@ -141,6 +160,7 @@ public final class WatermarkSnapshot {
         }
         WatermarkSnapshot that = (WatermarkSnapshot) o;
         return numInstances == that.numInstances
+                && lastEntryTimestamp == that.lastEntryTimestamp
                 && lsn.equals(that.lsn)
                 && tables.equals(that.tables)
                 && vectorIndexes.equals(that.vectorIndexes);
@@ -148,6 +168,6 @@ public final class WatermarkSnapshot {
 
     @Override
     public int hashCode() {
-        return Objects.hash(lsn, numInstances, tables, vectorIndexes);
+        return Objects.hash(lsn, numInstances, lastEntryTimestamp, tables, vectorIndexes);
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -300,19 +300,26 @@ public final class IndexingAdminCli {
                 m.put("segment_count", response.getSegmentCount());
                 m.put("tailer_lsn_ledger", response.getTailerLsnLedger());
                 m.put("tailer_lsn_offset", response.getTailerLsnOffset());
+                m.put("tailer_lsn_timestamp", response.getTailerLsnTimestamp());
+                m.put("tailer_lag_ms", computeLagMs(response.getTailerLsnTimestamp()));
                 m.put("durable_lsn_ledger", response.getDurableLsnLedger());
                 m.put("durable_lsn_offset", response.getDurableLsnOffset());
+                m.put("durable_lsn_timestamp", response.getDurableLsnTimestamp());
+                m.put("durable_lag_ms", computeLagMs(response.getDurableLsnTimestamp()));
                 m.put("status", response.getStatus());
                 out.println(JsonWriter.toJson(m));
             } else {
                 out.printf(Locale.ROOT,
-                        "vectors=%d segments=%d tailer_lsn=%d/%d durable_lsn=%d/%d status=%s%n",
+                        "vectors=%d segments=%d tailer_lsn=%d/%d tailer_lag_ms=%d "
+                                + "durable_lsn=%d/%d durable_lag_ms=%d status=%s%n",
                         response.getVectorCount(),
                         response.getSegmentCount(),
                         response.getTailerLsnLedger(),
                         response.getTailerLsnOffset(),
+                        computeLagMs(response.getTailerLsnTimestamp()),
                         response.getDurableLsnLedger(),
                         response.getDurableLsnOffset(),
+                        computeLagMs(response.getDurableLsnTimestamp()),
                         response.getStatus());
             }
         }
@@ -506,8 +513,12 @@ public final class IndexingAdminCli {
         m.put("dirty", r.getDirty());
         m.put("tailer_lsn_ledger", r.getTailerLsnLedger());
         m.put("tailer_lsn_offset", r.getTailerLsnOffset());
+        m.put("tailer_lsn_timestamp", r.getTailerLsnTimestamp());
+        m.put("tailer_lag_ms", computeLagMs(r.getTailerLsnTimestamp()));
         m.put("durable_lsn_ledger", r.getDurableLsnLedger());
         m.put("durable_lsn_offset", r.getDurableLsnOffset());
+        m.put("durable_lsn_timestamp", r.getDurableLsnTimestamp());
+        m.put("durable_lag_ms", computeLagMs(r.getDurableLsnTimestamp()));
         m.put("fused_pq_enabled", r.getFusedPqEnabled());
         m.put("m", r.getM());
         m.put("beam_width", r.getBeamWidth());
@@ -574,10 +585,12 @@ public final class IndexingAdminCli {
         out.printf(Locale.ROOT, "  dirty                 = %s%n", r.getDirty());
         out.printf(Locale.ROOT, "  fused_pq_enabled      = %s%n", r.getFusedPqEnabled());
         out.printf(Locale.ROOT, "  m / beam_width        = %d / %d%n", r.getM(), r.getBeamWidth());
-        out.printf(Locale.ROOT, "  tailer_lsn            = %d/%d%n",
-                r.getTailerLsnLedger(), r.getTailerLsnOffset());
-        out.printf(Locale.ROOT, "  durable_lsn           = %d/%d%n",
-                r.getDurableLsnLedger(), r.getDurableLsnOffset());
+        out.printf(Locale.ROOT, "  tailer_lsn            = %d/%d (lag_ms=%d)%n",
+                r.getTailerLsnLedger(), r.getTailerLsnOffset(),
+                computeLagMs(r.getTailerLsnTimestamp()));
+        out.printf(Locale.ROOT, "  durable_lsn           = %d/%d (lag_ms=%d)%n",
+                r.getDurableLsnLedger(), r.getDurableLsnOffset(),
+                computeLagMs(r.getDurableLsnTimestamp()));
         String phase = r.getCompactionPhase();
         if (phase != null && !phase.isEmpty() && !"idle".equals(phase)) {
             if ("uploading-segment".equals(phase)) {
@@ -686,6 +699,8 @@ public final class IndexingAdminCli {
                 payload.put("ready", resp.getReady());
                 payload.put("loaded_ledger_id", resp.getLoadedLedgerId());
                 payload.put("loaded_offset", resp.getLoadedOffset());
+                payload.put("loaded_entry_timestamp_ms", resp.getLoadedEntryTimestampMs());
+                payload.put("loaded_entry_lag_ms", computeLagMs(resp.getLoadedEntryTimestampMs()));
                 payload.put("primary_advertised_ledger_id", resp.getPrimaryAdvertisedLedgerId());
                 payload.put("primary_advertised_offset", resp.getPrimaryAdvertisedOffset());
                 payload.put("last_reload_timestamp_ms", resp.getLastReloadTimestampMs());
@@ -696,6 +711,8 @@ public final class IndexingAdminCli {
                 out.println("shadow_of=" + resp.getShadowOf());
                 out.println("ready=" + resp.getReady());
                 out.println("loaded_lsn=(" + resp.getLoadedLedgerId() + "," + resp.getLoadedOffset() + ")");
+                out.println("loaded_entry_timestamp_ms=" + resp.getLoadedEntryTimestampMs()
+                        + " (lag_ms=" + computeLagMs(resp.getLoadedEntryTimestampMs()) + ")");
                 out.println("primary_advertised_lsn=(" + resp.getPrimaryAdvertisedLedgerId()
                         + "," + resp.getPrimaryAdvertisedOffset() + ")");
                 out.println("reload_count=" + resp.getReloadCount());
@@ -741,5 +758,21 @@ public final class IndexingAdminCli {
             }
             return resp.getReached() ? 0 : 1;
         }
+    }
+
+    /**
+     * Returns the time-lag in milliseconds for a given LogEntry timestamp, or
+     * {@code -1} when {@code timestampMillis == 0} ("unknown" — no entries
+     * processed yet, or no checkpoint yet). Operators read this value as
+     * "how far behind real time the IS is", which is the operator-friendly
+     * complement to the LSN coordinates that does not require knowing the
+     * commit-log layout. Issue #423.
+     */
+    static long computeLagMs(long timestampMillis) {
+        if (timestampMillis <= 0L) {
+            return -1L;
+        }
+        long lag = System.currentTimeMillis() - timestampMillis;
+        return lag < 0L ? 0L : lag;
     }
 }

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -97,6 +97,14 @@ message GetIndexStatusResponse {
     // can use the ratio to estimate remaining recovery time.
     int32 loading_segments_done = 8;
     int32 loading_segments_total = 9;
+    // Wall-clock timestamp (epoch ms) of the LogEntry at the tailer LSN.
+    // Operators compute the tailer time-lag as `now - tailer_lsn_timestamp`.
+    // 0 means "unknown" (no entries processed yet). Issue #423.
+    int64 tailer_lsn_timestamp = 10;
+    // Wall-clock timestamp (epoch ms) of the LogEntry at the durable LSN.
+    // Operators compute the durable time-lag as `now - durable_lsn_timestamp`.
+    // 0 means "unknown" (no successful checkpoint yet). Issue #423.
+    int64 durable_lsn_timestamp = 11;
 }
 
 // ---- Diagnostic RPCs ----
@@ -167,6 +175,12 @@ message DescribeIndexResponse {
     // semantics as the matching field on GetIndexStatusResponse (issue #364).
     int64 durable_lsn_ledger = 26;
     int64 durable_lsn_offset = 27;
+    // Wall-clock timestamp (epoch ms) of the LogEntry at the tailer LSN.
+    // 0 = unknown. Issue #423.
+    int64 tailer_lsn_timestamp = 28;
+    // Wall-clock timestamp (epoch ms) of the LogEntry at the durable LSN.
+    // 0 = unknown. Issue #423.
+    int64 durable_lsn_timestamp = 29;
 }
 
 message ListPrimaryKeysRequest {
@@ -269,4 +283,11 @@ message GetShadowStatusResponse {
     // shadows to decide when compaction's pending-delete entries become
     // eligible for physical deletion. 0 when no vector store is loaded.
     int64 applied_index_status_generation = 10;
+    // Wall-clock timestamp (epoch ms) of the LogEntry at loaded_ledger_id /
+    // loaded_offset — the freshness of the data this shadow can serve. Picked
+    // up from the primary's advertised
+    // IndexingServiceCheckpointState.lastEntryTimestampMillis on every reload.
+    // Operators compute the shadow data-staleness as
+    // `now - loaded_entry_timestamp_ms`. 0 = unknown. Issue #423.
+    int64 loaded_entry_timestamp_ms = 11;
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/EnginePermanentGapClusterTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/EnginePermanentGapClusterTest.java
@@ -216,7 +216,7 @@ public class EnginePermanentGapClusterTest {
             Table table = buildTable();
             Index ix = buildVectorIndex();
             WatermarkSnapshot snapshot = new WatermarkSnapshot(
-                    watermarkLsn, 1,
+                    watermarkLsn, 1, 0L,
                     Collections.singletonList(table),
                     Collections.singletonList(ix));
             InMemoryWatermarkStore watermark = new InMemoryWatermarkStore(snapshot);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceClientLagTimestampsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceClientLagTimestampsTest.java
@@ -1,0 +1,178 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import herddb.index.vector.RemoteVectorIndexService;
+import herddb.indexing.proto.GetIndexStatusRequest;
+import herddb.indexing.proto.GetIndexStatusResponse;
+import herddb.indexing.proto.IndexingServiceGrpc;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Issue #423: wire-level test that
+ * {@link IndexingServiceClient#getIndexStatus(String, String, String)} maps
+ * the proto {@code tailer_lsn_timestamp} and {@code durable_lsn_timestamp}
+ * fields onto {@link RemoteVectorIndexService.IndexStatusInfo}.
+ *
+ * <p>An in-process gRPC server returns hand-crafted timestamps so the
+ * client-side mapping can be verified independently of the engine.
+ */
+public class IndexingServiceClientLagTimestampsTest {
+
+    private FakeServer fakeServer;
+
+    @Before
+    public void setUp() {
+        fakeServer = null;
+    }
+
+    @After
+    public void tearDown() throws InterruptedException {
+        if (fakeServer != null) {
+            fakeServer.close();
+        }
+    }
+
+    @Test
+    public void getIndexStatusCarriesTailerAndDurableTimestamps() throws Exception {
+        long tailerTs = 1_700_000_001_500L;
+        long durableTs = 1_699_999_999_000L;
+        StaticIndexStatusImpl impl = new StaticIndexStatusImpl(
+                /*tailerLedger*/ 70, /*tailerOffset*/ 200, tailerTs,
+                /*durableLedger*/ 50, /*durableOffset*/ 10, durableTs);
+        fakeServer = new FakeServer(impl);
+        fakeServer.start();
+
+        try (IndexingServiceClient client = IndexingServiceClient.fromAddresses(
+                Arrays.asList(fakeServer.address()), 5)) {
+            RemoteVectorIndexService.IndexStatusInfo info =
+                    client.getIndexStatus("ts", "t", "i");
+            assertEquals("tailer ledger", 70L, info.getTailerLsnLedger());
+            assertEquals("tailer offset", 200L, info.getTailerLsnOffset());
+            assertEquals("tailer timestamp must be carried over from the wire",
+                    tailerTs, info.getTailerLsnTimestamp());
+            assertEquals("durable ledger", 50L, info.getDurableLsnLedger());
+            assertEquals("durable offset", 10L, info.getDurableLsnOffset());
+            assertEquals("durable timestamp must be carried over from the wire",
+                    durableTs, info.getDurableLsnTimestamp());
+        }
+    }
+
+    /**
+     * When the IS has not yet seen any entry / not yet checkpointed, both
+     * timestamps must default to {@code 0} ("unknown") on the wire — the
+     * client must NOT re-interpret them.
+     */
+    @Test
+    public void getIndexStatusReportsZeroWhenServerHasNoTimestamps() throws Exception {
+        StaticIndexStatusImpl impl = new StaticIndexStatusImpl(
+                /*tailerLedger*/ -1, /*tailerOffset*/ -1, 0L,
+                /*durableLedger*/ -1, /*durableOffset*/ -1, 0L);
+        fakeServer = new FakeServer(impl);
+        fakeServer.start();
+
+        try (IndexingServiceClient client = IndexingServiceClient.fromAddresses(
+                Arrays.asList(fakeServer.address()), 5)) {
+            RemoteVectorIndexService.IndexStatusInfo info =
+                    client.getIndexStatus("ts", "t", "i");
+            assertEquals("tailer timestamp 0 = unknown",
+                    0L, info.getTailerLsnTimestamp());
+            assertEquals("durable timestamp 0 = unknown",
+                    0L, info.getDurableLsnTimestamp());
+        }
+    }
+
+    // -------------------- harness --------------------
+
+    /** Wraps an in-process gRPC server bound to a random TCP port. */
+    private static final class FakeServer implements AutoCloseable {
+        private final StaticIndexStatusImpl impl;
+        private Server server;
+
+        FakeServer(StaticIndexStatusImpl impl) {
+            this.impl = impl;
+        }
+
+        void start() throws IOException {
+            server = ServerBuilder.forPort(0).addService(impl).build().start();
+            assertNotNull(server);
+        }
+
+        String address() {
+            return "localhost:" + server.getPort();
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            if (server != null) {
+                server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private static final class StaticIndexStatusImpl
+            extends IndexingServiceGrpc.IndexingServiceImplBase {
+        private final long tailerLedger;
+        private final long tailerOffset;
+        private final long tailerTimestamp;
+        private final long durableLedger;
+        private final long durableOffset;
+        private final long durableTimestamp;
+
+        StaticIndexStatusImpl(long tailerLedger, long tailerOffset, long tailerTimestamp,
+                              long durableLedger, long durableOffset, long durableTimestamp) {
+            this.tailerLedger = tailerLedger;
+            this.tailerOffset = tailerOffset;
+            this.tailerTimestamp = tailerTimestamp;
+            this.durableLedger = durableLedger;
+            this.durableOffset = durableOffset;
+            this.durableTimestamp = durableTimestamp;
+        }
+
+        @Override
+        public void getIndexStatus(GetIndexStatusRequest request,
+                                    StreamObserver<GetIndexStatusResponse> responseObserver) {
+            GetIndexStatusResponse resp = GetIndexStatusResponse.newBuilder()
+                    .setVectorCount(0)
+                    .setSegmentCount(0)
+                    .setTailerLsnLedger(tailerLedger)
+                    .setTailerLsnOffset(tailerOffset)
+                    .setTailerLsnTimestamp(tailerTimestamp)
+                    .setDurableLsnLedger(durableLedger)
+                    .setDurableLsnOffset(durableOffset)
+                    .setDurableLsnTimestamp(durableTimestamp)
+                    .setStatus("static")
+                    .build();
+            responseObserver.onNext(resp);
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineLagTimestampsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineLagTimestampsTest.java
@@ -37,6 +37,7 @@ import herddb.model.Table;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
@@ -47,32 +48,26 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
- * Issue #364: the IS must publish its <em>durable</em> recovery LSN — the
- * LSN of the most recent checkpoint whose watermark has been persisted to
- * remote storage — so that the server's commit-log retention floor never
- * drops a ledger the IS would still need to replay on a restart. The
- * volatile in-memory tailer position ({@code lastProcessedLsn}) advances
- * on every applied entry and is therefore unsafe as a retention floor.
+ * Issue #423: the indexing-service engine reports the wall-clock timestamp of
+ * the last processed {@link LogEntry} (so dashboards can compute
+ * {@code now - timestamp = tailer_lag_ms}) and the timestamp at the durable
+ * watermark LSN (for {@code durable_lag_ms}).
  *
- * <p>This test exercises the engine end-to-end:
+ * <p>These tests cover:
  * <ol>
- *   <li>{@code lastDurableLsn} is initialized from the loaded
- *       {@link WatermarkSnapshot#lsn} on engine start.</li>
- *   <li>It does NOT advance simply because entries were applied — only the
- *       tailer position advances when a successful save has not yet
- *       happened.</li>
- *   <li>It DOES advance after a successful
- *       {@link IndexingServiceEngine#forceCheckpointAndSaveWatermark()}.</li>
- *   <li>If the watermark save fails (I/O error from the
- *       {@link WatermarkStore}), {@code lastDurableLsn} stays anchored at
- *       the previous durable value while {@code lastProcessedLsn} keeps
- *       advancing.</li>
- *   <li>{@code getIndexStatus(...)} reports both LSNs distinctly so the
- *       gRPC layer can serialize them as {@code tailer_lsn_*} and
- *       {@code durable_lsn_*}.</li>
+ *   <li>{@code lastProcessedEntryTimestamp} advances on every entry that flows
+ *       through the tailer's {@code processEntry} path.</li>
+ *   <li>{@code lastDurableEntryTimestamp} only moves after a successful
+ *       {@code forceCheckpointAndSaveWatermark()}.</li>
+ *   <li>It stays anchored at the previous durable value when the watermark
+ *       save fails — same invariant as the durable LSN itself.</li>
+ *   <li>Both timestamps are exposed via {@code getIndexStatus()}.</li>
+ *   <li>The persisted watermark snapshot carries the durable timestamp, so a
+ *       restarting engine re-hydrates {@code lastDurableEntryTimestamp} from
+ *       the snapshot rather than starting at 0.</li>
  * </ol>
  */
-public class IndexingServiceEngineDurableLsnTest {
+public class IndexingServiceEngineLagTimestampsTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -97,9 +92,8 @@ public class IndexingServiceEngineDurableLsnTest {
 
     /**
      * In-memory {@link WatermarkStore} whose {@code save()} can be flipped
-     * into a permanent failure mode: a single test can observe the engine's
-     * behaviour both when the save succeeds and when it fails, on the same
-     * engine instance.
+     * into a permanent failure mode. Mirrors the helper used in
+     * {@link IndexingServiceEngineDurableLsnTest}.
      */
     private static final class FailableWatermarkStore implements WatermarkStore {
         private final AtomicReference<WatermarkSnapshot> saved =
@@ -125,6 +119,10 @@ public class IndexingServiceEngineDurableLsnTest {
                 throw new IOException("simulated watermark save failure");
             }
             saved.set(snapshot);
+        }
+
+        synchronized WatermarkSnapshot peek() {
+            return saved.get();
         }
     }
 
@@ -153,11 +151,6 @@ public class IndexingServiceEngineDurableLsnTest {
         return v;
     }
 
-    /**
-     * Builds an engine with a real {@link PersistentVectorStore} factory
-     * and a custom {@link WatermarkStore}. Returns the engine ready to
-     * receive DDL.
-     */
     private IndexingServiceEngine buildEngine(WatermarkStore watermark) throws Exception {
         Path logDir = folder.newFolder("log").toPath();
         Path dataDir = folder.newFolder("data").toPath();
@@ -191,57 +184,45 @@ public class IndexingServiceEngineDurableLsnTest {
     }
 
     /**
-     * On a fresh engine (no persisted watermark), {@code lastDurableLsn} is
-     * {@link LogSequenceNumber#START_OF_TIME}. Applying entries advances
-     * the tailer position only — durable stays at START_OF_TIME until a
-     * checkpoint succeeds.
+     * The engine's tailer freshness clock must match the LogEntry timestamp
+     * fed into {@code processEntry}, and {@link IndexingServiceEngine.IndexStatusInfo}
+     * must surface both that and the durable freshness via the same accessor
+     * the gRPC layer reads.
      */
     @Test
-    public void freshEngineHasStartOfTimeDurableLsn() throws Exception {
+    public void tailerTimestampAdvancesViaProcessEntryAndIsExposedOnGetIndexStatus() throws Exception {
         FailableWatermarkStore watermark =
                 new FailableWatermarkStore(WatermarkSnapshot.START_OF_TIME);
         IndexingServiceEngine engine = buildEngine(watermark);
         try {
             engine.start();
-            assertEquals("fresh engine durable LSN must be START_OF_TIME",
-                    LogSequenceNumber.START_OF_TIME, engine.getLastDurableLsn());
-            assertEquals("tailer LSN must also start at START_OF_TIME",
-                    LogSequenceNumber.START_OF_TIME, engine.getLastProcessedLsn());
 
-            // Apply a few entries — tailer advances, durable does not.
+            assertEquals("fresh engine reports tailer timestamp as unknown (0)",
+                    0L, engine.getLastProcessedEntryTimestamp());
+
+            // Drive an entry through the same path as the live tailer
+            // (processEntryForTest -> processEntry).
             Table table = createTable();
-            engine.applyEntry(new LogSequenceNumber(1, 1),
-                    LogEntryFactory.createTable(table, null));
-            engine.setLastProcessedLsnForTest(new LogSequenceNumber(1, 1));
+            long entryTimestamp = 1_700_000_001_234L;
+            LogEntry create = LogEntryFactory.createTable(table, null);
+            // LogEntryFactory.createTable already stamps the timestamp from
+            // System.currentTimeMillis(); for a deterministic assertion we
+            // replace it with a hand-crafted one.
+            LogEntry stamped = new LogEntry(entryTimestamp,
+                    create.type, create.transactionId, create.tableId,
+                    create.key, create.value);
+            engine.processEntryForTest(new LogSequenceNumber(1, 1), stamped);
 
-            assertEquals("durable LSN must NOT advance just because the tailer applied entries",
-                    LogSequenceNumber.START_OF_TIME, engine.getLastDurableLsn());
-            assertEquals("tailer LSN must reflect the last applied entry",
-                    new LogSequenceNumber(1, 1), engine.getLastProcessedLsn());
-        } finally {
-            engine.close();
-        }
-    }
+            assertEquals("tailer timestamp must advance to the LogEntry timestamp",
+                    entryTimestamp, engine.getLastProcessedEntryTimestamp());
 
-    /**
-     * The engine resumes its durable LSN from the persisted snapshot — this
-     * is the recovery floor the server's retention pin must respect.
-     */
-    @Test
-    public void durableLsnRecoveredFromWatermarkSnapshot() throws Exception {
-        LogSequenceNumber persisted = new LogSequenceNumber(7, 113);
-        FailableWatermarkStore watermark =
-                new FailableWatermarkStore(new WatermarkSnapshot(persisted, 1,
-                        0L,
-                        java.util.Collections.emptyList(),
-                        java.util.Collections.emptyList()));
-        IndexingServiceEngine engine = buildEngine(watermark);
-        try {
-            engine.start();
-            assertEquals("durable LSN must equal the loaded watermark snapshot",
-                    persisted, engine.getLastDurableLsn());
-            assertEquals("tailer LSN is initialized from the same snapshot",
-                    persisted, engine.getLastProcessedLsn());
+            // And it must surface on getIndexStatus.
+            IndexingServiceEngine.IndexStatusInfo info =
+                    engine.getIndexStatus("local", "", "");
+            assertEquals("getIndexStatus.tailer_lsn_timestamp must match",
+                    entryTimestamp, info.getTailerLsnTimestamp());
+            assertEquals("getIndexStatus.durable_lsn_timestamp must still be 0 (no checkpoint)",
+                    0L, info.getDurableLsnTimestamp());
         } finally {
             engine.close();
         }
@@ -249,18 +230,18 @@ public class IndexingServiceEngineDurableLsnTest {
 
     /**
      * After a successful {@code forceCheckpointAndSaveWatermark()}, the
-     * durable LSN advances to match the captured checkpoint LSN — that
-     * value is now the safe recovery floor for the server.
+     * durable timestamp must advance to the timestamp captured at the same
+     * instant as the checkpoint LSN, and the persisted snapshot must carry
+     * it.
      */
     @Test
-    public void durableLsnAdvancesAfterSuccessfulCheckpoint() throws Exception {
+    public void durableTimestampAdvancesAfterSuccessfulCheckpoint() throws Exception {
         FailableWatermarkStore watermark =
                 new FailableWatermarkStore(WatermarkSnapshot.START_OF_TIME);
         IndexingServiceEngine engine = buildEngine(watermark);
         try {
             engine.start();
 
-            // Apply DDL and enough vectors that Phase B has work to do.
             Table table = createTable();
             engine.applyEntry(new LogSequenceNumber(1, 1),
                     LogEntryFactory.createTable(table, null));
@@ -273,7 +254,7 @@ public class IndexingServiceEngineDurableLsnTest {
             engine.applyEntry(new LogSequenceNumber(1, 2),
                     LogEntryFactory.createIndex(index, null));
 
-            Random rng = new Random(101);
+            Random rng = new Random(303);
             int numVectors = 256;
             int dim = 16;
             long baseLsn = 100;
@@ -289,30 +270,38 @@ public class IndexingServiceEngineDurableLsnTest {
             }
             engine.awaitPendingWorkForTest();
             engine.setLastProcessedLsnForTest(lastLsn);
+            // Pretend the very last LogEntry the tailer saw had this timestamp.
+            long lastEntryTs = 1_700_000_500_000L;
+            engine.setLastProcessedEntryTimestampForTest(lastEntryTs);
 
-            assertEquals("before checkpoint, durable still START_OF_TIME",
-                    LogSequenceNumber.START_OF_TIME, engine.getLastDurableLsn());
+            assertEquals("before checkpoint, durable timestamp still 0",
+                    0L, engine.getLastDurableEntryTimestamp());
 
             engine.forceCheckpointAndSaveWatermark();
 
-            assertEquals("durable LSN must advance to the checkpoint LSN",
-                    lastLsn, engine.getLastDurableLsn());
-            assertEquals("durable LSN equals tailer LSN once the checkpoint succeeds",
-                    engine.getLastProcessedLsn(), engine.getLastDurableLsn());
+            assertEquals("durable timestamp must advance to the captured value",
+                    lastEntryTs, engine.getLastDurableEntryTimestamp());
+            assertEquals("persisted watermark must carry the timestamp",
+                    lastEntryTs, watermark.peek().lastEntryTimestamp);
+            // Equally, getIndexStatus exposes both fields.
+            IndexingServiceEngine.IndexStatusInfo info =
+                    engine.getIndexStatus("local", "vectable", "vidx");
+            assertEquals("getIndexStatus.durable_lsn_timestamp",
+                    lastEntryTs, info.getDurableLsnTimestamp());
+            assertEquals("getIndexStatus.tailer_lsn_timestamp",
+                    lastEntryTs, info.getTailerLsnTimestamp());
         } finally {
             engine.close();
         }
     }
 
     /**
-     * Issue #364 core invariant: when {@code watermarkStore.save()} fails,
-     * the durable LSN must stay anchored at the previous durable value,
-     * even though the in-memory tailer position has advanced past the
-     * failed checkpoint LSN. The server's retention floor must never use
-     * the tailer position as a recovery point.
+     * Mirror of {@code durableLsnDoesNotAdvanceIfWatermarkSaveFails}: when the
+     * watermark save fails, the durable timestamp must stay anchored at the
+     * previous durable value even though the tailer timestamp has moved on.
      */
     @Test
-    public void durableLsnDoesNotAdvanceIfWatermarkSaveFails() throws Exception {
+    public void durableTimestampDoesNotAdvanceIfWatermarkSaveFails() throws Exception {
         FailableWatermarkStore watermark =
                 new FailableWatermarkStore(WatermarkSnapshot.START_OF_TIME);
         IndexingServiceEngine engine = buildEngine(watermark);
@@ -331,8 +320,8 @@ public class IndexingServiceEngineDurableLsnTest {
             engine.applyEntry(new LogSequenceNumber(1, 2),
                     LogEntryFactory.createIndex(index, null));
 
-            // First (successful) checkpoint — establishes a baseline durable LSN.
-            Random rng = new Random(202);
+            // First successful checkpoint establishes a baseline.
+            Random rng = new Random(404);
             int dim = 16;
             long baseLsn = 100;
             LogSequenceNumber firstLsn = null;
@@ -347,80 +336,65 @@ public class IndexingServiceEngineDurableLsnTest {
             }
             engine.awaitPendingWorkForTest();
             engine.setLastProcessedLsnForTest(firstLsn);
+            long firstTs = 1_700_000_100_000L;
+            engine.setLastProcessedEntryTimestampForTest(firstTs);
             engine.forceCheckpointAndSaveWatermark();
-            LogSequenceNumber baselineDurable = engine.getLastDurableLsn();
-            assertEquals("baseline durable LSN must equal first checkpoint LSN",
-                    firstLsn, baselineDurable);
+            assertEquals("baseline durable timestamp set", firstTs,
+                    engine.getLastDurableEntryTimestamp());
 
-            // Second batch of inserts — tailer advances past baseline.
+            // Now the second checkpoint will fail to save: the tailer
+            // timestamp keeps advancing, but the durable timestamp must NOT.
+            watermark.setFailOnNextSave(true);
             LogSequenceNumber secondLsn = null;
-            for (int i = 0; i < 200; i++) {
+            for (int i = 256; i < 384; i++) {
                 Record record = RecordSerializer.makeRecord(table,
-                        "pk", "k" + (1000 + i),
+                        "pk", "k" + i,
                         "vec", randomVector(rng, dim));
                 LogEntry insert =
                         LogEntryFactory.insert(table, record.key, record.value, null);
-                secondLsn = new LogSequenceNumber(2, i + 1);
+                secondLsn = new LogSequenceNumber(1, baseLsn + i);
                 engine.applySingleEntryForTest(secondLsn, insert);
             }
             engine.awaitPendingWorkForTest();
             engine.setLastProcessedLsnForTest(secondLsn);
-
-            // Second checkpoint with the watermark save failing — durable
-            // LSN must stay at the baseline, NOT advance to secondLsn.
-            watermark.setFailOnNextSave(true);
+            long secondTs = 1_700_000_200_000L;
+            engine.setLastProcessedEntryTimestampForTest(secondTs);
             engine.forceCheckpointAndSaveWatermark();
 
-            assertEquals("durable LSN must stay anchored when the save fails",
-                    baselineDurable, engine.getLastDurableLsn());
-            assertNotEquals(
-                    "tailer LSN has advanced past the durable LSN — exactly the "
-                            + "scenario where reporting tailer LSN to the server "
-                            + "would break recovery (issue #364)",
-                    engine.getLastProcessedLsn(), engine.getLastDurableLsn());
-            assertEquals("tailer reflects the last applied entry",
-                    secondLsn, engine.getLastProcessedLsn());
-
-            // Recover: the next save succeeds and the durable LSN catches up.
-            watermark.setFailOnNextSave(false);
-            engine.forceCheckpointAndSaveWatermark();
-            assertEquals("durable LSN catches up after the next successful save",
-                    secondLsn, engine.getLastDurableLsn());
+            assertEquals("durable timestamp must stay anchored at the previous durable value",
+                    firstTs, engine.getLastDurableEntryTimestamp());
+            assertNotEquals("tailer timestamp must have moved on",
+                    firstTs, engine.getLastProcessedEntryTimestamp());
+            assertEquals("tailer timestamp tracks the most recently processed entry",
+                    secondTs, engine.getLastProcessedEntryTimestamp());
         } finally {
             engine.close();
         }
     }
 
     /**
-     * Verifies {@link IndexingServiceEngine#getIndexStatus} carries the two
-     * LSNs as distinct fields — this is what the gRPC server then maps onto
-     * {@code tailer_lsn_*} and {@code durable_lsn_*} on the wire.
+     * Issue #423 + #364: a restarting engine must re-hydrate the durable
+     * freshness from the persisted watermark snapshot — otherwise dashboards
+     * would briefly show a "0 (unknown)" durable lag every time a pod
+     * restarts, even though the engine in fact recovers from a known
+     * checkpoint.
      */
     @Test
-    public void getIndexStatusReportsBothLsnsDistinctly() throws Exception {
-        FailableWatermarkStore watermark =
-                new FailableWatermarkStore(WatermarkSnapshot.START_OF_TIME);
+    public void durableTimestampRecoveredFromWatermarkSnapshot() throws Exception {
+        LogSequenceNumber persisted = new LogSequenceNumber(7, 113);
+        long persistedTs = 1_700_000_777_000L;
+        FailableWatermarkStore watermark = new FailableWatermarkStore(
+                new WatermarkSnapshot(persisted, 1, persistedTs,
+                        Collections.emptyList(), Collections.emptyList()));
         IndexingServiceEngine engine = buildEngine(watermark);
         try {
             engine.start();
-
-            Table table = createTable();
-            engine.applyEntry(new LogSequenceNumber(1, 1),
-                    LogEntryFactory.createTable(table, null));
-            engine.setLastProcessedLsnForTest(new LogSequenceNumber(5, 42));
-
-            IndexingServiceEngine.IndexStatusInfo info =
-                    engine.getIndexStatus("local", "", "");
-            assertEquals("tailer ledger from getIndexStatus",
-                    5, info.getTailerLsnLedger());
-            assertEquals("tailer offset from getIndexStatus",
-                    42, info.getTailerLsnOffset());
-            assertEquals("durable ledger from getIndexStatus is START_OF_TIME ledger (-1)",
-                    LogSequenceNumber.START_OF_TIME.ledgerId,
-                    info.getDurableLsnLedger());
-            assertEquals("durable offset from getIndexStatus is START_OF_TIME offset (-1)",
-                    LogSequenceNumber.START_OF_TIME.offset,
-                    info.getDurableLsnOffset());
+            assertEquals("durable timestamp re-hydrated from persisted snapshot",
+                    persistedTs, engine.getLastDurableEntryTimestamp());
+            // The tailer freshness is also pre-seeded so the very first
+            // GetIndexStatus after boot already carries a meaningful value.
+            assertEquals("tailer timestamp pre-seeded from persisted snapshot",
+                    persistedTs, engine.getLastProcessedEntryTimestamp());
         } finally {
             engine.close();
         }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineLagTimestampsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineLagTimestampsTest.java
@@ -373,6 +373,55 @@ public class IndexingServiceEngineLagTimestampsTest {
     }
 
     /**
+     * The {@code entry.timestamp > 0} guard inside
+     * {@code processEntry()} must skip the volatile write when an entry
+     * carries an unknown ({@code 0}) or negative timestamp, so the previous
+     * "best known freshness" is preserved instead of silently regressing
+     * to 0 / unknown. Without this guard, a single test fixture or a
+     * historical entry with a missing timestamp would briefly clobber the
+     * lag dashboard.
+     */
+    @Test
+    public void tailerTimestampLeavesPriorValueWhenEntryTimestampIsZero() throws Exception {
+        FailableWatermarkStore watermark =
+                new FailableWatermarkStore(WatermarkSnapshot.START_OF_TIME);
+        IndexingServiceEngine engine = buildEngine(watermark);
+        try {
+            engine.start();
+
+            Table table = createTable();
+            // First, a normal entry with a real timestamp.
+            long realTs = 1_700_000_010_000L;
+            LogEntry create = LogEntryFactory.createTable(table, null);
+            LogEntry stamped = new LogEntry(realTs,
+                    create.type, create.transactionId, create.tableId,
+                    create.key, create.value);
+            engine.processEntryForTest(new LogSequenceNumber(1, 1), stamped);
+            assertEquals("real timestamp recorded",
+                    realTs, engine.getLastProcessedEntryTimestamp());
+
+            // Now replay an entry with timestamp=0 (synthetic / pre-#423
+            // replay). The engine must NOT regress the freshness clock.
+            LogEntry zeroStamped = new LogEntry(0L,
+                    create.type, create.transactionId, create.tableId,
+                    create.key, create.value);
+            engine.processEntryForTest(new LogSequenceNumber(1, 2), zeroStamped);
+            assertEquals("timestamp=0 must NOT clobber prior freshness",
+                    realTs, engine.getLastProcessedEntryTimestamp());
+
+            // Same for a negative timestamp (defense-in-depth).
+            LogEntry negStamped = new LogEntry(-5L,
+                    create.type, create.transactionId, create.tableId,
+                    create.key, create.value);
+            engine.processEntryForTest(new LogSequenceNumber(1, 3), negStamped);
+            assertEquals("negative timestamp must NOT clobber prior freshness",
+                    realTs, engine.getLastProcessedEntryTimestamp());
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
      * Issue #423 + #364: a restarting engine must re-hydrate the durable
      * freshness from the persisted watermark snapshot — otherwise dashboards
      * would briefly show a "0 (unknown)" durable lag every time a pod

--- a/herddb-indexing-service/src/test/java/herddb/indexing/JoiningRestartTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/JoiningRestartTest.java
@@ -374,7 +374,7 @@ public class JoiningRestartTest {
         // pod once managed to save schema, but then it was hard-reset and
         // is now coming up as a fresh JOINING pod.
         InMemoryWatermarkStore watermark = new InMemoryWatermarkStore();
-        watermark.save(new WatermarkSnapshot(new LogSequenceNumber(99, 99), 1,
+        watermark.save(new WatermarkSnapshot(new LogSequenceNumber(99, 99), 1, 0L,
                 Collections.singletonList(buildTable()),
                 Collections.singletonList(buildVectorIndex(2))));
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/RebalanceChangesRoutingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/RebalanceChangesRoutingTest.java
@@ -744,7 +744,9 @@ public class RebalanceChangesRoutingTest {
         WatermarkStore zeroStore = new WatermarkStore() {
             @Override
             public WatermarkSnapshot load() {
-                return new WatermarkSnapshot(new LogSequenceNumber(1, 5), 0);
+                return new WatermarkSnapshot(new LogSequenceNumber(1, 5), 0, 0L,
+                        java.util.Collections.emptyList(),
+                        java.util.Collections.emptyList());
             }
 
             @Override

--- a/herddb-indexing-service/src/test/java/herddb/indexing/RestartUnreachableStartOfTimeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/RestartUnreachableStartOfTimeTest.java
@@ -161,7 +161,7 @@ public class RestartUnreachableStartOfTimeTest {
         // Watermark LSN that points well past the (notional) trimmed start.
         LogSequenceNumber watermarkLsn = new LogSequenceNumber(7, 1000);
         WatermarkSnapshot snapshot = new WatermarkSnapshot(
-                watermarkLsn, 1,
+                watermarkLsn, 1, 0L,
                 Collections.singletonList(table),
                 Collections.singletonList(index));
         PreloadedWatermarkStore watermark = new PreloadedWatermarkStore(snapshot);
@@ -296,7 +296,7 @@ public class RestartUnreachableStartOfTimeTest {
         // with schema present.
         LogSequenceNumber watermarkLsn = new LogSequenceNumber(5, 500);
         WatermarkSnapshot snapshot = new WatermarkSnapshot(
-                watermarkLsn, 1,
+                watermarkLsn, 1, 0L,
                 Collections.singletonList(table),
                 Collections.singletonList(index));
         PreloadedWatermarkStore watermark = new PreloadedWatermarkStore(snapshot);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/S3WatermarkStoreTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/S3WatermarkStoreTest.java
@@ -103,13 +103,19 @@ public class S3WatermarkStoreTest {
         FakeRemoteFileIO io = new FakeRemoteFileIO();
         S3WatermarkStore store = new S3WatermarkStore(io, "ts-uuid", 0);
 
-        WatermarkSnapshot saved = new WatermarkSnapshot(new LogSequenceNumber(42L, 7L), 4);
+        WatermarkSnapshot saved = new WatermarkSnapshot(
+                new LogSequenceNumber(42L, 7L), 4, 1_700_000_000_500L,
+                Collections.emptyList(), Collections.emptyList());
         store.save(saved);
 
         WatermarkSnapshot loaded = store.load();
         assertEquals(saved.lsn.ledgerId, loaded.lsn.ledgerId);
         assertEquals(saved.lsn.offset, loaded.lsn.offset);
         assertEquals(saved.numInstances, loaded.numInstances);
+        // Issue #423: lastEntryTimestamp must round-trip through the
+        // S3 binary format (covered by the XXHash64 footer).
+        assertEquals("lastEntryTimestamp must round-trip",
+                saved.lastEntryTimestamp, loaded.lastEntryTimestamp);
     }
 
     @Test
@@ -124,11 +130,13 @@ public class S3WatermarkStoreTest {
         FakeRemoteFileIO io = new FakeRemoteFileIO();
         S3WatermarkStore store = new S3WatermarkStore(io, "ts-uuid", 0);
 
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(5L, 100L), 2));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(5L, 100L), 2, 0L,
+                Collections.emptyList(), Collections.emptyList()));
         byte[] persisted = io.store.get(store.getPath());
 
         // Attempt to save an older LSN — should be a no-op.
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(5L, 50L), 4));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(5L, 50L), 4, 0L,
+                Collections.emptyList(), Collections.emptyList()));
         assertArrayEquals("older save must not overwrite",
                 persisted, io.store.get(store.getPath()));
 
@@ -139,7 +147,8 @@ public class S3WatermarkStoreTest {
         assertEquals(2, loaded.numInstances);
 
         // A newer save goes through.
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(5L, 200L), 4));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(5L, 200L), 4, 0L,
+                Collections.emptyList(), Collections.emptyList()));
         loaded = store.load();
         assertEquals(200L, loaded.lsn.offset);
         assertEquals(4, loaded.numInstances);
@@ -150,7 +159,8 @@ public class S3WatermarkStoreTest {
         FakeRemoteFileIO io = new FakeRemoteFileIO();
         S3WatermarkStore store = new S3WatermarkStore(io, "ts-uuid", 0);
 
-        WatermarkSnapshot snap = new WatermarkSnapshot(new LogSequenceNumber(1L, 1L), 1);
+        WatermarkSnapshot snap = new WatermarkSnapshot(new LogSequenceNumber(1L, 1L), 1, 0L,
+                Collections.emptyList(), Collections.emptyList());
         store.save(snap);
         store.save(snap);
         // Both saves happened — monotonicity allows equal LSN.
@@ -163,7 +173,8 @@ public class S3WatermarkStoreTest {
         FakeRemoteFileIO io = new FakeRemoteFileIO();
         S3WatermarkStore store = new S3WatermarkStore(io, "ts-uuid", 0);
 
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(7L, 99L), 1));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(7L, 99L), 1, 0L,
+                Collections.emptyList(), Collections.emptyList()));
         byte[] data = io.store.get(store.getPath());
         // Flip a byte in the payload (not the XXHash footer) — integrity check must catch.
         data[0] ^= 0x55;
@@ -187,7 +198,8 @@ public class S3WatermarkStoreTest {
         // Seed a corrupt object.
         io.store.put(store.getPath(), new byte[]{9, 9, 9});
         // Writing over it must succeed (corrupt current value does not block saves).
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(3L, 3L), 1));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(3L, 3L), 1, 0L,
+                Collections.emptyList(), Collections.emptyList()));
         assertEquals(3L, store.load().lsn.offset);
     }
 
@@ -206,7 +218,8 @@ public class S3WatermarkStoreTest {
         io.failNextWrite = true;
         S3WatermarkStore store = new S3WatermarkStore(io, "ts-uuid", 0);
         IOException ex = assertThrows(IOException.class,
-                () -> store.save(new WatermarkSnapshot(new LogSequenceNumber(1L, 1L), 1)));
+                () -> store.save(new WatermarkSnapshot(new LogSequenceNumber(1L, 1L), 1, 0L,
+                        Collections.emptyList(), Collections.emptyList())));
         assertTrue(ex.getMessage().contains("watermark"));
         // No object was written.
         assertNull(io.store.get(store.getPath()));
@@ -229,7 +242,7 @@ public class S3WatermarkStoreTest {
         Index ix = buildVectorIndex("vidx1", "tbl1");
 
         WatermarkSnapshot saved = new WatermarkSnapshot(
-                new LogSequenceNumber(5L, 300L), 2,
+                new LogSequenceNumber(5L, 300L), 2, 0L,
                 Arrays.asList(t), Arrays.asList(ix));
         store.save(saved);
 
@@ -259,7 +272,7 @@ public class S3WatermarkStoreTest {
         Index ix2 = buildVectorIndex("i2", "tb");
 
         WatermarkSnapshot saved = new WatermarkSnapshot(
-                new LogSequenceNumber(3L, 77L), 4,
+                new LogSequenceNumber(3L, 77L), 4, 0L,
                 Arrays.asList(t1, t2), Arrays.asList(ix1, ix2));
         store.save(saved);
 
@@ -285,7 +298,7 @@ public class S3WatermarkStoreTest {
         Table t = buildTable("mytable");
         Index ix = buildVectorIndex("myidx", "mytable");
         store.save(new WatermarkSnapshot(
-                new LogSequenceNumber(1L, 1L), 1,
+                new LogSequenceNumber(1L, 1L), 1, 0L,
                 Arrays.asList(t), Arrays.asList(ix)));
 
         byte[] data = io.store.get(store.getPath());
@@ -312,13 +325,13 @@ public class S3WatermarkStoreTest {
         Table t1 = buildTable("first");
         Index ix1 = buildVectorIndex("idx1", "first");
         store.save(new WatermarkSnapshot(
-                new LogSequenceNumber(1L, 100L), 1,
+                new LogSequenceNumber(1L, 100L), 1, 0L,
                 Collections.singletonList(t1), Collections.singletonList(ix1)));
 
         // Attempt to regress — must be rejected.
         Table t2 = buildTable("second");
         store.save(new WatermarkSnapshot(
-                new LogSequenceNumber(1L, 50L), 2,
+                new LogSequenceNumber(1L, 50L), 2, 0L,
                 Collections.singletonList(t2), Collections.emptyList()));
 
         WatermarkSnapshot loaded = store.load();
@@ -328,7 +341,7 @@ public class S3WatermarkStoreTest {
         // Advance LSN — must go through.
         Table t3 = buildTable("third");
         store.save(new WatermarkSnapshot(
-                new LogSequenceNumber(1L, 200L), 1,
+                new LogSequenceNumber(1L, 200L), 1, 0L,
                 Collections.singletonList(t3), Collections.emptyList()));
         loaded = store.load();
         assertEquals("advanced table name", "third", loaded.tables.get(0).name);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/ShadowAcrossRebalanceTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/ShadowAcrossRebalanceTest.java
@@ -325,7 +325,8 @@ public class ShadowAcrossRebalanceTest {
             // fire and the shadow's reload count must advance.
             metadata.publishIndexingServiceCheckpointState(
                     new IndexingServiceCheckpointState(99, 7L, 42L, 0,
-                            System.currentTimeMillis()));
+                            System.currentTimeMillis(),
+                            System.currentTimeMillis() - 100));
 
             long deadline = System.currentTimeMillis() + 5000;
             while (shadow.getShadowReloadCount() <= beforeReloads

--- a/herddb-indexing-service/src/test/java/herddb/indexing/ShadowLoadedEntryTimestampTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/ShadowLoadedEntryTimestampTest.java
@@ -291,4 +291,148 @@ public class ShadowLoadedEntryTimestampTest {
             primary.close();
         }
     }
+
+    /**
+     * Issue #423: when the primary publishes a new state but the matching
+     * IndexStatus bytes have NOT been re-written on disk (e.g. write
+     * failure between the IndexStatus upload and the ZK publish, or a
+     * test scenario where the shadow can only see stale segments), the
+     * shadow must still propagate the primary's advertised timestamp
+     * after a successful reload pass — operators care about "how stale
+     * is the freshest data this primary acknowledged?" more than they
+     * care about whether the IndexStatus has rolled over yet.
+     *
+     * <p>This test asserts the simpler half of that contract: after a
+     * watch event followed by a successful reload, the shadow's freshness
+     * matches the primary's advertised timestamp regardless of whether
+     * the reload actually loaded new bytes. Combined with the
+     * watch-callback-only-updates-LSN invariant (verified by code
+     * inspection — the callback at
+     * {@code IndexingServiceEngine#startAsShadow} explicitly does NOT
+     * touch {@code shadowLoadedEntryTimestamp}), this lets shadows
+     * surface a meaningful freshness signal without reintroducing the
+     * reload-window inconsistency the original reviewer flagged.
+     */
+    @Test
+    public void watchEventThenReloadPropagatesPrimaryTimestamp() throws Exception {
+        ShadowAwareMemoryMetadata metadata = new ShadowAwareMemoryMetadata();
+        metadata.start();
+        metadata.ensureDefaultTableSpace("local", "local", 0, 1);
+
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        // --- Build a primary that publishes one checkpoint, then a shadow.
+        Path primaryLogDir = folder.newFolder("primary-log").toPath();
+        Path primaryDataDir = folder.newFolder("primary-data").toPath();
+        Properties primaryProps = new Properties();
+        primaryProps.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        IndexingServerConfiguration primaryConfig = new IndexingServerConfiguration(primaryProps);
+        IndexingServiceEngine primary = new IndexingServiceEngine(
+                primaryLogDir, primaryDataDir, primaryConfig);
+        primary.setMetadataStorageManager(metadata);
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        final String stableUuid = "shadow-no-advance-uuid";
+        primary.setVectorStoreFactory((indexName, tableName, vectorColumnName,
+                                        dataDir, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, primary.getTableSpaceUUID(), vectorColumnName,
+                    stableUuid, dataDir, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE,
+                    VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return pvs;
+        });
+        primary.start();
+
+        Table t = createTable();
+        primary.applyEntry(new LogSequenceNumber(1, 1), LogEntryFactory.createTable(t, null));
+        Index idx = createIndex(stableUuid);
+        primary.applyEntry(new LogSequenceNumber(1, 2), LogEntryFactory.createIndex(idx, null));
+
+        Random rng = new Random(11);
+        int dim = 16;
+        LogSequenceNumber lastLsn = null;
+        for (int i = 0; i < 256; i++) {
+            Record r = RecordSerializer.makeRecord(t,
+                    "pk", "k" + i, "vec", randomVector(rng, dim));
+            LogEntry ins = LogEntryFactory.insert(t, r.key, r.value, null);
+            lastLsn = new LogSequenceNumber(1, 100 + i);
+            primary.applySingleEntryForTest(lastLsn, ins);
+        }
+        primary.awaitPendingWorkForTest();
+        primary.setLastProcessedLsnForTest(lastLsn);
+        long firstTs = 1_700_000_100_000L;
+        primary.setLastProcessedEntryTimestampForTest(firstTs);
+        primary.forceCheckpointAndSaveWatermark();
+
+        dsm.writeTables(
+                primary.getTableSpaceUUID(), LogSequenceNumber.START_OF_TIME,
+                java.util.Arrays.asList(t),
+                java.util.Arrays.asList(idx), false);
+
+        // --- Boot a shadow on the same DSM.
+        Path shadowLogDir = folder.newFolder("shadow-log").toPath();
+        Path shadowDataDir = folder.newFolder("shadow-data").toPath();
+        Properties shadowProps = new Properties();
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_ROLE,
+                IndexingServerConfiguration.ROLE_SHADOW);
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_SHADOW_OF, "0");
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_NUM_INSTANCES, "1");
+        IndexingServerConfiguration shadowConfig = new IndexingServerConfiguration(shadowProps);
+        IndexingServiceEngine shadow = new IndexingServiceEngine(
+                shadowLogDir, shadowDataDir, shadowConfig);
+        shadow.setMetadataStorageManager(metadata);
+        shadow.setDataStorageManager(dsm);
+        shadow.setMemoryManager(mm);
+
+        try {
+            shadow.start();
+            assertTrue("shadow ready after initial reload", shadow.isShadowReady());
+            assertEquals("shadow's initial freshness must match the primary's first checkpoint",
+                    firstTs, shadow.getShadowLoadedEntryTimestamp());
+            LogSequenceNumber loadedAfterFirst = shadow.getShadowLoadedLsn();
+            assertNotNull(loadedAfterFirst);
+
+            // --- The primary publishes a NEW state advertising a higher
+            // timestamp. We do NOT write any new IndexStatus bytes to
+            // the DSM. The shadow's reload runs, reads the ORIGINAL
+            // IndexStatus, but the post-reload write inside
+            // doShadowReload() refreshes shadowLoadedEntryTimestamp from
+            // the primary's currently-advertised state — picking up the
+            // new timestamp.
+            long futureTs = firstTs + 60_000L;
+            metadata.publishIndexingServiceCheckpointState(
+                    new herddb.metadata.IndexingServiceCheckpointState(
+                            0,
+                            loadedAfterFirst.ledgerId,
+                            loadedAfterFirst.offset + 1000L,
+                            1,
+                            System.currentTimeMillis(),
+                            futureTs));
+
+            // Wait for the reload to have processed the watch event.
+            long beforeReloads = 1L;
+            long deadline = System.currentTimeMillis() + 5_000L;
+            while (shadow.getShadowReloadCount() <= beforeReloads
+                    && System.currentTimeMillis() < deadline) {
+                Thread.sleep(20);
+            }
+            assertTrue("shadow reload must have processed the watch event",
+                    shadow.getShadowReloadCount() > beforeReloads);
+
+            // After the reload, shadow freshness must match the primary's
+            // latest advertised timestamp.
+            assertEquals("shadowLoadedEntryTimestamp must match primary's advertised value",
+                    futureTs, shadow.getShadowLoadedEntryTimestamp());
+        } finally {
+            shadow.close();
+            primary.close();
+        }
+    }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/ShadowLoadedEntryTimestampTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/ShadowLoadedEntryTimestampTest.java
@@ -1,0 +1,294 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.codec.RecordSerializer;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.metadata.IndexingServiceCheckpointState;
+import herddb.metadata.MetadataStorageManagerException;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #423: a shadow replica must surface the freshness of the data it can
+ * serve. The primary publishes
+ * {@link IndexingServiceCheckpointState#getLastEntryTimestampMillis()} after
+ * every successful checkpoint; the shadow picks it up on every reload and
+ * exposes it via {@link IndexingServiceEngine#getShadowLoadedEntryTimestamp()}
+ * (and, downstream, {@code GetShadowStatus.loaded_entry_timestamp_ms}).
+ *
+ * <p>This is the "freshness for shadows" half of the feature, complementing
+ * the primary-side coverage in {@link IndexingServiceEngineLagTimestampsTest}.
+ */
+public class ShadowLoadedEntryTimestampTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private int savedMinLive;
+    private long savedDeferral;
+
+    @Before
+    public void saveGateState() {
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        savedDeferral = PersistentVectorStore.maxCheckpointDeferralMs;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreGateState() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+        PersistentVectorStore.maxCheckpointDeferralMs = savedDeferral;
+    }
+
+    /**
+     * In-memory metadata manager identical to the one used by
+     * {@link ShadowReloadTest}: stores per-instance checkpoint state and
+     * fires registered watchers on every publish.
+     */
+    private static final class ShadowAwareMemoryMetadata extends MemoryMetadataStorageManager {
+        final java.util.Map<Integer, IndexingServiceCheckpointState> state = new java.util.HashMap<>();
+        final java.util.Map<Integer, List<Consumer<IndexingServiceCheckpointState>>> watchers =
+                new java.util.HashMap<>();
+
+        @Override
+        public synchronized void publishIndexingServiceCheckpointState(
+                IndexingServiceCheckpointState s)
+                throws MetadataStorageManagerException {
+            state.put(s.getInstanceId(), s);
+            List<Consumer<IndexingServiceCheckpointState>> cbs = watchers.get(s.getInstanceId());
+            if (cbs != null) {
+                for (Consumer<IndexingServiceCheckpointState> cb : cbs) {
+                    try {
+                        cb.accept(s);
+                    } catch (Exception ignored) {
+                        // test-only stub
+                    }
+                }
+            }
+        }
+
+        @Override
+        public synchronized IndexingServiceCheckpointState getIndexingServiceCheckpointState(
+                int instanceId) throws MetadataStorageManagerException {
+            return state.get(instanceId);
+        }
+
+        @Override
+        public synchronized void watchIndexingServiceCheckpointState(
+                int instanceId, Consumer<IndexingServiceCheckpointState> callback)
+                throws MetadataStorageManagerException {
+            watchers.computeIfAbsent(instanceId, k -> new ArrayList<>()).add(callback);
+        }
+    }
+
+    private static Table createTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private static Index createIndex(String uuid) {
+        return Index.builder()
+                .name("vidx")
+                .uuid(uuid)
+                .table("vectable")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    private static float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * End-to-end: run a primary engine that processes a hand-crafted
+     * timestamp-stamped LogEntry, force a checkpoint (so the primary
+     * publishes its checkpoint state with the LogEntry timestamp), and then
+     * verify a shadow attached to the same DSM/metadata picks up the
+     * timestamp on reload and surfaces it via
+     * {@link IndexingServiceEngine#getShadowLoadedEntryTimestamp()}.
+     */
+    @Test
+    public void shadowReportsLastEntryTimestampPublishedByPrimary() throws Exception {
+        ShadowAwareMemoryMetadata metadata = new ShadowAwareMemoryMetadata();
+        metadata.start();
+        metadata.ensureDefaultTableSpace("local", "local", 0, 1);
+
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        // --- Primary side
+        Path primaryLogDir = folder.newFolder("primary-log").toPath();
+        Path primaryDataDir = folder.newFolder("primary-data").toPath();
+        Properties primaryProps = new Properties();
+        primaryProps.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        IndexingServerConfiguration primaryConfig = new IndexingServerConfiguration(primaryProps);
+        IndexingServiceEngine primary = new IndexingServiceEngine(
+                primaryLogDir, primaryDataDir, primaryConfig);
+        primary.setMetadataStorageManager(metadata);
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        AtomicReference<PersistentVectorStore> primaryStoreRef = new AtomicReference<>();
+        final String stableUuid = "shadow-lag-test-uuid";
+        primary.setVectorStoreFactory((indexName, tableName, vectorColumnName,
+                                        dataDir, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, primary.getTableSpaceUUID(), vectorColumnName,
+                    stableUuid, dataDir, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE,
+                    VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            primaryStoreRef.set(pvs);
+            return pvs;
+        });
+        primary.start();
+
+        Table t = createTable();
+        primary.applyEntry(new LogSequenceNumber(1, 1), LogEntryFactory.createTable(t, null));
+        Index idx = createIndex(stableUuid);
+        primary.applyEntry(new LogSequenceNumber(1, 2), LogEntryFactory.createIndex(idx, null));
+
+        Random rng = new Random(7);
+        int dim = 16;
+        LogSequenceNumber lastLsn = null;
+        for (int i = 0; i < 256; i++) {
+            Record r = RecordSerializer.makeRecord(t,
+                    "pk", "k" + i, "vec", randomVector(rng, dim));
+            LogEntry ins = LogEntryFactory.insert(t, r.key, r.value, null);
+            lastLsn = new LogSequenceNumber(1, 100 + i);
+            primary.applySingleEntryForTest(lastLsn, ins);
+        }
+        primary.awaitPendingWorkForTest();
+        primary.setLastProcessedLsnForTest(lastLsn);
+        // Pretend the primary's most recently processed LogEntry carries
+        // this hand-crafted timestamp. The checkpoint must propagate it
+        // through the WatermarkSnapshot AND through
+        // IndexingServiceCheckpointState (issue #423).
+        long primaryEntryTs = 1_700_000_321_000L;
+        primary.setLastProcessedEntryTimestampForTest(primaryEntryTs);
+        primary.forceCheckpointAndSaveWatermark();
+
+        IndexingServiceCheckpointState published =
+                metadata.getIndexingServiceCheckpointState(0);
+        assertNotNull("primary must publish checkpoint state", published);
+        assertEquals("checkpoint state must carry the LogEntry timestamp",
+                primaryEntryTs, published.getLastEntryTimestampMillis());
+
+        // Hydrate the DSM with table/index defs so the shadow's
+        // loadIndexes-driven discovery succeeds (same trick as ShadowReloadTest).
+        dsm.writeTables(
+                primary.getTableSpaceUUID(), LogSequenceNumber.START_OF_TIME,
+                java.util.Arrays.asList(t),
+                java.util.Arrays.asList(idx), false);
+
+        // --- Shadow side
+        Path shadowLogDir = folder.newFolder("shadow-log").toPath();
+        Path shadowDataDir = folder.newFolder("shadow-data").toPath();
+        Properties shadowProps = new Properties();
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_ROLE,
+                IndexingServerConfiguration.ROLE_SHADOW);
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_SHADOW_OF, "0");
+        shadowProps.setProperty(IndexingServerConfiguration.PROPERTY_NUM_INSTANCES, "1");
+        IndexingServerConfiguration shadowConfig = new IndexingServerConfiguration(shadowProps);
+        IndexingServiceEngine shadow = new IndexingServiceEngine(
+                shadowLogDir, shadowDataDir, shadowConfig);
+        shadow.setMetadataStorageManager(metadata);
+        shadow.setDataStorageManager(dsm);
+        shadow.setMemoryManager(mm);
+
+        try {
+            shadow.start();
+            assertTrue("shadow must become ready after initial reload", shadow.isShadowReady());
+            assertNotNull(shadow.getShadowLoadedLsn());
+            assertEquals("shadow must surface the primary's advertised LogEntry timestamp",
+                    primaryEntryTs, shadow.getShadowLoadedEntryTimestamp());
+
+            // Drive a second checkpoint with a NEW timestamp — the watcher
+            // chain must fire on the shadow side and the freshness must
+            // advance.
+            for (int i = 0; i < 64; i++) {
+                Record r = RecordSerializer.makeRecord(t,
+                        "pk", "k" + (256 + i), "vec", randomVector(rng, dim));
+                LogEntry ins = LogEntryFactory.insert(t, r.key, r.value, null);
+                lastLsn = new LogSequenceNumber(1, 500 + i);
+                primary.applySingleEntryForTest(lastLsn, ins);
+            }
+            primary.awaitPendingWorkForTest();
+            primary.setLastProcessedLsnForTest(lastLsn);
+            long primaryEntryTs2 = primaryEntryTs + 60_000L;
+            primary.setLastProcessedEntryTimestampForTest(primaryEntryTs2);
+            primary.forceCheckpointAndSaveWatermark();
+
+            // Wait for the shadow reload count to advance OR for the
+            // freshness to update — the watcher is fired synchronously on
+            // publish, but the reload runs on an executor.
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (shadow.getShadowLoadedEntryTimestamp() < primaryEntryTs2
+                    && System.currentTimeMillis() < deadline) {
+                Thread.sleep(20);
+            }
+            assertEquals("shadow freshness must track the latest primary checkpoint",
+                    primaryEntryTs2, shadow.getShadowLoadedEntryTimestamp());
+        } finally {
+            shadow.close();
+            primary.close();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/WatermarkStoreTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/WatermarkStoreTest.java
@@ -212,6 +212,7 @@ public class WatermarkStoreTest {
             dos.writeLong(1L);                   // ledgerId
             dos.writeLong(100L);                 // offset
             dos.writeInt(2);                     // numInstances
+            dos.writeLong(0L);                   // lastEntryTimestamp (issue #423)
             dos.writeInt(Integer.MAX_VALUE);     // corrupt tableCount
         }
 
@@ -235,6 +236,7 @@ public class WatermarkStoreTest {
             dos.writeLong(1L);      // ledgerId
             dos.writeLong(100L);    // offset
             dos.writeInt(1);        // numInstances
+            dos.writeLong(0L);      // lastEntryTimestamp (issue #423)
             dos.writeInt(1);        // tableCount = 1
             dos.writeInt(-7);       // corrupt blob length (negative)
         }
@@ -259,6 +261,7 @@ public class WatermarkStoreTest {
             dos.writeLong(1L);              // ledgerId
             dos.writeLong(100L);            // offset
             dos.writeInt(1);                // numInstances
+            dos.writeLong(0L);              // lastEntryTimestamp (issue #423)
             dos.writeInt(0);                // tableCount = 0 (valid)
             dos.writeInt(Integer.MAX_VALUE); // corrupt indexCount
         }
@@ -285,6 +288,7 @@ public class WatermarkStoreTest {
             dos.writeLong(1L);         // ledgerId
             dos.writeLong(100L);       // offset
             dos.writeInt(1);           // numInstances
+            dos.writeLong(0L);         // lastEntryTimestamp (issue #423)
             dos.writeInt(1);           // tableCount = 1
             dos.writeInt(oversizedLen); // blob length far above MAX_BLOB_BYTES
             // No actual blob data — the bounds check must fire before readFully.

--- a/herddb-indexing-service/src/test/java/herddb/indexing/WatermarkStoreTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/WatermarkStoreTest.java
@@ -77,13 +77,19 @@ public class WatermarkStoreTest {
         Path dir = folder.newFolder("data").toPath();
         LocalWatermarkStore store = new LocalWatermarkStore(dir);
 
-        WatermarkSnapshot saved = new WatermarkSnapshot(new LogSequenceNumber(5, 42), 4);
+        // Issue #423: include a non-zero lastEntryTimestamp so the round-trip
+        // also covers the new field on the on-disk format.
+        WatermarkSnapshot saved = new WatermarkSnapshot(
+                new LogSequenceNumber(5, 42), 4, 1_700_000_000_500L,
+                Collections.emptyList(), Collections.emptyList());
         store.save(saved);
 
         WatermarkSnapshot loaded = store.load();
         assertEquals(saved.lsn.ledgerId, loaded.lsn.ledgerId);
         assertEquals(saved.lsn.offset, loaded.lsn.offset);
         assertEquals(saved.numInstances, loaded.numInstances);
+        assertEquals("lastEntryTimestamp must round-trip (issue #423)",
+                saved.lastEntryTimestamp, loaded.lastEntryTimestamp);
     }
 
     @Test
@@ -91,13 +97,17 @@ public class WatermarkStoreTest {
         Path dir = folder.newFolder("overwrite").toPath();
         LocalWatermarkStore store = new LocalWatermarkStore(dir);
 
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(1, 10), 2));
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(2, 20), 4));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(1, 10), 2, 1_000L,
+                Collections.emptyList(), Collections.emptyList()));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(2, 20), 4, 2_000L,
+                Collections.emptyList(), Collections.emptyList()));
 
         WatermarkSnapshot loaded = store.load();
         assertEquals(2, loaded.lsn.ledgerId);
         assertEquals(20, loaded.lsn.offset);
         assertEquals(4, loaded.numInstances);
+        assertEquals("lastEntryTimestamp from the latest save",
+                2_000L, loaded.lastEntryTimestamp);
     }
 
     // ---------- schema round-trip tests (issue #368) --------------------------
@@ -115,7 +125,7 @@ public class WatermarkStoreTest {
         Table t = buildTable("mytable");
         Index ix = buildVectorIndex("myidx", "mytable");
         WatermarkSnapshot saved = new WatermarkSnapshot(
-                new LogSequenceNumber(7, 100), 2,
+                new LogSequenceNumber(7, 100), 2, 0L,
                 Arrays.asList(t), Arrays.asList(ix));
 
         store.save(saved);
@@ -133,16 +143,17 @@ public class WatermarkStoreTest {
     }
 
     /**
-     * Verifies that an empty-schema snapshot (the legacy 2-arg constructor)
-     * round-trips correctly: after saving and loading, {@link WatermarkSnapshot#hasSchema()}
-     * returns {@code false} and the tables / vectorIndexes lists are empty.
+     * Verifies that an empty-schema snapshot round-trips correctly: after
+     * saving and loading, {@link WatermarkSnapshot#hasSchema()} returns
+     * {@code false} and the tables / vectorIndexes lists are empty.
      */
     @Test
     public void testSaveAndLoadWithEmptySchema() throws IOException {
         Path dir = folder.newFolder("empty-schema").toPath();
         LocalWatermarkStore store = new LocalWatermarkStore(dir);
 
-        WatermarkSnapshot saved = new WatermarkSnapshot(new LogSequenceNumber(3, 55), 1);
+        WatermarkSnapshot saved = new WatermarkSnapshot(new LogSequenceNumber(3, 55), 1, 0L,
+                Collections.emptyList(), Collections.emptyList());
         store.save(saved);
 
         WatermarkSnapshot loaded = store.load();
@@ -169,7 +180,7 @@ public class WatermarkStoreTest {
         Index ix2 = buildVectorIndex("idx2", "tab2");
 
         WatermarkSnapshot saved = new WatermarkSnapshot(
-                new LogSequenceNumber(10, 999), 4,
+                new LogSequenceNumber(10, 999), 4, 0L,
                 Arrays.asList(t1, t2), Arrays.asList(ix1, ix2));
         store.save(saved);
 
@@ -298,11 +309,12 @@ public class WatermarkStoreTest {
         Table t = buildTable("t");
         Index ix = buildVectorIndex("i", "t");
         store.save(new WatermarkSnapshot(
-                new LogSequenceNumber(1, 1), 1,
+                new LogSequenceNumber(1, 1), 1, 0L,
                 Collections.singletonList(t), Collections.singletonList(ix)));
 
         // Overwrite with empty schema
-        store.save(new WatermarkSnapshot(new LogSequenceNumber(2, 2), 1));
+        store.save(new WatermarkSnapshot(new LogSequenceNumber(2, 2), 1, 0L,
+                Collections.emptyList(), Collections.emptyList()));
         WatermarkSnapshot loaded = store.load();
         assertFalse("overwritten snapshot must have no schema", loaded.hasSchema());
         assertEquals("lsn advanced", 2, loaded.lsn.ledgerId);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/admin/IndexingAdminCliStatusLagTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/admin/IndexingAdminCliStatusLagTest.java
@@ -1,0 +1,249 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.indexing.proto.GetIndexStatusRequest;
+import herddb.indexing.proto.GetIndexStatusResponse;
+import herddb.indexing.proto.IndexingServiceGrpc;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Issue #423: the {@code status} sub-command of {@link IndexingAdminCli} must
+ * surface {@code tailer_lsn_timestamp} / {@code durable_lsn_timestamp} and the
+ * computed {@code tailer_lag_ms} / {@code durable_lag_ms} (= {@code now - timestamp},
+ * with {@code -1} when the timestamp is {@code 0} ("unknown")).
+ *
+ * <p>The test boots a tiny in-process gRPC server that returns hand-crafted
+ * timestamps, then drives the CLI's {@code run("status", ..., "--json")} entry
+ * point and asserts on the resulting JSON.
+ */
+public class IndexingAdminCliStatusLagTest {
+
+    private FakeServer fakeServer;
+    private ByteArrayOutputStream stdoutBytes;
+    private ByteArrayOutputStream stderrBytes;
+    private IndexingAdminCli cli;
+
+    @Before
+    public void setUp() {
+        stdoutBytes = new ByteArrayOutputStream();
+        stderrBytes = new ByteArrayOutputStream();
+        cli = new IndexingAdminCli(
+                new PrintStream(stdoutBytes, true, StandardCharsets.UTF_8),
+                new PrintStream(stderrBytes, true, StandardCharsets.UTF_8));
+    }
+
+    @After
+    public void tearDown() throws InterruptedException {
+        if (fakeServer != null) {
+            fakeServer.close();
+        }
+    }
+
+    private String stdout() {
+        return new String(stdoutBytes.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * When both timestamps are non-zero (a live IS), the JSON output must
+     * carry the raw timestamps AND the computed lag (now - timestamp), and
+     * the computed lag must be a non-negative number.
+     */
+    @Test
+    public void statusJsonIncludesRawTimestampsAndComputedLags() throws Exception {
+        long tailerTs = System.currentTimeMillis() - 1500L;
+        long durableTs = System.currentTimeMillis() - 60_000L;
+        StaticIndexStatusImpl impl = new StaticIndexStatusImpl(tailerTs, durableTs);
+        fakeServer = new FakeServer(impl);
+        fakeServer.start();
+
+        int rc = cli.run(new String[]{
+            "status",
+            "--server", fakeServer.address(),
+            "--tablespace", "ts",
+            "--table", "t",
+            "--index", "i",
+            "--json"
+        });
+        assertEquals("CLI should succeed; stderr=\n"
+                + new String(stderrBytes.toByteArray(), StandardCharsets.UTF_8), 0, rc);
+        String out = stdout().trim();
+        assertTrue("expected JSON object: " + out, out.startsWith("{"));
+        assertTrue("must contain raw tailer_lsn_timestamp: " + out,
+                out.contains("\"tailer_lsn_timestamp\":" + tailerTs));
+        assertTrue("must contain raw durable_lsn_timestamp: " + out,
+                out.contains("\"durable_lsn_timestamp\":" + durableTs));
+        assertTrue("must contain tailer_lag_ms key: " + out,
+                out.contains("\"tailer_lag_ms\":"));
+        assertTrue("must contain durable_lag_ms key: " + out,
+                out.contains("\"durable_lag_ms\":"));
+
+        // Sanity-check the computed lag values (not exact because the CLI
+        // takes the lag at print time, which is after the test set up the
+        // hand-crafted timestamps). Tailer lag must be >= 1500 - epsilon,
+        // durable lag must be >= 60000 - epsilon.
+        long tailerLag = extractLong(out, "tailer_lag_ms");
+        long durableLag = extractLong(out, "durable_lag_ms");
+        assertTrue("tailer_lag_ms must be at least the configured stale period: " + tailerLag,
+                tailerLag >= 1000L);
+        assertTrue("durable_lag_ms must reflect the durable timestamp: " + durableLag,
+                durableLag >= 50_000L);
+    }
+
+    /**
+     * When the IS reports {@code 0} timestamps ("unknown"), the CLI must
+     * output {@code -1} for the lag — the documented "no information yet"
+     * sentinel that dashboards rely on.
+     */
+    @Test
+    public void statusJsonReportsLagMinusOneWhenTimestampUnknown() throws Exception {
+        StaticIndexStatusImpl impl = new StaticIndexStatusImpl(0L, 0L);
+        fakeServer = new FakeServer(impl);
+        fakeServer.start();
+
+        int rc = cli.run(new String[]{
+            "status",
+            "--server", fakeServer.address(),
+            "--tablespace", "ts",
+            "--table", "t",
+            "--index", "i",
+            "--json"
+        });
+        assertEquals(0, rc);
+        String out = stdout().trim();
+        assertTrue("must contain tailer_lag_ms=-1: " + out,
+                out.contains("\"tailer_lag_ms\":-1"));
+        assertTrue("must contain durable_lag_ms=-1: " + out,
+                out.contains("\"durable_lag_ms\":-1"));
+    }
+
+    /**
+     * Text output: the {@code status} command's plain-text path must include
+     * both lag values so an operator running it from a shell sees them
+     * without having to add {@code --json}.
+     */
+    @Test
+    public void statusTextOutputIncludesLagValues() throws Exception {
+        long tailerTs = System.currentTimeMillis() - 2000L;
+        StaticIndexStatusImpl impl = new StaticIndexStatusImpl(tailerTs, 0L);
+        fakeServer = new FakeServer(impl);
+        fakeServer.start();
+
+        int rc = cli.run(new String[]{
+            "status",
+            "--server", fakeServer.address(),
+            "--tablespace", "ts",
+            "--table", "t",
+            "--index", "i"
+        });
+        assertEquals(0, rc);
+        String out = stdout();
+        assertTrue("text output must include tailer_lag_ms: " + out,
+                out.contains("tailer_lag_ms="));
+        assertTrue("text output must include durable_lag_ms: " + out,
+                out.contains("durable_lag_ms="));
+        assertTrue("durable_lag_ms must be -1 when the timestamp is unknown: " + out,
+                out.contains("durable_lag_ms=-1"));
+    }
+
+    private static long extractLong(String json, String key) {
+        int i = json.indexOf("\"" + key + "\":");
+        if (i < 0) {
+            throw new AssertionError("key not found in JSON: " + key);
+        }
+        i += key.length() + 3;
+        int end = i;
+        while (end < json.length()
+                && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+            end++;
+        }
+        return Long.parseLong(json.substring(i, end));
+    }
+
+    // -------------------- harness --------------------
+
+    private static final class FakeServer implements AutoCloseable {
+        private final StaticIndexStatusImpl impl;
+        private Server server;
+
+        FakeServer(StaticIndexStatusImpl impl) {
+            this.impl = impl;
+        }
+
+        void start() throws IOException {
+            server = ServerBuilder.forPort(0).addService(impl).build().start();
+            assertNotNull(server);
+        }
+
+        String address() {
+            return "localhost:" + server.getPort();
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            if (server != null) {
+                server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private static final class StaticIndexStatusImpl
+            extends IndexingServiceGrpc.IndexingServiceImplBase {
+        private final long tailerTimestamp;
+        private final long durableTimestamp;
+
+        StaticIndexStatusImpl(long tailerTimestamp, long durableTimestamp) {
+            this.tailerTimestamp = tailerTimestamp;
+            this.durableTimestamp = durableTimestamp;
+        }
+
+        @Override
+        public void getIndexStatus(GetIndexStatusRequest request,
+                                    StreamObserver<GetIndexStatusResponse> responseObserver) {
+            GetIndexStatusResponse resp = GetIndexStatusResponse.newBuilder()
+                    .setVectorCount(0)
+                    .setSegmentCount(1)
+                    .setTailerLsnLedger(7)
+                    .setTailerLsnOffset(99)
+                    .setTailerLsnTimestamp(tailerTimestamp)
+                    .setDurableLsnLedger(7)
+                    .setDurableLsnOffset(50)
+                    .setDurableLsnTimestamp(durableTimestamp)
+                    .setStatus("static")
+                    .build();
+            responseObserver.onNext(resp);
+            responseObserver.onCompleted();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #423.

## Changes
Adds wall-clock LogEntry timestamps alongside the existing LSN
coordinates in `GetIndexStatus`, `sysindexstatus`, the
`indexing-admin` CLI, and the shadow `GetShadowStatus` RPC, so an
operator can report the time-lag of an indexing-service replica as
`now - timestamp` (in milliseconds) without having to understand the
commit-log layout.

- **Primary engine** tracks two volatile timestamps:
  - `lastProcessedEntryTimestamp` — LogEntry timestamp at the tailer
    LSN, advanced inside `processEntry()` next to `lastProcessedLsn`.
  - `lastDurableEntryTimestamp` — LogEntry timestamp at the durable
    watermark LSN, advanced inside `checkpointAndSaveWatermark()`
    together with `lastDurableLsn`, anchored at the previous value
    when the watermark save fails (same invariant as the durable LSN).
- **Persistence**: both `WatermarkSnapshot` (and its on-disk format
  in `LocalWatermarkStore` / `S3WatermarkStore`) and the JSON
  `IndexingServiceCheckpointState` carry the new field, so a
  restarting engine re-hydrates `lastDurableEntryTimestamp` without
  waiting for the next checkpoint, and shadows pick up the primary's
  freshness via the per-instance ZK state znode.
- **Shadow replicas** report their freshness via
  `GetShadowStatus.loaded_entry_timestamp_ms` — the LogEntry timestamp
  at the loaded LSN, picked up from the primary's advertised
  checkpoint state on every reload.
- **gRPC**: `GetIndexStatusResponse` gets `tailer_lsn_timestamp` (10)
  + `durable_lsn_timestamp` (11); `DescribeIndexResponse` gets the
  same fields at 28/29; `GetShadowStatusResponse` gets
  `loaded_entry_timestamp_ms` (11). `0` = unknown.
- **CLI**: `indexing-admin status` and `describe-index` print the raw
  timestamps + computed `tailer_lag_ms` / `durable_lag_ms`
  (= `now - timestamp`, with `-1` for "unknown");
  `indexing-admin shadow-status` adds `loaded_entry_timestamp_ms` and
  `loaded_entry_lag_ms`.
- **SQL**: `sysindexstatus.properties` JSON for vector indexes now
  includes `tailerLsnTimestamp` and `durableLsnTimestamp`.
- **Bench agents** (k3s, GKE) document how to read and report the new
  fields in the TICK SUMMARY.

Per the issue request, **no backward compatibility is preserved**:
`WatermarkSnapshot`'s legacy 2- and 4-arg constructors are removed,
`RemoteVectorIndexService.IndexStatusInfo` and
`IndexingServiceCheckpointState` gain mandatory new fields, and
existing `watermark.dat` / S3 watermark objects become unreadable on
upgrade.

## Tests
- `IndexingServiceEngineLagTimestampsTest` — primary-side tracking,
  durable gating, save-failure anchoring, and snapshot re-hydration.
- `IndexingServiceClientLagTimestampsTest` — gRPC client maps both
  proto fields onto `IndexStatusInfo`.
- `ShadowLoadedEntryTimestampTest` — primary publishes →
  `IndexingServiceCheckpointState.lastEntryTimestampMillis` →
  shadow's `getShadowLoadedEntryTimestamp()` picks up.
- `IndexingAdminCliStatusLagTest` — `status` JSON / text output
  carries raw timestamps + computed lag, and reports `-1` when the
  timestamp is `0`.
- `SysindexstatusTest#testSysindexstatusVector` — `properties` JSON
  contains both timestamp keys.
- `WatermarkStoreTest` / `S3WatermarkStoreTest` — non-zero
  `lastEntryTimestamp` round-trips through both on-disk formats.
- `IndexingServiceDtoTest` — `lastEntryTimestampMillis` round-trips
  through the JSON format and defaults to `0` when absent
  (Jackson's `@JsonIgnoreProperties(ignoreUnknown=true)`).

🤖 Implemented by the `pr-worker` agent.