### PR TITLE
issue #448: parallelize eviction-driven page unloads in onTransactionCommit

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -239,6 +239,15 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             new java.util.concurrent.atomic.AtomicLong();
 
     /**
+     * Counts how many eviction-driven {@code unload(pageId)} calls were dispatched
+     * to the checkpoint-flush executor by {@link #onTransactionCommit} via the
+     * commit-time {@code CheckpointFlushBatch}. Issue #448. Lets tests assert that
+     * the new parallel-unload path was actually exercised.
+     */
+    private final java.util.concurrent.atomic.AtomicLong parallelUnloadsCount =
+            new java.util.concurrent.atomic.AtomicLong();
+
+    /**
      * Allow checkpoint
      */
     private final StampedLock checkpointLock = new StampedLock();
@@ -849,6 +858,35 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private Long allocateLivePage(Long lastKnownPageId) {
+        return allocateLivePage(lastKnownPageId, null);
+    }
+
+    /**
+     * Allocate a fresh mutable page when the previous "current" page filled up.
+     *
+     * <p>Issue #448: when {@code unloadBatch} is non-{@code null}, the
+     * eviction victim returned by {@link #pageReplacementPolicy} is dispatched
+     * to the batch (which runs on the DBManager checkpoint-flush executor)
+     * instead of being unloaded synchronously on the caller thread. This lets
+     * {@link #onTransactionCommit} overlap many remote-storage page writes
+     * during a bulk-insert commit; the caller awaits the batch before
+     * releasing the commit-apply slot.
+     *
+     * <p>When {@code unloadBatch} is {@code null}, behaviour is unchanged from
+     * the legacy path: the caller waits for the unload synchronously. Used by
+     * {@link #apply(CommitLogResult, LogEntry, boolean)} (single-record log
+     * replay), the autocommit DML path, and the Phase-B
+     * {@code cleanAndCompactPage} caller.
+     *
+     * @param lastKnownPageId the page id the caller observed as
+     *                        {@code currentDirtyRecordsPage} before discovering it
+     *                        was full
+     * @param unloadBatch     optional batch that absorbs the unload of the
+     *                        replacement policy's eviction victim; may be
+     *                        {@code null} for synchronous behaviour
+     * @return the page id of the new (or already-rotated) current dirty page
+     */
+    private Long allocateLivePage(Long lastKnownPageId, CheckpointFlushBatch unloadBatch) {
         /* This method expect that a new page actually exists! */
         nextPageLock.lock();
 
@@ -900,7 +938,23 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
         /* Dereferenced page unload. Out of locking */
         if (unload != null) {
-            unload.owner.unload(unload.pageId);
+            if (unloadBatch != null) {
+                /*
+                 * Issue #448: dispatch the eviction-driven unload to the
+                 * checkpoint-flush executor. The submit() call blocks on a
+                 * semaphore once the parallelism cap is reached, so the
+                 * number of in-flight (still-resident) victim pages is
+                 * bounded by checkpointFlushParallelism. The caller of
+                 * onTransactionCommit awaits the batch before releasing the
+                 * commit-apply slot, so victim pages cannot survive past
+                 * the commit boundary.
+                 */
+                final Page.Metadata captured = unload;
+                unloadBatch.submit(() -> captured.owner.unload(captured.pageId));
+                parallelUnloadsCount.incrementAndGet();
+            } else {
+                unload.owner.unload(unload.pageId);
+            }
         }
 
         /* Both created now or already created */
@@ -1007,9 +1061,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     /**
-     * Bounded-parallel collector of {@code dataStorageManager.writePage} calls
-     * submitted to the DBManager checkpoint-flush executor during Phase B
-     * (issue #202). Lives for a single Phase-B invocation on one table.
+     * Bounded-parallel collector of page-flush actions submitted to the
+     * DBManager checkpoint-flush executor.
+     *
+     * <p>Originally introduced for the Phase-B {@code dataStorageManager.writePage}
+     * fan-out (issue #202) and reused by:
+     * <ul>
+     *   <li>Phase-C {@code drainPendingNewPages} (issue #431),</li>
+     *   <li>{@link #onTransactionCommit} for parallelizing eviction-driven
+     *       {@link #unload(long)} calls triggered by {@link #allocateLivePage}
+     *       (issue #448).</li>
+     * </ul>
      *
      * <p>The {@link #submit(Runnable)} call blocks (on a semaphore) when the
      * configured parallelism limit is reached, so the caller cannot run ahead
@@ -1243,6 +1305,16 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      */
     long getDrainedNewPagesOutsideLock() {
         return drainedNewPagesOutsideLock.get();
+    }
+
+    /**
+     * @return number of eviction-driven {@code unload(pageId)} calls dispatched
+     *         to the checkpoint-flush executor by {@link #onTransactionCommit}
+     *         since this {@code TableManager} was instantiated. Issue #448.
+     *         Visible for tests.
+     */
+    long getParallelUnloadsCount() {
+        return parallelUnloadsCount.get();
     }
 
     /**
@@ -2362,26 +2434,42 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             throw new DataStorageManagerException(
                     "timed out waiting for checkpoint Phase C gate during a commit");
         }
+        /*
+         * Issue #448: dispatch eviction-driven page unloads (triggered when
+         * applyInsert / applyUpdate fill a page and allocateLivePage rotates
+         * to a fresh one) to the checkpoint-flush executor. The semaphore
+         * inside CheckpointFlushBatch caps the number of in-flight unloads at
+         * checkpointFlushParallelism, so the extra resident memory budget is
+         * bounded. We awaitAll() before publishing the commit LSN, so victim
+         * pages cannot survive past this commit's boundary — Phase C and the
+         * next commits see a quiescent state.
+         *
+         * keyToPage.put(...) and lastAppliedSequenceNumber.updateAndGet(...)
+         * remain on this thread, in program order: only the I/O of pages that
+         * are no longer being written to is parallelized.
+         */
+        final CheckpointFlushBatch unloadBatch = new CheckpointFlushBatch(
+                tableSpaceManager.getCheckpointFlushExecutor(), checkpointFlushParallelism);
         try {
             Map<Bytes, Record> changedRecords = transaction.changedRecords.get(table.name);
             // transaction is still holding locks on each record, so we can change records
             Map<Bytes, Record> newRecords = transaction.newRecords.get(table.name);
             if (newRecords != null) {
                 for (Record record : newRecords.values()) {
-                    applyInsert(record.key, record.value, true);
+                    applyInsert(record.key, record.value, true, unloadBatch);
                 }
             }
             if (changedRecords != null) {
                 for (Record r : changedRecords.values()) {
                     try {
-                        applyUpdate(r.key, r.value);
+                        applyUpdate(r.key, r.value, unloadBatch);
                     } catch (PageNotFoundException e) {
                         if (recovery) {
                             LOGGER.log(Level.FINE,
                                     "{0}.{1} recovery: re-applying update for key {2} as delete+insert (transaction commit)",
                                     new Object[]{table.tablespace, table.name, r.key});
                             keyToPage.remove(r.key);
-                            applyInsert(r.key, r.value, false);
+                            applyInsert(r.key, r.value, false, unloadBatch);
                         } else {
                             throw e;
                         }
@@ -2406,6 +2494,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 }
             }
             /*
+             * Issue #448: wait for all parallel unloads to finish before
+             * publishing the commit LSN and releasing the apply slot. This
+             * preserves the issue #157 invariant — Phase C, when it observes
+             * activeCommitApplies == 0, must see both the LSN update and a
+             * quiescent page state for every commit that already passed.
+             */
+            unloadBatch.awaitAll();
+            /*
              * Publish the commit's LSN as "last fully applied" BEFORE releasing the
              * apply slot. Phase C drains activeCommitApplies to zero; the JMM
              * happens-before chain (program order within this thread + volatile read of
@@ -2416,6 +2512,30 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             if (commitLsn != null) {
                 lastAppliedSequenceNumber.updateAndGet(cur -> commitLsn.after(cur) ? commitLsn : cur);
             }
+        } catch (RuntimeException | Error primary) {
+            /*
+             * Issue #448: on any failure inside the apply loop (or in
+             * unloadBatch.awaitAll() above), drain the batch best-effort
+             * before releasing the apply slot. Otherwise executor threads
+             * might still touch pages — and update the (now stale)
+             * pageReplacementPolicy — after the caller has observed our
+             * exception. The drain will fast-path to a no-op when awaitAll()
+             * already succeeded above, since CompletableFuture.allOf on
+             * already-completed futures returns instantly.
+             *
+             * Note: DataStorageManagerException extends HerdDBInternalException
+             * extends RuntimeException, so it is covered by the
+             * RuntimeException alternative — Java forbids listing a subclass
+             * separately in a multi-catch. Catching (RuntimeException | Error)
+             * deliberately excludes checked exceptions that the apply path
+             * does not declare.
+             */
+            try {
+                unloadBatch.awaitAll();
+            } catch (DataStorageManagerException secondary) {
+                primary.addSuppressed(secondary);
+            }
+            throw primary;
         } finally {
             activeCommitApplies.decrementAndGet();
         }
@@ -2746,6 +2866,20 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private void applyUpdate(Bytes key, Bytes value) throws DataStorageManagerException {
+        applyUpdate(key, value, null);
+    }
+
+    /**
+     * Apply an UPDATE effect to the in-memory state.
+     *
+     * <p>Issue #448: when {@code unloadBatch} is non-{@code null}, eviction-driven
+     * unloads triggered by {@link #allocateLivePage} (when an in-place update
+     * does not fit and the record is re-inserted onto a fresh page) are
+     * dispatched to the batch instead of running synchronously on the caller
+     * thread. See {@link #applyInsert(Bytes, Bytes, boolean, CheckpointFlushBatch)}.
+     */
+    private void applyUpdate(Bytes key, Bytes value,
+            CheckpointFlushBatch unloadBatch) throws DataStorageManagerException {
         // do not want to retain shared buffers as keys
         key = key.nonShared();
 
@@ -2925,7 +3059,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 }
 
                 /* Try allocate a new page if no already done */
-                insertionPageId = allocateLivePage(insertionPageId);
+                insertionPageId = allocateLivePage(insertionPageId, unloadBatch);
             }
 
             /* Update the value on keyToPage */
@@ -3087,6 +3221,20 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private void applyInsert(Bytes key, Bytes value, boolean onTransaction) throws DataStorageManagerException {
+        applyInsert(key, value, onTransaction, null);
+    }
+
+    /**
+     * Apply an INSERT effect to the in-memory state.
+     *
+     * <p>Issue #448: when {@code unloadBatch} is non-{@code null}, eviction-driven
+     * unloads triggered by {@link #allocateLivePage} are dispatched to the
+     * batch (and therefore to the checkpoint-flush executor) instead of running
+     * synchronously on the caller thread. {@link #onTransactionCommit} uses this
+     * to overlap remote-storage page writes during a bulk-insert commit.
+     */
+    private void applyInsert(Bytes key, Bytes value, boolean onTransaction,
+            CheckpointFlushBatch unloadBatch) throws DataStorageManagerException {
         // don't want to keep strong references to shared buffers in the keyToPages
         key = key.nonShared();
 
@@ -3136,7 +3284,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
 
             /* Try allocate a new page if no already done */
-            insertionPageId = allocateLivePage(insertionPageId);
+            insertionPageId = allocateLivePage(insertionPageId, unloadBatch);
         }
 
         /* Insert  the value on keyToPage */

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1311,9 +1311,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      * @return number of eviction-driven {@code unload(pageId)} calls dispatched
      *         to the checkpoint-flush executor by {@link #onTransactionCommit}
      *         since this {@code TableManager} was instantiated. Issue #448.
-     *         Visible for tests.
+     *         Public so cross-package hammer tests in
+     *         {@code herddb.server.hammer} can assert that the new
+     *         commit-time batched-unload path was actually exercised.
      */
-    long getParallelUnloadsCount() {
+    public long getParallelUnloadsCount() {
         return parallelUnloadsCount.get();
     }
 

--- a/herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java
+++ b/herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java
@@ -30,19 +30,25 @@ import static herddb.model.TransactionContext.NO_TRANSACTION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import herddb.file.FileCommitLogManager;
 import herddb.file.FileDataStorageManager;
 import herddb.file.FileMetadataStorageManager;
 import herddb.model.DataScanner;
+import herddb.model.Record;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
 import herddb.server.ServerConfiguration;
+import herddb.storage.DataStorageManagerException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -59,25 +65,33 @@ import org.junit.rules.TemporaryFolder;
  * committing a transaction with thousands of new vector-bearing records ends
  * up serializing thousands of remote writes on a single thread.
  *
- * <p>The fix dispatches those unloads to the DBManager checkpoint-flush executor
- * (the same pool used by Phase B and the Phase-C drain), bounded by the
- * existing {@code checkpointFlushParallelism} semaphore. This test:
- * <ul>
- *   <li>configures a tiny page size (2 KiB) and a tiny page-cache budget
- *       (32 KiB ≈ 16 pages) so that a few dozen inserts force the page
- *       replacement policy into steady-state eviction during the commit;</li>
- *   <li>commits a single transaction containing 200 inserts;</li>
- *   <li>asserts that {@link TableManager#getParallelUnloadsCount()} grew —
- *       proving the new batched path was actually exercised;</li>
- *   <li>asserts that the data is queryable both before and after a restart,
- *       proving the change preserves durability.</li>
- * </ul>
+ * <p>The fix dispatches those unloads to the DBManager checkpoint-flush
+ * executor (the same pool used by Phase B and the Phase-C drain), bounded by
+ * the existing {@code checkpointFlushParallelism} semaphore. The tests in
+ * this file cover:
  *
- * <p>A second test asserts that the legacy <em>synchronous</em> path is
- * preserved on the autocommit / log-replay code paths: an autocommit insert
- * goes through {@code apply()} → {@code applyInsert(key, value, false)}
- * (no batch), so the parallel-unloads counter must stay at zero even when
- * many records are inserted.
+ * <ul>
+ *   <li>{@link #bulkInsertCommitDispatchesParallelUnloads()} — the new
+ *       batched path is exercised by a transaction full of inserts;</li>
+ *   <li>{@link #bulkUpdateCommitDispatchesParallelUnloads()} — the same
+ *       batched path is exercised by a transaction full of updates that
+ *       force page rotation via {@code applyUpdate};</li>
+ *   <li>{@link #mixedInsertUpdateDeleteCommitDispatchesParallelUnloads()} —
+ *       a single transaction interleaving inserts, updates, and deletes
+ *       still produces the right durable end state under eviction;</li>
+ *   <li>{@link #commitFailureDrainsBatchAndReleasesApplySlot()} — when the
+ *       async unload throws (e.g., remote storage write fails), the commit
+ *       fails fast, the apply slot is released, and a follow-on commit
+ *       still completes successfully;</li>
+ *   <li>{@link #autocommitInsertsKeepLegacySynchronousPath()} — autocommit
+ *       DML, which goes through {@code apply()} → {@code applyInsert(..., false)}
+ *       (the no-batch overload), drives the legacy synchronous path under
+ *       eviction without ever bumping the parallel-unloads counter;</li>
+ *   <li>{@link #recoveryReplayUnderEvictionPressureUsesNoBatchOverload()} —
+ *       recovery / log replay of autocommit entries goes through the
+ *       no-batch overload, even under eviction pressure, and reproduces
+ *       all rows after restart.</li>
+ * </ul>
  */
 public class Issue448BulkInsertParallelUnloadTest {
 
@@ -85,35 +99,40 @@ public class Issue448BulkInsertParallelUnloadTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     /**
-     * Small enough that even a 200 B record fills the page after a handful of
-     * rows, so eviction kicks in well within a 200-row commit.
+     * Small enough that a few rows fill the page, so eviction kicks in well
+     * within each test's row count.
      */
     private static final long PAGE_SIZE_BYTES = 2 * 1024L;
 
     /**
-     * Cap data-page memory at ~16 pages. With {@link #PAGE_SIZE_BYTES} this
-     * means the page replacement policy is at capacity after the first ~16
-     * page rotations and every subsequent {@code allocateLivePage} call
-     * yields a non-null eviction victim — which is exactly the scenario the
-     * fix optimizes.
+     * Cap data-page memory at ~16 pages so the page replacement policy is at
+     * capacity quickly and every subsequent page rotation yields an
+     * eviction victim — exactly the scenario the fix optimizes.
      */
     private static final long DATA_MEMORY_BYTES = 32 * 1024L;
 
     /**
-     * One transaction with this many inserts. Large enough to trigger a
-     * comfortable number of evictions (≫ checkpointFlushParallelism, which
-     * defaults to 8) so the parallelism-gated path is exercised even on a
-     * single-CPU CI runner.
+     * One transaction with this many inserts. Generously over the 16-page
+     * budget so the parallel-unloads counter has comfortable margin against
+     * per-record-overhead variance on different runners (per pr-reviewer
+     * follow-up #6).
      */
-    private static final int RECORDS_PER_TXN = 200;
+    private static final int RECORDS_PER_TXN = 800;
+
+    /**
+     * Padded value attached to every test row. ~200 B together with the
+     * key plus serializer overhead means roughly half a dozen rows per 2 KiB
+     * page, so {@link #RECORDS_PER_TXN} rows cause many page rotations.
+     */
+    private static final String PADDED_VALUE = repeat("x", 200);
 
     private static ServerConfiguration baseConfig() {
         ServerConfiguration cfg = newServerConfigurationWithAutoPort();
         cfg.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, PAGE_SIZE_BYTES);
         cfg.set(ServerConfiguration.PROPERTY_MAX_DATA_MEMORY, DATA_MEMORY_BYTES);
-        // Keep the PK budget large enough that BLink-internal evictions do
-        // not dominate; this test is about data-page evictions in the
-        // commit path, not BLink behaviour.
+        // Keep the PK budget large so BLink-internal evictions do not
+        // dominate; this test is about data-page evictions in the commit
+        // path, not BLink behaviour.
         cfg.set(ServerConfiguration.PROPERTY_MAX_PK_MEMORY, 4 * 1024 * 1024L);
         return cfg;
     }
@@ -130,46 +149,30 @@ public class Issue448BulkInsertParallelUnloadTest {
         Path metadataPath = folder.newFolder("metadata").toPath();
         Path tmpDir = folder.newFolder("tmpDir").toPath();
 
-        long parallelUnloads;
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
                 new FileCommitLogManager(logsPath),
                 tmpDir, null, baseConfig(), null)) {
             manager.start();
-            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
-                    Collections.singleton("localhost"), "localhost", 1, 0, 0);
-            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    NO_TRANSACTION);
-            manager.waitForTablespace("tblspace1", 10_000);
+            createTableSpaceAndTable(manager);
+            TableManager t1Manager = tableManager(manager);
 
-            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
-                    Collections.emptyList());
-
-            TableManager t1Manager = (TableManager) manager.getTableSpaceManager("tblspace1")
-                    .getTableManager("t1");
-
-            // Sanity: counter starts at zero.
             assertEquals("counter must start at zero",
                     0L, t1Manager.getParallelUnloadsCount());
-
-            // Pad each value so a handful of rows fill a 2 KiB page.
-            String paddedValue = repeat("x", 200);
 
             long tx = beginTransaction(manager, "tblspace1");
             for (int i = 0; i < RECORDS_PER_TXN; i++) {
                 executeUpdate(manager,
                         "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
-                        Arrays.asList(String.format("k_%04d", i), paddedValue),
+                        Arrays.asList(String.format("k_%05d", i), PADDED_VALUE),
                         new TransactionContext(tx));
             }
             commitTransaction(manager, "tblspace1", tx);
 
-            parallelUnloads = t1Manager.getParallelUnloadsCount();
+            long parallelUnloads = t1Manager.getParallelUnloadsCount();
             assertTrue("commit-time parallel unloads must have been dispatched: counter=" + parallelUnloads,
                     parallelUnloads > 0);
-
-            // All inserted rows must be visible from the same DBManager.
             assertRowCount(manager, RECORDS_PER_TXN);
         }
 
@@ -187,11 +190,279 @@ public class Issue448BulkInsertParallelUnloadTest {
     }
 
     /**
+     * A transaction that updates many existing rows (growing each row enough
+     * to overflow its current page) drives {@code applyUpdate} →
+     * {@code allocateLivePage} → eviction; the same parallel batch must be
+     * used. Covers the {@code applyUpdate(..., unloadBatch)} overload at
+     * {@link TableManager} (issue #448 review follow-up #2).
+     */
+    @Test
+    public void bulkUpdateCommitDispatchesParallelUnloads() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int rowCount = 500;
+        String shortValue = repeat("a", 20);
+        String longValue = repeat("z", 250);
+
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+            TableManager t1Manager = tableManager(manager);
+
+            // Pre-populate with autocommit (legacy path) and checkpoint so
+            // pages are immutable on disk before we start the test.
+            for (int i = 0; i < rowCount; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%05d", i), shortValue),
+                        NO_TRANSACTION);
+            }
+            manager.checkpoint();
+
+            long counterBeforeUpdates = t1Manager.getParallelUnloadsCount();
+
+            // Now the transaction-mode commit: many UPDATEs that grow each
+            // row. applyUpdate sees the writeTargetPage as null (immutable
+            // after checkpoint), falls back to the insertion-page path, and
+            // invokes allocateLivePage(insertionPageId, unloadBatch). The
+            // batched path must drive at least one eviction.
+            long tx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < rowCount; i++) {
+                executeUpdate(manager,
+                        "UPDATE tblspace1.t1 set v1=? where k1=?",
+                        Arrays.asList(longValue, String.format("k_%05d", i)),
+                        new TransactionContext(tx));
+            }
+            commitTransaction(manager, "tblspace1", tx);
+
+            long counterAfterUpdates = t1Manager.getParallelUnloadsCount();
+            long delta = counterAfterUpdates - counterBeforeUpdates;
+            assertTrue("UPDATE-driven parallel unloads must have been dispatched: delta=" + delta
+                            + " before=" + counterBeforeUpdates + " after=" + counterAfterUpdates,
+                    delta > 0);
+
+            assertRowCount(manager, rowCount);
+            assertAllRowsHaveValue(manager, longValue, rowCount);
+        }
+
+        // Durability across restart.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            assertRowCount(manager, rowCount);
+            assertAllRowsHaveValue(manager, longValue, rowCount);
+        }
+    }
+
+    /**
+     * One transaction interleaving inserts, updates, and deletes under
+     * eviction pressure must produce the correct end state and survive
+     * restart (issue #448 review follow-up #3).
+     */
+    @Test
+    public void mixedInsertUpdateDeleteCommitDispatchesParallelUnloads() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int prepopulated = 200;
+        int updates = 80;
+        int deletes = 50;
+        int inserts = 200;
+        String preValue = repeat("p", 20);
+        String updatedValue = repeat("u", 250);
+        String insertedValue = repeat("n", 250);
+
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+            TableManager t1Manager = tableManager(manager);
+
+            // Pre-populate (autocommit).
+            for (int i = 0; i < prepopulated; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%05d", i), preValue),
+                        NO_TRANSACTION);
+            }
+            manager.checkpoint();
+            long counterBefore = t1Manager.getParallelUnloadsCount();
+
+            long tx = beginTransaction(manager, "tblspace1");
+            // updates: keys 0..updates-1
+            for (int i = 0; i < updates; i++) {
+                executeUpdate(manager,
+                        "UPDATE tblspace1.t1 set v1=? where k1=?",
+                        Arrays.asList(updatedValue, String.format("k_%05d", i)),
+                        new TransactionContext(tx));
+            }
+            // deletes: keys updates..updates+deletes-1
+            for (int i = updates; i < updates + deletes; i++) {
+                executeUpdate(manager,
+                        "DELETE FROM tblspace1.t1 where k1=?",
+                        Arrays.asList(String.format("k_%05d", i)),
+                        new TransactionContext(tx));
+            }
+            // inserts: keys prepopulated..prepopulated+inserts-1
+            for (int i = 0; i < inserts; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%05d", prepopulated + i), insertedValue),
+                        new TransactionContext(tx));
+            }
+            commitTransaction(manager, "tblspace1", tx);
+
+            long delta = t1Manager.getParallelUnloadsCount() - counterBefore;
+            assertTrue("mixed-DML commit should have dispatched parallel unloads: delta=" + delta,
+                    delta > 0);
+
+            int expectedRowCount = (prepopulated - deletes) + inserts;
+            assertRowCount(manager, expectedRowCount);
+        }
+
+        // Durability across restart.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            int expectedRowCount = (prepopulated - deletes) + inserts;
+            assertRowCount(manager, expectedRowCount);
+        }
+    }
+
+    /**
+     * If a {@code writePage} call dispatched by the commit-time batch fails,
+     * the commit must throw, but the apply slot must still be released and
+     * a subsequent commit must complete successfully — proving the
+     * {@code finally activeCommitApplies.decrementAndGet()} block in
+     * {@link TableManager#onTransactionCommit} is not bypassed (issue #448
+     * review follow-up #4).
+     */
+    @Test
+    public void commitFailureDrainsBatchAndReleasesApplySlot() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        FailingFileDataStorageManager failingDsm = new FailingFileDataStorageManager(dataPath);
+
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                failingDsm,
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+            TableManager t1Manager = tableManager(manager);
+
+            // Arm the failure: the very next writePage call from this
+            // DBManager will throw. The first transaction-mode commit below
+            // should drive several evictions, the first eviction's
+            // writePage will fail, and the parallel batch's awaitAll() will
+            // re-throw.
+            failingDsm.armFailure();
+
+            long failingTx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < RECORDS_PER_TXN; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("fail_%05d", i), PADDED_VALUE),
+                        new TransactionContext(failingTx));
+            }
+            try {
+                commitTransaction(manager, "tblspace1", failingTx);
+                fail("commitTransaction should have failed because writePage was rigged to throw");
+            } catch (Exception expected) {
+                // Either the commit itself or its tracking future surfaces
+                // a DataStorageManagerException (possibly wrapped). Walk
+                // the cause chain to confirm.
+                Throwable t = expected;
+                boolean foundDsmFailure = false;
+                while (t != null) {
+                    if (t instanceof DataStorageManagerException
+                            && t.getMessage() != null
+                            && t.getMessage().contains("test-injected")) {
+                        foundDsmFailure = true;
+                        break;
+                    }
+                    t = t.getCause();
+                }
+                assertTrue("expected the test-injected DataStorageManagerException in the cause chain, got: "
+                                + expected, foundDsmFailure);
+            }
+
+            // Disarm, then a subsequent commit must complete normally —
+            // this is the load-bearing assertion: if the failed commit
+            // had not decremented activeCommitApplies, the next commit
+            // would block forever (or time out) while Phase C waits.
+            failingDsm.disarmFailure();
+
+            long okTx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < 50; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("ok_%05d", i), PADDED_VALUE),
+                        new TransactionContext(okTx));
+            }
+            commitTransaction(manager, "tblspace1", okTx);
+
+            // The follow-on commit must have advanced the LSN (verified
+            // indirectly via successful query of the new rows).
+            try (DataScanner scanner = scan(manager,
+                    "SELECT count(*) as c FROM tblspace1.t1 where k1 like 'ok_%'",
+                    Collections.emptyList())) {
+                assertTrue("count(*) must return a row", scanner.hasNext());
+                Object[] row = (Object[]) scanner.next().getValues();
+                assertNotNull(row);
+                assertEquals("follow-on commit's rows must be visible",
+                        50L, ((Number) row[0]).longValue());
+            }
+
+            // The parallel-unloads counter must have grown — both the
+            // failed commit and the successful one ran the batched path.
+            assertTrue("parallel unloads must have been dispatched: counter="
+                            + t1Manager.getParallelUnloadsCount(),
+                    t1Manager.getParallelUnloadsCount() > 0);
+        }
+    }
+
+    /**
      * Autocommit / log-replay inserts go through {@code apply()} →
-     * {@code applyInsert(key, value, false)} which calls the no-batch
-     * {@code allocateLivePage(Long)} overload and must therefore NOT bump
-     * the parallel-unloads counter. This protects the recovery path from
-     * accidentally being routed through the new batched path.
+     * {@code applyInsert(key, value, false)} (no-batch overload). This test
+     * drives enough autocommit inserts to force eviction (so the legacy
+     * synchronous {@code unload} path is actually exercised under load) and
+     * asserts:
+     *
+     * <ul>
+     *   <li>{@code getParallelUnloadsCount()} stays at zero — proving the
+     *       no-batch overload remained on the autocommit path;</li>
+     *   <li>all rows are queryable and durable across a restart — proving
+     *       the legacy synchronous path remains correct under eviction.</li>
+     * </ul>
+     *
+     * <p>Issue #448 review follow-up #1: replaces a previous version of this
+     * test that was trivially satisfied because autocommit does not go
+     * through {@link TableManager#onTransactionCommit} at all.
      */
     @Test
     public void autocommitInsertsKeepLegacySynchronousPath() throws Exception {
@@ -200,58 +471,135 @@ public class Issue448BulkInsertParallelUnloadTest {
         Path metadataPath = folder.newFolder("metadata").toPath();
         Path tmpDir = folder.newFolder("tmpDir").toPath();
 
+        // Big enough to force >16 page rotations and therefore many
+        // eviction-driven unloads on the synchronous path.
+        int autocommitRows = 200;
+
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
                 new FileCommitLogManager(logsPath),
                 tmpDir, null, baseConfig(), null)) {
             manager.start();
-            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
-                    Collections.singleton("localhost"), "localhost", 1, 0, 0);
-            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    NO_TRANSACTION);
-            manager.waitForTablespace("tblspace1", 10_000);
+            createTableSpaceAndTable(manager);
+            TableManager t1Manager = tableManager(manager);
 
