### PR TITLE
issue #451: fix IS cross-instance sharding silently disabled by malformed numShards DDL

### DIFF
--- a/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
@@ -20,6 +20,9 @@
 
 package herddb.core.system;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import herddb.codec.RecordSerializer;
 import herddb.core.AbstractIndexManager;
 import herddb.core.TableSpaceManager;
@@ -46,6 +49,7 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
             .column("index_name", ColumnTypes.STRING)
             .column("index_uuid", ColumnTypes.STRING)
             .column("index_type", ColumnTypes.STRING)
+            .column("properties", ColumnTypes.STRING)
             .column("unique", ColumnTypes.INTEGER)
             .primaryKey("table_name", false)
             .primaryKey("index_name", false)
@@ -74,9 +78,48 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
                         "index_name", r.name,
                         "index_uuid", r.uuid,
                         "index_type", r.type,
+                        "properties", encodePropertiesAsJson(r.properties),
                         "unique", r.unique ? 1 : 0
                 ))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Single shared {@link ObjectMapper} configured to emit map entries in
+     * key-sorted order. Jackson's {@code ObjectMapper} is documented as
+     * thread-safe for the read/write methods after configuration, and we
+     * never mutate it after construction.
+     */
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper()
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+
+    /**
+     * Serializes the {@code properties} map of an {@link herddb.model.Index} as
+     * a deterministic JSON object (keys sorted lexicographically). Used by the
+     * {@code properties} column of {@code sysindexes} so operators can read the
+     * full set of WITH-clause values from any JDBC client without going through
+     * the indexing-service admin tool. See issue #451.
+     *
+     * <p>Always returns a syntactically valid JSON object: {@code "{}"} for an
+     * empty / null map, and a {@code {"key":"value", ...}} object otherwise.
+     * Escaping and ordering are delegated to Jackson's {@link ObjectMapper}
+     * with {@link SerializationFeature#ORDER_MAP_ENTRIES_BY_KEYS} enabled, so
+     * the same input always produces the same JSON regardless of the
+     * iteration order of the underlying map.
+     */
+    static String encodePropertiesAsJson(Map<String, String> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return JSON_MAPPER.writeValueAsString(properties);
+        } catch (JsonProcessingException e) {
+            // The input is a Map<String, String> with no nulls expected, so
+            // Jackson should never fail on it — but if it does, surface the
+            // failure rather than silently returning malformed JSON.
+            throw new IllegalStateException(
+                    "failed to encode index properties as JSON: " + properties, e);
+        }
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -857,9 +857,17 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                 continue;
             }
             int eq = part.indexOf('=');
