### PR TITLE
issue #433: per-request-type stats and Grafana panels for request execution

### DIFF
--- a/herddb-core/src/main/java/herddb/server/RequestStats.java
+++ b/herddb-core/src/main/java/herddb/server/RequestStats.java
@@ -1,0 +1,123 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
+
+/**
+ * Per-request-type statistics exposed under the {@code requests} scope of the
+ * server's root {@link StatsLogger}.
+ *
+ * <p>Each request type has a single {@link OpStatsLogger} that produces both a
+ * latency distribution (with {@code quantile} label) and a count series (suffix
+ * {@code _count}); the latter, combined with Prometheus {@code rate()},
+ * provides the request rate broken down by type. Each {@link OpStatsLogger}
+ * also exposes a {@code success} label so failed requests can be tracked
+ * separately from successful ones.</p>
+ *
+ * <p>The metric names produced by this class are:
+ * <ul>
+ *   <li>{@code requests_execute_statement}</li>
+ *   <li>{@code requests_execute_statements}</li>
+ *   <li>{@code requests_prepare_statement}</li>
+ *   <li>{@code requests_open_scanner}</li>
+ *   <li>{@code requests_fetch_scanner_data}</li>
+ *   <li>{@code requests_close_scanner}</li>
+ *   <li>{@code requests_tx_begin}</li>
+ *   <li>{@code requests_tx_commit}</li>
+ *   <li>{@code requests_tx_rollback}</li>
+ *   <li>{@code requests_request_tablespace_dump}</li>
+ * </ul>
+ *
+ * <p>Latency values are stored in milliseconds (the BookKeeper Prometheus
+ * provider converts the registered {@code TimeUnit.NANOSECONDS} value to ms
+ * before exporting), so dashboard panels should use the {@code ms} format.</p>
+ */
+public class RequestStats {
+
+    private static final String SCOPE = "requests";
+
+    private final OpStatsLogger executeStatement;
+    private final OpStatsLogger executeStatements;
+    private final OpStatsLogger prepareStatement;
+    private final OpStatsLogger openScanner;
+    private final OpStatsLogger fetchScannerData;
+    private final OpStatsLogger closeScanner;
+    private final OpStatsLogger txBegin;
+    private final OpStatsLogger txCommit;
+    private final OpStatsLogger txRollback;
+    private final OpStatsLogger requestTablespaceDump;
+
+    public RequestStats(StatsLogger rootStatsLogger) {
+        StatsLogger scope = rootStatsLogger.scope(SCOPE);
+        this.executeStatement = scope.getOpStatsLogger("execute_statement");
+        this.executeStatements = scope.getOpStatsLogger("execute_statements");
+        this.prepareStatement = scope.getOpStatsLogger("prepare_statement");
+        this.openScanner = scope.getOpStatsLogger("open_scanner");
+        this.fetchScannerData = scope.getOpStatsLogger("fetch_scanner_data");
+        this.closeScanner = scope.getOpStatsLogger("close_scanner");
+        this.txBegin = scope.getOpStatsLogger("tx_begin");
+        this.txCommit = scope.getOpStatsLogger("tx_commit");
+        this.txRollback = scope.getOpStatsLogger("tx_rollback");
+        this.requestTablespaceDump = scope.getOpStatsLogger("request_tablespace_dump");
+    }
+
+    public OpStatsLogger executeStatement() {
+        return executeStatement;
+    }
+
+    public OpStatsLogger executeStatements() {
+        return executeStatements;
+    }
+
+    public OpStatsLogger prepareStatement() {
+        return prepareStatement;
+    }
+
+    public OpStatsLogger openScanner() {
+        return openScanner;
+    }
+
+    public OpStatsLogger fetchScannerData() {
+        return fetchScannerData;
+    }
+
+    public OpStatsLogger closeScanner() {
+        return closeScanner;
+    }
+
+    public OpStatsLogger txBegin() {
+        return txBegin;
+    }
+
+    public OpStatsLogger txCommit() {
+        return txCommit;
+    }
+
+    public OpStatsLogger txRollback() {
+        return txRollback;
+    }
+
+    public OpStatsLogger requestTablespaceDump() {
+        return requestTablespaceDump;
+    }
+}

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -84,6 +84,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
     private final ServerConfiguration configuration;
     private final StatsProvider statsProvider;
     private final StatsLogger statsLogger;
+    private final RequestStats requestStats;
     private final Path baseDirectory;
     private final Path dataDirectory;
     private final Path tmpDirectory;
@@ -148,6 +149,15 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         return manager;
     }
 
+    /**
+     * Returns the per-request-type statistics exposed by this server. Each
+     * handler in {@link ServerSideConnectionPeer} records request latency and
+     * counts on the corresponding {@link org.apache.bookkeeper.stats.OpStatsLogger}.
+     */
+    public RequestStats getRequestStats() {
+        return requestStats;
+    }
+
     public NettyChannelAcceptor getNetworkServer() {
         return networkServer;
     }
@@ -159,6 +169,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
     public Server(ServerConfiguration configuration, StatsProvider statsProvider) {
         this.statsProvider = statsProvider;
         this.statsLogger = statsProvider == null ? new NullStatsLogger() : statsProvider.getStatsLogger("");
+        this.requestStats = new RequestStats(this.statsLogger);
         this.configuration = configuration;
         // Expose Netty direct-memory counters so the unified JVM dashboard
         // can correlate pool-arena growth against -XX:MaxDirectMemorySize

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -88,10 +88,12 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.calcite.tools.ValidationException;
 
 /**
@@ -141,6 +143,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
     @Override
     public void requestReceived(Pdu message, Channel channel) {
         // message is handled by current thread
+        long startNanos = System.nanoTime();
         boolean releaseMessageSync = true;
         try {
             LOGGER.log(Level.FINEST, "messageReceived {0}", message);
@@ -149,28 +152,31 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 case Pdu.TYPE_EXECUTE_STATEMENT: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().executeStatement(), startNanos, false);
                         break;
                     }
                     releaseMessageSync = false;
-                    handleExecuteStatement(message, channel);
+                    handleExecuteStatement(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_PREPARE_STATEMENT: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().prepareStatement(), startNanos, false);
                         break;
                     }
                     releaseMessageSync = false;
-                    handlePrepareStatement(message, channel);
+                    handlePrepareStatement(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_EXECUTE_STATEMENTS: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().executeStatements(), startNanos, false);
                         break;
                     }
                     releaseMessageSync = false;
-                    handleExecuteStatements(message, channel);
+                    handleExecuteStatements(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_SASL_TOKEN_MESSAGE_REQUEST: {
@@ -183,44 +189,51 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 break;
                 case Pdu.TYPE_TX_COMMAND: {
                     if (!authenticated) {
+                        // Tx command type is not yet decoded, attribute to the
+                        // tx_commit metric arbitrarily so the failure surfaces.
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().txCommit(), startNanos, false);
                         break;
                     }
                     releaseMessageSync = false;
-                    handleTxCommand(message, channel);
+                    handleTxCommand(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_OPENSCANNER: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().openScanner(), startNanos, false);
                         break;
                     }
-                    handleOpenScanner(message, channel);
+                    handleOpenScanner(message, channel, startNanos);
 
                 }
                 break;
                 case Pdu.TYPE_FETCHSCANNERDATA: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().fetchScannerData(), startNanos, false);
                         break;
                     }
-                    handleFetchScannerData(message, channel);
+                    handleFetchScannerData(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_CLOSESCANNER: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().closeScanner(), startNanos, false);
                         break;
                     }
-                    handleCloseScanner(message, channel);
+                    handleCloseScanner(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_REQUEST_TABLESPACE_DUMP: {
                     if (!authenticated) {
                         sendAuthRequiredError(channel, message);
+                        recordRequest(server.getRequestStats().requestTablespaceDump(), startNanos, false);
                         break;
                     }
-                    handleRequestTablespaceDump(message, channel);
+                    handleRequestTablespaceDump(message, channel, startNanos);
                 }
                 break;
                 case Pdu.TYPE_REQUEST_TABLE_RESTORE: {
@@ -307,6 +320,21 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
 
     private static ByteBuf composeErrorResponse(long messageId, Throwable err) {
         return PduCodec.ErrorResponse.write(messageId, err, err instanceof NotLeaderException, false);
+    }
+
+    /**
+     * Records the latency of a request that started at {@code startNanos} on the
+     * given per-request-type {@link OpStatsLogger}. The BookKeeper Prometheus
+     * provider converts the registered nanosecond value to milliseconds before
+     * exporting; dashboards must use the {@code ms} format accordingly.
+     */
+    private static void recordRequest(OpStatsLogger latency, long startNanos, boolean success) {
+        long elapsed = System.nanoTime() - startNanos;
+        if (success) {
+            latency.registerSuccessfulEvent(elapsed, TimeUnit.NANOSECONDS);
+        } else {
+            latency.registerFailedEvent(elapsed, TimeUnit.NANOSECONDS);
+        }
     }
 
     private void handleTableRestoreFinished(Pdu message, Channel channel) {
@@ -422,7 +450,8 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
     }
 
-    private void handleOpenScanner(Pdu message, Channel channel) {
+    private void handleOpenScanner(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().openScanner();
 
         long txId = PduCodec.OpenScanner.readTx(message);
 
@@ -434,6 +463,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         if (query == null) {
             ByteBuf error = PduCodec.ErrorResponse.writeMissingPreparedStatementError(message.messageId, "bad statement id: " + statementId);
             channel.sendReplyMessage(message.messageId, error);
+            recordRequest(latency, startNanos, false);
             return;
         }
 
@@ -460,6 +490,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         RunningStatementsStats runningStatements = server.getManager().getRunningStatements();
         RunningStatementInfo statementInfo = new RunningStatementInfo(query,
                 System.currentTimeMillis(), tableSpace, "", 1);
+        boolean success = false;
         try {
             TranslatedQuery translatedQuery = server
                     .getManager()
@@ -505,6 +536,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                     // no need to hold the scanner anymore
                     scanner.close();
                 }
+                success = true;
             } else {
                 ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unsupported query type for scan " + query + ": PLAN is " + translatedQuery.plan);
                 channel.sendReplyMessage(message.messageId, error);
@@ -521,60 +553,73 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             channel.sendReplyMessage(message.messageId, error);
         } finally {
             runningStatements.unregisterRunningStatement(statementInfo);
+            recordRequest(latency, startNanos, success);
         }
     }
 
-    private void handleFetchScannerData(Pdu message, Channel channel) {
-        long scannerId = PduCodec.FetchScannerData.readScannerId(message);
-        int fetchSize = PduCodec.FetchScannerData.readFetchSize(message);
-        if (fetchSize <= 0) {
-            fetchSize = 10;
-        }
-        ServerSideScannerPeer scanner = scanners.get(scannerId);
-        if (scanner != null) {
-            try {
-                DataScanner dataScanner = scanner.getScanner();
-                List<DataAccessor> records = dataScanner.consume(fetchSize);
-                String[] columns = dataScanner.getFieldNames();
-                TuplesList tuplesList = new TuplesList(columns, records);
-
-                boolean last = false;
-                if (dataScanner.isFinished()) {
-                    LOGGER.log(Level.FINEST, "unregistering scanner {0}, resultset is finished", scannerId);
-                    scanners.remove(scannerId);
-                    last = true;
-                }
-//                        LOGGER.log(Level.SEVERE, "sending " + converted.size() + " records to scanner " + scannerId);
+    private void handleFetchScannerData(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().fetchScannerData();
+        boolean success = false;
+        try {
+            long scannerId = PduCodec.FetchScannerData.readScannerId(message);
+            int fetchSize = PduCodec.FetchScannerData.readFetchSize(message);
+            if (fetchSize <= 0) {
+                fetchSize = 10;
+            }
+            ServerSideScannerPeer scanner = scanners.get(scannerId);
+            if (scanner != null) {
                 try {
-                    ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.getTransactionId());
-                    channel.sendReplyMessage(message.messageId, result);
-                } catch (HerdDBInternalException err) {
-                    // do not leak an unserializable scanner
-                    scanners.remove(scannerId);
-                    scanner.close();
-                    throw err;
+                    DataScanner dataScanner = scanner.getScanner();
+                    List<DataAccessor> records = dataScanner.consume(fetchSize);
+                    String[] columns = dataScanner.getFieldNames();
+                    TuplesList tuplesList = new TuplesList(columns, records);
+
+                    boolean last = false;
+                    if (dataScanner.isFinished()) {
+                        LOGGER.log(Level.FINEST, "unregistering scanner {0}, resultset is finished", scannerId);
+                        scanners.remove(scannerId);
+                        last = true;
+                    }
+//                        LOGGER.log(Level.SEVERE, "sending " + converted.size() + " records to scanner " + scannerId);
+                    try {
+                        ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.getTransactionId());
+                        channel.sendReplyMessage(message.messageId, result);
+                    } catch (HerdDBInternalException err) {
+                        // do not leak an unserializable scanner
+                        scanners.remove(scannerId);
+                        scanner.close();
+                        throw err;
+                    }
+                    if (last) {
+                        dataScanner.close();
+                    }
+                    success = true;
+                } catch (DataScannerException | StatementExecutionException err) {
+                    ByteBuf error = composeErrorResponse(message.messageId, err);
+                    channel.sendReplyMessage(message.messageId, error);
                 }
-                if (last) {
-                    dataScanner.close();
-                }
-            } catch (DataScannerException | StatementExecutionException err) {
-                ByteBuf error = composeErrorResponse(message.messageId, err);
+            } else {
+                ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "no such scanner " + scannerId);
                 channel.sendReplyMessage(message.messageId, error);
             }
-        } else {
-            ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "no such scanner " + scannerId);
-            channel.sendReplyMessage(message.messageId, error);
+        } finally {
+            recordRequest(latency, startNanos, success);
         }
     }
 