-            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
-                    Collections.emptyList());
-
-            TableManager t1Manager = (TableManager) manager.getTableSpaceManager("tblspace1")
-                    .getTableManager("t1");
-
-            String paddedValue = repeat("x", 200);
-
-            // Autocommit: each INSERT statement runs in its own implicit
-            // transaction whose commit goes through onTransactionCommit too,
-            // BUT each transaction has only a single record, so an
-            // allocateLivePage triggered by it will at most evict one
-            // victim per commit. We submit the legacy path explicitly via
-            // a non-transactional INSERT batch on the apply() path: the
-            // best way to drive that is to use NO_TRANSACTION.
-            //
-            // Even if onTransactionCommit fires for each implicit tx, the
-            // counter increments only on actual evictions. We therefore use
-            // a small enough record count that fits inside the data-page
-            // budget so no eviction is required at all — the counter must
-            // remain at zero.
-            for (int i = 0; i < 8; i++) {
+            for (int i = 0; i < autocommitRows; i++) {
                 executeUpdate(manager,
                         "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
-                        Arrays.asList(String.format("k_%04d", i), paddedValue),
+                        Arrays.asList(String.format("k_%05d", i), PADDED_VALUE),
                         NO_TRANSACTION);
             }
 
-            // No eviction needed for ~8 small rows under a 32 KiB / 2 KiB =
-            // 16 page budget; counter must still be zero.
-            assertEquals("autocommit path that does not evict must keep the counter at zero",
+            // The number of unloads on the synchronous path can be observed
+            // indirectly via TableManager.getStats().getUnloadedPagesCount();
+            // confirm at least a few happened, otherwise this test does not
+            // actually exercise the no-batch eviction path it claims to.
+            long unloadedPages = t1Manager.getStats().getUnloadedPagesCount();
+            assertTrue("test must drive enough autocommit inserts to actually evict pages: unloaded="
+                            + unloadedPages, unloadedPages > 0);
+
+            // The commit-time batched-unload counter must remain at zero —
+            // autocommit DML never reaches onTransactionCommit, so the
+            // batch is never instantiated, and no unload is ever dispatched
+            // through it.
+            assertEquals("autocommit path must not bump the parallel-unloads counter under eviction",
                     0L, t1Manager.getParallelUnloadsCount());
 
-            assertRowCount(manager, 8);
+            assertRowCount(manager, autocommitRows);
         }
+
+        // Durability across restart.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            assertRowCount(manager, autocommitRows);
+        }
+    }
+
+    /**
+     * Recovery / log replay must use the no-batch
+     * {@code applyInsert(key, value, false)} overload, even under eviction
+     * pressure. This test produces a commit log with many autocommit-mode
+     * INSERT entries (which are NOT followed by a checkpoint, so they
+     * remain in the log), restarts, and asserts that:
+     *
+     * <ul>
+     *   <li>recovery completes and every row is present;</li>
+     *   <li>the parallel-unloads counter on the restarted
+     *       {@link TableManager} stays at zero throughout the replay —
+     *       proving the no-batch overload is on the recovery path
+     *       (issue #448 review follow-up #5).</li>
+     * </ul>
+     */
+    @Test
+    public void recoveryReplayUnderEvictionPressureUsesNoBatchOverload() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int loggedRows = 300;
+
+        // Phase 1: write rows with autocommit, do NOT checkpoint, close.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+            for (int i = 0; i < loggedRows; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%05d", i), PADDED_VALUE),
+                        NO_TRANSACTION);
+            }
+            // No checkpoint here — DBManager.close() does not force one,
+            // so the next start replays the log (verified by extensive
+            // existing tests like CheckpointStaleLsnRecoveryTest).
+        }
+
+        // Phase 2: restart; recovery replays the log via the no-batch
+        // overload. The parallel-unloads counter must stay at zero.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            TableManager t1Manager = tableManager(manager);
+
+            assertEquals("recovery path must not bump the parallel-unloads counter",
+                    0L, t1Manager.getParallelUnloadsCount());
+            assertRowCount(manager, loggedRows);
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private static void createTableSpaceAndTable(DBManager manager) throws Exception {
+        CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                Collections.singleton("localhost"), "localhost", 1, 0, 0);
+        manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                NO_TRANSACTION);
+        manager.waitForTablespace("tblspace1", 10_000);
+        execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
+                Collections.emptyList());
+    }
+
+    private static TableManager tableManager(DBManager manager) {
+        return (TableManager) manager.getTableSpaceManager("tblspace1").getTableManager("t1");
     }
 
     private static void assertRowCount(DBManager manager, int expectedRows) throws Exception {
         try (DataScanner scanner = scan(manager,
-                "SELECT k1, v1 FROM tblspace1.t1", Collections.emptyList())) {
+                "SELECT k1 FROM tblspace1.t1", Collections.emptyList())) {
             int actual = 0;
             List<String> seenKeys = new ArrayList<>();
             while (scanner.hasNext()) {
@@ -261,7 +609,26 @@ public class Issue448BulkInsertParallelUnloadTest {
                 actual++;
             }
             assertEquals("scan returned wrong number of rows: " + seenKeys.size()
-                    + " keys=" + seenKeys, expectedRows, actual);
+                            + " keys (showing first 10 if too many): "
+                            + seenKeys.subList(0, Math.min(10, seenKeys.size())),
+                    expectedRows, actual);
+        }
+    }
+
+    private static void assertAllRowsHaveValue(DBManager manager,
+            String expectedValue, int expectedRows) throws Exception {
+        try (DataScanner scanner = scan(manager,
+                "SELECT k1, v1 FROM tblspace1.t1", Collections.emptyList())) {
+            int actual = 0;
+            while (scanner.hasNext()) {
+                Object[] row = (Object[]) scanner.next().getValues();
+                assertNotNull(row);
+                assertNotNull("v1 must not be null for key " + row[0], row[1]);
+                assertEquals("each row must carry the expected updated value (key=" + row[0] + ")",
+                        expectedValue, String.valueOf(row[1]));
+                actual++;
+            }
+            assertEquals(expectedRows, actual);
         }
     }
 