-            if (eq > 0) {
-                props.put(part.substring(0, eq).trim(), part.substring(eq + 1).trim());
+            // Reject tokens without '=': previously dropped silently, which let
+            // space-separated DDL like "WITH ... numShards 4" land an empty
+            // properties map and silently disable cross-instance sharding in
+            // the indexing service (issue #451). Mirror the strict-loud
+            // behaviour of the JSQLParser-native WITH parser at line ~795.
+            if (eq <= 0 || eq == part.length() - 1) {
+                throw new StatementExecutionException(
+                        "invalid index property syntax: expected key=value but got '"
+                                + part + "' in WITH clause '" + withText + "'");
             }
+            props.put(part.substring(0, eq).trim(), part.substring(eq + 1).trim());
         }
 
         if (!props.isEmpty()) {

--- a/herddb-core/src/test/java/herddb/core/system/SysindexesPropertiesTest.java
+++ b/herddb-core/src/test/java/herddb/core/system/SysindexesPropertiesTest.java
@@ -1,0 +1,191 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core.system;
+
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
+import herddb.core.indexes.MockRemoteVectorIndexService;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.server.ServerConfiguration;
+import herddb.utils.DataAccessor;
+import herddb.utils.RawString;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that the {@code properties} column added to {@code sysindexes}
+ * (issue #451) surfaces the WITH-clause configuration of every index from any
+ * SQL client, with a deterministic JSON encoding.
+ */
+public class SysindexesPropertiesTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void emptyMapEncodesAsEmptyObject() {
+        assertEquals("{}", SysindexesTableManager.encodePropertiesAsJson(null));
+        assertEquals("{}", SysindexesTableManager.encodePropertiesAsJson(Collections.emptyMap()));
+    }
+
+    @Test
+    public void keysAreSortedAlphabetically() {
+        // Insertion order is z, a, m — encoded order must be a, m, z so that
+        // the same input always produces the same JSON output, regardless of
+        // the underlying map implementation.
+        Map<String, String> in = new LinkedHashMap<>();
+        in.put("z", "1");
+        in.put("a", "2");
+        in.put("m", "3");
+        assertEquals("{\"a\":\"2\",\"m\":\"3\",\"z\":\"1\"}",
+                SysindexesTableManager.encodePropertiesAsJson(in));
+    }
+
+    @Test
+    public void encodesTypicalVectorIndexProperties() {
+        Map<String, String> in = new TreeMap<>();
+        in.put("m", "16");
+        in.put("beamWidth", "100");
+        in.put("similarity", "euclidean");
+        in.put("fusedPQ", "true");
+        in.put("numShards", "4");
+        // TreeMap is alphabetical; the encoder must produce the same order.
+        assertEquals("{\"beamWidth\":\"100\",\"fusedPQ\":\"true\","
+                        + "\"m\":\"16\",\"numShards\":\"4\",\"similarity\":\"euclidean\"}",
+                SysindexesTableManager.encodePropertiesAsJson(in));
+    }
+
+    @Test
+    public void specialCharactersAreEscaped() {
+        Map<String, String> in = new LinkedHashMap<>();
+        in.put("quote", "a\"b");
+        in.put("backslash", "a\\b");
+        in.put("newline", "a\nb");
+        in.put("tab", "a\tb");
+        in.put("ctrl", "ab");
+        // Keys are sorted: backslash, ctrl, newline, quote, tab.
+        String expected = "{\"backslash\":\"a\\\\b\","
+                + "\"ctrl\":\"a\\u0001b\","
+                + "\"newline\":\"a\\nb\","
+                + "\"quote\":\"a\\\"b\","
+                + "\"tab\":\"a\\tb\"}";
+        assertEquals(expected, SysindexesTableManager.encodePropertiesAsJson(in));
+    }
+
+    @Test
+    public void sysindexesPropertiesColumnPresentForAllIndexTypes() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        final String nodeId = "localhost";
+        ServerConfiguration config = new ServerConfiguration();
+        // Vector index DDL (`CREATE VECTOR INDEX ... WITH ...`) is only
+        // accepted by the JSQLParser planner. The default planner would
+        // reject the WITH clause entirely.
+        config.set(ServerConfiguration.PROPERTY_PLANNER_TYPE,
+                ServerConfiguration.PLANNER_TYPE_JSQLPARSER);
+
+        try (DBManager manager = new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null, config, null)) {
+            manager.setRemoteVectorIndexService(new MockRemoteVectorIndexService());
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement(
+                    "tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager,
+                    "CREATE TABLE tblspace1.t1 (id int primary key, cat varchar(20), vec floata not null)",
+                    Collections.emptyList());
+            // BRIN index — no WITH clause → properties must be the empty
+            // JSON object.
+            execute(manager, "CREATE BRIN INDEX bidx ON tblspace1.t1 (cat)",
+                    Collections.emptyList());
+            // Vector index with the full WITH clause → properties must round-
+            // trip every key=value pair as JSON, sorted alphabetically.
+            execute(manager,
+                    "CREATE VECTOR INDEX vidx ON tblspace1.t1 (vec)"
+                            + " WITH m=16 beamWidth=100 similarity=cosine fusedPQ=true numShards=4",
+                    Collections.emptyList());
+
+            try (DataScanner scn = scan(manager,
+                    "SELECT index_name, index_type, properties FROM tblspace1.sysindexes"
+                            + " ORDER BY index_name",
+                    Collections.emptyList())) {
+                List<DataAccessor> records = scn.consume();
+                assertEquals("expected exactly two indexes", 2, records.size());
+
+                DataAccessor brin = records.get(0);
+                assertEquals(RawString.of("bidx"), brin.get("index_name"));
+                assertEquals(RawString.of("brin"), brin.get("index_type"));
+                Object brinProps = brin.get("properties");
+                assertNotNull("properties column must not be null for BRIN", brinProps);
+                assertEquals(RawString.of("{}"), brinProps);
+
+                DataAccessor vec = records.get(1);
+                assertEquals(RawString.of("vidx"), vec.get("index_name"));
+                assertEquals(RawString.of("vector"), vec.get("index_type"));
+                Object vecProps = vec.get("properties");
+                assertNotNull("properties column must not be null for VECTOR", vecProps);
+                String vecPropsStr = vecProps.toString();
+                // Keys are alphabetical, so the full string is deterministic
+                // and we can assert it verbatim — locking down the format so
+                // operator dashboards / tests / scripts that parse this column
+                // do not have to cope with insertion-order flakes.
+                assertEquals(
+                        "{\"beamWidth\":\"100\",\"fusedPQ\":\"true\","
+                                + "\"m\":\"16\",\"numShards\":\"4\",\"similarity\":\"cosine\"}",
+                        vecPropsStr);
+                // Belt-and-suspenders: the JSON must contain every WITH-clause
+                // value the user typed, regardless of key ordering.
+                assertTrue("must contain numShards=4: " + vecPropsStr,
+                        vecPropsStr.contains("\"numShards\":\"4\""));
+                assertTrue("must contain m=16: " + vecPropsStr,
+                        vecPropsStr.contains("\"m\":\"16\""));
+                assertTrue("must contain similarity=cosine: " + vecPropsStr,
+                        vecPropsStr.contains("\"similarity\":\"cosine\""));
+            }
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/sql/CreateVectorIndexWithClauseTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CreateVectorIndexWithClauseTest.java
@@ -1,0 +1,310 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql;
+
+import static herddb.core.TestUtils.execute;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.DBManager;
+import herddb.core.indexes.MockRemoteVectorIndexService;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.index.vector.VectorIndexManager;
+import herddb.model.Index;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.server.ServerConfiguration;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end coverage of the {@code CREATE VECTOR INDEX ... WITH ...} parsing
+ * pipeline (issue #451 regression gate).
+ *
+ * <p>The {@code numShards} property in the WITH clause drives cross-instance
+ * routing in {@code IndexingServiceEngine.isAcceptedLocally}: if the SQL
+ * parser silently drops the property, every indexing-service replica
+ * short-circuits to "accept everything" and re-indexes every vector — which
+ * is exactly what issue #451 observed in production.
+ *
+ * <p>Pre-fix, {@code JSQLParserPlanner.extractIndexWithClause} silently
+ * skipped tokens without an {@code =}, so the bench DDL
+ * {@code ... fusedPQ=true numShards 4} (with a space) created an Index with
+ * an empty properties map. The fix tightens the parser so missing-{@code =}
+ * tokens throw {@link StatementExecutionException} loudly. These tests lock
+ * down both the success path (key=value) and the failure path (the silent-
+ * drop regression).
+ */
+public class CreateVectorIndexWithClauseTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private DBManager buildManager(Path dataPath, Path logsPath, Path metadataPath, Path tmoDir)
+            throws Exception {
+        ServerConfiguration config = new ServerConfiguration();
+        // The default planner rejects CREATE VECTOR INDEX outright;
+        // JSQLParserPlanner is the only one that pre-processes the WITH
+        // clause via extractIndexWithClause.
+        config.set(ServerConfiguration.PROPERTY_PLANNER_TYPE,
+                ServerConfiguration.PLANNER_TYPE_JSQLPARSER);
+        DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null, config, null);
+        manager.setRemoteVectorIndexService(new MockRemoteVectorIndexService());
+        return manager;
+    }
+
+    private void bootstrapTablespaceAndTable(DBManager manager) throws Exception {
+        CreateTableSpaceStatement st1 = new CreateTableSpaceStatement(
+                "tblspace1", Collections.singleton("localhost"), "localhost", 1, 0, 0);
+        manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                TransactionContext.NO_TRANSACTION);
+        manager.waitForTablespace("tblspace1", 10000);
+        execute(manager,
+                "CREATE TABLE tblspace1.t1 (id int primary key, vec floata not null)",
+                Collections.emptyList());
+    }
+
+    private Index getVectorIndex(DBManager manager) {
+        return manager.getTableSpaceManager("tblspace1")
+                .getIndexesOnTable("t1").get("vidx").getIndex();
+    }
+
+    /**
+     * The full WITH clause (every property in {@code key=value} form) must
+     * survive the parser end-to-end into {@link Index#properties}. This is
+     * the shape that {@code VectorBench.buildCreateVectorIndexSql} now
+     * emits after the issue #451 fix.
+     */
+    @Test
+    public void numShardsKeyEqualsValueLandsOnIndex() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir)) {
+            manager.start();
+            bootstrapTablespaceAndTable(manager);
+
+            execute(manager,
+                    "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)"
+                            + " WITH m=16 beamWidth=100 similarity=cosine"
+                            + " fusedPQ=true numShards=4",
+                    Collections.emptyList());
+
+            Index idx = getVectorIndex(manager);
+            assertNotNull("vector index must exist", idx);
+            assertEquals(Index.TYPE_VECTOR, idx.type);
+            assertEquals("16", idx.properties.get(VectorIndexManager.PROP_M));
+            assertEquals("100", idx.properties.get(VectorIndexManager.PROP_BEAM_WIDTH));
+            assertEquals("cosine", idx.properties.get("similarity"));
+            assertEquals("true", idx.properties.get(VectorIndexManager.PROP_FUSED_PQ));
+            // The headline assertion: the routing knob actually made it
+            // through. Pre-fix this returned null and the cluster
+            // short-circuited to "accept everything".
+            assertEquals("4", idx.properties.get(VectorIndexManager.PROP_NUM_SHARDS));
+        }
+    }
+
+    /**
+     * Comma-separated key=value pairs work too — {@code split("[\\s,]+")}
+     * tolerates both whitespace and commas as token separators, and that
+     * shape is the documented form in the planner JavaDoc.
+     */
+    @Test
+    public void commaSeparatedKeyEqualsValueLandsOnIndex() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir)) {
+            manager.start();
+            bootstrapTablespaceAndTable(manager);
+
+            execute(manager,
+                    "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)"
+                            + " WITH m=32, beamWidth=200, numShards=8",
+                    Collections.emptyList());
+
+            Index idx = getVectorIndex(manager);
+            assertEquals("32", idx.properties.get(VectorIndexManager.PROP_M));
+            assertEquals("200", idx.properties.get(VectorIndexManager.PROP_BEAM_WIDTH));
+            assertEquals("8", idx.properties.get(VectorIndexManager.PROP_NUM_SHARDS));
+        }
+    }
+
+    /**
+     * Issue #451 regression: pre-fix, {@code numShards 4} (with a space, no
+     * {@code =}) was silently dropped, the Index was persisted with no
+     * {@code numShards} property, and every IS replica re-indexed every
+     * vector. After the fix, the parser refuses the malformed token loudly
+     * so the misconfiguration cannot ship to production.
+     */
+    @Test
+    public void numShardsWithSpaceSyntaxIsRejected() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir)) {
+            manager.start();
+            bootstrapTablespaceAndTable(manager);
+
+            try {
+                execute(manager,
+                        "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)"
+                                + " WITH m=16 beamWidth=100 similarity=cosine"
+                                + " fusedPQ=true numShards 4",
+                        Collections.emptyList());
+                fail("expected the planner to reject space-separated numShards 4");
+            } catch (StatementExecutionException ex) {
+                // The error must mention the offending token AND the
+                // expected key=value shape so an operator can fix it
+                // without spelunking through the parser source.
+                String msg = ex.getMessage() == null ? "" : ex.getMessage();
+                assertTrue("error must mention 'numShards' or '4', got: " + msg,
+                        msg.contains("numShards") || msg.contains("'4'"));
+                assertTrue("error must mention the expected key=value shape, got: " + msg,
+                        msg.contains("key=value"));
+            }
+        }
+    }
+
+    /**
+     * Bare keyword tokens (no value at all) must also be refused, not silently
+     * dropped — this is the same class of bug as issue #451 with a slightly
+     * different shape.
+     */
+    @Test
+    public void bareKeywordWithoutValueIsRejected() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir)) {
+            manager.start();
+            bootstrapTablespaceAndTable(manager);
+
+            try {
+                execute(manager,
+                        "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)"
+                                + " WITH m=16 fusedPQ",
+                        Collections.emptyList());
+                fail("expected the planner to reject the bare 'fusedPQ' token");
+            } catch (StatementExecutionException ex) {
+                String msg = ex.getMessage() == null ? "" : ex.getMessage();
+                assertTrue("error must mention 'fusedPQ', got: " + msg,
+                        msg.contains("fusedPQ"));
+            }
+        }
+    }
+
+    /**
+     * Locks the literal DDL shape that {@code VectorBench.buildCreateVectorIndexSql}
+     * emits in production against the parser, so a refactor on either side
+     * cannot silently regress. The string is intentionally hard-coded
+     * (rather than imported from {@code VectorBench}) to avoid a circular
+     * herddb-core ↔ vector-testings dependency — the matching producer-side
+     * assertion lives in
+     * {@code VectorBenchTest.buildCreateVectorIndexSqlDefaultIncludesNumShardsFour}.
+     * If that test changes, this one must change in lockstep.
+     */
+    @Test
+    public void vectorBenchProductionDdlParsesIntoExpectedIndex() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir)) {
+            manager.start();
+            bootstrapTablespaceAndTable(manager);
+
+            // Mirror VectorBench.buildCreateVectorIndexSql output verbatim.
+            // Anything that drifts here (e.g. dropping the '=' on numShards)
+            // breaks the indexing-service cluster's load distribution — see
+            // issue #451.
+            execute(manager,
+                    "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)"
+                            + " WITH m=16 beamWidth=100 similarity=euclidean"
+                            + " fusedPQ=true numShards=4",
+                    Collections.emptyList());
+
+            Index idx = getVectorIndex(manager);
+            assertEquals("16", idx.properties.get(VectorIndexManager.PROP_M));
+            assertEquals("100", idx.properties.get(VectorIndexManager.PROP_BEAM_WIDTH));
+            assertEquals("euclidean", idx.properties.get("similarity"));
+            assertEquals("true", idx.properties.get(VectorIndexManager.PROP_FUSED_PQ));
+            assertEquals("4", idx.properties.get(VectorIndexManager.PROP_NUM_SHARDS));
+            // The whole point of the fix: numShards must round-trip with
+            // exactly the value the user typed, so the IS routing math
+            // (shardId % numInstances == instanceId) actually splits the
+            // workload across replicas.
+            assertEquals("Index must carry exactly the 5 WITH-clause props",
+                    5, idx.properties.size());
+        }
+    }
+
+    /**
+     * Trailing-{@code =} tokens (key with no value) must be refused too — the
+     * resulting empty-string value would never round-trip through any
+     * downstream property reader, so failing fast is the right call.
+     */
+    @Test
+    public void keyWithEmptyValueIsRejected() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmo").toPath();
+
+        try (DBManager manager = buildManager(dataPath, logsPath, metadataPath, tmoDir)) {
+            manager.start();
+            bootstrapTablespaceAndTable(manager);
+
+            try {
+                execute(manager,
+                        "CREATE VECTOR INDEX vidx ON tblspace1.t1(vec)"
+                                + " WITH m=16 numShards=",
+                        Collections.emptyList());
+                fail("expected the planner to reject the empty-value 'numShards=' token");
+            } catch (StatementExecutionException ex) {
+                String msg = ex.getMessage() == null ? "" : ex.getMessage();
+                assertTrue("error must mention 'numShards', got: " + msg,
+                        msg.contains("numShards"));
+            }
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -2635,6 +2635,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         d.liveVectorsMemoryBytes = store.estimatedMemoryUsageBytes();
         d.storeClass = store.getClass().getSimpleName();
         d.persistent = store instanceof PersistentVectorStore;
+        // Surface the per-index `numShards` configuration alongside the live
+        // counters so operators can correlate sharding decisions with what the
+        // index was actually created with (issue #451). The schema tracker is
+        // the source of truth for the Index.properties map; if the index has
+        // been dropped between the vectorStores lookup and here we just leave
+        // d.numShards at its default (1).
+        Index indexDef = schemaTracker.getIndex(index);
+        if (indexDef != null) {
+            d.numShards = getNumShardsForIndex(indexDef);
+        }
         if (store instanceof PersistentVectorStore) {
             PersistentVectorStore pvs = (PersistentVectorStore) store;
             d.dimension = pvs.getDimension();
@@ -3905,5 +3915,9 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // Global monotonic node-id counter (issue #256). Widened to long end-to-end;
         // surfaced so clients and dashboards can observe the burn rate.
         public long nextNodeId;
+        // Per-index `numShards` from the CREATE VECTOR INDEX WITH clause.
+        // Controls within-instance HNSW graph-bucket granularity; defaults to
+        // 1 when the property is absent. Issue #451.
+        public int numShards = 1;
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -343,7 +343,8 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setCompactionNodesTotal(details.compactionNodesTotal)
                     .setUploadBytesDone(details.uploadBytesDone)
                     .setUploadBytesTotal(details.uploadBytesTotal)
-                    .setNextNodeId(details.nextNodeId);
+                    .setNextNodeId(details.nextNodeId)
+                    .setNumShards(details.numShards);
             responseObserver.onNext(builder.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -530,6 +530,7 @@ public final class IndexingAdminCli {
         m.put("compaction_nodes_total", r.getCompactionNodesTotal());
         m.put("upload_bytes_done", r.getUploadBytesDone());
         m.put("upload_bytes_total", r.getUploadBytesTotal());
+        m.put("num_shards", r.getNumShards());
         return m;
     }
 
@@ -585,6 +586,7 @@ public final class IndexingAdminCli {
         out.printf(Locale.ROOT, "  dirty                 = %s%n", r.getDirty());
         out.printf(Locale.ROOT, "  fused_pq_enabled      = %s%n", r.getFusedPqEnabled());
         out.printf(Locale.ROOT, "  m / beam_width        = %d / %d%n", r.getM(), r.getBeamWidth());
+        out.printf(Locale.ROOT, "  num_shards            = %d%n", r.getNumShards());
         out.printf(Locale.ROOT, "  tailer_lsn            = %d/%d (lag_ms=%d)%n",
                 r.getTailerLsnLedger(), r.getTailerLsnOffset(),
                 computeLagMs(r.getTailerLsnTimestamp()));

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -181,6 +181,12 @@ message DescribeIndexResponse {
     // Wall-clock timestamp (epoch ms) of the LogEntry at the durable LSN.
     // 0 = unknown. Issue #423.
     int64 durable_lsn_timestamp = 29;
+    // Per-index `numShards` value from the CREATE VECTOR INDEX WITH clause
+    // (Index.properties[numShards]). Controls within-instance HNSW
+    // graph-bucket granularity. Defaults to 1 when not set on the index.
+    // Issue #451 — exposed so operators can verify what sharding configuration
+    // an index is actually running with from the admin CLI.
+    int32 num_shards = 30;
 }
 
 message ListPrimaryKeysRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/DescribeIndexNumShardsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/DescribeIndexNumShardsTest.java
@@ -1,0 +1,132 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import herddb.index.vector.VectorIndexManager;
+import herddb.indexing.admin.IndexingAdminClient;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that {@link IndexingServiceEngine#describeIndex} reads the
+ * per-index {@code numShards} property from the schema tracker and that the
+ * gRPC {@code DescribeIndexResponse} surfaces it via {@code num_shards} so the
+ * admin CLI / dashboards can show what an index was created with (issue #451).
+ */
+public class DescribeIndexNumShardsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+
+    @Before
+    public void setUp() throws Exception {
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private Index vectorIndex(String name, int numShards) {
+        Index.Builder b = Index.builder()
+                .name(name)
+                .table("docs")
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY);
+        // numShards <= 0 means "do not set the property"; the engine must then
+        // fall back to its default of 1 (matching getNumShardsForIndex).
+        if (numShards > 0) {
+            b.property(VectorIndexManager.PROP_NUM_SHARDS, String.valueOf(numShards));
+        }
+        return b.build();
+    }
+
+    @Test
+    public void numShardsFromPropertyIsSurfacedOnEngineDescribe() {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        store.addVector(Bytes.from_int(1), new float[]{1f, 0f, 0f});
+        service.getEngine().registerIndexForTest(vectorIndex("idx_with_shards", 4), store);
+
+        IndexingServiceEngine.IndexDetails details =
+                service.getEngine().describeIndex("default", "docs", "idx_with_shards");
+        assertNotNull(details);
+        assertEquals("numShards must be read from index.properties via the schema tracker",
+                4, details.numShards);
+    }
+
+    @Test
+    public void numShardsDefaultsToOneWhenPropertyAbsent() {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        store.addVector(Bytes.from_int(1), new float[]{1f, 0f, 0f});
+        service.getEngine().registerIndexForTest(vectorIndex("idx_no_shards", -1), store);
+
+        IndexingServiceEngine.IndexDetails details =
+                service.getEngine().describeIndex("default", "docs", "idx_no_shards");
+        assertNotNull(details);
+        assertEquals("missing numShards property must default to 1",
+                1, details.numShards);
+    }
+
+    @Test
+    public void grpcDescribeIndexIncludesNumShards() throws Exception {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        store.addVector(Bytes.from_int(1), new float[]{1f, 0f, 0f});
+        service.getEngine().registerIndexForTest(vectorIndex("idx_grpc", 8), store);
+
+        try (IndexingAdminClient client = new IndexingAdminClient(service.getAddress(), 10)) {
+            DescribeIndexResponse resp = client.describeIndex("default", "docs", "idx_grpc");
+            assertNotNull(resp);
+            assertEquals("DescribeIndexResponse.num_shards must echo the index property",
+                    8, resp.getNumShards());
+        }
+    }
+
+    @Test
+    public void grpcDescribeIndexDefaultNumShardsIsOne() throws Exception {
+        InMemoryVectorStore store = new InMemoryVectorStore("embedding");
+        store.addVector(Bytes.from_int(1), new float[]{1f, 0f, 0f});
+        service.getEngine().registerIndexForTest(vectorIndex("idx_grpc_default", -1), store);
+
+        try (IndexingAdminClient client = new IndexingAdminClient(service.getAddress(), 10)) {
+            DescribeIndexResponse resp = client.describeIndex("default", "docs", "idx_grpc_default");
+            assertNotNull(resp);
+            assertEquals(1, resp.getNumShards());
+        }
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -120,7 +120,7 @@ public class Config {
         opts.addOption(null, "beam-width", true, "Vector index beamWidth (default: 100)");
         opts.addOption(null, "index-num-shards", true,
                 "Vector index numShards (default: 4). Set to 1 to disable sharding; "
-                        + "otherwise emitted as `numShards N` in the CREATE VECTOR INDEX DDL.");
+                        + "otherwise emitted as `numShards=N` in the CREATE VECTOR INDEX DDL.");
         opts.addOption(null, "skip-ingest", false, "Skip ingestion phase");
         opts.addOption(null, "skip-index", false, "Skip index creation");
         opts.addOption(null, "skip-verify", false, "Skip row count verification after ingestion");

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -57,7 +57,15 @@ public class VectorBench {
                 .append(" similarity=").append(config.effectiveSimilarity())
                 .append(" fusedPQ=true");
         if (config.indexNumShards > 1) {
-            sb.append(" numShards ").append(config.indexNumShards);
+            // Use key=value syntax to match every other property in the WITH
+            // clause. Space-separated "numShards 4" was silently dropped by
+            // JSQLParserPlanner.extractIndexWithClause (parts without '=' were
+            // skipped without warning), so the Index ended up with no
+            // numShards property and IndexingServiceEngine.isAcceptedLocally
+            // short-circuited to "accept everything" — every IS replica
+            // re-indexed every vector instead of the expected
+            // total / numInstances split. See issue #451.
+            sb.append(" numShards=").append(config.indexNumShards);
         }
         return sb.toString();
     }

--- a/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/VectorBenchTest.java
@@ -154,7 +154,7 @@ class VectorBenchTest {
         assertEquals(
                 "CREATE VECTOR INDEX vidx ON vector_bench(vec)"
                         + " WITH m=16 beamWidth=100 similarity=" + cfg.effectiveSimilarity()
-                        + " fusedPQ=true numShards 4",
+                        + " fusedPQ=true numShards=4",
                 sql);
     }
 
@@ -192,8 +192,8 @@ class VectorBenchTest {
         String sql = VectorBench.buildCreateVectorIndexSql(cfg);
 
         org.junit.jupiter.api.Assertions.assertTrue(
-                sql.endsWith("numShards 8"),
-                "expected trailing `numShards 8`, got: " + sql);
+                sql.endsWith("numShards=8"),
+                "expected trailing `numShards=8`, got: " + sql);
     }
 
     @Test
@@ -211,7 +211,7 @@ class VectorBenchTest {
         assertEquals(
                 "CREATE VECTOR INDEX vidx ON my_vectors(vec)"
                         + " WITH m=32 beamWidth=200 similarity=cosine"
-                        + " fusedPQ=true numShards 2",
+                        + " fusedPQ=true numShards=2",
                 sql);
     }
 


### PR DESCRIPTION
Fixes #451.

## Summary

Two-replica indexing-service clusters were re-indexing every vector on **both** replicas (~78%/~76% of rows each) instead of splitting ~50%/50%. This PR fixes the root cause and adds diagnostic surface so operators can verify the assignment without log spelunking.

## Root cause

`IndexingServiceEngine.isAcceptedLocally` short-circuits to `return true;` when an index has no `numShards` property:

```java
boolean isAcceptedLocally(Bytes key, Index index) {
    int n = currentNumInstances;
    int indexNumShards = getNumShardsForIndex(index);
    if (n <= 1 || indexNumShards <= 1) {
        return true;   // <-- accept everything when numShards is unset
    }
    ...
}
```

`VectorBench` (since `f32adf65`, issue #221) emitted the DDL `CREATE VECTOR INDEX vidx ... WITH ... fusedPQ=true numShards 4` — note the **space** before `4`, not `=`. `JSQLParserPlanner.extractIndexWithClause` silently dropped tokens without `=`, so the persisted `Index` had **no** `numShards` property at all, and every IS replica accepted every vector.

The bug had been live since 2026-04-22 (PR #222) and was missed because every existing test for shard assignment built `Index` programmatically via `Index.builder().property(numShards, …)`, bypassing the SQL parser. **Not** introduced by `b4178d84` (PR #337) as initially suspected — that commit only changed UPDATE/DELETE semantics; INSERT routing was unchanged.

## Fix

1. **`VectorBench.buildCreateVectorIndexSql`** — emit `numShards=N` instead of `numShards N` so it matches every other property in the WITH clause.
2. **`JSQLParserPlanner.extractIndexWithClause`** — throw `StatementExecutionException` on tokens without `=` (or with empty value), mirroring the loud behaviour of the JSQLParser-native WITH parser. Silent property loss can no longer ship.

## Diagnostic surface (carried over from the first commit on this branch)

- `sysindexes.properties` — JSON column with deterministic key ordering, exposing every WITH-clause value to JDBC clients.
- `DescribeIndexResponse.num_shards` (proto tag 30) — gRPC + `indexing-admin describe-index` show the per-index numShards, defaulting to 1 when unset.

## Tests

- **`herddb.sql.CreateVectorIndexWithClauseTest`** *(new — 6 tests)* — full SQL→`Index.properties` pipeline:
  - `numShardsKeyEqualsValueLandsOnIndex` — every WITH-clause key/value lands on the Index.
  - `commaSeparatedKeyEqualsValueLandsOnIndex` — comma-separated form works too.
  - `vectorBenchProductionDdlParsesIntoExpectedIndex` — locks the literal `VectorBench` output against the parser; the matching producer-side assertion is `VectorBenchTest.buildCreateVectorIndexSqlDefaultIncludesNumShardsFour`.
  - `numShardsWithSpaceSyntaxIsRejected` — issue #451 regression gate: `numShards 4` (space) now throws.
  - `bareKeywordWithoutValueIsRejected` — `WITH m=16 fusedPQ` throws.
  - `keyWithEmptyValueIsRejected` — `WITH numShards=` throws.
- **`VectorBenchTest`** — assertions updated to expect `numShards=N` syntax.
- Diagnostic-surface tests from the previous commit on this branch (`SysindexesPropertiesTest`, `DescribeIndexNumShardsTest`) still pass.
- Pre-PR validation green: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`.
- All existing routing tests still green: `ShardAssignmentTest` (7), `MultiInstanceFileShardingTest` (8), and the broader `herddb-indexing-service` set.

## Term overloading note

`shard` now means two unrelated things in the codebase:

| Concept | Where | Description |
|---|---|---|
| Routing hash bucket | `Index.numShards`, `IndexingServiceEngine.isAcceptedLocally` | Cross-instance fan-out: `(hash(pk) % numShards) % numInstances == instanceId` |
| HNSW graph segment | `PersistentVectorStore.{liveShards, frozenShards}`, `live_shard_count` gauge | In-memory HNSW segment that gets rotated/sealed/compacted into S3 graph+map files |

Renaming the HNSW concept to `liveSegments`/`frozenSegments` is deliberately **not** included in this PR — it touches many files and gauges and deserves its own issue. Will open a follow-up.

🤖 Implemented by the `pr-worker` agent.