-    private void handleCloseScanner(Pdu message, Channel channel) {
-        long scannerId = PduCodec.CloseScanner.readScannerId(message);
-        ServerSideScannerPeer removed = scanners.remove(scannerId);
-        if (removed != null) {
-            if (LOGGER.isLoggable(Level.FINER)) {
-                LOGGER.log(Level.FINER, "remove scanner {0} as requested by client", scannerId);
+    private void handleCloseScanner(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().closeScanner();
+        try {
+            long scannerId = PduCodec.CloseScanner.readScannerId(message);
+            ServerSideScannerPeer removed = scanners.remove(scannerId);
+            if (removed != null) {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(Level.FINER, "remove scanner {0} as requested by client", scannerId);
+                }
+                removed.clientClose();
             }
-            removed.clientClose();
+        } finally {
+            recordRequest(latency, startNanos, true);
         }
     }
 
@@ -584,18 +629,26 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         channel.sendReplyMessage(message.messageId, error);
     }
 
-    private void handleRequestTablespaceDump(Pdu message, Channel channel) {
-        String dumpId = PduCodec.RequestTablespaceDump.readDumpId(message);
-        int fetchSize = PduCodec.RequestTablespaceDump.readFetchSize(message);
-        if (fetchSize <= 0) {
-            fetchSize = 10;
+    private void handleRequestTablespaceDump(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().requestTablespaceDump();
+        boolean success = false;
+        try {
+            String dumpId = PduCodec.RequestTablespaceDump.readDumpId(message);
+            int fetchSize = PduCodec.RequestTablespaceDump.readFetchSize(message);
+            if (fetchSize <= 0) {
+                fetchSize = 10;
+            }
+            String tableSpace = PduCodec.RequestTablespaceDump.readTablespace(message);
+            boolean includeTransactionLog = PduCodec.RequestTablespaceDump.readInludeTransactionLog(message);
+            server.getManager().dumpTableSpace(tableSpace, dumpId, message, channel, fetchSize, includeTransactionLog);
+            success = true;
+        } finally {
+            recordRequest(latency, startNanos, success);
         }
-        String tableSpace = PduCodec.RequestTablespaceDump.readTablespace(message);
-        boolean includeTransactionLog = PduCodec.RequestTablespaceDump.readInludeTransactionLog(message);
-        server.getManager().dumpTableSpace(tableSpace, dumpId, message, channel, fetchSize, includeTransactionLog);
     }
 
-    private void handleExecuteStatements(Pdu message, Channel channel) {
+    private void handleExecuteStatements(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().executeStatements();
         long transactionId = PduCodec.ExecuteStatements.readTx(message);
         String tableSpace = PduCodec.ExecuteStatements.readTablespace(message);
         long statementId = PduCodec.ExecuteStatements.readStatementId(message);
@@ -606,6 +659,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             ByteBuf error = PduCodec.ErrorResponse.writeMissingPreparedStatementError(message.messageId, "bad statement id: " + statementId);
             channel.sendReplyMessage(message.messageId, error);
             message.close();
+            recordRequest(latency, startNanos, false);
             return;
         }
         boolean returnValues = PduCodec.ExecuteStatements.readReturnValues(message);
@@ -655,6 +709,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                         channel.sendReplyMessage(message.messageId, errorMsg);
                         message.close();
                         runningStatements.unregisterRunningStatement(statementInfo);
+                        recordRequest(latency, startNanos, false);
                         return;
                     }
                     if (result instanceof DMLStatementExecutionResult) {
@@ -684,18 +739,26 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                         channel.sendReplyMessage(message.messageId, response);
                         message.close();
                         runningStatements.unregisterRunningStatement(statementInfo);
+                        recordRequest(latency, startNanos, false);
                         return;
                     }
 
                     long newTransactionId = result.transactionId;
                     if (current == queries.size()) {
+                        boolean writeOk = false;
                         try {
                             ByteBuf response = PduCodec.ExecuteStatementsResult.write(message.messageId, updateCounts, otherDatas, newTransactionId);
                             channel.sendReplyMessage(message.messageId, response);
                             message.close();
                             runningStatements.unregisterRunningStatement(statementInfo);
+                            writeOk = true;
                         } catch (Throwable t) {
+                            // Reply serialization is best-effort: log here and
+                            // record the request as failed so dashboards reflect
+                            // the actual error rate rather than masking it.
                             LOGGER.log(Level.SEVERE, "Internal error", t);
+                        } finally {
+                            recordRequest(latency, startNanos, writeOk);
                         }
                         return;
                     }
@@ -718,6 +781,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             channel.sendReplyMessage(message.messageId, response);
             message.close();
             runningStatements.unregisterRunningStatement(statementInfo);
+            recordRequest(latency, startNanos, false);
         }
     }
 
@@ -836,7 +900,8 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
     }
 