@@ -271,5 +638,39 @@ public class Issue448BulkInsertParallelUnloadTest {
             sb.append(fragment);
         }
         return sb.toString();
+    }
+
+    /**
+     * A {@link FileDataStorageManager} that throws
+     * {@link DataStorageManagerException} from {@link #writePage} when
+     * armed. Used by {@link #commitFailureDrainsBatchAndReleasesApplySlot()}
+     * to verify the failure path inside
+     * {@link TableManager#onTransactionCommit} releases the apply slot.
+     */
+    private static final class FailingFileDataStorageManager extends FileDataStorageManager {
+        private final AtomicBoolean armed = new AtomicBoolean();
+        private final AtomicInteger failedCalls = new AtomicInteger();
+
+        FailingFileDataStorageManager(Path baseDir) {
+            super(baseDir);
+        }
+
+        void armFailure() {
+            armed.set(true);
+        }
+
+        void disarmFailure() {
+            armed.set(false);
+        }
+
+        @Override
+        public void writePage(String tableSpace, String tableName, long pageId,
+                Collection<Record> newPage) throws DataStorageManagerException {
+            if (armed.get()) {
+                failedCalls.incrementAndGet();
+                throw new DataStorageManagerException("test-injected failure on writePage for page " + pageId);
+            }
+            super.writePage(tableSpace, tableName, pageId, newPage);
+        }
     }
 }

