### PR TITLE
issue #443, #445: HdrHistogram-backed MetricsCollector + producer optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
         <libs.caffeine>3.1.8</libs.caffeine>
         <libs.awssdk>2.42.34</libs.awssdk>
         <libs.testcontainers>1.21.4</libs.testcontainers>
+        <!--
+            HdrHistogram is used by vector-testings/MetricsCollector for
+            allocation-free latency recording. See issue #443. Tiny dep
+            (~120 KB, no transitives, Apache 2.0).
+        -->
+        <libs.hdrhistogram>2.2.2</libs.hdrhistogram>
     </properties>
 
     <dependencies>
@@ -151,6 +157,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>${libs.hdrhistogram}</version>
+            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>

--- a/vector-testings/pom.xml
+++ b/vector-testings/pom.xml
@@ -81,6 +81,14 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
         </dependency>
+        <!--
+            HdrHistogram backs MetricsCollector for allocation-free latency
+            recording and O(buckets) percentile snapshots — see issue #443.
+        -->
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>

--- a/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
@@ -772,14 +772,22 @@ public class DatasetLoader {
      * Skip {@code count} vectors in-place from a DataInputStream of FVECS
      * or BVECS format.
      *
-     * <p>Issue #443: SIFT files have a constant dim across every record,
-     * so the per-vector {@code readInt(dim) + skip(payload)} dance the
-     * original code performed was wasted work — for a 100 M-row resume
-     * that's 100 M small reads followed by 100 M skip calls. The new
-     * implementation reads dim from the first record only and then
-     * bulk-skips the remaining {@code count - 1} records as a single
-     * skip operation, leaving the underlying {@code BufferedInputStream}
-     * (or {@code GZIPInputStream}) free to short-circuit via {@code
+     * <p><b>Correctness requirement:</b> the SIFT format guarantees a
+     * constant {@code dim} across every record in a single file. The
+     * bulk-skip implementation below relies on this — it reads dim from
+     * the first record only, computes the per-record byte size, and then
+     * skips the remaining {@code count - 1} records as a single
+     * {@link DataInputStream#skip(long)}. A file that violates the
+     * constant-dim invariant would silently land at the wrong byte
+     * offset, so do <em>not</em> introduce a partial-fallback path here
+     * that re-reads dim per record without also detecting and surfacing
+     * the inconsistency loudly.
+     *
+     * <p>Issue #443: the previous per-vector {@code readInt + skip} loop
+     * was wasted work — for a 100 M-row resume that was 100 M small
+     * reads followed by 100 M skip calls. Folding into one bulk skip
+     * lets the underlying {@code BufferedInputStream} (or
+     * {@code GZIPInputStream}) short-circuit via {@code
      * FileInputStream.skip()} where supported.
      */
     private static void skipVecsInStream(DataInputStream dis, VecFormat format, long count) throws IOException {
@@ -805,19 +813,40 @@ public class DatasetLoader {
     }
 
     /**
-     * Skip exactly {@code totalBytes} bytes from {@code dis}, looping
-     * until the stream returns 0 (EOF) or we've advanced enough. Throws
-     * if EOF arrives early.
+     * Skip exactly {@code totalBytes} bytes from {@code dis}, throwing
+     * if EOF is reached early.
+     *
+     * <p>Implemented via chunked {@link DataInputStream#readFully(byte[],
+     * int, int)} into a 64 KB scratch buffer rather than
+     * {@link InputStream#skip(long)}. Reason: {@code FileInputStream.skip}
+     * delegates to {@code lseek}, which on most platforms succeeds even
+     * when seeking past EOF (the next {@code read()} returns -1, but the
+     * {@code skip()} itself does not throw). A bulk-skip that silently
+     * lands past EOF would let a corrupted / short file slip through the
+     * resume path undetected. {@code readFully} reads bytes through user
+     * space and surfaces EOF as a loud {@link java.io.EOFException},
+     * which we re-wrap into an actionable {@link IOException} below.
+     *
+     * <p>The throughput cost vs raw {@code skip()} is meaningful (a few
+     * hundred MB/s of memcpy), but resume is a one-time startup cost so
+     * we trade it for reliable error reporting.
      */
     private static void skipExactly(DataInputStream dis, long totalBytes, String what) throws IOException {
+        if (totalBytes <= 0) {
+            return;
+        }
+        int bufSize = (int) Math.min(64L * 1024L, totalBytes);
+        byte[] discard = new byte[bufSize];
         long remaining = totalBytes;
         while (remaining > 0) {
-            long skipped = dis.skip(remaining);
-            if (skipped <= 0) {
+            int chunk = (int) Math.min((long) bufSize, remaining);
+            try {
+                dis.readFully(discard, 0, chunk);
+            } catch (java.io.EOFException e) {
                 throw new IOException("Unexpected end of stream while skipping " + what
-                        + " (asked for " + totalBytes + " bytes, " + remaining + " left)");
+                        + " (asked for " + totalBytes + " bytes, " + remaining + " left)", e);
             }
-            remaining -= skipped;
+            remaining -= chunk;
         }
     }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -665,6 +666,30 @@ public class DatasetLoader {
                     private long count = 0;
                     private float[] next = null;
                     private boolean eof = false;
+                    /**
+                     * Reusable byte-buffer for the raw payload; allocated
+                     * lazily on the first read once dim is known. Issue
+                     * #443: hoisting the byte[] out of the per-vector
+                     * read loop eliminates ~4 KB of garbage per vector at
+                     * dim=1024 (~400 GB on a 100 M ingest).
+                     */
+                    private byte[] scratchBytes;
+                    /**
+                     * Reusable little-endian FloatBuffer view over
+                     * {@link #scratchBytes}; only populated for FVECS.
+                     * Saves both the {@code ByteBuffer.wrap(...)} and
+                     * {@code asFloatBuffer()} wrapper allocations per
+                     * vector.
+                     */
+                    private FloatBuffer scratchFloatView;
+                    /**
+                     * Cached dim from the previous vector; SIFT files
+                     * have a constant dim, so reusing the scratch is safe
+                     * unless we encounter a file that violates the
+                     * invariant — in which case we transparently
+                     * reallocate.
+                     */
+                    private int cachedDim = -1;
 
                     private float[] readNext() {
                         if (count >= maxVectors || eof) {
@@ -678,27 +703,42 @@ public class DatasetLoader {
                                 eof = true;
                                 return null;
                             }
+                            ensureScratch(dim);
+                            dis.readFully(scratchBytes);
+                            // float[] is the one allocation we cannot
+                            // avoid — the iterator contract hands the
+                            // array to the caller, who keeps it.
+                            float[] vec = new float[dim];
                             if (format == VecFormat.BVECS) {
-                                byte[] bytes = new byte[dim];
-                                dis.readFully(bytes);
-                                float[] vec = new float[dim];
                                 for (int i = 0; i < dim; i++) {
-                                    vec[i] = (bytes[i] & 0xFF);
+                                    vec[i] = (scratchBytes[i] & 0xFF);
                                 }
-                                return vec;
                             } else {
-                                byte[] bytes = new byte[dim * 4];
-                                dis.readFully(bytes);
-                                ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-                                float[] vec = new float[dim];
-                                for (int i = 0; i < dim; i++) {
-                                    vec[i] = bb.getFloat();
-                                }
-                                return vec;
+                                // Issue #443: bulk decode via reused
+                                // FloatBuffer view. The JIT can vectorize
+                                // the underlying byte→float conversion
+                                // and the wrappers are not re-allocated.
+                                scratchFloatView.rewind();
+                                scratchFloatView.get(vec);
                             }
+                            return vec;
                         } catch (IOException e) {
                             eof = true;
                             throw new RuntimeException("Error reading vector stream", e);
+                        }
+                    }
+
+                    private void ensureScratch(int dim) {
+                        if (scratchBytes != null && cachedDim == dim) {
+                            return;
+                        }
+                        cachedDim = dim;
+                        int payloadBytes = (format == VecFormat.BVECS) ? dim : dim * 4;
+                        scratchBytes = new byte[payloadBytes];
+                        if (format != VecFormat.BVECS) {
+                            scratchFloatView = ByteBuffer.wrap(scratchBytes)
+                                    .order(ByteOrder.LITTLE_ENDIAN)
+                                    .asFloatBuffer();
                         }
                     }
 
@@ -728,22 +768,56 @@ public class DatasetLoader {
         };
     }
 
-    /** Skip {@code count} vectors in-place from a DataInputStream of FVECS or BVECS format. */
+    /**
+     * Skip {@code count} vectors in-place from a DataInputStream of FVECS
+     * or BVECS format.
+     *
+     * <p>Issue #443: SIFT files have a constant dim across every record,
+     * so the per-vector {@code readInt(dim) + skip(payload)} dance the
+     * original code performed was wasted work — for a 100 M-row resume
+     * that's 100 M small reads followed by 100 M skip calls. The new
+     * implementation reads dim from the first record only and then
+     * bulk-skips the remaining {@code count - 1} records as a single
+     * skip operation, leaving the underlying {@code BufferedInputStream}
+     * (or {@code GZIPInputStream}) free to short-circuit via {@code
+     * FileInputStream.skip()} where supported.
+     */
     private static void skipVecsInStream(DataInputStream dis, VecFormat format, long count) throws IOException {
-        for (long i = 0; i < count; i++) {
-            int dim = readLittleEndianInt(dis);
-            long bytesToSkip = (format == VecFormat.BVECS) ? dim : (long) dim * 4;
-            long remaining = bytesToSkip;
-            while (remaining > 0) {
-                long skipped = dis.skip(remaining);
-                if (skipped <= 0) {
-                    throw new IOException("Unexpected end of stream while skipping vector " + i);
-                }
-                remaining -= skipped;
+        if (count <= 0) {
+            return;
+        }
+        // Read dim from the first record. SIFT format guarantees this
+        // value is identical for every subsequent record in the same file.
+        int dim = readLittleEndianInt(dis);
+        long payloadBytes = (format == VecFormat.BVECS) ? dim : (long) dim * 4;
+        long recordBytes = 4L + payloadBytes;
+
+        // Skip the rest of the first record's payload.
+        skipExactly(dis, payloadBytes, "first vector payload");
+
+        // Bulk-skip the remaining (count - 1) records.
+        long remainingRecords = count - 1L;
+        if (remainingRecords > 0) {
+            long bytesToSkip = remainingRecords * recordBytes;
+            skipExactly(dis, bytesToSkip, "bulk-skip of " + remainingRecords + " vectors");
+        }
+        System.out.println("  Skipped " + count + " vectors (dim=" + dim + ").");
+    }
+
+    /**
+     * Skip exactly {@code totalBytes} bytes from {@code dis}, looping
+     * until the stream returns 0 (EOF) or we've advanced enough. Throws
+     * if EOF arrives early.
+     */
+    private static void skipExactly(DataInputStream dis, long totalBytes, String what) throws IOException {
+        long remaining = totalBytes;
+        while (remaining > 0) {
+            long skipped = dis.skip(remaining);
+            if (skipped <= 0) {
+                throw new IOException("Unexpected end of stream while skipping " + what
+                        + " (asked for " + totalBytes + " bytes, " + remaining + " left)");
             }
-            if ((i + 1) % 1_000_000 == 0) {
-                System.out.println("  Skipped " + (i + 1) + " vectors...");
-            }
+            remaining -= skipped;
         }
     }
 
@@ -882,6 +956,12 @@ public class DatasetLoader {
     private List<float[]> loadFvecs(InputStream in, int maxVectors) throws IOException {
         List<float[]> vectors = new ArrayList<>();
         try (DataInputStream dis = new DataInputStream(in)) {
+            // Issue #443: reuse the byte[] and FloatBuffer view across
+            // every vector in this file. SIFT files have constant dim,
+            // so a single allocation suffices.
+            byte[] scratchBytes = null;
+            FloatBuffer scratchView = null;
+            int cachedDim = -1;
             while (vectors.size() < maxVectors) {
                 int dim;
                 try {
@@ -889,13 +969,17 @@ public class DatasetLoader {
                 } catch (java.io.EOFException e) {
                     break;
                 }
-                byte[] bytes = new byte[dim * 4];
-                dis.readFully(bytes);
-                ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-                float[] vec = new float[dim];
-                for (int i = 0; i < dim; i++) {
-                    vec[i] = bb.getFloat();
+                if (scratchBytes == null || cachedDim != dim) {
+                    cachedDim = dim;
+                    scratchBytes = new byte[dim * 4];
+                    scratchView = ByteBuffer.wrap(scratchBytes)
+                            .order(ByteOrder.LITTLE_ENDIAN)
+                            .asFloatBuffer();
                 }
+                dis.readFully(scratchBytes);
+                float[] vec = new float[dim];
+                scratchView.rewind();
+                scratchView.get(vec);
                 vectors.add(vec);
                 if (vectors.size() % 1_000_000 == 0) {
                     System.out.println("  Loaded " + vectors.size() + " vectors...");
@@ -908,6 +992,9 @@ public class DatasetLoader {
     private List<float[]> loadBvecs(InputStream in, int maxVectors) throws IOException {
         List<float[]> vectors = new ArrayList<>();
         try (DataInputStream dis = new DataInputStream(in)) {
+            // Issue #443: reuse the byte[] across every vector.
+            byte[] scratchBytes = null;
+            int cachedDim = -1;
             while (vectors.size() < maxVectors) {
                 int dim;
                 try {
@@ -915,11 +1002,14 @@ public class DatasetLoader {
                 } catch (java.io.EOFException e) {
                     break;
                 }
-                byte[] bytes = new byte[dim];
-                dis.readFully(bytes);
+                if (scratchBytes == null || cachedDim != dim) {
+                    cachedDim = dim;
+                    scratchBytes = new byte[dim];
+                }
+                dis.readFully(scratchBytes);
                 float[] vec = new float[dim];
                 for (int i = 0; i < dim; i++) {
-                    vec[i] = (bytes[i] & 0xFF);
+                    vec[i] = (scratchBytes[i] & 0xFF);
                 }
                 vectors.add(vec);
                 if (vectors.size() % 1_000_000 == 0) {

--- a/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/DatasetLoader.java
@@ -650,7 +650,20 @@ public class DatasetLoader {
 
         if (skipVectors > 0) {
             System.out.println("  Skipping " + skipVectors + " vectors to resume from position " + skipVectors + "...");
-            skipVecsInStream(dis, format, skipVectors);
+            try {
+                skipVecsInStream(dis, format, skipVectors);
+            } catch (IOException e) {
+                // The new "loud EOF" semantics in skipExactly makes this
+                // throw path reachable on corrupt / truncated files; close
+                // the file handle before propagating so a partially-built
+                // VectorStream doesn't leak the FD across retries.
+                try {
+                    dis.close();
+                } catch (IOException closeEx) {
+                    e.addSuppressed(closeEx);
+                }
+                throw e;
+            }
             System.out.println("  Skip complete.");
         }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -133,7 +133,8 @@ public class IngestionWorker implements Runnable {
         this.runtime = runtime;
     }
 
-    private static String formatEta(double seconds) {
+    /** Package-private so {@link VectorBench}'s progress thread can format ETA consistently. */
+    static String formatEta(double seconds) {
         if (seconds <= 0) {
             return "N/A";
         }
@@ -526,26 +527,12 @@ public class IngestionWorker implements Runnable {
                 preAcquireForNextTransaction();
             }
 
-            if (rowsIngested % 10_000 == 0 && rowsIngested > 0) {
-                MetricsCollector.Stats s = metrics.computeStats();
-                double elapsedSecs = (System.nanoTime() - ingestStartNanos) / 1e9;
-                double rowsPerSec = rowsIngested / elapsedSecs;
-                long remaining = config.numRows - rowsIngested;
-                double etaSecs = rowsPerSec > 0 ? remaining / rowsPerSec : 0;
-                String etaStr = formatEta(etaSecs);
-                statusLine.set(String.format(
-                        "Ingested %d/%d rows | %.0f ops/s | commits: %d (recovered: %d) | "
-                                + "batch mean: %.2f ms | batch p50: %.2f ms | batch p99: %.2f ms | ETA: %s",
-                        rowsIngested,
-                        config.numRows,
-                        rowsPerSec,
-                        commitsTotal.get(),
-                        commitsRecovered.get(),
-                        s.meanNanos() / 1_000_000.0,
-                        s.p50Nanos() / 1_000_000.0,
-                        s.p99Nanos() / 1_000_000.0,
-                        etaStr));
-            }
+            // Status-line publication moved to VectorBench's progress thread
+            // (issue #443): every worker calling computeStats() and
+            // overwriting the shared statusLine on its own cadence dominated
+            // the CPU profile and produced racy partial views. The progress
+            // thread publishes a single coherent line every 500 ms using the
+            // global counters and an HdrHistogram-backed snapshot.
         }
         // Final drain at end-of-input: flush any remaining sub-batch and
         // commit whatever remains in the transaction. The commit unit may be

--- a/vector-testings/src/main/java/herddb/vectortesting/MetricsCollector.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/MetricsCollector.java
@@ -19,41 +19,104 @@
  */
 package herddb.vectortesting;
 
-import java.util.Arrays;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
 
+/**
+ * Latency collector for the VectorBench client.
+ *
+ * <p>Backed by HdrHistogram (issue #443). The previous reservoir-sampling
+ * implementation allocated an 800 KB {@code long[]} on every
+ * {@link #computeStats()} call and sorted it ({@code O(n log n)}); when the
+ * benchmark workers ran that path from their hot loops it dominated the CPU
+ * profile and left no headroom for actual ingestion / query work.
+ *
+ * <p>HdrHistogram replaces both the reservoir and the sort:
+ * <ul>
+ *   <li>{@link #record(long)} is allocation-free and lock-free — it is a
+ *       constant-time atomic increment on a single bucket counter.</li>
+ *   <li>{@link #computeStats()} produces an immutable snapshot in
+ *       {@code O(buckets)} time (a few microseconds) — no array copy, no
+ *       sort, no boxing.</li>
+ *   <li>Memory footprint is bounded (~24 KB) regardless of how many values
+ *       were recorded.</li>
+ * </ul>
+ *
+ * <p>A short TTL cache on {@link #computeStats()} lets concurrent status /
+ * progress threads share one snapshot per refresh window so they don't all
+ * pay the buffer-swap cost.
+ */
 public class MetricsCollector {
 
-    // Reservoir sampling: keep at most MAX_SAMPLES latency values so that memory
-    // usage stays bounded even when ingesting hundreds of millions of rows.
-    private static final int MAX_SAMPLES = 100_000;
+    /**
+     * Histogram value range. Latencies below 1 ns and above 1 hour are
+     * clamped to the bounds; in practice every commit / query latency is
+     * well within this range, so clamping is a defensive guard rather than
+     * an accuracy concern.
+     */
+    private static final long LOWEST_NANOS = 1L;
+    private static final long HIGHEST_NANOS = TimeUnit.HOURS.toNanos(1);
+    /** 3 significant digits → ±0.1% precision; ~24 KB per histogram. */
+    private static final int SIGNIFICANT_DIGITS = 3;
+
+    /**
+     * Cache TTL for {@link #computeStats()}. Multiple status / progress
+     * threads refresh on roughly 500 ms intervals, so a 200 ms cache means
+     * concurrent callers within the same refresh tick reuse one snapshot.
+     * Snapshots can be at most {@code CACHE_TTL_NANOS} stale — well under
+     * the 500 ms display cadence — which is the trade-off for not paying
+     * the buffer-swap cost on every progress tick.
+     */
+    private static final long CACHE_TTL_NANOS = TimeUnit.MILLISECONDS.toNanos(200);
+
+    /** Sentinel used to mark the cache as initially empty. */
+    private static final Snapshot INVALID = new Snapshot(null, Long.MIN_VALUE);
 
     private final LongAdder count = new LongAdder();
-    private final long[] reservoir = new long[MAX_SAMPLES];
-    private final AtomicLong samplesStored = new AtomicLong(0);
+    private final Recorder recorder = new Recorder(LOWEST_NANOS, HIGHEST_NANOS, SIGNIFICANT_DIGITS);
+    /**
+     * Accumulator merged with each {@link Recorder#getIntervalHistogram(Histogram)}
+     * call so {@link #computeStats()} reports running totals rather than just
+     * the most recent interval.
+     */
+    private final Histogram cumulative = new Histogram(LOWEST_NANOS, HIGHEST_NANOS, SIGNIFICANT_DIGITS);
+    /** Reusable receiver for the recorder swap; {@code null} on first call. */
+    private Histogram intervalRecycle;
+    /** Guards {@link #cumulative} and {@link #intervalRecycle}. */
+    private final Object snapshotLock = new Object();
+
     /** Nanoseconds of the most recently recorded event; 0 when none recorded yet. */
     private final AtomicLong lastNanos = new AtomicLong(0);
 
+    /**
+     * Cached snapshot. Reads via {@link AtomicReference#get()} are lock-free;
+     * writes happen only under {@link #snapshotLock} so the visible cache is
+     * monotone (a later lock holder has merged at least as much data as
+     * earlier holders into {@link #cumulative}, so the count / max stored
+     * here only ever grows).
+     */
+    private final AtomicReference<Snapshot> cached = new AtomicReference<>(INVALID);
+
     public void record(long nanos) {
-        long n = count.longValue() + 1; // approximate position before increment
+        long clamped = nanos;
+        if (clamped < LOWEST_NANOS) {
+            clamped = LOWEST_NANOS;
+        } else if (clamped > HIGHEST_NANOS) {
+            clamped = HIGHEST_NANOS;
+        }
+        recorder.recordValue(clamped);
         count.increment();
         lastNanos.set(nanos);
-        long stored = samplesStored.get();
-        if (stored < MAX_SAMPLES) {
-            // Fill reservoir sequentially until full
-            long idx = samplesStored.getAndIncrement(); // may race, but bounded by MAX_SAMPLES
-            if (idx < MAX_SAMPLES) {
-                reservoir[(int) idx] = nanos;
-            }
-        } else {
-            // Reservoir sampling: replace a random slot with probability MAX_SAMPLES/n
-            long slot = ThreadLocalRandom.current().nextLong(n);
-            if (slot < MAX_SAMPLES) {
-                reservoir[(int) slot] = nanos;
-            }
-        }
+        // Deliberately do NOT invalidate the cache: under the workloads
+        // this collector serves (continuous record() from many worker
+        // threads), invalidating per-record would prevent the cache from
+        // ever serving a hit. The TTL alone bounds staleness to
+        // CACHE_TTL_NANOS, which is well below the 500 ms progress-display
+        // cadence — fresh enough for the benchmark UI.
     }
 
     public long getCount() {
@@ -66,25 +129,48 @@ public class MetricsCollector {
     }
 
     public Stats computeStats() {
-        int size = (int) Math.min(samplesStored.get(), MAX_SAMPLES);
-        if (size == 0) {
-            return new Stats(0, 0, 0, 0, 0, 0);
+        Snapshot prev = cached.get();
+        if (prev != INVALID && System.nanoTime() - prev.timestampNanos < CACHE_TTL_NANOS) {
+            return prev.stats;
         }
-        long[] sorted = Arrays.copyOf(reservoir, size);
-        Arrays.sort(sorted);
-        double mean = Arrays.stream(sorted).average().orElse(0);
-        return new Stats(
-                count.sum(),
-                mean,
-                sorted[percentileIndex(size, 50)],
-                sorted[percentileIndex(size, 95)],
-                sorted[percentileIndex(size, 99)],
-                sorted[size - 1]
-        );
+        return computeStatsLocked();
     }
 
-    private static int percentileIndex(int size, int percentile) {
-        return Math.min(size - 1, (int) ((long) size * percentile / 100.0));
+    private Stats computeStatsLocked() {
+        synchronized (snapshotLock) {
+            // Re-check the cache under the lock: another caller may have
+            // refreshed it while we were waiting. This avoids redundant
+            // buffer swaps when many readers contend for the lock at once.
+            Snapshot prev = cached.get();
+            long now = System.nanoTime();
+            if (prev != INVALID && now - prev.timestampNanos < CACHE_TTL_NANOS) {
+                return prev.stats;
+            }
+            // Atomically swap the active recorder buffer and merge the
+            // just-completed interval into the running cumulative histogram.
+            // The recycled receiver avoids an allocation on every snapshot.
+            intervalRecycle = recorder.getIntervalHistogram(intervalRecycle);
+            cumulative.add(intervalRecycle);
+            long total = cumulative.getTotalCount();
+            Stats fresh;
+            if (total == 0) {
+                fresh = new Stats(0, 0, 0, 0, 0, 0);
+            } else {
+                fresh = new Stats(
+                        total,
+                        cumulative.getMean(),
+                        cumulative.getValueAtPercentile(50.0),
+                        cumulative.getValueAtPercentile(95.0),
+                        cumulative.getValueAtPercentile(99.0),
+                        cumulative.getMaxValue()
+                );
+            }
+            // Cache write inside the lock: write order = lock acquisition
+            // order = monotonically increasing cumulative state, so the
+            // cached snapshot's count and max never go backwards.
+            cached.set(new Snapshot(fresh, now));
+            return fresh;
+        }
     }
 
     public record Stats(long count, double meanNanos, long p50Nanos, long p95Nanos, long p99Nanos, long maxNanos) {
@@ -103,6 +189,17 @@ public class MetricsCollector {
                     p95Nanos / 1_000_000.0,
                     p99Nanos / 1_000_000.0,
                     maxNanos / 1_000_000.0);
+        }
+    }
+
+    /** Cache slot — pairs a snapshot with the nanoTime it was produced at. */
+    private static final class Snapshot {
+        final Stats stats;
+        final long timestampNanos;
+
+        Snapshot(Stats stats, long timestampNanos) {
+            this.stats = stats;
+            this.timestampNanos = timestampNanos;
         }
     }
 }

--- a/vector-testings/src/main/java/herddb/vectortesting/MetricsCollector.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/MetricsCollector.java
@@ -110,7 +110,11 @@ public class MetricsCollector {
         }
         recorder.recordValue(clamped);
         count.increment();
-        lastNanos.set(nanos);
+        // Store the clamped value so getLastNanos() and the histogram
+        // agree on what was recorded — otherwise record(0) would put
+        // 1 ns in the histogram but expose 0 via getLastNanos(), which
+        // is confusing and arguably wrong.
+        lastNanos.set(clamped);
         // Deliberately do NOT invalidate the cache: under the workloads
         // this collector serves (continuous record() from many worker
         // threads), invalidating per-record would prevent the cache from
@@ -133,18 +137,34 @@ public class MetricsCollector {
         if (prev != INVALID && System.nanoTime() - prev.timestampNanos < CACHE_TTL_NANOS) {
             return prev.stats;
         }
-        return computeStatsLocked();
+        return computeStatsLocked(/* bypassCache */ false);
     }
 
-    private Stats computeStatsLocked() {
+    /**
+     * Snapshot the current state without consulting (or honouring) the
+     * TTL cache. Use this for canonical end-of-run summary lines where
+     * stats up to {@link #CACHE_TTL_NANOS} stale would silently omit the
+     * last batch of recorded latencies. The freshly-computed snapshot is
+     * still installed in the cache so a subsequent live-UI {@link
+     * #computeStats()} call does not have to redo the work.
+     */
+    public Stats computeStatsUncached() {
+        return computeStatsLocked(/* bypassCache */ true);
+    }
+
+    private Stats computeStatsLocked(boolean bypassCache) {
         synchronized (snapshotLock) {
             // Re-check the cache under the lock: another caller may have
             // refreshed it while we were waiting. This avoids redundant
             // buffer swaps when many readers contend for the lock at once.
-            Snapshot prev = cached.get();
-            long now = System.nanoTime();
-            if (prev != INVALID && now - prev.timestampNanos < CACHE_TTL_NANOS) {
-                return prev.stats;
+            // Bypassed when the caller explicitly requested a fresh snapshot
+            // (final run summary) — see computeStatsUncached().
+            if (!bypassCache) {
+                Snapshot prev = cached.get();
+                long checkNow = System.nanoTime();
+                if (prev != INVALID && checkNow - prev.timestampNanos < CACHE_TTL_NANOS) {
+                    return prev.stats;
+                }
             }
             // Atomically swap the active recorder buffer and merge the
             // just-completed interval into the running cumulative histogram.
@@ -165,6 +185,11 @@ public class MetricsCollector {
                         cumulative.getMaxValue()
                 );
             }
+            // Capture the timestamp AFTER the buffer-swap+merge so the
+            // cached entry's age reflects the data it actually contains
+            // (not the moment we entered the lock — a few μs earlier in
+            // contended cases).
+            long now = System.nanoTime();
             // Cache write inside the lock: write order = lock acquisition
             // order = monotonically increasing cumulative state, so the
             // cached snapshot's count and max never go backwards.

--- a/vector-testings/src/main/java/herddb/vectortesting/QueryWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/QueryWorker.java
@@ -100,17 +100,12 @@ public class QueryWorker implements Runnable {
                     metrics.record(elapsed);
                     allResults.set(i, ids);
 
-                    long total = metrics.getCount();
-                    if (total % 100 == 0) {
-                        MetricsCollector.Stats s = metrics.computeStats();
-                        statusLine.set(String.format("Executed %d queries | mean: %.2f ms | p50: %.2f ms | p95: %.2f ms | p99: %.2f ms | max: %.2f ms",
-                                total,
-                                s.meanNanos() / 1_000_000.0,
-                                s.p50Nanos() / 1_000_000.0,
-                                s.p95Nanos() / 1_000_000.0,
-                                s.p99Nanos() / 1_000_000.0,
-                                s.maxNanos() / 1_000_000.0));
-                    }
+                    // Status-line publication moved to VectorBench's query
+                    // progress loop (issue #443): every worker calling
+                    // computeStats() every 100 queries and overwriting the
+                    // shared statusLine added redundant CPU on the hot
+                    // path. The query progress loop already emits the same
+                    // fields every 500 ms.
                 }
             } finally {
                 if (ps != null) {

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -580,7 +580,12 @@ public class VectorBench {
             ingestionWallSecs = ingestSecs;
             ingestionRows = rowId.get() - config.resumeFrom;
             ingestionThroughput = ingestionRows / ingestSecs;
-            ingestionLatency = ingestMetrics.computeStats();
+            // Bypass the 200 ms TTL cache: this snapshot ends up in the
+            // canonical "=== INGESTION RESULTS ===" block and the JSON
+            // commit_latency, so it must include every recorded value —
+            // even the ones written between the progress thread's last
+            // tick and the workers finishing.
+            ingestionLatency = ingestMetrics.computeStatsUncached();
 
             if (!out.suppressesText()) {
                 System.out.printf("=== INGESTION RESULTS ===%n");
@@ -761,7 +766,9 @@ public class VectorBench {
         queryWallSecs = querySecs;
         queriesRun = queryMetrics.getCount();
         queryThroughput = queriesRun / querySecs;
-        queryLatency = queryMetrics.computeStats();
+        // Bypass the 200 ms TTL cache for the canonical "=== QUERY RESULTS ==="
+        // block — see the matching ingestionLatency comment above.
+        queryLatency = queryMetrics.computeStatsUncached();
 
         if (!out.suppressesText()) {
             System.out.printf("=== QUERY RESULTS ===%n");

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -325,7 +325,12 @@ public class VectorBench {
             MetricsCollector ingestMetrics = new MetricsCollector();
             AtomicReference<String> ingestStatus = new AtomicReference<>("");
 
-            BlockingQueue<float[]> ingestQueue = new ArrayBlockingQueue<>(1000);
+            // Issue #443: previously a fixed 1000-slot queue, which meant a
+            // single worker pause stalled the entire pool. Sizing per-thread
+            // with a 2 048 lower bound lets short pauses absorb without
+            // back-pressuring the producer thread.
+            int ingestQueueCapacity = Math.max(2048, config.ingestThreads * 64);
+            BlockingQueue<float[]> ingestQueue = new ArrayBlockingQueue<>(ingestQueueCapacity);
             AtomicBoolean producerDone = new AtomicBoolean(false);
             AtomicLong rowId = new AtomicLong(config.resumeFrom);
             AtomicLong commitsTotal = new AtomicLong(0);
@@ -400,7 +405,15 @@ public class VectorBench {
                 return m;
             });
 
-            // Progress display thread runs during the entire ingestion
+            // Progress display thread runs during the entire ingestion.
+            // Issue #443: this thread is now the *single* publisher of
+            // ingestStatus — workers used to overwrite it from their hot
+            // loop on every 10 000 rows, which was both racy (each worker
+            // saw only its own rowsIngested counter) and CPU-expensive
+            // (every overwrite triggered a computeStats() call from N
+            // parallel workers). Producing one coherent line every 500 ms
+            // here uses a single computeStats() call against the cached
+            // HdrHistogram snapshot.
             AtomicBoolean ingestDone = new AtomicBoolean(false);
             final long totalRowsTarget = config.numRows;
             Thread progressThread = new Thread(() -> {
@@ -423,6 +436,27 @@ public class VectorBench {
                     fields.put("recovered_commits", commitsRecovered.get());
                     fields.put("heap_used_mb", usedMb);
                     fields.put("heap_max_mb", maxMb);
+
+                    // Refresh ingestStatus with the same fields the workers
+                    // used to publish — so the spinner output shape is
+                    // unchanged for log scrapers / dashboards. The previous
+                    // value of ingestStatus may still hold a transient
+                    // commit-retry error message set by IngestionWorker; we
+                    // overwrite it with the steady-state line here.
+                    MetricsCollector.Stats s = ingestMetrics.computeStats();
+                    String etaStr = IngestionWorker.formatEta(etaSecs);
+                    ingestStatus.set(String.format(
+                            "Ingested %d/%d rows | %.0f ops/s | commits: %d (recovered: %d) | "
+                                    + "batch mean: %.2f ms | batch p50: %.2f ms | batch p99: %.2f ms | ETA: %s",
+                            rowsIngested,
+                            totalRowsTarget,
+                            opsPerSec,
+                            commitsTotal.get(),
+                            commitsRecovered.get(),
+                            s.meanNanos() / 1_000_000.0,
+                            s.p50Nanos() / 1_000_000.0,
+                            s.p99Nanos() / 1_000_000.0,
+                            etaStr));
 
                     String spinnerLine = String.format("heap: %d/%d MB | %s", usedMb, maxMb, ingestStatus.get());
 
@@ -707,6 +741,18 @@ public class VectorBench {
             fields.put("latency_p95_ms", round2(intermediateStats.p95Nanos() / 1e6));
             fields.put("latency_p99_ms", round2(intermediateStats.p99Nanos() / 1e6));
             fields.put("latency_max_ms", round2(intermediateStats.maxNanos() / 1e6));
+            // Issue #443: query progress loop is now the single publisher
+            // of queryStatus — QueryWorker no longer overwrites it from
+            // its hot loop. We reuse the same line shape the workers used
+            // so log scrapers see no format change.
+            queryStatus.set(String.format(
+                    "Executed %d queries | mean: %.2f ms | p50: %.2f ms | p95: %.2f ms | p99: %.2f ms | max: %.2f ms",
+                    queriesDone,
+                    intermediateStats.meanNanos() / 1_000_000.0,
+                    intermediateStats.p50Nanos() / 1_000_000.0,
+                    intermediateStats.p95Nanos() / 1_000_000.0,
+                    intermediateStats.p99Nanos() / 1_000_000.0,
+                    intermediateStats.maxNanos() / 1_000_000.0));
             out.progress("query", elapsed, queryStatus.get(), fields);
         }
         double querySecs = (System.nanoTime() - queryStart) / 1e9;

--- a/vector-testings/src/test/java/herddb/vectortesting/DatasetLoaderFvecsBulkDecodeTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/DatasetLoaderFvecsBulkDecodeTest.java
@@ -1,0 +1,203 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import herddb.vectortesting.DatasetLoader.DatasetPreset;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Round-trip test for the FVECS streaming reader — see issue #443.
+ *
+ * <p>Validates the producer-side optimisations:
+ * <ul>
+ *   <li>{@code asFloatBuffer().get(float[])} bulk decode produces
+ *       bit-identical results to writing via {@link SiftWriter}.</li>
+ *   <li>The reused scratch byte buffer + FloatBuffer view does not leak
+ *       data between consecutive vectors.</li>
+ *   <li>{@code skipVectors} bulk-skip semantics correctly position the
+ *       stream past the skipped portion (exact dim, no re-read of dim
+ *       per skipped vector).</li>
+ *   <li>The iterator returns a fresh {@code float[]} per vector — the
+ *       reused scratch is internal-only.</li>
+ * </ul>
+ */
+class DatasetLoaderFvecsBulkDecodeTest {
+
+    @Test
+    void bulkDecodeRoundtripsSmallDimVectors(@TempDir Path tmp) throws Exception {
+        // dim=4 hits every code path with cheap data; the CUSTOM preset
+        // exposes the full streamBaseVectors machinery to the test.
+        roundtrip(tmp, /* dim */ 4, /* total */ 32, /* skip */ 0, /* maxRead */ 32);
+    }
+
+    @Test
+    void bulkDecodeRoundtripsCommonProductionDim(@TempDir Path tmp) throws Exception {
+        // dim=128 is the SIFT1M dimension; covers the bulk-FloatBuffer.get
+        // hot path with realistic record sizes.
+        roundtrip(tmp, /* dim */ 128, /* total */ 64, /* skip */ 0, /* maxRead */ 64);
+    }
+
+    @Test
+    void bulkDecodeRoundtripsLargeDim(@TempDir Path tmp) throws Exception {
+        // dim=1024 is typical of modern embedding models. Confirms the
+        // bulk decode handles a record size that the JIT can vectorize.
+        roundtrip(tmp, /* dim */ 1024, /* total */ 16, /* skip */ 0, /* maxRead */ 16);
+    }
+
+    @Test
+    void skipBypassDoesNotMaterializeVectorsButLandsAtCorrectPosition(@TempDir Path tmp) throws Exception {
+        // The bulk-skip path reads dim from the first record and then
+        // bulk-skips the remaining (skipVectors - 1) records. We confirm
+        // the stream resumes at the *correct* vector by verifying the
+        // first emitted vector matches the (skipVectors)th written one.
+        roundtrip(tmp, /* dim */ 8, /* total */ 100, /* skip */ 73, /* maxRead */ 27);
+    }
+
+    @Test
+    void iteratorReturnsFreshFloatArrayPerVector(@TempDir Path tmp) throws Exception {
+        // Issue #443: the optimised reader reuses an internal byte[] /
+        // FloatBuffer view, but each iterator next() must still return a
+        // distinct float[] so the caller can hold onto it without seeing
+        // it overwritten by the next read.
+        int dim = 16;
+        int total = 8;
+        Path subDir = setupCustomDataset(tmp, dim, total);
+        List<float[]> written = generateAndWriteFvecs(
+                subDir.resolve("bulk_base.fvecs").toFile(), dim, total);
+        // Also write a query file (required by descriptor loader).
+        generateAndWriteFvecs(subDir.resolve("bulk_query.fvecs").toFile(), dim, /* numQueries */ 2);
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset();
+        loader.loadDescriptor();
+
+        try (DatasetLoader.VectorStream stream = loader.streamBaseVectors(0L, total)) {
+            Iterator<float[]> it = stream.iterator();
+            float[] first = it.next();
+            float[] second = it.next();
+            assertNotSame(first, second, "iterator must return a fresh float[] per call");
+            // Also verify the FIRST array is preserved — i.e., the second
+            // read did not mutate it via the reused scratch.
+            assertArrayEquals(written.get(0), first, "first vector should remain intact after second read");
+            assertArrayEquals(written.get(1), second, "second vector should match the source");
+        }
+    }
+
+    /**
+     * End-to-end: write {@code total} vectors of dim {@code dim} via
+     * {@link SiftWriter}, then re-read them via the streaming loader
+     * with the configured {@code skipVectors} / {@code maxVectors}, and
+     * assert bit-identical round-trip.
+     */
+    private void roundtrip(Path tmp, int dim, int total, int skip, int maxRead) throws Exception {
+        Path subDir = setupCustomDataset(tmp, dim, total);
+        List<float[]> written = generateAndWriteFvecs(
+                subDir.resolve("bulk_base.fvecs").toFile(), dim, total);
+        // Query file is required by the descriptor; one with the same
+        // dim is enough for the loader to be happy.
+        generateAndWriteFvecs(subDir.resolve("bulk_query.fvecs").toFile(), dim, /* numQueries */ 2);
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset();
+        loader.loadDescriptor();
+
+        List<float[]> read = new ArrayList<>(maxRead);
+        try (DatasetLoader.VectorStream stream = loader.streamBaseVectors((long) skip, (long) maxRead)) {
+            for (float[] vec : stream) {
+                read.add(vec);
+            }
+        }
+
+        int expectedReadCount = Math.min(maxRead, total - skip);
+        assertEquals(expectedReadCount, read.size(),
+                "expected " + expectedReadCount + " vectors after skip=" + skip
+                        + " maxRead=" + maxRead + " total=" + total);
+
+        for (int i = 0; i < read.size(); i++) {
+            float[] expected = written.get(skip + i);
+            float[] actual = read.get(i);
+            assertArrayEquals(expected, actual,
+                    "round-trip mismatch at vector " + (skip + i)
+                            + " (dim=" + dim + ", skip=" + skip + ")");
+        }
+        // Sanity: the iteration emitted *the right vectors*, not just
+        // any plausible-looking dim-aligned data.
+        assertFalse(read.isEmpty(), "read list should not be empty for this configuration");
+    }
+
+    /**
+     * Seeds a CUSTOM-preset dataset directory with a descriptor pointing
+     * at the soon-to-be-written {@code bulk_base.fvecs} / {@code
+     * bulk_query.fvecs} files.
+     */
+    private static Path setupCustomDataset(Path tmp, int dim, int totalVectors) throws IOException {
+        Path subDir = tmp.resolve(DatasetPreset.CUSTOM.subDir);
+        Files.createDirectories(subDir);
+        String json = "{\n"
+                + "  \"name\": \"bulk\",\n"
+                + "  \"format\": \"fvecs\",\n"
+                + "  \"dimensions\": " + dim + ",\n"
+                + "  \"similarity\": \"euclidean\",\n"
+                + "  \"totalVectors\": " + totalVectors + ",\n"
+                + "  \"numQueries\": 2,\n"
+                + "  \"groundTruthK\": 1,\n"
+                + "  \"baseFile\": \"bulk_base.fvecs\",\n"
+                + "  \"queryFile\": \"bulk_query.fvecs\",\n"
+                + "  \"groundTruthFile\": \"bulk_groundtruth.ivecs\"\n"
+                + "}\n";
+        Files.writeString(subDir.resolve("bulk_descriptor.json"), json);
+        return subDir;
+    }
+
+    /**
+     * Writes {@code count} deterministic vectors of dimension {@code dim}
+     * to {@code file}. The values are constructed so each component is
+     * unique across the entire dataset (so off-by-one or wrap-around
+     * round-trip bugs cannot accidentally pass).
+     */
+    private static List<float[]> generateAndWriteFvecs(File file, int dim, int count) throws IOException {
+        List<float[]> vectors = new ArrayList<>(count);
+        try (SiftWriter w = new SiftWriter(file)) {
+            for (int v = 0; v < count; v++) {
+                float[] vec = new float[dim];
+                for (int d = 0; d < dim; d++) {
+                    // (v + 1) * 1000 + d  → distinct float for every
+                    // (vector, component) pair across the test dataset.
+                    vec[d] = (v + 1) * 1000.0f + d;
+                }
+                w.writeFvec(vec);
+                vectors.add(vec);
+            }
+        }
+        return vectors;
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/DatasetLoaderFvecsBulkDecodeTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/DatasetLoaderFvecsBulkDecodeTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import herddb.vectortesting.DatasetLoader.DatasetPreset;
 import java.io.File;
 import java.io.IOException;
@@ -80,6 +82,88 @@ class DatasetLoaderFvecsBulkDecodeTest {
         // the stream resumes at the *correct* vector by verifying the
         // first emitted vector matches the (skipVectors)th written one.
         roundtrip(tmp, /* dim */ 8, /* total */ 100, /* skip */ 73, /* maxRead */ 27);
+    }
+
+    @Test
+    void skipExceedingFileLengthThrowsClearException(@TempDir Path tmp) throws Exception {
+        // Issue #443 review: the bulk-skip path reads dim from the first
+        // record and then asks the underlying stream for one big skip(N)
+        // covering the rest. A short / corrupt file must surface a loud
+        // IOException rather than silently land at the wrong offset.
+        int dim = 8;
+        int totalWritten = 10;
+        Path subDir = setupCustomDataset(tmp, dim, /* descriptorTotal */ 200);
+        generateAndWriteFvecs(
+                subDir.resolve("bulk_base.fvecs").toFile(), dim, totalWritten);
+        generateAndWriteFvecs(subDir.resolve("bulk_query.fvecs").toFile(), dim, 2);
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset();
+        loader.loadDescriptor();
+
+        IOException ex = assertThrows(IOException.class,
+                () -> loader.streamBaseVectors(/* skip */ 50, /* maxRead */ 1));
+        // The bulk-skip path produces a "Unexpected end of stream while
+        // skipping ..." message — assert that rather than a generic EOF.
+        String msg = ex.getMessage();
+        assertTrue(msg != null && msg.contains("Unexpected end of stream"),
+                "expected bulk-skip EOF message, got: " + msg);
+    }
+
+    @Test
+    void scratchReallocatesOnDimChange(@TempDir Path tmp) throws Exception {
+        // Issue #443 review: the streaming reader caches one byte[] +
+        // FloatBuffer view sized to the first vector's dim. A file that
+        // violates the constant-dim invariant must still decode every
+        // record correctly — the cachedDim != dim branch in
+        // ensureScratch reallocates the scratch on the fly.
+        Path subDir = tmp.resolve(DatasetPreset.CUSTOM.subDir);
+        Files.createDirectories(subDir);
+        // Write a hand-crafted FVECS file with two records of different
+        // dim. We keep the descriptor's "dimensions" set to the first
+        // record's dim (since the loader uses it for sanity logging
+        // only — the streaming reader reads dim from each record header).
+        File baseFile = subDir.resolve("bulk_base.fvecs").toFile();
+        try (SiftWriter w = new SiftWriter(baseFile)) {
+            float[] firstDim4 = new float[]{1.0f, 2.0f, 3.0f, 4.0f};
+            float[] secondDim8 = new float[]{
+                    10.5f, 11.5f, 12.5f, 13.5f, 14.5f, 15.5f, 16.5f, 17.5f};
+            w.writeFvec(firstDim4);
+            w.writeFvec(secondDim8);
+        }
+        // Query file required by descriptor (consistent dim is fine).
+        generateAndWriteFvecs(subDir.resolve("bulk_query.fvecs").toFile(), 4, 2);
+        // Descriptor declares dim=4; the second record's dim=8 is read
+        // from the per-record header by the streamer.
+        Files.writeString(subDir.resolve("bulk_descriptor.json"),
+                "{\n"
+                + "  \"name\": \"bulk\",\n"
+                + "  \"format\": \"fvecs\",\n"
+                + "  \"dimensions\": 4,\n"
+                + "  \"similarity\": \"euclidean\",\n"
+                + "  \"totalVectors\": 2,\n"
+                + "  \"numQueries\": 2,\n"
+                + "  \"groundTruthK\": 1,\n"
+                + "  \"baseFile\": \"bulk_base.fvecs\",\n"
+                + "  \"queryFile\": \"bulk_query.fvecs\",\n"
+                + "  \"groundTruthFile\": \"bulk_groundtruth.ivecs\"\n"
+                + "}\n");
+
+        DatasetLoader loader = new DatasetLoader(tmp.toString(), DatasetPreset.CUSTOM, null);
+        loader.ensureDataset();
+        loader.loadDescriptor();
+
+        try (DatasetLoader.VectorStream stream = loader.streamBaseVectors(0L, 2)) {
+            Iterator<float[]> it = stream.iterator();
+            float[] first = it.next();
+            float[] second = it.next();
+            assertEquals(4, first.length, "first record should be dim=4");
+            assertEquals(8, second.length, "second record should be dim=8 (scratch reallocated)");
+            assertArrayEquals(new float[]{1.0f, 2.0f, 3.0f, 4.0f}, first);
+            assertArrayEquals(
+                    new float[]{10.5f, 11.5f, 12.5f, 13.5f, 14.5f, 15.5f, 16.5f, 17.5f},
+                    second);
+        }
     }
 
     @Test

--- a/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorCacheTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorCacheTest.java
@@ -1,0 +1,102 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates the short-TTL cache on {@link MetricsCollector#computeStats()} —
+ * see issue #443. Concurrent status / progress threads call computeStats at
+ * 500 ms cadence; we want them to share one snapshot per refresh tick rather
+ * than each repeat the (now cheap, but still non-zero) HdrHistogram buffer
+ * swap.
+ */
+class MetricsCollectorCacheTest {
+
+    @Test
+    void repeatedCallsWithinTtlReturnSameInstance() {
+        MetricsCollector mc = new MetricsCollector();
+        mc.record(5_000_000L);
+        // Two back-to-back calls should hit the cache and return the same
+        // immutable snapshot reference. HdrHistogram's recompute is fast but
+        // not free — sharing the result avoids redundant buffer-swaps.
+        MetricsCollector.Stats first = mc.computeStats();
+        MetricsCollector.Stats second = mc.computeStats();
+        assertSame(first, second, "cached snapshot should be returned for in-window calls");
+    }
+
+    @Test
+    void newRecordsBecomeVisibleAfterTtlExpiry() throws InterruptedException {
+        // The cache deliberately does NOT invalidate on record() — under
+        // continuous benchmark load that would prevent the cache from ever
+        // serving a hit. Instead, the TTL bounds staleness; once it
+        // expires the next computeStats() reflects all values recorded
+        // since the previous snapshot.
+        MetricsCollector mc = new MetricsCollector();
+        mc.record(5_000_000L);
+        MetricsCollector.Stats first = mc.computeStats();
+        assertEquals(1, first.count());
+
+        mc.record(20_000_000L);
+        // Sleep past the cache TTL so the next computeStats refreshes.
+        Thread.sleep(300L);
+        MetricsCollector.Stats afterTtl = mc.computeStats();
+        assertEquals(2, afterTtl.count(), "second record must be visible after TTL expiry");
+        assertNotEquals(first, afterTtl, "snapshot must be recomputed after TTL expiry");
+        assertTrue(afterTtl.maxNanos() >= 19_900_000L,
+                "max should reflect the new value, got " + afterTtl.maxNanos());
+    }
+
+    @Test
+    void cacheEventuallyExpires() throws InterruptedException {
+        // The cache TTL inside MetricsCollector is 200 ms; sleeping 300 ms
+        // guarantees we cross the boundary. After that, a no-op call (no
+        // record between) should still recompute and return a fresh
+        // snapshot instance — we can't assert different *contents* without
+        // new data, but we can assert the cached identity changed once the
+        // TTL elapses.
+        MetricsCollector mc = new MetricsCollector();
+        mc.record(5_000_000L);
+        MetricsCollector.Stats snapshot1 = mc.computeStats();
+        Thread.sleep(300L);
+        MetricsCollector.Stats snapshot2 = mc.computeStats();
+        // Contents must be equal (no new data), but the snapshot reference
+        // is recomputed because the TTL expired.
+        assertEquals(snapshot1, snapshot2);
+        assertTrue(snapshot1 != snapshot2,
+                "TTL expiry should produce a fresh Stats instance");
+    }
+
+    @Test
+    void emptyHistogramHonoursCache() {
+        // The fast-path for an empty collector still routes through the
+        // cache. Two back-to-back calls on an empty collector should not
+        // diverge.
+        MetricsCollector mc = new MetricsCollector();
+        MetricsCollector.Stats first = mc.computeStats();
+        MetricsCollector.Stats second = mc.computeStats();
+        assertEquals(0, first.count());
+        assertSame(first, second);
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorCacheTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorCacheTest.java
@@ -99,4 +99,44 @@ class MetricsCollectorCacheTest {
         assertEquals(0, first.count());
         assertSame(first, second);
     }
+
+    @Test
+    void uncachedAlwaysRecomputesAndIncludesEveryRecord() {
+        // The canonical run-summary path uses computeStatsUncached() to
+        // bypass the 200 ms TTL — otherwise the very last batch of
+        // record() calls (made between the progress thread's last tick
+        // and the workers finishing) would be silently omitted from the
+        // printed final stats.
+        MetricsCollector mc = new MetricsCollector();
+        for (int i = 1; i <= 50; i++) {
+            mc.record(i * 1_000_000L);
+        }
+        // Populate the cache via the live-UI path.
+        MetricsCollector.Stats cached = mc.computeStats();
+        assertEquals(50, cached.count());
+
+        // Record additional values; computeStats() within TTL will return
+        // the stale cached snapshot, but computeStatsUncached() must see
+        // every value recorded so far.
+        for (int i = 51; i <= 100; i++) {
+            mc.record(i * 1_000_000L);
+        }
+        MetricsCollector.Stats stale = mc.computeStats();
+        assertEquals(50, stale.count(), "TTL cache should still report the pre-record snapshot");
+
+        MetricsCollector.Stats fresh = mc.computeStatsUncached();
+        assertEquals(100, fresh.count(),
+                "uncached snapshot must reflect every record() up to this moment");
+        assertNotEquals(stale, fresh,
+                "uncached path must produce a distinct snapshot from the stale cached one");
+        assertTrue(fresh.maxNanos() >= 99_000_000L,
+                "max should reflect the highest recorded value, got " + fresh.maxNanos());
+
+        // After computeStatsUncached(), the cache holds the fresh snapshot,
+        // so a subsequent computeStats() within TTL hits the new value
+        // (no redundant buffer-swap).
+        MetricsCollector.Stats afterUncached = mc.computeStats();
+        assertSame(fresh, afterUncached,
+                "uncached path should also refresh the cache for subsequent live-UI reads");
+    }
 }

--- a/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorConcurrencyTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorConcurrencyTest.java
@@ -1,0 +1,150 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Stress test for the HdrHistogram-backed {@link MetricsCollector} — see
+ * issue #443. Validates that:
+ * <ul>
+ *   <li>{@link MetricsCollector#record(long)} is safe under heavy concurrent
+ *       load (HdrHistogram's {@code Recorder} is lock-free for writers).</li>
+ *   <li>Concurrent {@link MetricsCollector#computeStats()} callers do not
+ *       deadlock and observe a self-consistent view (count never decreases,
+ *       max never decreases).</li>
+ *   <li>A sentinel max value injected by one thread shows up in the final
+ *       snapshot, proving the snapshot path actually merges in-flight data
+ *       from all writers.</li>
+ * </ul>
+ */
+class MetricsCollectorConcurrencyTest {
+
+    private static final int RECORDER_THREADS = 16;
+    private static final int RECORDS_PER_THREAD = 100_000;
+    private static final int SNAPSHOT_THREADS = 4;
+
+    @Test
+    void concurrentRecordAndComputeStats() throws Exception {
+        MetricsCollector mc = new MetricsCollector();
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(RECORDER_THREADS);
+        AtomicBoolean snapshotsRunning = new AtomicBoolean(true);
+        AtomicBoolean failure = new AtomicBoolean(false);
+
+        ExecutorService pool = Executors.newFixedThreadPool(RECORDER_THREADS + SNAPSHOT_THREADS);
+        try {
+            // Recorder threads
+            for (int t = 0; t < RECORDER_THREADS; t++) {
+                final int threadIdx = t;
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 1; i <= RECORDS_PER_THREAD; i++) {
+                            // Spread values across a wide range to populate
+                            // many HdrHistogram buckets. Last record from one
+                            // thread (idx == 0) is a sentinel large value.
+                            long nanos;
+                            if (threadIdx == 0 && i == RECORDS_PER_THREAD) {
+                                nanos = 500_000_000L; // 500 ms — the "max"
+                            } else {
+                                nanos = ((threadIdx + 1L) * 1_000L) + (i % 1_000L) * 100L;
+                            }
+                            mc.record(nanos);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (RuntimeException e) {
+                        // Anything thrown by HdrHistogram — record() should
+                        // be allocation-free and lock-free, so a failure
+                        // here means we broke the contract.
+                        failure.set(true);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            // Snapshot threads — concurrent readers
+            long[] lastCount = new long[SNAPSHOT_THREADS];
+            long[] lastMax = new long[SNAPSHOT_THREADS];
+            for (int t = 0; t < SNAPSHOT_THREADS; t++) {
+                final int snapIdx = t;
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        while (snapshotsRunning.get()) {
+                            MetricsCollector.Stats s = mc.computeStats();
+                            // Monotonicity: count and max can only grow.
+                            if (s.count() < lastCount[snapIdx]) {
+                                failure.set(true);
+                            }
+                            if (s.maxNanos() < lastMax[snapIdx]) {
+                                failure.set(true);
+                            }
+                            lastCount[snapIdx] = s.count();
+                            lastMax[snapIdx] = s.maxNanos();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertTrue(done.await(60, TimeUnit.SECONDS),
+                    "recorder threads should finish within 60 s");
+            // Stop snapshot threads.
+            snapshotsRunning.set(false);
+        } finally {
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+        }
+
+        assertTrue(!failure.get(), "monotonicity / record exception observed");
+
+        // Sleep past the cache TTL so the final computeStats is forced to
+        // recompute from the recorder rather than serving a snapshot taken
+        // while recorders were still mid-flight.
+        Thread.sleep(250);
+
+        // Final snapshot must reflect every recorded value.
+        MetricsCollector.Stats finalStats = mc.computeStats();
+        assertEquals((long) RECORDER_THREADS * RECORDS_PER_THREAD,
+                finalStats.count(),
+                "every record() must show up in the final count");
+
+        // The sentinel 500 ms value injected by thread 0 must dominate the
+        // max — proves the snapshot path actually merged data from all
+        // writers (and isn't reading a stale per-thread buffer).
+        assertTrue(finalStats.maxNanos() >= 499_000_000L,
+                "max should reflect the sentinel 500 ms value, got " + finalStats.maxNanos());
+        assertTrue(finalStats.maxNanos() <= 501_000_000L,
+                "max should be close to 500 ms (HdrHistogram bucket precision), got "
+                        + finalStats.maxNanos());
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorTest.java
@@ -75,6 +75,38 @@ class MetricsCollectorTest {
     }
 
     @Test
+    void recordClampsBelowLowestAndAboveHighest() {
+        // HdrHistogram is configured for 1 ns – 1 hour at 3 sig digits;
+        // record() must clamp values outside that range rather than
+        // throw. Also asserts getLastNanos() returns the same clamped
+        // value the histogram saw (issue #443 review feedback).
+        MetricsCollector mcLow = new MetricsCollector();
+        mcLow.record(0L);
+        MetricsCollector.Stats lowStats = mcLow.computeStats();
+        assertEquals(1L, lowStats.count());
+        assertEquals(1L, lowStats.maxNanos(),
+                "record(0) should clamp to LOWEST_NANOS=1 ns");
+        assertEquals(1L, mcLow.getLastNanos(),
+                "getLastNanos() must reflect the clamped value, not the raw input");
+
+        MetricsCollector mcNeg = new MetricsCollector();
+        mcNeg.record(-42L);
+        assertEquals(1L, mcNeg.computeStats().maxNanos());
+        assertEquals(1L, mcNeg.getLastNanos());
+
+        long oneHourNanos = java.util.concurrent.TimeUnit.HOURS.toNanos(1);
+        MetricsCollector mcHigh = new MetricsCollector();
+        mcHigh.record(Long.MAX_VALUE);
+        MetricsCollector.Stats highStats = mcHigh.computeStats();
+        assertEquals(1L, highStats.count());
+        // HdrHistogram quantizes to bucket boundaries — assert the value
+        // is within tolerance of HIGHEST_NANOS rather than exact-equal.
+        assertWithinTolerance(oneHourNanos, highStats.maxNanos());
+        assertEquals(oneHourNanos, mcHigh.getLastNanos(),
+                "getLastNanos() must reflect the HIGHEST_NANOS clamp");
+    }
+
+    @Test
     void percentileIndexDoesNotOverflowWithLargeSize() {
         // Original (pre-issue-443) regression guard: with the old reservoir-based
         // implementation, percentileIndex could overflow when size > ~21M because

--- a/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/MetricsCollectorTest.java
@@ -25,6 +25,19 @@ import org.junit.jupiter.api.Test;
 
 class MetricsCollectorTest {
 
+    /**
+     * HdrHistogram with 3 significant digits has ~0.1 % quantization error
+     * on each recorded value. We assert percentile / max values within this
+     * band rather than exact-equal — see issue #443.
+     */
+    private static final double HDR_TOLERANCE = 0.002; // 0.2 %, 2x the bucket precision
+
+    private static void assertWithinTolerance(long expected, long actual) {
+        long band = Math.max(1L, (long) (expected * HDR_TOLERANCE));
+        assertTrue(Math.abs(actual - expected) <= band,
+                "expected " + expected + " ±" + band + ", got " + actual);
+    }
+
     @Test
     void computeStatsEmpty() {
         MetricsCollector mc = new MetricsCollector();
@@ -38,9 +51,10 @@ class MetricsCollectorTest {
         mc.record(5_000_000L);
         MetricsCollector.Stats stats = mc.computeStats();
         assertEquals(1, stats.count());
-        assertEquals(5_000_000L, stats.p50Nanos());
-        assertEquals(5_000_000L, stats.p99Nanos());
-        assertEquals(5_000_000L, stats.maxNanos());
+        // HdrHistogram quantizes to 3 significant digits — ~0.1% band.
+        assertWithinTolerance(5_000_000L, stats.p50Nanos());
+        assertWithinTolerance(5_000_000L, stats.p99Nanos());
+        assertWithinTolerance(5_000_000L, stats.maxNanos());
     }
 
     @Test
@@ -51,21 +65,24 @@ class MetricsCollectorTest {
         }
         MetricsCollector.Stats stats = mc.computeStats();
         assertEquals(100, stats.count());
-        // p50 should be around 50ms, p99 around 99ms
-        assertTrue(stats.p50Nanos() >= 50_000_000L);
-        assertTrue(stats.p99Nanos() >= 99_000_000L);
-        assertEquals(100_000_000L, stats.maxNanos());
+        // p50 should be around 50ms, p99 around 99ms, allowing for HdrHistogram's
+        // bucket boundary effects (a sample may land in the next-higher bucket).
+        assertTrue(stats.p50Nanos() >= 49_000_000L && stats.p50Nanos() <= 51_000_000L,
+                "p50=" + stats.p50Nanos());
+        assertTrue(stats.p99Nanos() >= 98_000_000L && stats.p99Nanos() <= 100_500_000L,
+                "p99=" + stats.p99Nanos());
+        assertWithinTolerance(100_000_000L, stats.maxNanos());
     }
 
     @Test
     void percentileIndexDoesNotOverflowWithLargeSize() {
-        // This is the scenario that caused the original bug:
-        // size * percentile would overflow int when size > ~21M
-        // We test via computeStats by recording enough entries to trigger the overflow.
-        // Since we can't easily record 22M entries in a unit test, we verify the
-        // fix indirectly by checking the arithmetic doesn't produce negative indices.
+        // Original (pre-issue-443) regression guard: with the old reservoir-based
+        // implementation, percentileIndex could overflow when size > ~21M because
+        // of int×int multiplication. HdrHistogram does its percentile lookup over
+        // bucket counts (longs internally) so the overflow class is gone, but we
+        // keep the test to assert the public API still returns sane percentile
+        // values for small samples.
         MetricsCollector mc = new MetricsCollector();
-        // Record 10 entries and verify all percentile indices are non-negative
         for (int i = 0; i < 10; i++) {
             mc.record((i + 1) * 1_000_000L);
         }
@@ -73,16 +90,6 @@ class MetricsCollectorTest {
         assertTrue(stats.p50Nanos() > 0);
         assertTrue(stats.p95Nanos() > 0);
         assertTrue(stats.p99Nanos() > 0);
-
-        // Direct arithmetic check: simulate the old vs new calculation for large size
-        int largeSize = 22_000_000;
-        // Old code: (int)(size * percentile / 100.0) - would overflow
-        int oldResult = (int) (largeSize * 99 / 100.0);
-        // New code: (int)((long) size * percentile / 100.0) - correct
-        int newResult = (int) ((long) largeSize * 99 / 100.0);
-
-        assertTrue(oldResult < 0, "Old calculation should overflow to negative");
-        assertTrue(newResult > 0, "New calculation should be positive");
-        assertEquals(21_780_000, newResult);
+        assertTrue(stats.maxNanos() > 0);
     }
 }


### PR DESCRIPTION
Fixes #443.
Fixes #445.

Both issues report the same root problem from different angles: VectorBench client spends most of its CPU inside `MetricsCollector.computeStats()` instead of doing actual ingestion / query work. Issue #445 documents that **94% of client CPU was consumed by the per-call sort of a 100k-element reservoir** (`DualPivotQuicksort` dominating the profile).

## What changed

### `MetricsCollector` — HdrHistogram replaces the reservoir + sort
- Backed by HdrHistogram (`Recorder` + accumulating `Histogram`).
- `record(long)` is now allocation-free and lock-free (a constant-time atomic increment on a single bucket counter).
- `computeStats()` is O(buckets) ≈ a few microseconds, on ~24 KB of state — no more per-call 800 KB allocation + O(n log n) sort.
- Configured for 1 ns – 1 hour at 3 significant digits (~0.1 % precision).
- Short 200 ms TTL cache on `computeStats()` lets concurrent progress / status threads share one snapshot per refresh tick. Cache writes happen inside the snapshot lock so write order = lock acquisition order = monotonically increasing cumulative state — readers can never see counts go backwards.

### Workers stop calling `computeStats()` on the hot path
- `IngestionWorker.runIngestLoop` no longer calls `computeStats()` every 10k rows just to overwrite the shared `statusLine`. That branch was both racy (each worker only saw its own local `rowsIngested` counter) and CPU-expensive (per #445 it was 96% of all `computeStats` invocations).
- `QueryWorker` no longer calls `computeStats()` every 100 queries.
- `VectorBench`'s 500 ms ingest progress thread and the query-progress loop are now the **single publisher** of `ingestStatus` / `queryStatus`, using the same line shape the workers used so log scrapers see no format change.

### Producer-side optimizations (`DatasetLoader`)
Addresses the secondary observation in #443 (\"ingestion threads do not receive vectors fast enough\"):
- Reuse a single `byte[]` + `FloatBuffer` view across every vector in a stream / bulk-load. SIFT files have constant `dim`, so a single allocation suffices. At dim=1024 over a 100M-row ingest this saves ~400 GB of garbage on the producer thread.
- Bulk `asFloatBuffer().get(float[])` decode replaces the per-element `ByteBuffer.getFloat()` loop — JIT-vectorizable.
- `skipVecsInStream` reads `dim` from the first record and **bulk-skips** the remaining `(count - 1)` records as a single `skip(N)` call, instead of one `readInt` + one `skip` per skipped record. For a 100M-row resume this collapses 200M small operations into one.
- `ingestQueue` capacity grows from a fixed `1000` to `max(2048, ingestThreads * 64)` so a brief pause in one worker no longer back-pressures the producer.

## Tests

| Test | What it covers |
|---|---|
| `MetricsCollectorTest` (updated) | Existing assertions migrated to HdrHistogram's 3-sig-digit tolerance band; preserves the original public API contract and the percentile-overflow regression guard. |
| `MetricsCollectorCacheTest` (new) | 200 ms TTL cache: same `Stats` instance returned within window; fresh recompute after TTL; empty-collector path still cached. |
| `MetricsCollectorConcurrencyTest` (new) | 16 recorder threads × 100k records each + 4 concurrent snapshot threads. Asserts (a) no exceptions, (b) snapshot count / max are monotone per reader, (c) the final snapshot reflects every recorded value (1.6M) including a sentinel 500 ms max injected by one thread. |
| `DatasetLoaderFvecsBulkDecodeTest` (new) | Round-trips vectors through `SiftWriter` → `streamBaseVectors` at dim=4 / 128 / 1024. Validates bulk decode bit-for-bit, asserts the iterator returns a fresh `float[]` per call (reused scratch is internal-only), and exercises `skipVectors=73` against the new bulk-skip path. |

All 213 tests in `vector-testings` pass. Pre-PR validation (checkstyle, apache-rat, spotbugs) is green.

## Test plan

- [x] `mvn -pl vector-testings test` — 213 tests pass
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green
- [ ] Re-profile a real 1B-vector ingest run to confirm `MetricsCollector.computeStats` is no longer in the top of the CPU profile (manual follow-up; the synthetic stress in `MetricsCollectorConcurrencyTest` already validates correctness under contention).

🤖 Implemented by the `pr-worker` agent.