-    private void handleExecuteStatement(Pdu message, Channel channel) {
+    private void handleExecuteStatement(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().executeStatement();
         long txId = PduCodec.ExecuteStatement.readTx(message);
         String tablespace = PduCodec.ExecuteStatement.readTablespace(message);
         long statementId = PduCodec.ExecuteStatement.readStatementId(message);
@@ -847,6 +912,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             ByteBuf error = PduCodec.ErrorResponse.writeMissingPreparedStatementError(message.messageId, "bad statement id: " + statementId);
             channel.sendReplyMessage(message.messageId, error);
             message.close();
+            recordRequest(latency, startNanos, false);
             return;
         }
         boolean returnValues = PduCodec.ExecuteStatement.readReturnValues(message);
@@ -870,6 +936,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             ByteBuf error = composeErrorResponse(message.messageId, ex);
             channel.sendReplyMessage(message.messageId, error);
             message.close();
+            recordRequest(latency, startNanos, false);
             return;
         }
 
@@ -882,6 +949,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 .executePlanAsync(translatedQuery.plan, translatedQuery.context, transactionContext);
 //                    LOGGER.log(Level.SEVERE, "query " + query + ", " + parameters + ", result:" + result);
         res.whenComplete((result, err) -> {
+            boolean success = false;
             try {
                 runningStatements.unregisterRunningStatement(statementInfo);
                 if (err != null) {
@@ -923,6 +991,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                     channel.sendReplyMessage(message.messageId,
                             PduCodec.ExecuteStatementResult.write(
                                     message.messageId, dml.getUpdateCount(), dml.transactionId, newRecord));
+                    success = true;
                 } else if (result instanceof GetResult) {
                     GetResult get = (GetResult) result;
                     if (!get.found()) {
@@ -935,31 +1004,41 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                                 PduCodec.ExecuteStatementResult.write(
                                         message.messageId, 1, get.transactionId, record));
                     }
+                    success = true;
                 } else if (result instanceof TransactionResult) {
                     TransactionResult txresult = (TransactionResult) result;
                     channel.sendReplyMessage(message.messageId,
                             PduCodec.ExecuteStatementResult.write(
                                     message.messageId, 1, txresult.getTransactionId(), null));
+                    success = true;
                 } else if (result instanceof DDLStatementExecutionResult) {
                     DDLStatementExecutionResult ddl = (DDLStatementExecutionResult) result;
                     channel.sendReplyMessage(message.messageId,
                             PduCodec.ExecuteStatementResult.write(
                                     message.messageId, 1, ddl.transactionId, null));
+                    success = true;
                 } else if (result instanceof DataConsistencyStatementResult) {
                     channel.sendReplyMessage(message.messageId,
                             PduCodec.ExecuteStatementResult.write(
                                     message.messageId, 0, 0, null));
+                    success = true;
                 } else {
                     ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unknown result type:" + result);
                     channel.sendReplyMessage(message.messageId, error);
                 }
             } finally {
-                message.close();
+                try {
+                    message.close();
+                } finally {
+                    recordRequest(latency, startNanos, success);
+                }
             }
         });
     }
 
-    private void handlePrepareStatement(Pdu message, Channel channel) {
+    private void handlePrepareStatement(Pdu message, Channel channel, long startNanos) {
+        OpStatsLogger latency = server.getRequestStats().prepareStatement();
+        boolean success = false;
         try {
             String query = PduCodec.PrepareStatement.readQuery(message);
             String tablespace = PduCodec.PrepareStatement.readTablespace(message);
@@ -977,8 +1056,13 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             channel.sendReplyMessage(message.messageId,
                     PduCodec.PrepareStatementResult.write(
                             message.messageId, newId));
+            success = true;
         } finally {
-            message.close();
+            try {
+                message.close();
+            } finally {
+                recordRequest(latency, startNanos, success);
+            }
         }
     }
 
@@ -1012,37 +1096,47 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
     }
 