--- a/herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java
+++ b/herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java
@@ -1,0 +1,275 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.beginTransaction;
+import static herddb.core.TestUtils.commitTransaction;
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.executeUpdate;
+import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
+import static herddb.core.TestUtils.scan;
+import static herddb.model.TransactionContext.NO_TRANSACTION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.server.ServerConfiguration;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #448: parallelize eviction-driven page unloads in
+ * {@link TableManager#onTransactionCommit}.
+ *
+ * <p>Before the fix, every {@code applyInsert} that filled a page during a
+ * transaction commit called {@code allocateLivePage} → {@code pageReplacementPolicy.add(victim)}
+ * → {@code unload(victim)} synchronously on the commit thread. For a remote
+ * (S3-backed) data storage manager, each unload of a mutable page issues a
+ * {@code RemoteFileDataStorageManager.writeAsMultipart} round-trip, so
+ * committing a transaction with thousands of new vector-bearing records ends
+ * up serializing thousands of remote writes on a single thread.
+ *
+ * <p>The fix dispatches those unloads to the DBManager checkpoint-flush executor
+ * (the same pool used by Phase B and the Phase-C drain), bounded by the
+ * existing {@code checkpointFlushParallelism} semaphore. This test:
+ * <ul>
+ *   <li>configures a tiny page size (2 KiB) and a tiny page-cache budget
+ *       (32 KiB ≈ 16 pages) so that a few dozen inserts force the page
+ *       replacement policy into steady-state eviction during the commit;</li>
+ *   <li>commits a single transaction containing 200 inserts;</li>
+ *   <li>asserts that {@link TableManager#getParallelUnloadsCount()} grew —
+ *       proving the new batched path was actually exercised;</li>
+ *   <li>asserts that the data is queryable both before and after a restart,
+ *       proving the change preserves durability.</li>
+ * </ul>
+ *
+ * <p>A second test asserts that the legacy <em>synchronous</em> path is
+ * preserved on the autocommit / log-replay code paths: an autocommit insert
+ * goes through {@code apply()} → {@code applyInsert(key, value, false)}
+ * (no batch), so the parallel-unloads counter must stay at zero even when
+ * many records are inserted.
+ */
+public class Issue448BulkInsertParallelUnloadTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Small enough that even a 200 B record fills the page after a handful of
+     * rows, so eviction kicks in well within a 200-row commit.
+     */
+    private static final long PAGE_SIZE_BYTES = 2 * 1024L;
+
+    /**
+     * Cap data-page memory at ~16 pages. With {@link #PAGE_SIZE_BYTES} this
+     * means the page replacement policy is at capacity after the first ~16
+     * page rotations and every subsequent {@code allocateLivePage} call
+     * yields a non-null eviction victim — which is exactly the scenario the
+     * fix optimizes.
+     */
+    private static final long DATA_MEMORY_BYTES = 32 * 1024L;
+
+    /**
+     * One transaction with this many inserts. Large enough to trigger a
+     * comfortable number of evictions (≫ checkpointFlushParallelism, which
+     * defaults to 8) so the parallelism-gated path is exercised even on a
+     * single-CPU CI runner.
+     */
+    private static final int RECORDS_PER_TXN = 200;
+
+    private static ServerConfiguration baseConfig() {
+        ServerConfiguration cfg = newServerConfigurationWithAutoPort();
+        cfg.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, PAGE_SIZE_BYTES);
+        cfg.set(ServerConfiguration.PROPERTY_MAX_DATA_MEMORY, DATA_MEMORY_BYTES);
+        // Keep the PK budget large enough that BLink-internal evictions do
+        // not dominate; this test is about data-page evictions in the
+        // commit path, not BLink behaviour.
+        cfg.set(ServerConfiguration.PROPERTY_MAX_PK_MEMORY, 4 * 1024 * 1024L);
+        return cfg;
+    }
+
+    /**
+     * One transaction with {@value #RECORDS_PER_TXN} inserts must dispatch at
+     * least one eviction-driven unload to the parallel batch (and typically
+     * many more), and the data must survive a restart.
+     */
+    @Test
+    public void bulkInsertCommitDispatchesParallelUnloads() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        long parallelUnloads;
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton("localhost"), "localhost", 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10_000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
+                    Collections.emptyList());
+
+            TableManager t1Manager = (TableManager) manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+
+            // Sanity: counter starts at zero.
+            assertEquals("counter must start at zero",
+                    0L, t1Manager.getParallelUnloadsCount());
+
+            // Pad each value so a handful of rows fill a 2 KiB page.
+            String paddedValue = repeat("x", 200);
+
+            long tx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < RECORDS_PER_TXN; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%04d", i), paddedValue),
+                        new TransactionContext(tx));
+            }
+            commitTransaction(manager, "tblspace1", tx);
+
+            parallelUnloads = t1Manager.getParallelUnloadsCount();
+            assertTrue("commit-time parallel unloads must have been dispatched: counter=" + parallelUnloads,
+                    parallelUnloads > 0);
+
+            // All inserted rows must be visible from the same DBManager.
+            assertRowCount(manager, RECORDS_PER_TXN);
+        }
+
+        // Restart and verify durability — no record may be lost just because
+        // its hosting page was unloaded asynchronously during the commit.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            assertRowCount(manager, RECORDS_PER_TXN);
+        }
+    }
+
+    /**
+     * Autocommit / log-replay inserts go through {@code apply()} →
+     * {@code applyInsert(key, value, false)} which calls the no-batch
+     * {@code allocateLivePage(Long)} overload and must therefore NOT bump
+     * the parallel-unloads counter. This protects the recovery path from
+     * accidentally being routed through the new batched path.
+     */
+    @Test
+    public void autocommitInsertsKeepLegacySynchronousPath() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    Collections.singleton("localhost"), "localhost", 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10_000);
+
+            execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
+                    Collections.emptyList());
+
+            TableManager t1Manager = (TableManager) manager.getTableSpaceManager("tblspace1")
+                    .getTableManager("t1");
+
+            String paddedValue = repeat("x", 200);
+
+            // Autocommit: each INSERT statement runs in its own implicit
+            // transaction whose commit goes through onTransactionCommit too,
+            // BUT each transaction has only a single record, so an
+            // allocateLivePage triggered by it will at most evict one
+            // victim per commit. We submit the legacy path explicitly via
+            // a non-transactional INSERT batch on the apply() path: the
+            // best way to drive that is to use NO_TRANSACTION.
+            //
+            // Even if onTransactionCommit fires for each implicit tx, the
+            // counter increments only on actual evictions. We therefore use
+            // a small enough record count that fits inside the data-page
+            // budget so no eviction is required at all — the counter must
+            // remain at zero.
+            for (int i = 0; i < 8; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%04d", i), paddedValue),
+                        NO_TRANSACTION);
+            }
+
+            // No eviction needed for ~8 small rows under a 32 KiB / 2 KiB =
+            // 16 page budget; counter must still be zero.
+            assertEquals("autocommit path that does not evict must keep the counter at zero",
+                    0L, t1Manager.getParallelUnloadsCount());
+
+            assertRowCount(manager, 8);
+        }
+    }
+
+    private static void assertRowCount(DBManager manager, int expectedRows) throws Exception {
+        try (DataScanner scanner = scan(manager,
+                "SELECT k1, v1 FROM tblspace1.t1", Collections.emptyList())) {
+            int actual = 0;
+            List<String> seenKeys = new ArrayList<>();
+            while (scanner.hasNext()) {
+                Object[] row = (Object[]) scanner.next().getValues();
+                assertNotNull("scan row must contain a key", row);
+                seenKeys.add(String.valueOf(row[0]));
+                actual++;
+            }
+            assertEquals("scan returned wrong number of rows: " + seenKeys.size()
+                    + " keys=" + seenKeys, expectedRows, actual);
+        }
+    }
+
+    private static String repeat(String fragment, int count) {
+        StringBuilder sb = new StringBuilder(fragment.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(fragment);
+        }
+        return sb.toString();
+    }
+}

--- a/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerNoIndexesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerNoIndexesTest.java
@@ -1,0 +1,51 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import org.junit.Test;
+
+/**
+ * Issue #448 hammer — multi-op transactions, no secondary indexes.
+ * Two variants: with and without a periodic checkpoint thread.
+ */
+public class Issue448BulkCommitHammerNoIndexesTest extends Issue448BulkCommitHammerSuite {
+
+    /**
+     * No periodic checkpoint: every page-eviction unload during a commit
+     * must therefore go through the new commit-time
+     * {@code CheckpointFlushBatch} path — there is no concurrent Phase B
+     * /Phase C to interfere.
+     */
+    @Test(timeout = 180_000)
+    public void hammerNoCheckpoint() throws Exception {
+        performHammer(0, false, false);
+    }
+
+    /**
+     * Periodic checkpoint at 2 s — exercises the interleaving between
+     * Phase B / Phase C and the new commit-batched unload dispatch (the
+     * issue #157 / #431 / #448 invariants).
+     */
+    @Test(timeout = 240_000)
+    public void hammerWithCheckpoint() throws Exception {
+        performHammer(2_000, false, false);
+    }
+}

--- a/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerSuite.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerSuite.java
@@ -1,0 +1,439 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import static herddb.core.TestUtils.beginTransaction;
+import static herddb.core.TestUtils.commitTransaction;
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.executeUpdate;
+import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.DBManager;
+import herddb.core.TableManager;
+import herddb.core.stats.TableManagerStats;
+import herddb.model.DataScanner;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.utils.DataAccessor;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * Hammer suite for issue #448 — multi-operation transactions under eviction
+ * pressure, with optional concurrent checkpoints.
+ *
+ * <p>The pre-existing {@link DirectMultipleConcurrentUpdatesSuite} hammer
+ * exercises {@link herddb.core.TableManager#onTransactionCommit
+ * onTransactionCommit} only in its <em>pre-populate</em> phase (one big
+ * INSERT-only transaction); its hot loop uses single-statement
+ * auto-transactions, so each commit applies exactly one record. That leaves
+ * a coverage gap exactly where issue #448 changes behaviour: the
+ * commit-time apply loop in {@code onTransactionCommit} that now dispatches
+ * eviction-driven {@code unload} calls to the checkpoint-flush executor via
+ * {@code CheckpointFlushBatch}.
+ *
+ * <p>This suite closes the gap by driving many concurrent <em>multi-op</em>
+ * transactions (random INSERT / UPDATE / DELETE inside one BEGIN/COMMIT)
+ * against a tiny page-cache budget so that almost every commit triggers
+ * several eviction-driven unloads. Every worker thread owns a disjoint key
+ * range — concurrent commits cannot collide on locks, so any failure must
+ * come from the page / keyToPage / LSN machinery this PR touches.
+ *
+ * <p>Subclasses parameterize:
+ * <ul>
+ *   <li>presence and uniqueness of a secondary index (no-index, non-unique,
+ *       unique) — exercises the {@code applyUpdate} +
+ *       {@code AbstractIndexManager.recordUpdated} fan-out under eviction;</li>
+ *   <li>whether a periodic checkpoint runs concurrently — exercises the
+ *       interleaving between Phase B / Phase C and the new commit-batched
+ *       unload dispatch (issue #157 / #431 / #448 invariants).</li>
+ * </ul>
+ *
+ * <p>Each test verifies both the in-memory state immediately after the run
+ * AND the post-restart state (after replaying the commit log), so any
+ * regression in keyToPage durability or LSN ordering surfaces immediately.
+ */
+public abstract class Issue448BulkCommitHammerSuite {
+
+    /** Number of worker threads driving transactions in parallel. */
+    protected static final int THREADS = 8;
+
+    /** Number of multi-op transactions each worker thread runs. */
+    protected static final int TXNS_PER_THREAD = 25;
+
+    /** Minimum number of operations per transaction (inclusive). */
+    protected static final int MIN_OPS_PER_TXN = 5;
+
+    /** Maximum number of operations per transaction (inclusive). */
+    protected static final int MAX_OPS_PER_TXN = 15;
+
+    /**
+     * Per-thread initial population. Each thread starts with this many rows
+     * keyed in its own disjoint range; subsequent transactions grow,
+     * shrink, or modify that set.
+     */
+    protected static final int INITIAL_ROWS_PER_THREAD = 60;
+
+    /**
+     * Per-future timeout for the worker pool. Strictly less than each
+     * subclass's {@code @Test(timeout=...)} so a stuck future fires
+     * {@link TimeoutException} before JUnit interrupts the test thread —
+     * lets the {@link #dumpOnFailure} TestWatcher capture a meaningful
+     * thread dump (same pattern as
+     * {@link DirectMultipleConcurrentUpdatesSuite}).
+     */
+    protected static final long FUTURE_TIMEOUT_SECONDS = 90L;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TestWatcher dumpOnFailure = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            DirectMultipleConcurrentUpdatesSuite.dumpAllThreads(
+                    description.getMethodName() + " failed: " + e.getClass().getSimpleName());
+        }
+    };
+
+    /**
+     * @param checkPointPeriod 0 disables the periodic checkpoint thread,
+     *                         &gt; 0 sets the checkpoint interval in
+     *                         milliseconds.
+     * @param withIndexes      if true, a secondary index on column n1 is
+     *                         created (forces every applyInsert and
+     *                         applyUpdate inside the commit to also walk
+     *                         the index manager).
+     * @param uniqueIndexes    if {@code withIndexes}, controls UNIQUE vs
+     *                         non-unique. Ignored otherwise.
+     */
+    protected void performHammer(long checkPointPeriod, boolean withIndexes, boolean uniqueIndexes) throws Exception {
+        Path baseDir = folder.newFolder().toPath();
+        ServerConfiguration cfg = newServerConfigurationWithAutoPort(baseDir);
+
+        // Tiny page-cache budget so commits routinely evict pages.
+        // ~16 pages of 2 KiB; per-thread row sizes (~250 B each) mean a few
+        // rows per page, so many commits trigger 2-5 evictions each.
+        cfg.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, 2 * 1024L);
+        cfg.set(ServerConfiguration.PROPERTY_MAX_DATA_MEMORY, 32 * 1024L);
+        cfg.set(ServerConfiguration.PROPERTY_MAX_PK_MEMORY, 1024 * 1024L);
+        cfg.set(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, checkPointPeriod);
+        cfg.set(ServerConfiguration.PROPERTY_DATADIR, folder.newFolder().getAbsolutePath());
+        cfg.set(ServerConfiguration.PROPERTY_LOGDIR, folder.newFolder().getAbsolutePath());
+
+        // Expected end state: shared across threads only because each
+        // thread writes into its own key range (no overlap). ConcurrentHashMap
+        // is sufficient because no key is ever touched by more than one thread.
+        ConcurrentHashMap<String, Long> expectedState = new ConcurrentHashMap<>();
+
+        try (Server server = new Server(cfg)) {
+            server.start();
+            server.waitForStandaloneBoot();
+            DBManager manager = server.getManager();
+
+            execute(manager, "CREATE TABLE mytable (id string primary key, n1 long, payload string)",
+                    Collections.emptyList());
+            if (withIndexes) {
+                if (uniqueIndexes) {
+                    execute(manager, "CREATE UNIQUE INDEX theindex ON mytable (n1, id)",
+                            Collections.emptyList());
+                } else {
+                    execute(manager, "CREATE INDEX theindex ON mytable (n1)",
+                            Collections.emptyList());
+                }
+            }
+
+            // Pre-populate per-thread key ranges with autocommit so the page
+            // cache fills up before the first transaction-mode commit.
+            String basePayload = repeat("p", 220);
+            for (int t = 0; t < THREADS; t++) {
+                for (int i = 0; i < INITIAL_ROWS_PER_THREAD; i++) {
+                    String key = String.format("t%02d_k%05d", t, i);
+                    long val = (long) (t * 1_000_000L + i);
+                    executeUpdate(manager,
+                            "INSERT INTO mytable(id,n1,payload) values(?,?,?)",
+                            Arrays.asList(key, val, basePayload),
+                            TransactionContext.NO_TRANSACTION);
+                    expectedState.put(key, val);
+                }
+            }
+            // Force a checkpoint so most pre-populate pages are now immutable
+            // on disk; later commits will evict immutable pages too.
+            manager.checkpoint();
+
+            // Snapshot the parallel-unloads counter so we can assert that
+            // the new code path is actually exercised by the hammer.
+            TableManager tableManager = (TableManager) server.getManager()
+                    .getTableSpaceManager(TableSpace.DEFAULT).getTableManager("mytable");
+            long parallelUnloadsBefore = tableManager.getParallelUnloadsCount();
+
+            // Hot loop: each thread runs TXNS_PER_THREAD multi-op transactions
+            // against its own disjoint key range. Each transaction interleaves
+            // INSERTs, UPDATEs, and DELETEs.
+            ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+            List<Future<?>> futures = new ArrayList<>(THREADS);
+            try {
+                for (int t = 0; t < THREADS; t++) {
+                    final int threadId = t;
+                    futures.add(pool.submit(() -> runWorker(manager, threadId, expectedState, basePayload)));
+                }
+                for (Future<?> f : futures) {
+                    try {
+                        f.get(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    } catch (TimeoutException te) {
+                        DirectMultipleConcurrentUpdatesSuite.dumpAllThreads(
+                                "issue #448 hammer worker timed out");
+                        throw te;
+                    }
+                }
+            } finally {
+                pool.shutdown();
+                pool.awaitTermination(1, TimeUnit.MINUTES);
+            }
+
+            long parallelUnloadsAfter = tableManager.getParallelUnloadsCount();
+            long delta = parallelUnloadsAfter - parallelUnloadsBefore;
+            // The hot loop must have driven at least one eviction-driven
+            // unload through the new commit-time CheckpointFlushBatch — else
+            // the test does not actually exercise the code path it claims.
+            assertTrue("issue #448 hammer must dispatch parallel unloads from onTransactionCommit:"
+                            + " delta=" + delta + " before=" + parallelUnloadsBefore
+                            + " after=" + parallelUnloadsAfter,
+                    delta > 0);
+
+            // In-memory consistency after the run.
+            verifyAgainstExpected(manager, expectedState, "PRE-RESTART");
+
+            TableManagerStats stats = tableManager.getStats();
+            System.out.println("issue-448 hammer stats:: tablesize=" + stats.getTablesize()
+                    + " unloadedPages=" + stats.getUnloadedPagesCount()
+                    + " loadedPages=" + stats.getLoadedPagesCount()
+                    + " parallelUnloads=" + parallelUnloadsAfter);
+            assertEquals("table-size after hot loop must equal expected map size",
+                    expectedState.size(), stats.getTablesize());
+        }
+
+        // Restart and verify durability — any commit whose pages were
+        // unloaded asynchronously must still be replayed correctly.
+        try (Server server = new Server(cfg)) {
+            server.start();
+            server.waitForTableSpaceBoot(TableSpace.DEFAULT, 300_000, true);
+            verifyAgainstExpected(server.getManager(), expectedState, "POST-RESTART");
+        }
+    }
+
+    /**
+     * Worker body: runs {@link #TXNS_PER_THREAD} multi-op transactions on
+     * keys in this worker's disjoint range. Mutates {@code expectedState}
+     * in lock-step with successful commits so the post-run verification has
+     * an authoritative reference.
+     *
+     * <p>Each transaction picks a random ops-per-txn count in
+     * {@code [MIN_OPS_PER_TXN, MAX_OPS_PER_TXN]} and, for each op,
+     * randomly chooses an INSERT / UPDATE / DELETE biased by the current
+     * size of the live key set. Transactions are committed atomically;
+     * {@code expectedState} is updated only after a successful commit so a
+     * commit-failure path (e.g. a hypothetical regression that throws mid
+     * apply) cannot corrupt the reference map.
+     */
+    private void runWorker(DBManager manager, int threadId,
+            ConcurrentHashMap<String, Long> expectedState, String basePayload) {
+        try {
+            // Reconstruct this worker's local view of its own keys from the
+            // pre-population. Subsequent inserts grow this set; deletes shrink
+            // it. All keys in this set are exclusive to this thread.
+            Set<String> liveKeys = new HashSet<>();
+            for (int i = 0; i < INITIAL_ROWS_PER_THREAD; i++) {
+                liveKeys.add(String.format("t%02d_k%05d", threadId, i));
+            }
+            int nextInsertSeq = INITIAL_ROWS_PER_THREAD;
+
+            ThreadLocalRandom rng = ThreadLocalRandom.current();
+
+            for (int txn = 0; txn < TXNS_PER_THREAD; txn++) {
+                long tx = beginTransaction(manager, TableSpace.DEFAULT);
+
+                // Stage local mutations and only apply them to expectedState
+                // after the commit succeeds.
+                List<Map.Entry<String, Long>> staged = new ArrayList<>();
+                List<String> stagedDeletes = new ArrayList<>();
+
+                int ops = rng.nextInt(MIN_OPS_PER_TXN, MAX_OPS_PER_TXN + 1);
+                for (int op = 0; op < ops; op++) {
+                    int choice = chooseOp(liveKeys.size(), rng);
+                    if (choice == 0) {
+                        // INSERT a brand-new key.
+                        String key = String.format("t%02d_k%05d", threadId, nextInsertSeq++);
+                        long val = (long) (threadId * 1_000_000L + 100_000L + op + txn);
+                        executeUpdate(manager,
+                                "INSERT INTO mytable(id,n1,payload) values(?,?,?)",
+                                Arrays.asList(key, val, basePayload),
+                                new TransactionContext(tx));
+                        liveKeys.add(key);
+                        staged.add(Map.entry(key, val));
+                    } else if (choice == 1) {
+                        // UPDATE an existing key.
+                        String key = pickRandomKey(liveKeys, rng);
+                        long val = (long) (threadId * 1_000_000L + 200_000L + op + txn);
+                        executeUpdate(manager,
+                                "UPDATE mytable SET n1=? WHERE id=?",
+                                Arrays.asList(val, key),
+                                new TransactionContext(tx));
+                        staged.add(Map.entry(key, val));
+                    } else {
+                        // DELETE an existing key.
+                        String key = pickRandomKey(liveKeys, rng);
+                        executeUpdate(manager,
+                                "DELETE FROM mytable WHERE id=?",
+                                Arrays.asList(key),
+                                new TransactionContext(tx));
+                        liveKeys.remove(key);
+                        stagedDeletes.add(key);
+                    }
+                }
+                commitTransaction(manager, TableSpace.DEFAULT, tx);
+
+                // Commit succeeded — propagate staged mutations to the
+                // shared expected state.
+                for (Map.Entry<String, Long> e : staged) {
+                    expectedState.put(e.getKey(), e.getValue());
+                }
+                for (String k : stagedDeletes) {
+                    expectedState.remove(k);
+                }
+            }
+        } catch (RuntimeException err) {
+            // Worker-thread death guard: any unexpected failure must surface
+            // as a wrapped RuntimeException so the future captures it.
+            // CLAUDE.md: this broad catch is the worker-thread top-level
+            // diagnostic boundary — narrower would lose checked exceptions
+            // from executeUpdate / beginTransaction.
+            throw err;
+        } catch (Exception err) {
+            throw new RuntimeException("worker " + threadId + " failed", err);
+        }
+    }
+
+    /**
+     * Op-selector biased by {@code liveKeys.size()} so the live set neither
+     * collapses to zero (which would starve UPDATE / DELETE forever) nor
+     * grows unboundedly. Returns 0 for INSERT, 1 for UPDATE, 2 for DELETE.
+     */
+    private static int chooseOp(int liveKeyCount, ThreadLocalRandom rng) {
+        if (liveKeyCount == 0) {
+            return 0; // must INSERT — nothing to update or delete
+        }
+        // Roll on a small biased die: insert ~40 %, update ~40 %, delete ~20 %.
+        int r = rng.nextInt(10);
+        if (r < 4) {
+            return 0;
+        }
+        if (r < 8) {
+            return 1;
+        }
+        return 2;
+    }
+
+    /**
+     * Pick a uniformly-random key from a {@link Set} without allocating a
+     * snapshot list each time (the live set can have hundreds of keys).
+     */
+    private static String pickRandomKey(Set<String> liveKeys, ThreadLocalRandom rng) {
+        int target = rng.nextInt(liveKeys.size());
+        int i = 0;
+        for (String k : liveKeys) {
+            if (i++ == target) {
+                return k;
+            }
+        }
+        throw new AssertionError("liveKeys mutated during pickRandomKey");
+    }
+
+    private static void verifyAgainstExpected(DBManager manager,
+            Map<String, Long> expectedState, String stage) throws Exception {
+        // (1) Row count matches.
+        try (DataScanner sc = scan(manager,
+                "SELECT count(*) AS c FROM mytable", Collections.emptyList())) {
+            assertTrue(sc.hasNext());
+            Object[] row = (Object[]) sc.next().getValues();
+            long actualCount = ((Number) row[0]).longValue();
+            assertEquals(stage + ": row count must equal expected map size",
+                    expectedState.size(), actualCount);
+        }
+        // (2) Each expected key carries the expected n1 value.
+        List<String> errors = new ArrayList<>();
+        for (Map.Entry<String, Long> e : expectedState.entrySet()) {
+            try (DataScanner sc = scan(manager,
+                    "SELECT n1 FROM mytable WHERE id=?",
+                    Arrays.asList(e.getKey()))) {
+                List<DataAccessor> rs = sc.consume();
+                if (rs.isEmpty()) {
+                    errors.add(stage + ": missing key " + e.getKey()
+                            + ", expected n1=" + e.getValue());
+                } else if (!e.getValue().equals(rs.get(0).get("n1"))) {
+                    errors.add(stage + ": key " + e.getKey() + " has n1="
+                            + rs.get(0).get("n1") + ", expected " + e.getValue());
+                }
+            }
+        }
+        if (!errors.isEmpty()) {
+            // Fail with up to 20 errors to keep the surefire report readable.
+            int show = Math.min(20, errors.size());
+            StringBuilder sb = new StringBuilder(stage)
+                    .append(": ").append(errors.size())
+                    .append(" key-level mismatches; first ").append(show).append(":\n");
+            for (int i = 0; i < show; i++) {
+                sb.append("  ").append(errors.get(i)).append('\n');
+            }
+            fail(sb.toString());
+        }
+    }
+
+    private static String repeat(String fragment, int count) {
+        StringBuilder sb = new StringBuilder(fragment.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(fragment);
+        }
+        return sb.toString();
+    }
+}