-    private void handleTxCommand(Pdu message, Channel channel) {
+    private void handleTxCommand(Pdu message, Channel channel, long startNanos) {
         long txId = PduCodec.TxCommand.readTx(message);
         int type = PduCodec.TxCommand.readCommand(message);
         String tableSpace = PduCodec.TxCommand.readTablespace(message);
         TransactionContext transactionContext = new TransactionContext(txId);
         Statement statement;
+        OpStatsLogger latency;
         switch (type) {
             case TX_COMMAND_COMMIT_TRANSACTION:
                 statement = new CommitTransactionStatement(tableSpace, txId);
+                latency = server.getRequestStats().txCommit();
                 break;
             case TX_COMMAND_ROLLBACK_TRANSACTION:
                 statement = new RollbackTransactionStatement(tableSpace, txId);
+                latency = server.getRequestStats().txRollback();
                 break;
             case TX_COMMAND_BEGIN_TRANSACTION:
                 statement = new BeginTransactionStatement(tableSpace);
+                latency = server.getRequestStats().txBegin();
                 break;
             default:
                 statement = null;
+                // Unknown command: charge to commit metric so the failure is
+                // still visible somewhere instead of being silently dropped.
+                latency = server.getRequestStats().txCommit();
 
         }
         if (statement == null) {
             ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unknown txcommand type:" + type);
             channel.sendReplyMessage(message.messageId, error);
             message.close();
+            recordRequest(latency, startNanos, false);
         } else {
 //            LOGGER.log(Level.SEVERE, "statement " + statement);
             CompletableFuture<StatementExecutionResult> res = server
                     .getManager()
                     .executeStatementAsync(statement, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), transactionContext);
 //                    LOGGER.log(Level.SEVERE, "query " + query + ", " + parameters + ", result:" + result);
+            final OpStatsLogger latencyForCallback = latency;
             res.whenComplete((result, err) -> {
+                boolean success = false;
                 try {
                     if (err != null) {
                         if (err instanceof NotLeaderException) {
@@ -1061,6 +1155,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                             TransactionResult txresult = (TransactionResult) result;
                             ByteBuf response = PduCodec.TxCommandResult.write(message.messageId, txresult.transactionId);
                             channel.sendReplyMessage(message.messageId, response);
+                            success = true;
                         } else {
                             ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unknown result type:" + result);
                             channel.sendReplyMessage(message.messageId, error);
@@ -1068,7 +1163,11 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                         }
                     }
                 } finally {
-                    message.close();
+                    try {
+                        message.close();
+                    } finally {
+                        recordRequest(latencyForCallback, startNanos, success);
+                    }
                 }
             });
         }

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -714,11 +714,18 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                     // broad: anything reaching it is by definition unexpected,
                     // so we log it, send an error reply best-effort, unregister
                     // the running statement, and record a failed request event.
+                    //
+                    // Pdu.close() is NOT idempotent (it calls Recycler.recycle,
+                    // which must not be invoked twice on the same handle), so we
+                    // track whether the message has already been closed and skip
+                    // a second close in the catch block.
+                    boolean[] messageClosed = {false};
                     try {
                         if (error != null) {
                             ByteBuf errorMsg = composeErrorResponse(message.messageId, error);
                             channel.sendReplyMessage(message.messageId, errorMsg);
                             message.close();
+                            messageClosed[0] = true;
                             runningStatements.unregisterRunningStatement(statementInfo);
                             recordRequest(latency, startNanos, false);
                             return;
@@ -749,6 +756,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                             ByteBuf response = PduCodec.ErrorResponse.write(message.messageId, "bad result type " + result.getClass() + " (" + result + ")");
                             channel.sendReplyMessage(message.messageId, response);
                             message.close();
+                            messageClosed[0] = true;
                             runningStatements.unregisterRunningStatement(statementInfo);
                             recordRequest(latency, startNanos, false);
                             return;
@@ -761,6 +769,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                                 ByteBuf response = PduCodec.ExecuteStatementsResult.write(message.messageId, updateCounts, otherDatas, newTransactionId);
                                 channel.sendReplyMessage(message.messageId, response);
                                 message.close();
+                                messageClosed[0] = true;
                                 runningStatements.unregisterRunningStatement(statementInfo);
                                 writeOk = true;
                             } catch (Throwable t) {
@@ -783,17 +792,38 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                         // Defensive: any thrown exception inside a whenComplete
                         // lambda is silently dropped by the JDK; we cannot let
                         // that swallow both the protocol reply AND the metric.
+                        // In practice this catches: RuntimeException from the
+                        // table-manager / RecordSerializer chain (e.g. table
+                        // dropped concurrently), unserializable column types
+                        // bubbling up from PduCodec, and Errors such as OOM.
                         LOGGER.log(Level.SEVERE, "Unexpected error in execute_statements callback", t);
+                        ByteBuf errBuf = null;
                         try {
-                            channel.sendReplyMessage(message.messageId, composeErrorResponse(message.messageId, t));
+                            errBuf = composeErrorResponse(message.messageId, t);
+                            channel.sendReplyMessage(message.messageId, errBuf);
+                            errBuf = null;
                         } catch (Throwable ignored) {
                             // Suppressed: best-effort error reply; the channel
-                            // may already be closed.
+                            // may already be closed. We still need to release
+                            // the buffer if we allocated one but never handed
+                            // it to the channel.
+                            if (errBuf != null) {
+                                try {
+                                    errBuf.release();
+                                } catch (Throwable ignoredRelease) {
+                                    // Suppressed: nothing useful we can do here.
+                                }
+                            }
                         }
-                        try {
-                            message.close();
-                        } catch (Throwable ignored) {
-                            // Suppressed: idempotent close.
+                        if (!messageClosed[0]) {
+                            try {
+                                message.close();
+                            } catch (Throwable ignored) {
+                                // Suppressed: best-effort; Pdu.close() must not
+                                // be retried on failure (Recycler.recycle is
+                                // not idempotent). Logging the original error
+                                // above is sufficient.
+                            }
                         }
                         runningStatements.unregisterRunningStatement(statementInfo);
                         recordRequest(latency, startNanos, false);

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -609,6 +609,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
 
     private void handleCloseScanner(Pdu message, Channel channel, long startNanos) {
         OpStatsLogger latency = server.getRequestStats().closeScanner();
+        boolean success = false;
         try {
             long scannerId = PduCodec.CloseScanner.readScannerId(message);
             ServerSideScannerPeer removed = scanners.remove(scannerId);
@@ -618,8 +619,9 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 }
                 removed.clientClose();
             }
+            success = true;
         } finally {
-            recordRequest(latency, startNanos, true);
+            recordRequest(latency, startNanos, success);
         }
     }
 
@@ -704,70 +706,98 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
 
                 @Override
                 public void accept(StatementExecutionResult result, Throwable error) {
-                    if (error != null) {
-                        ByteBuf errorMsg = composeErrorResponse(message.messageId, error);
-                        channel.sendReplyMessage(message.messageId, errorMsg);
-                        message.close();
-                        runningStatements.unregisterRunningStatement(statementInfo);
-                        recordRequest(latency, startNanos, false);
-                        return;
-                    }
-                    if (result instanceof DMLStatementExecutionResult) {
-                        DMLStatementExecutionResult dml = (DMLStatementExecutionResult) result;
-                        Map<String, Object> otherData = Collections.emptyMap();
-                        if (returnValues && dml.getKey() != null) {
-                            TranslatedQuery translatedQuery = queries.get(current - 1);
-                            Statement statement = translatedQuery.plan.mainStatement;
-                            TableAwareStatement tableStatement = (TableAwareStatement) statement;
-                            Table table = server.getManager().getTableSpaceManager(statement.getTableSpace()).getTableManager(tableStatement.getTable()).getTable();
-                            Object key = RecordSerializer.deserializePrimaryKey(dml.getKey(), table);
-                            otherData = new HashMap<>();
-                            otherData.put("_key", key);
-                            if (dml.getNewvalue() != null) {
-                                Map<String, Object> newvalue = RecordSerializer.toBean(new Record(dml.getKey(), dml.getNewvalue()), table);
-                                otherData.putAll(newvalue);
-                            }
+                    // The whole body is wrapped in a try/catch because a thrown
+                    // exception inside a CompletableFuture#whenComplete callback
+                    // is dropped by the JDK with no error reply to the client and
+                    // no metric record, which would silently break both the
+                    // protocol and the dashboards. The catch is intentionally
+                    // broad: anything reaching it is by definition unexpected,
+                    // so we log it, send an error reply best-effort, unregister
+                    // the running statement, and record a failed request event.
+                    try {
+                        if (error != null) {
+                            ByteBuf errorMsg = composeErrorResponse(message.messageId, error);
+                            channel.sendReplyMessage(message.messageId, errorMsg);
+                            message.close();
+                            runningStatements.unregisterRunningStatement(statementInfo);
+                            recordRequest(latency, startNanos, false);
+                            return;
                         }
-                        updateCounts.add((long) dml.getUpdateCount());
-                        otherDatas.add(otherData);
-                    } else if (result instanceof DDLStatementExecutionResult) {
-                        Map<String, Object> otherData = Collections.emptyMap();
-                        updateCounts.add(1L);
-                        otherDatas.add(otherData);
-                    } else {
-                        ByteBuf response = PduCodec.ErrorResponse.write(message.messageId, "bad result type " + result.getClass() + " (" + result + ")");
-                        channel.sendReplyMessage(message.messageId, response);
-                        message.close();
-                        runningStatements.unregisterRunningStatement(statementInfo);
-                        recordRequest(latency, startNanos, false);
-                        return;
-                    }
-
-                    long newTransactionId = result.transactionId;
-                    if (current == queries.size()) {
-                        boolean writeOk = false;
-                        try {
-                            ByteBuf response = PduCodec.ExecuteStatementsResult.write(message.messageId, updateCounts, otherDatas, newTransactionId);
+                        if (result instanceof DMLStatementExecutionResult) {
+                            DMLStatementExecutionResult dml = (DMLStatementExecutionResult) result;
+                            Map<String, Object> otherData = Collections.emptyMap();
+                            if (returnValues && dml.getKey() != null) {
+                                TranslatedQuery translatedQuery = queries.get(current - 1);
+                                Statement statement = translatedQuery.plan.mainStatement;
+                                TableAwareStatement tableStatement = (TableAwareStatement) statement;
+                                Table table = server.getManager().getTableSpaceManager(statement.getTableSpace()).getTableManager(tableStatement.getTable()).getTable();
+                                Object key = RecordSerializer.deserializePrimaryKey(dml.getKey(), table);
+                                otherData = new HashMap<>();
+                                otherData.put("_key", key);
+                                if (dml.getNewvalue() != null) {
+                                    Map<String, Object> newvalue = RecordSerializer.toBean(new Record(dml.getKey(), dml.getNewvalue()), table);
+                                    otherData.putAll(newvalue);
+                                }
+                            }
+                            updateCounts.add((long) dml.getUpdateCount());
+                            otherDatas.add(otherData);
+                        } else if (result instanceof DDLStatementExecutionResult) {
+                            Map<String, Object> otherData = Collections.emptyMap();
+                            updateCounts.add(1L);
+                            otherDatas.add(otherData);
+                        } else {
+                            ByteBuf response = PduCodec.ErrorResponse.write(message.messageId, "bad result type " + result.getClass() + " (" + result + ")");
                             channel.sendReplyMessage(message.messageId, response);
                             message.close();
                             runningStatements.unregisterRunningStatement(statementInfo);
-                            writeOk = true;
-                        } catch (Throwable t) {
-                            // Reply serialization is best-effort: log here and
-                            // record the request as failed so dashboards reflect
-                            // the actual error rate rather than masking it.
-                            LOGGER.log(Level.SEVERE, "Internal error", t);
-                        } finally {
-                            recordRequest(latency, startNanos, writeOk);
+                            recordRequest(latency, startNanos, false);
+                            return;
                         }
-                        return;
-                    }
 
-                    TranslatedQuery nextPlannedQuery = queries.get(current);
-                    TransactionContext transactionContext = new TransactionContext(newTransactionId);
-                    CompletableFuture<StatementExecutionResult> nextPromise =
-                            server.getManager().executePlanAsync(nextPlannedQuery.plan, nextPlannedQuery.context, transactionContext);
-                    nextPromise.whenComplete(new ComputeNext(current + 1));
+                        long newTransactionId = result.transactionId;
+                        if (current == queries.size()) {
+                            boolean writeOk = false;
+                            try {
+                                ByteBuf response = PduCodec.ExecuteStatementsResult.write(message.messageId, updateCounts, otherDatas, newTransactionId);
+                                channel.sendReplyMessage(message.messageId, response);
+                                message.close();
+                                runningStatements.unregisterRunningStatement(statementInfo);
+                                writeOk = true;
+                            } catch (Throwable t) {
+                                // Reply serialization is best-effort: log here and
+                                // record the request as failed so dashboards reflect
+                                // the actual error rate rather than masking it.
+                                LOGGER.log(Level.SEVERE, "Internal error", t);
+                            } finally {
+                                recordRequest(latency, startNanos, writeOk);
+                            }
+                            return;
+                        }
+
+                        TranslatedQuery nextPlannedQuery = queries.get(current);
+                        TransactionContext transactionContext = new TransactionContext(newTransactionId);
+                        CompletableFuture<StatementExecutionResult> nextPromise =
+                                server.getManager().executePlanAsync(nextPlannedQuery.plan, nextPlannedQuery.context, transactionContext);
+                        nextPromise.whenComplete(new ComputeNext(current + 1));
+                    } catch (Throwable t) {
+                        // Defensive: any thrown exception inside a whenComplete
+                        // lambda is silently dropped by the JDK; we cannot let
+                        // that swallow both the protocol reply AND the metric.
+                        LOGGER.log(Level.SEVERE, "Unexpected error in execute_statements callback", t);
+                        try {
+                            channel.sendReplyMessage(message.messageId, composeErrorResponse(message.messageId, t));
+                        } catch (Throwable ignored) {
+                            // Suppressed: best-effort error reply; the channel
+                            // may already be closed.
+                        }
+                        try {
+                            message.close();
+                        } catch (Throwable ignored) {
+                            // Suppressed: idempotent close.
+                        }
+                        runningStatements.unregisterRunningStatement(statementInfo);
+                        recordRequest(latency, startNanos, false);
+                    }
                 }
             }
 

--- a/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
+++ b/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
@@ -35,14 +35,13 @@ import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
 import herddb.model.commands.GetStatement;
 import herddb.utils.Bytes;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.apache.bookkeeper.test.TestStatsProvider.TestOpStatsLogger;
 import org.junit.Rule;
@@ -140,12 +139,39 @@ public class RequestStatsTest {
             assertSuccessRecorded(statsProvider, "requests.tx_begin");
             assertSuccessRecorded(statsProvider, "requests.tx_commit");
             assertSuccessRecorded(statsProvider, "requests.tx_rollback");
+
+            // Tighten the assertions on the deterministic-count metrics so a
+            // regression that records spurious extras (e.g. a stray
+            // registerSuccessfulEvent in the wrong branch) is caught.
+            TestOpStatsLogger txBegin = statsProvider.getOpStatsLogger("requests.tx_begin");
+            assertEquals("tx_begin success count", 2L, txBegin.getSuccessCount());
+            assertEquals("tx_begin failure count", 0L, txBegin.getFailureCount());
+            TestOpStatsLogger txCommit = statsProvider.getOpStatsLogger("requests.tx_commit");
+            assertEquals("tx_commit success count", 1L, txCommit.getSuccessCount());
+            assertEquals("tx_commit failure count", 0L, txCommit.getFailureCount());
+            TestOpStatsLogger txRollback = statsProvider.getOpStatsLogger("requests.tx_rollback");
+            assertEquals("tx_rollback success count", 1L, txRollback.getSuccessCount());
+            assertEquals("tx_rollback failure count", 0L, txRollback.getFailureCount());
+
+            // request_tablespace_dump is the only non-trivial admin request
+            // type covered by RequestStats. Driving it requires a TableSpace
+            // dump receiver scaffolding that adds non-trivial complexity
+            // without exercising new code paths in ServerSideConnectionPeer
+            // (handleRequestTablespaceDump just calls dumpTableSpace). The
+            // metric registration / wiring is verified structurally: the
+            // logger must exist (the OpStatsLogger is created eagerly in
+            // RequestStats's constructor).
+            assertTrue("requests.request_tablespace_dump logger missing — "
+                    + "RequestStats wiring regressed",
+                    statsProvider.getOpStatsLogger("requests.request_tablespace_dump") != null);
         }
     }
 
     /**
-     * Executes a scan with a fetch size larger than the result so the client
-     * library issues an explicit CLOSESCANNER, hitting the close_scanner path.
+     * Executes a scan with a small fetch size and partial consumption so the
+     * client library issues an explicit CLOSESCANNER, hitting the close_scanner
+     * handler. Because CLOSESCANNER is sent fire-and-forget (one-way, no ack),
+     * we must poll the metric instead of asserting it immediately.
      */
     @Test
     public void testCloseScannerRecorded() throws Exception {
@@ -175,9 +201,12 @@ public class RequestStatsTest {
                         rs.next();
                     }
                 }
-            }
 
-            assertSuccessRecorded(statsProvider, "requests.close_scanner");
+                // CLOSESCANNER is one-way; poll the metric until the server
+                // has handled it, instead of relying on a synchronous reply.
+                awaitSuccess(statsProvider, "requests.close_scanner",
+                        Duration.ofSeconds(10));
+            }
         }
     }
 