--- a/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerWithNonUniqueIndexesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerWithNonUniqueIndexesTest.java
@@ -1,0 +1,43 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import org.junit.Test;
+
+/**
+ * Issue #448 hammer — multi-op transactions plus a non-unique secondary
+ * index on column {@code n1}. Forces every applyInsert / applyUpdate inside
+ * the commit to also fan out into {@code AbstractIndexManager.recordInserted}
+ * / {@code recordUpdated}, on top of the eviction-driven unloads that this
+ * suite stresses.
+ */
+public class Issue448BulkCommitHammerWithNonUniqueIndexesTest extends Issue448BulkCommitHammerSuite {
+
+    @Test(timeout = 180_000)
+    public void hammerNoCheckpoint() throws Exception {
+        performHammer(0, true, false);
+    }
+
+    @Test(timeout = 240_000)
+    public void hammerWithCheckpoint() throws Exception {
+        performHammer(2_000, true, false);
+    }
+}

--- a/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerWithUniqueIndexesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/Issue448BulkCommitHammerWithUniqueIndexesTest.java
@@ -1,0 +1,44 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import org.junit.Test;
+
+/**
+ * Issue #448 hammer — multi-op transactions plus a UNIQUE secondary index
+ * on (n1, id). The {@code id} component avoids collisions and lock
+ * timeouts (same trick as
+ * {@link DirectMultipleConcurrentUpdatesSuite}); n1 still drives the index
+ * write fan-out so we exercise the unique-constraint check inside the
+ * commit's apply loop.
+ */
+public class Issue448BulkCommitHammerWithUniqueIndexesTest extends Issue448BulkCommitHammerSuite {
+
+    @Test(timeout = 180_000)
+    public void hammerNoCheckpoint() throws Exception {
+        performHammer(0, true, true);
+    }
+
+    @Test(timeout = 240_000)
+    public void hammerWithCheckpoint() throws Exception {
+        performHammer(2_000, true, true);
+    }
+}


### PR DESCRIPTION
Fixes #448.

## Problem

When a transaction commits thousands of new (vector-bearing) records,
`TableManager.applyInsert` / `applyUpdate` fill data pages quickly and
each `allocateLivePage` rotation calls
`pageReplacementPolicy.add(victim)` → `unload(victim)` **on the commit
thread**. For a remote (S3-backed) data storage manager, every
mutable-page unload issues a `RemoteFileDataStorageManager.writeAsMultipart`
round-trip, so a 2 000–10 000 record commit ends up serializing that many
remote writes on a single thread. The CPU/wall/lock profiles in the
issue confirm the dominant frames under `onTransactionCommit` are
`flushNewPage` → `flushNewPageForUnload` → `writeAsMultipart`.

## Changes

- `herddb-core/src/main/java/herddb/core/TableManager.java`
  - Refactor `allocateLivePage(Long)` into an overload
    `allocateLivePage(Long, CheckpointFlushBatch)`; when the batch is
    non-null, eviction victims are submitted to the
    `DBManager.checkpointFlushExecutor` instead of being unloaded
    synchronously on the caller thread. The legacy no-batch overload is
    preserved for log replay (`apply()`), autocommit DML, and the
    Phase-B `cleanAndCompactPage` caller.
  - Add the same opt-in batch parameter to `applyInsert` and
    `applyUpdate`.
  - In `onTransactionCommit`, instantiate one `CheckpointFlushBatch` per
    commit, pass it through the apply loop, and `awaitAll()` **before**
    publishing the commit LSN — preserving the issue #157 invariant
    (Phase C, on draining `activeCommitApplies` to zero, sees a
    quiescent page state and every commit's LSN).
  - On any failure inside the apply loop, the batch is drained
    best-effort (with `addSuppressed`) before the apply slot is
    released, so executor threads cannot still touch pages after the
    caller observes the failure.
  - Reuse the existing `CheckpointFlushBatch` (semaphore-bounded by
    `checkpointFlushParallelism`) — no new threading primitives. JavaDoc
    updated to reflect the dual use.
  - Add a `parallelUnloadsCount` counter (`AtomicLong`) with a
    package-private `getParallelUnloadsCount()` getter so tests can
    assert the new path was exercised.

- `herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java` *(new)*
  - `bulkInsertCommitDispatchesParallelUnloads` — 200-row transaction
    with `PROPERTY_MAX_LOGICAL_PAGE_SIZE=2 KiB` and
    `PROPERTY_MAX_DATA_MEMORY=32 KiB` so the page-replacement policy is
    at capacity throughout the commit. Asserts
    `getParallelUnloadsCount() > 0` (proves the batched path runs) and
    that all rows are queryable both immediately and after a restart
    (proves durability).
  - `autocommitInsertsKeepLegacySynchronousPath` — autocommit inserts
    that fit in budget must not bump the counter, protecting the
    recovery / autocommit code path from being accidentally rerouted.

## Risk and design notes

- **Memory overshoot is bounded.** Between `pageReplacementPolicy.add(victim)`
  and the executor running `unload(victim)`, the victim is still
  resident. The `CheckpointFlushBatch` semaphore caps in-flight unloads
  at `checkpointFlushParallelism` (default 8), so worst-case overshoot
  per commit is ~8 × `maxLogicalPageSize`.
- **No LSN / index ordering change.** `keyToPage.put(...)` and
  `lastAppliedSequenceNumber.updateAndGet(...)` remain on the commit
  thread, in program order. Only the I/O of pages **no longer being
  written to** is parallelized.
- **Direct-executor mode preserved.** When
  `PROPERTY_CHECKPOINT_FLUSH_THREADS ≤ 0`,
  `MoreExecutors.newDirectExecutorService()` runs `runAsync` in the
  caller thread → behaviour identical to today.
- **Concurrent reads of a victim during the async window.** Same race
  window as today (synchronous `unload` already left this window
  between `pageReplacementPolicy.add` and `pages.computeIfPresent`);
  page-level `pageLock` continues to serialize reads vs.
  `flushNewPageForUnload`. Covered by `BLinkConcurrentSearchInsertTest`
  and the `LazyValueCacheConcurrentUpdatesSuite*` regression gates.

## Tests

- [x] New unit test passes: `Issue448BulkInsertParallelUnloadTest` (2/2)
- [x] Hammer suites pass on **two** consecutive runs (CLAUDE.md flake-check):
  - `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` (12/12, 12/12)
  - `LazyValueCacheConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` (12/12, 12/12)
- [x] `BLinkConcurrentSearchInsertTest` passes (1/1)
- [x] Pre-PR validation green: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`

## Test plan for reviewers

- [ ] Re-run the new test and the hammer suites locally
- [ ] Eyeball the commit-failure path in `onTransactionCommit` (the
      `catch (RuntimeException | Error primary)` block) and confirm
      that `unloadBatch.awaitAll()` is always called before
      `activeCommitApplies.decrementAndGet()` releases the apply slot
- [ ] Sanity-check that the no-batch overloads remain on the recovery /
      log-replay path (`apply()` at the INSERT/UPDATE switch arms)

🤖 Implemented by the `pr-worker` agent.