@@ -247,6 +276,27 @@ public class RequestStatsTest {
             assertFailureRecorded(statsProvider, "requests.open_scanner");
             assertFailureRecorded(statsProvider, "requests.tx_commit");
             assertFailureRecorded(statsProvider, "requests.tx_rollback");
+
+            // Tighten: metrics whose only intended driver in this test is a
+            // failure path must NOT have any successful events. (CREATE TABLE
+            // at the start does succeed, so requests.execute_statement does
+            // legitimately have one success — we don't pin it here.)
+            TestOpStatsLogger executeBatch =
+                    statsProvider.getOpStatsLogger("requests.execute_statements");
+            assertEquals("execute_statements should have no successes in this test",
+                    0L, executeBatch.getSuccessCount());
+            TestOpStatsLogger openScanner =
+                    statsProvider.getOpStatsLogger("requests.open_scanner");
+            assertEquals("open_scanner should have no successes in this test",
+                    0L, openScanner.getSuccessCount());
+            TestOpStatsLogger txCommit =
+                    statsProvider.getOpStatsLogger("requests.tx_commit");
+            assertEquals("tx_commit should have no successes in this test",
+                    0L, txCommit.getSuccessCount());
+            TestOpStatsLogger txRollback =
+                    statsProvider.getOpStatsLogger("requests.tx_rollback");
+            assertEquals("tx_rollback should have no successes in this test",
+                    0L, txRollback.getSuccessCount());
         }
     }
 
@@ -277,6 +327,13 @@ public class RequestStatsTest {
                  HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
+                // Warm the SASL handshake on a successful call first so the
+                // doomed call below races only against the actual PREPARE
+                // round-trip, not server bootstrap.
+                connection.executeUpdate(TableSpace.DEFAULT,
+                        "CREATE TABLE warmup (id string primary key)",
+                        0, false, true, Collections.emptyList());
+
                 ExecutorService runner = Executors.newSingleThreadExecutor();
                 Future<?> doomed = runner.submit(() -> {
                     try {
@@ -287,11 +344,15 @@ public class RequestStatsTest {
                     }
                 });
                 try {
-                    doomed.get(2, TimeUnit.SECONDS);
-                } catch (TimeoutException expected) {
-                    // Client is in its retry loop — that's fine, the very
-                    // first PREPARE attempt has already failed and the metric
-                    // has been recorded.
+                    // Poll the failure metric instead of relying on a hard
+                    // 2-second cap; a slow CI runner may need more time for
+                    // the first PREPARE round-trip. We cap the overall wait
+                    // at 30 s and cancel the doomed call once the metric has
+                    // moved (the client would otherwise retry forever because
+                    // LeaderChangedException.getMaxRetry() returns
+                    // Integer.MAX_VALUE).
+                    awaitFailure(statsProvider, "requests.prepare_statement",
+                            Duration.ofSeconds(30));
                 } finally {
                     doomed.cancel(true);
                     runner.shutdownNow();
@@ -370,8 +431,6 @@ public class RequestStatsTest {
     private static void assertSuccessRecorded(TestStatsProvider provider, String fullPath) {
         TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
         assertTrue(fullPath + " OpStatsLogger missing", logger != null);
-        long total = logger.getSuccessCount() + logger.getFailureCount();
-        assertTrue("expected at least one event for " + fullPath + ", got " + total, total >= 1);
         assertTrue(
                 "expected at least one successful event for " + fullPath
                         + ", success=" + logger.getSuccessCount()
@@ -387,6 +446,51 @@ public class RequestStatsTest {
                         + ", success=" + logger.getSuccessCount()
                         + " failure=" + logger.getFailureCount(),
                 logger.getFailureCount() >= 1);
+    }
+
+    private static void assertNoEvents(TestStatsProvider provider, String fullPath) {
+        TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+        if (logger == null) {
+            return;
+        }
+        assertEquals("expected no successful events for " + fullPath,
+                0L, logger.getSuccessCount());
+        assertEquals("expected no failed events for " + fullPath,
+                0L, logger.getFailureCount());
+    }
+
+    private static void awaitSuccess(TestStatsProvider provider, String fullPath,
+                                     Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+            if (logger != null && logger.getSuccessCount() >= 1) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+        long success = logger == null ? -1 : logger.getSuccessCount();
+        long failure = logger == null ? -1 : logger.getFailureCount();
+        org.junit.Assert.fail("timed out waiting for a successful event on " + fullPath
+                + " after " + timeout + ", success=" + success + " failure=" + failure);
+    }
+
+    private static void awaitFailure(TestStatsProvider provider, String fullPath,
+                                     Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+            if (logger != null && logger.getFailureCount() >= 1) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+        long success = logger == null ? -1 : logger.getSuccessCount();
+        long failure = logger == null ? -1 : logger.getFailureCount();
+        org.junit.Assert.fail("timed out waiting for a failed event on " + fullPath
+                + " after " + timeout + ", success=" + success + " failure=" + failure);
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
+++ b/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
@@ -309,11 +309,11 @@ public class RequestStatsTest {
      *
      * <p>The client retries {@link herddb.client.impl.LeaderChangedException}
      * up to {@code Integer.MAX_VALUE} times (it overrides
-     * {@code getMaxRetry()} unconditionally) so the call would loop forever on
-     * its own. We bound the wait by running the doomed call on a separate
-     * thread with a 2-second cap and asserting the metric immediately after —
-     * by then the very first PREPARE PDU has already been processed and
-     * recorded as a failure.</p>
+     * {@code getMaxRetry()} unconditionally) so the call would loop forever
+     * on its own. We bound the wait by running the doomed call on a separate
+     * thread, polling the failure metric for up to 30 seconds, and cancelling
+     * the doomed call once the very first PREPARE PDU has been processed and
+     * recorded.</p>
      */
     @Test
     public void testPrepareStatementFailureRecorded() throws Exception {
@@ -446,17 +446,6 @@ public class RequestStatsTest {
                         + ", success=" + logger.getSuccessCount()
                         + " failure=" + logger.getFailureCount(),
                 logger.getFailureCount() >= 1);
-    }
-
-    private static void assertNoEvents(TestStatsProvider provider, String fullPath) {
-        TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
-        if (logger == null) {
-            return;
-        }
-        assertEquals("expected no successful events for " + fullPath,
-                0L, logger.getSuccessCount());
-        assertEquals("expected no failed events for " + fullPath,
-                0L, logger.getFailureCount());
     }
 
     private static void awaitSuccess(TestStatsProvider provider, String fullPath,

--- a/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
+++ b/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
@@ -1,0 +1,164 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server;
+
+import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.client.ClientConfiguration;
+import herddb.client.DMLResult;
+import herddb.client.HDBClient;
+import herddb.client.HDBConnection;
+import herddb.client.ScanResultSet;
+import herddb.model.TableSpace;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.apache.bookkeeper.test.TestStatsProvider.TestOpStatsLogger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that the per-request-type metrics exposed under the {@code requests}
+ * scope are populated by {@link ServerSideConnectionPeer} for every kind of
+ * client request. The Grafana dashboard panels added in the same change rely
+ * on these series to display request rate and latency by type.
+ */
+public class RequestStatsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testRequestStatsArePopulated() throws Exception {
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        ServerConfiguration config = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
+        try (Server server = new Server(config, statsProvider)) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
+                 HDBConnection connection = client.openConnection()) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+
+                // 1. CREATE TABLE — execute_statement (DDL)
+                long created = connection.executeUpdate(TableSpace.DEFAULT,
+                        "CREATE TABLE mytable (id string primary key, n1 long)",
+                        0, false, true, Collections.emptyList()).updateCount;
+                assertEquals(1, created);
+
+                // 2. INSERT — execute_statement (DML)
+                long inserted = connection.executeUpdate(TableSpace.DEFAULT,
+                        "INSERT INTO mytable (id, n1) values (?, ?)",
+                        0, false, true, Arrays.asList("k1", 10L)).updateCount;
+                assertEquals(1, inserted);
+
+                // 3. Batch INSERT — execute_statements
+                List<DMLResult> batched = connection.executeUpdates(TableSpace.DEFAULT,
+                        "INSERT INTO mytable (id, n1) values (?, ?)",
+                        0, false, true,
+                        Arrays.asList(
+                                Arrays.asList("k2", 20L),
+                                Arrays.asList("k3", 30L)));
+                assertEquals(2, batched.size());
+
+                // 4. SCAN — open_scanner + (potentially) fetch_scanner_data + close_scanner.
+                // fetchSize=1 with 3 rows guarantees that fetch_scanner_data is reached.
+                int rows = 0;
+                try (ScanResultSet rs = connection.executeScan(TableSpace.DEFAULT,
+                        "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 1, true)) {
+                    while (rs.hasNext()) {
+                        rs.next();
+                        rows++;
+                    }
+                }
+                assertEquals(3, rows);
+
+                // 5. BEGIN / COMMIT
+                long txCommit = connection.beginTransaction(TableSpace.DEFAULT);
+                connection.commitTransaction(TableSpace.DEFAULT, txCommit);
+
+                // 6. BEGIN / ROLLBACK
+                long txRollback = connection.beginTransaction(TableSpace.DEFAULT);
+                connection.rollbackTransaction(TableSpace.DEFAULT, txRollback);
+            }
+
+            // Each handler must be reachable under the requests.<type> scope.
+            assertSuccessRecorded(statsProvider, "requests.execute_statement");
+            assertSuccessRecorded(statsProvider, "requests.execute_statements");
+            assertSuccessRecorded(statsProvider, "requests.open_scanner");
+            assertSuccessRecorded(statsProvider, "requests.tx_begin");
+            assertSuccessRecorded(statsProvider, "requests.tx_commit");
+            assertSuccessRecorded(statsProvider, "requests.tx_rollback");
+        }
+    }
+
+    @Test
+    public void testFailedRequestRecordedAsFailure() throws Exception {
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        ServerConfiguration config = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
+        try (Server server = new Server(config, statsProvider)) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
+                 HDBConnection connection = client.openConnection()) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+
+                // Send an INSERT that targets a non-existing table — the planner
+                // will reject it and the handler must record a failed event.
+                try {
+                    connection.executeUpdate(TableSpace.DEFAULT,
+                            "INSERT INTO does_not_exist (id) values (?)",
+                            0, false, true, Arrays.asList("k1"));
+                    // Some failures are surfaced as zero updateCount instead of
+                    // an exception; the metric assertion below is the real check.
+                } catch (Exception expected) {
+                    // expected: missing table
+                }
+            }
+
+            TestOpStatsLogger logger = statsProvider.getOpStatsLogger("requests.execute_statement");
+            // The logger MUST exist (the request reached the handler).
+            assertTrue("execute_statement OpStatsLogger missing", logger != null);
+            long total = logger.getSuccessCount() + logger.getFailureCount();
+            assertTrue("expected at least one execute_statement event, got total=" + total, total >= 1);
+            assertTrue(
+                    "expected at least one failed execute_statement event, success="
+                            + logger.getSuccessCount() + " failure=" + logger.getFailureCount(),
+                    logger.getFailureCount() >= 1);
+        }
+    }
+
+    private static void assertSuccessRecorded(TestStatsProvider provider, String fullPath) {
+        TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+        assertTrue(fullPath + " OpStatsLogger missing", logger != null);
+        long total = logger.getSuccessCount() + logger.getFailureCount();
+        assertTrue("expected at least one event for " + fullPath + ", got " + total, total >= 1);
+        assertTrue(
+                "expected at least one successful event for " + fullPath
+                        + ", success=" + logger.getSuccessCount()
+                        + " failure=" + logger.getFailureCount(),
+                logger.getSuccessCount() >= 1);
+    }
+}

--- a/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
+++ b/herddb-core/src/test/java/herddb/server/RequestStatsTest.java
@@ -27,11 +27,22 @@ import herddb.client.ClientConfiguration;
 import herddb.client.DMLResult;
 import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
+import herddb.client.HDBException;
 import herddb.client.ScanResultSet;
+import herddb.model.StatementEvaluationContext;
 import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.model.commands.GetStatement;
+import herddb.utils.Bytes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.apache.bookkeeper.test.TestStatsProvider.TestOpStatsLogger;
 import org.junit.Rule;
@@ -41,14 +52,22 @@ import org.junit.rules.TemporaryFolder;
 /**
  * Verifies that the per-request-type metrics exposed under the {@code requests}
  * scope are populated by {@link ServerSideConnectionPeer} for every kind of
- * client request. The Grafana dashboard panels added in the same change rely
- * on these series to display request rate and latency by type.
+ * client request, that failures are reported as failed events, and that
+ * in-JVM "local-mode" execution paths (which bypass the wire protocol) do NOT
+ * touch these metrics. The Grafana dashboard panels added in the same change
+ * rely on these series to display request rate, failure rate, and latency by
+ * type.
  */
 public class RequestStatsTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
+    /**
+     * Drives every user-facing request type through {@link HDBConnection} and
+     * asserts the corresponding {@code requests.<type>} {@link TestOpStatsLogger}
+     * recorded at least one successful event. Covers all 9 request types.
+     */
     @Test
     public void testRequestStatsArePopulated() throws Exception {
         TestStatsProvider statsProvider = new TestStatsProvider();
@@ -61,13 +80,15 @@ public class RequestStatsTest {
                  HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
-                // 1. CREATE TABLE — execute_statement (DDL)
+                // 1. CREATE TABLE — execute_statement (DDL). usePreparedStatement=true
+                // forces the client to send a TYPE_PREPARE_STATEMENT first, which
+                // exercises the prepare_statement metric.
                 long created = connection.executeUpdate(TableSpace.DEFAULT,
                         "CREATE TABLE mytable (id string primary key, n1 long)",
                         0, false, true, Collections.emptyList()).updateCount;
                 assertEquals(1, created);
 
-                // 2. INSERT — execute_statement (DML)
+                // 2. INSERT — execute_statement (DML). Same prepare-first flow.
                 long inserted = connection.executeUpdate(TableSpace.DEFAULT,
                         "INSERT INTO mytable (id, n1) values (?, ?)",
                         0, false, true, Arrays.asList("k1", 10L)).updateCount;
@@ -82,8 +103,10 @@ public class RequestStatsTest {
                                 Arrays.asList("k3", 30L)));
                 assertEquals(2, batched.size());
 
-                // 4. SCAN — open_scanner + (potentially) fetch_scanner_data + close_scanner.
-                // fetchSize=1 with 3 rows guarantees that fetch_scanner_data is reached.
+                // 4. SCAN — open_scanner + fetch_scanner_data + close_scanner.
+                // fetchSize=1 with 3 rows guarantees that fetch_scanner_data is
+                // reached on the wire (otherwise the server returns last=true on
+                // the OPENSCANNER reply and no FETCHSCANNERDATA PDU is sent).
                 int rows = 0;
                 try (ScanResultSet rs = connection.executeScan(TableSpace.DEFAULT,
                         "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 1, true)) {
@@ -103,18 +126,29 @@ public class RequestStatsTest {
                 connection.rollbackTransaction(TableSpace.DEFAULT, txRollback);
             }
 
-            // Each handler must be reachable under the requests.<type> scope.
+            // Every request type the client can issue must be reachable under
+            // the requests.<type> scope. close_scanner is included here because
+            // the scanner produced by step 4 is closed once the result set is
+            // exhausted; if the server already returned last=true on the final
+            // FETCHSCANNERDATA reply the client may skip CLOSESCANNER, so close
+            // is verified separately via the explicit-close test below.
+            assertSuccessRecorded(statsProvider, "requests.prepare_statement");
             assertSuccessRecorded(statsProvider, "requests.execute_statement");
             assertSuccessRecorded(statsProvider, "requests.execute_statements");
             assertSuccessRecorded(statsProvider, "requests.open_scanner");
+            assertSuccessRecorded(statsProvider, "requests.fetch_scanner_data");
             assertSuccessRecorded(statsProvider, "requests.tx_begin");
             assertSuccessRecorded(statsProvider, "requests.tx_commit");
             assertSuccessRecorded(statsProvider, "requests.tx_rollback");
         }
     }
 
+    /**
+     * Executes a scan with a fetch size larger than the result so the client
+     * library issues an explicit CLOSESCANNER, hitting the close_scanner path.
+     */
     @Test
-    public void testFailedRequestRecordedAsFailure() throws Exception {
+    public void testCloseScannerRecorded() throws Exception {
         TestStatsProvider statsProvider = new TestStatsProvider();
         ServerConfiguration config = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
         try (Server server = new Server(config, statsProvider)) {
@@ -125,28 +159,211 @@ public class RequestStatsTest {
                  HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
-                // Send an INSERT that targets a non-existing table — the planner
-                // will reject it and the handler must record a failed event.
-                try {
+                connection.executeUpdate(TableSpace.DEFAULT,
+                        "CREATE TABLE mytable (id string primary key, n1 long)",
+                        0, false, true, Collections.emptyList());
+                for (int i = 0; i < 5; i++) {
                     connection.executeUpdate(TableSpace.DEFAULT,
-                            "INSERT INTO does_not_exist (id) values (?)",
-                            0, false, true, Arrays.asList("k1"));
-                    // Some failures are surfaced as zero updateCount instead of
-                    // an exception; the metric assertion below is the real check.
-                } catch (Exception expected) {
-                    // expected: missing table
+                            "INSERT INTO mytable (id, n1) values (?, ?)",
+                            0, false, true, Arrays.asList("k" + i, (long) i));
+                }
+                // Open a scanner but only consume one row, then close — this
+                // forces a CLOSESCANNER PDU because the server still has rows.
+                try (ScanResultSet rs = connection.executeScan(TableSpace.DEFAULT,
+                        "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 1, true)) {
+                    if (rs.hasNext()) {
+                        rs.next();
+                    }
                 }
             }
 
-            TestOpStatsLogger logger = statsProvider.getOpStatsLogger("requests.execute_statement");
-            // The logger MUST exist (the request reached the handler).
-            assertTrue("execute_statement OpStatsLogger missing", logger != null);
-            long total = logger.getSuccessCount() + logger.getFailureCount();
-            assertTrue("expected at least one execute_statement event, got total=" + total, total >= 1);
-            assertTrue(
-                    "expected at least one failed execute_statement event, success="
-                            + logger.getSuccessCount() + " failure=" + logger.getFailureCount(),
-                    logger.getFailureCount() >= 1);
+            assertSuccessRecorded(statsProvider, "requests.close_scanner");
+        }
+    }
+
+    /**
+     * Negative-path coverage: every metric used in the dashboard's
+     * "Failed Request Rate by Type" panel must be reachable as a failure.
+     */
+    @Test
+    public void testFailedRequestsRecordedAsFailures() throws Exception {
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        ServerConfiguration config = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
+        try (Server server = new Server(config, statsProvider)) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            // Cap the client-side retry count so a NotLeaderError on an unknown
+            // tablespace surfaces as an exception instead of looping forever.
+            ClientConfiguration clientConfig = new ClientConfiguration(folder.newFolder().toPath());
+            clientConfig.set(ClientConfiguration.PROPERTY_MAX_OPERATION_RETRY_COUNT, 1);
+            try (HDBClient client = new HDBClient(clientConfig);
+                 HDBConnection connection = client.openConnection()) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+
+                // Make sure CREATE TABLE succeeds (so we can later commit on it).
+                connection.executeUpdate(TableSpace.DEFAULT,
+                        "CREATE TABLE t (id string primary key)",
+                        0, false, true, Collections.emptyList());
+
+                // execute_statement failure — INSERT into a non-existing table.
+                ignoring(() -> connection.executeUpdate(TableSpace.DEFAULT,
+                        "INSERT INTO does_not_exist (id) values (?)",
+                        0, false, true, Arrays.asList("k1")));
+
+                // execute_statements failure — batch against a non-existing table.
+                ignoring(() -> connection.executeUpdates(TableSpace.DEFAULT,
+                        "INSERT INTO does_not_exist_either (id) values (?)",
+                        0, false, true,
+                        Arrays.asList(Arrays.asList("a"), Arrays.asList("b"))));
+
+                // open_scanner failure — query against a non-existing table.
+                ignoring(() -> {
+                    try (ScanResultSet rs = connection.executeScan(TableSpace.DEFAULT,
+                            "SELECT * FROM definitely_not_a_table", true, Collections.emptyList(),
+                            0, 0, 10, true)) {
+                        while (rs.hasNext()) {
+                            rs.next();
+                        }
+                    }
+                    return null;
+                });
+
+                // tx_commit failure — committing a tx id that doesn't exist.
+                ignoring(() -> {
+                    connection.commitTransaction(TableSpace.DEFAULT, 999_999L);
+                    return null;
+                });
+
+                // tx_rollback failure — rolling back a tx id that doesn't exist.
+                ignoring(() -> {
+                    connection.rollbackTransaction(TableSpace.DEFAULT, 999_999L);
+                    return null;
+                });
+            }
+
+            assertFailureRecorded(statsProvider, "requests.execute_statement");
+            assertFailureRecorded(statsProvider, "requests.execute_statements");
+            assertFailureRecorded(statsProvider, "requests.open_scanner");
+            assertFailureRecorded(statsProvider, "requests.tx_commit");
+            assertFailureRecorded(statsProvider, "requests.tx_rollback");
+        }
+    }
+
+    /**
+     * Drives a {@code prepare_statement} failure by issuing an
+     * {@code executeUpdate} with {@code usePreparedStatement=true} against a
+     * tablespace that does not exist. The client's prepare PDU surfaces the
+     * not-leader error, which the server records as a failed
+     * {@code requests.prepare_statement} event.
+     *
+     * <p>The client retries {@link herddb.client.impl.LeaderChangedException}
+     * up to {@code Integer.MAX_VALUE} times (it overrides
+     * {@code getMaxRetry()} unconditionally) so the call would loop forever on
+     * its own. We bound the wait by running the doomed call on a separate
+     * thread with a 2-second cap and asserting the metric immediately after —
+     * by then the very first PREPARE PDU has already been processed and
+     * recorded as a failure.</p>
+     */
+    @Test
+    public void testPrepareStatementFailureRecorded() throws Exception {
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        ServerConfiguration config = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
+        try (Server server = new Server(config, statsProvider)) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
+                 HDBConnection connection = client.openConnection()) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+
+                ExecutorService runner = Executors.newSingleThreadExecutor();
+                Future<?> doomed = runner.submit(() -> {
+                    try {
+                        connection.executeUpdate("no_such_tablespace",
+                                "SELECT 1", 0, false, true, Collections.emptyList());
+                    } catch (Exception ignored) {
+                        // expected: tablespace not found
+                    }
+                });
+                try {
+                    doomed.get(2, TimeUnit.SECONDS);
+                } catch (TimeoutException expected) {
+                    // Client is in its retry loop — that's fine, the very
+                    // first PREPARE attempt has already failed and the metric
+                    // has been recorded.
+                } finally {
+                    doomed.cancel(true);
+                    runner.shutdownNow();
+                }
+            }
+
+            assertFailureRecorded(statsProvider, "requests.prepare_statement");
+        }
+    }
+
+    /**
+     * In-JVM use of {@link herddb.core.DBManager#executeStatement} (the path
+     * taken by HerdDBEmbeddedDataSource and similar embedded callers) must NOT
+     * touch the request metrics — those are scoped to the wire protocol. This
+     * test guards against future refactors that accidentally instrument the
+     * embedded path.
+     */
+    @Test
+    public void testLocalExecutionDoesNotIncrementRequestStats() throws Exception {
+        TestStatsProvider statsProvider = new TestStatsProvider();
+        ServerConfiguration config = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
+        try (Server server = new Server(config, statsProvider)) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            // Run a statement directly against DBManager — the same code path
+            // that the local-mode public methods of ServerSideConnectionPeer
+            // (executeUpdate / executeGet / executeScan) ultimately call.
+            CreateTableSpaceStatement createTs = new CreateTableSpaceStatement(
+                    "ignored_check_ts", Collections.singleton("local"), "local", 1, 0, 0);
+            try {
+                server.getManager().executeStatement(createTs,
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        TransactionContext.NO_TRANSACTION);
+            } catch (Exception ignore) {
+                // It is fine if this particular statement fails; the only
+                // behaviour we care about is that no requests.* metric moved.
+            }
+
+            // A GetStatement against a non-existing tablespace should fail too,
+            // but again must not move any requests.* metric.
+            try {
+                server.getManager().executeStatement(
+                        new GetStatement(TableSpace.DEFAULT, "no_such_table",
+                                Bytes.from_string("k"), null, false),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        TransactionContext.NO_TRANSACTION);
+            } catch (Exception ignore) {
+                // expected
+            }
+
+            // None of the requests.* metrics may have been touched.
+            for (String metricName : new String[]{
+                    "requests.execute_statement",
+                    "requests.execute_statements",
+                    "requests.prepare_statement",
+                    "requests.open_scanner",
+                    "requests.fetch_scanner_data",
+                    "requests.close_scanner",
+                    "requests.tx_begin",
+                    "requests.tx_commit",
+                    "requests.tx_rollback",
+                    "requests.request_tablespace_dump"}) {
+                TestOpStatsLogger logger = statsProvider.getOpStatsLogger(metricName);
+                if (logger == null) {
+                    continue;
+                }
+                assertEquals("local-mode execution must not increment " + metricName + " success",
+                        0L, logger.getSuccessCount());
+                assertEquals("local-mode execution must not increment " + metricName + " failure",
+                        0L, logger.getFailureCount());
+            }
         }
     }
 
@@ -160,5 +377,35 @@ public class RequestStatsTest {
                         + ", success=" + logger.getSuccessCount()
                         + " failure=" + logger.getFailureCount(),
                 logger.getSuccessCount() >= 1);
+    }
+
+    private static void assertFailureRecorded(TestStatsProvider provider, String fullPath) {
+        TestOpStatsLogger logger = provider.getOpStatsLogger(fullPath);
+        assertTrue(fullPath + " OpStatsLogger missing", logger != null);
+        assertTrue(
+                "expected at least one failed event for " + fullPath
+                        + ", success=" + logger.getSuccessCount()
+                        + " failure=" + logger.getFailureCount(),
+                logger.getFailureCount() >= 1);
+    }
+
+    /**
+     * Helper that runs a possibly-failing call and swallows any exception so
+     * the test can keep driving subsequent failure paths. We cannot rely on
+     * the call always throwing — some failures are surfaced as zero
+     * updateCount instead of an exception — but the metric assertion is the
+     * real check.
+     */
+    private static void ignoring(ThrowingCallable r) {
+        try {
+            r.call();
+        } catch (Exception ignored) {
+            // expected
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingCallable {
+        Object call() throws HDBException, Exception;
     }
 }

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/herddb-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/herddb-dashboard.json
@@ -969,18 +969,25 @@
               "refId": "E"
             },
             {
+              "expr": "sum(rate(requests_tx_begin_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_begin [{{instance}}]",
+              "refId": "F"
+            },
+            {
               "expr": "sum(rate(requests_tx_commit_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "tx_commit [{{instance}}]",
-              "refId": "F"
+              "refId": "G"
             },
             {
               "expr": "sum(rate(requests_tx_rollback_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "tx_rollback [{{instance}}]",
-              "refId": "G"
+              "refId": "H"
             }
           ],
           "thresholds": [],

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/herddb-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/herddb-dashboard.json
@@ -757,6 +757,506 @@
     },
     {
       "collapse": false,
+      "height": 50,
+      "panels": [
+        {
+          "content": "<h3 style=\"text-align:center;color:#33b5e5;\">Request Execution</h3>",
+          "id": 300,
+          "mode": "html",
+          "span": 12,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        }
+      ],
+      "showTitle": false,
+      "title": "Request Execution Header",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 301,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(requests_execute_statement_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statement [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(requests_execute_statements_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statements [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(rate(requests_open_scanner_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "open_scanner [{{instance}}]",
+              "refId": "C"
+            },
+            {
+              "expr": "sum(rate(requests_fetch_scanner_data_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fetch_scanner_data [{{instance}}]",
+              "refId": "D"
+            },
+            {
+              "expr": "sum(rate(requests_close_scanner_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "close_scanner [{{instance}}]",
+              "refId": "E"
+            },
+            {
+              "expr": "sum(rate(requests_prepare_statement_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "prepare_statement [{{instance}}]",
+              "refId": "F"
+            },
+            {
+              "expr": "sum(rate(requests_tx_begin_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_begin [{{instance}}]",
+              "refId": "G"
+            },
+            {
+              "expr": "sum(rate(requests_tx_commit_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_commit [{{instance}}]",
+              "refId": "H"
+            },
+            {
+              "expr": "sum(rate(requests_tx_rollback_count{instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_rollback [{{instance}}]",
+              "refId": "I"
+            }
+          ],
+          "thresholds": [],
+          "title": "Request Rate by Type (1m rate, ops/sec)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 302,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(requests_execute_statement_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statement [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(requests_execute_statements_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statements [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(rate(requests_open_scanner_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "open_scanner [{{instance}}]",
+              "refId": "C"
+            },
+            {
+              "expr": "sum(rate(requests_fetch_scanner_data_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fetch_scanner_data [{{instance}}]",
+              "refId": "D"
+            },
+            {
+              "expr": "sum(rate(requests_prepare_statement_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "prepare_statement [{{instance}}]",
+              "refId": "E"
+            },
+            {
+              "expr": "sum(rate(requests_tx_commit_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_commit [{{instance}}]",
+              "refId": "F"
+            },
+            {
+              "expr": "sum(rate(requests_tx_rollback_count{success=\"false\",instance=~\"$instance\"}[1m])) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_rollback [{{instance}}]",
+              "refId": "G"
+            }
+          ],
+          "thresholds": [],
+          "title": "Failed Request Rate by Type (1m rate, ops/sec)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": false,
+      "title": "Request Rate Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 303,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "requests_execute_statement{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statement [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "requests_execute_statements{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statements [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "requests_open_scanner{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "open_scanner [{{instance}}]",
+              "refId": "C"
+            },
+            {
+              "expr": "requests_fetch_scanner_data{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fetch_scanner_data [{{instance}}]",
+              "refId": "D"
+            },
+            {
+              "expr": "requests_prepare_statement{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "prepare_statement [{{instance}}]",
+              "refId": "E"
+            },
+            {
+              "expr": "requests_tx_begin{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_begin [{{instance}}]",
+              "refId": "F"
+            },
+            {
+              "expr": "requests_tx_commit{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_commit [{{instance}}]",
+              "refId": "G"
+            },
+            {
+              "expr": "requests_tx_rollback{success=\"true\",quantile=\"0.95\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_rollback [{{instance}}]",
+              "refId": "H"
+            }
+          ],
+          "thresholds": [],
+          "title": "Request Latency p95 by Type (ms)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 304,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "requests_execute_statement{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statement [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "requests_execute_statements{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "execute_statements [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "requests_open_scanner{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "open_scanner [{{instance}}]",
+              "refId": "C"
+            },
+            {
+              "expr": "requests_fetch_scanner_data{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fetch_scanner_data [{{instance}}]",
+              "refId": "D"
+            },
+            {
+              "expr": "requests_prepare_statement{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "prepare_statement [{{instance}}]",
+              "refId": "E"
+            },
+            {
+              "expr": "requests_tx_begin{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_begin [{{instance}}]",
+              "refId": "F"
+            },
+            {
+              "expr": "requests_tx_commit{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_commit [{{instance}}]",
+              "refId": "G"
+            },
+            {
+              "expr": "requests_tx_rollback{success=\"true\",quantile=\"0.99\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tx_rollback [{{instance}}]",
+              "refId": "H"
+            }
+          ],
+          "thresholds": [],
+          "title": "Request Latency p99 by Type (ms)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": false,
+      "title": "Request Latency Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
       "height": 250,
       "panels": [
         {


### PR DESCRIPTION
Fixes #433.

The default Grafana dashboard was missing observability for the request layer:
no per-request rate, no per-request latency, no breakdown by request type. The
underlying metrics did not even exist — only `runningstatements` (an in-flight
gauge) was exposed.

## Changes

- **`herddb-core/src/main/java/herddb/server/RequestStats.java` (new)** —
  Holds one `OpStatsLogger` per request type under the `requests` scope of the
  server's root `StatsLogger`. Each logger produces both a latency distribution
  (with `quantile` + `success` labels) and a count series (`*_count`), so
  Grafana can derive request rate via `rate()`. Covered request types:
  `execute_statement`, `execute_statements`, `prepare_statement`,
  `open_scanner`, `fetch_scanner_data`, `close_scanner`, `tx_begin`,
  `tx_commit`, `tx_rollback`, `request_tablespace_dump`.

- **`herddb-core/src/main/java/herddb/server/Server.java`** — Constructs a
  `RequestStats` from the root `statsLogger` and exposes it via
  `getRequestStats()`.

- **`herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java`** —
  Captures `startNanos` at entry of `requestReceived(...)` and threads it
  through every handler. Each handler records the elapsed time at completion
  (sync paths in a `finally` block, async paths inside `whenComplete`) using
  `registerSuccessfulEvent` / `registerFailedEvent` with `TimeUnit.NANOSECONDS`
  — the BookKeeper Prometheus provider converts to milliseconds before
  exporting. `handleTxCommand` picks the correct sub-metric (`tx_begin` /
  `tx_commit` / `tx_rollback`) based on the decoded `TxCommand` value. Auth
  failures are recorded as failed events on the corresponding metric.

- **`herddb-kubernetes/.../grafana/dashboards/herddb-dashboard.json`** — Adds a
  new **Request Execution** section right after the existing HerdDB Overview
  Row, with three panels:
  - **Request Rate by Type** (1m rate, ops/sec) — covers all 9 user-facing
    request types.
  - **Failed Request Rate by Type** (`success="false"` only) — for quick
    spotting of error spikes.
  - **Request Latency p95 and p99 by Type** (ms) — one panel per quantile.

## Tests

- **`RequestStatsTest`** (new, plain unit/integration test) drives every
  request type through `HDBClient` (`CREATE TABLE`, single-row `INSERT`,
  batch `INSERT`, `SELECT` scan with `fetchSize=1` to force
  `fetch_scanner_data`, `BEGIN`/`COMMIT`, `BEGIN`/`ROLLBACK`) against a
  `Server` wired with `TestStatsProvider`. Asserts every request type's
  `OpStatsLogger` recorded at least one successful event under the expected
  metric path (`requests.execute_statement`, `requests.execute_statements`,
  `requests.open_scanner`, `requests.tx_begin`, `requests.tx_commit`,
  `requests.tx_rollback`).
- A second test (`testFailedRequestRecordedAsFailure`) sends an `INSERT`
  against a non-existent table and verifies that `requests.execute_statement`
  records at least one **failed** event, so the failure-rate panels in the
  dashboard are wired to a real signal.
- Re-ran `AtomicCounterTest`, `SimpleClientScanTest`,
  `ServerSidePreparedStatementCacheTest`, `JmxTest`, and `SimpleTransactionTest`
  to verify the instrumentation does not regress existing handler paths — all
  green.
- Pre-PR validation (`checkstyle:check apache-rat:check spotbugs:check
  install -DskipTests -Pci`) passes.

🤖 Implemented by the `pr-worker` agent.