### PR TITLE
issue #453: add windowed ingestion rate (1m / 5m) to GET /status

### DIFF
--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWindowTracker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWindowTracker.java
@@ -122,8 +122,13 @@ public class IngestionWindowTracker {
      * @param rows         number of rows committed in this transaction
      */
     public void recordCommit(long latencyNanos, long rows) {
-        long now = clock.getAsLong();
         synchronized (lock) {
+            // Capture the clock inside the lock so the deque stays monotonically
+            // ordered by timestamp — preventing the race where two threads capture
+            // their timestamps before either enters the lock and then insert in
+            // reverse order (which would break the trim loop's head-removal
+            // assumption for the rare case of a stale entry at the tail).
+            long now = clock.getAsLong();
             window.addLast(new Entry(now, rows, latencyNanos));
             // Trim entries that are outside the 5-minute retention window.
             // This runs on every write so the deque is bounded even if /status

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWindowTracker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWindowTracker.java
@@ -1,0 +1,227 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import java.util.ArrayDeque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import org.HdrHistogram.Histogram;
+
+/**
+ * Tracks per-commit {@code (timestamp, rowCount, latencyNanos)} entries in a
+ * sliding window of up to 5 minutes, enabling windowed ingestion-rate and
+ * commit-latency statistics for the {@code GET /status} endpoint (issue #453).
+ *
+ * <h3>Motivation</h3>
+ * <p>The all-time {@code ops_per_sec} field in {@code /status} is always a
+ * lagging average: after a BookKeeper stall or a rate-limiter change the
+ * global average climbs very slowly even if the current throughput has already
+ * normalised. A 1-minute and a 5-minute windowed rate allow operators and the
+ * supervision agent to detect recovery (or degradation) within one supervision
+ * tick.
+ *
+ * <h3>Data model</h3>
+ * <p>A bounded {@code ArrayDeque} holds one {@link Entry} per successful commit.
+ * Entries older than {@link #MAX_WINDOW_NANOS} (5 minutes) are trimmed from
+ * the head on every {@link #recordCommit} call, so the deque never accumulates
+ * more than {@code ~commits/s × 300 s} entries — typically well under 1000
+ * even at peak throughput.
+ *
+ * <h3>Thread safety</h3>
+ * <p>Written concurrently by multiple ingest workers (one entry per commit),
+ * read by the status supplier on each {@code /status} request. All access is
+ * guarded by {@link #lock}. Commit frequency is at most a few hundred per
+ * second, so contention is negligible.
+ *
+ * <h3>Windowed latency</h3>
+ * <p>A transient {@link Histogram} is built from the deque entries inside the
+ * window on every {@link #computeWindowedLatencyMap} call and discarded
+ * immediately. This avoids the complexity of maintaining a persistent
+ * per-window histogram while keeping the work proportional to the (small)
+ * number of entries in the window.
+ */
+public class IngestionWindowTracker {
+
+    /** Maximum window kept in the deque — also the 5-minute window duration. */
+    public static final long MAX_WINDOW_NANOS = TimeUnit.MINUTES.toNanos(5);
+
+    /** 5-minute rate window. */
+    public static final long FIVE_MIN_NANOS = MAX_WINDOW_NANOS;
+
+    /** 1-minute rate window. */
+    public static final long ONE_MIN_NANOS = TimeUnit.MINUTES.toNanos(1);
+
+    private static final long LOWEST_NANOS = 1L;
+    private static final long HIGHEST_NANOS = TimeUnit.HOURS.toNanos(1);
+    private static final int SIGNIFICANT_DIGITS = 3;
+
+    /** Immutable carrier for one commit's recorded data. */
+    private static final class Entry {
+        final long timestampNanos;
+        final long rowCount;
+        final long latencyNanos;
+
+        Entry(long timestampNanos, long rowCount, long latencyNanos) {
+            this.timestampNanos = timestampNanos;
+            this.rowCount = rowCount;
+            this.latencyNanos = latencyNanos;
+        }
+    }
+
+    private final ArrayDeque<Entry> window = new ArrayDeque<>();
+    private final Object lock = new Object();
+    private final LongSupplier clock;
+
+    /**
+     * Constructs a tracker backed by {@link System#nanoTime()}.
+     * This is the production constructor.
+     */
+    public IngestionWindowTracker() {
+        this(System::nanoTime);
+    }
+
+    /**
+     * Constructs a tracker with an injectable clock. Package-private so unit
+     * tests can drive time deterministically without sleeping.
+     *
+     * @param clock supplier of the current time in nanoseconds (monotonic)
+     */
+    IngestionWindowTracker(LongSupplier clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Records a successful commit. Called by each ingest worker after its
+     * transaction is committed.
+     *
+     * <p>Also trims entries that have fallen outside the maximum window
+     * ({@link #MAX_WINDOW_NANOS}) to keep memory bounded.
+     *
+     * @param latencyNanos wall-clock nanoseconds from transaction start to
+     *                     commit acknowledgement (clamped to the histogram
+     *                     range on read)
+     * @param rows         number of rows committed in this transaction
+     */
+    public void recordCommit(long latencyNanos, long rows) {
+        long now = clock.getAsLong();
+        synchronized (lock) {
+            window.addLast(new Entry(now, rows, latencyNanos));
+            // Trim entries that are outside the 5-minute retention window.
+            // This runs on every write so the deque is bounded even if /status
+            // is never queried.
+            long cutoff = now - MAX_WINDOW_NANOS;
+            while (!window.isEmpty() && window.peekFirst().timestampNanos < cutoff) {
+                window.removeFirst();
+            }
+        }
+    }
+
+    /**
+     * Computes the average ingestion rate (rows/s) over the last
+     * {@code windowNanos} nanoseconds.
+     *
+     * <p>The denominator is clamped to the actual elapsed time since
+     * {@code ingestStartNanos} when the run is shorter than the requested
+     * window, so the rate is well-defined from the very first commit and
+     * does not inflate during the ramp-up period.
+     *
+     * @param windowNanos      window duration in nanoseconds (e.g.
+     *                         {@link #ONE_MIN_NANOS}, {@link #FIVE_MIN_NANOS})
+     * @param ingestStartNanos {@link System#nanoTime()} value at the start of
+     *                         the ingestion phase — used to clamp the
+     *                         denominator for young runs
+     * @return rows per second, or {@code 0.0} if no commits have been
+     *         recorded within the window
+     */
+    public double computeWindowedRate(long windowNanos, long ingestStartNanos) {
+        long now = clock.getAsLong();
+        long cutoff = now - windowNanos;
+        long totalRows = 0;
+        synchronized (lock) {
+            for (Entry e : window) {
+                if (e.timestampNanos >= cutoff) {
+                    totalRows += e.rowCount;
+                }
+            }
+        }
+        if (totalRows == 0) {
+            return 0.0;
+        }
+        // Use the larger of cutoff and ingestStart as the window's effective
+        // start: when the run is shorter than the window, ingestStart > cutoff
+        // and the denominator is the actual elapsed time; when the run is
+        // longer, ingestStart <= cutoff and the denominator is windowNanos.
+        long windowStartNanos = Math.max(cutoff, ingestStartNanos);
+        double windowSecs = (now - windowStartNanos) / 1e9;
+        return windowSecs > 0 ? totalRows / windowSecs : 0.0;
+    }
+
+    /**
+     * Computes commit-latency statistics (mean, p50, p99, max in milliseconds)
+     * for commits that occurred within the last {@code windowNanos}.
+     *
+     * <p>Builds a transient {@link Histogram} from the deque entries that fall
+     * inside the window and discards it after the call — no persistent state.
+     * Latency values outside {@code [1 ns, 1 h]} are clamped to the histogram
+     * bounds, which is consistent with {@link MetricsCollector#record(long)}.
+     *
+     * @param windowNanos window duration in nanoseconds
+     * @return {@link LinkedHashMap} with keys {@code mean_ms}, {@code p50_ms},
+     *         {@code p99_ms}, {@code max_ms}; all values are {@code 0.0} when
+     *         no commits have been recorded within the window
+     */
+    public Map<String, Object> computeWindowedLatencyMap(long windowNanos) {
+        long now = clock.getAsLong();
+        long cutoff = now - windowNanos;
+        Histogram h = new Histogram(LOWEST_NANOS, HIGHEST_NANOS, SIGNIFICANT_DIGITS);
+        synchronized (lock) {
+            for (Entry e : window) {
+                if (e.timestampNanos >= cutoff) {
+                    long clamped = e.latencyNanos;
+                    if (clamped < LOWEST_NANOS) {
+                        clamped = LOWEST_NANOS;
+                    } else if (clamped > HIGHEST_NANOS) {
+                        clamped = HIGHEST_NANOS;
+                    }
+                    h.recordValue(clamped);
+                }
+            }
+        }
+        LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+        if (h.getTotalCount() == 0) {
+            m.put("mean_ms", 0.0);
+            m.put("p50_ms", 0.0);
+            m.put("p99_ms", 0.0);
+            m.put("max_ms", 0.0);
+        } else {
+            m.put("mean_ms", round2(h.getMean() / 1e6));
+            m.put("p50_ms", round2(h.getValueAtPercentile(50.0) / 1e6));
+            m.put("p99_ms", round2(h.getValueAtPercentile(99.0) / 1e6));
+            m.put("max_ms", round2(h.getMaxValue() / 1e6));
+        }
+        return m;
+    }
+
+    private static double round2(double v) {
+        return Math.round(v * 100.0) / 100.0;
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/IngestionWorker.java
@@ -77,6 +77,15 @@ public class IngestionWorker implements Runnable {
     private final BenchRuntime runtime;
 
     /**
+     * Optional sliding-window tracker for issue #453 (windowed ingestion rate
+     * and commit latency in {@code GET /status}). Receives one
+     * {@link IngestionWindowTracker#recordCommit} call after every successful
+     * commit. May be {@code null} in unit tests that do not exercise the
+     * windowed-rate feature.
+     */
+    private final IngestionWindowTracker windowTracker;
+
+    /**
      * Base of the exponential back-off between commit retries, in milliseconds.
      * Defaults to 10 seconds per issue #153 (10s, 20s, 40s, ...); tests override
      * this to a tiny value to keep the suite fast.
@@ -84,8 +93,9 @@ public class IngestionWorker implements Runnable {
     long backoffBaseMillis = 10_000L;
 
     /**
-     * Constructs an {@code IngestionWorker} without a {@link BenchRuntime} reference.
-     * Used in unit tests that do not need live thread-count tracking.
+     * Constructs an {@code IngestionWorker} without a {@link BenchRuntime}
+     * reference or window tracker. Used in unit tests that do not need live
+     * thread-count tracking or windowed rate reporting.
      */
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
@@ -93,31 +103,32 @@ public class IngestionWorker implements Runnable {
                            IngestRateLimiterGroup rateLimiterGroup, int rateLimiterIndex) {
         this(config, queue, done, rowId, metrics, statusLine, ingestStartNanos,
                 commitsTotal, commitsRecovered, rowsCommitted,
-                rateLimiterGroup, rateLimiterIndex, null);
+                rateLimiterGroup, rateLimiterIndex, null, null);
     }
 
     /**
      * Convenience constructor used by unit tests that don't exercise the rate
      * limiter at all (flush / retry tests). Equivalent to passing
-     * {@code rateLimiterGroup == null}.
+     * {@code rateLimiterGroup == null} and {@code windowTracker == null}.
      */
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
                            AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted) {
         this(config, queue, done, rowId, metrics, statusLine, ingestStartNanos,
-                commitsTotal, commitsRecovered, rowsCommitted, null, 0, null);
+                commitsTotal, commitsRecovered, rowsCommitted, null, 0, null, null);
     }
 
     /**
      * Constructs an {@code IngestionWorker} with an optional {@link BenchRuntime}
-     * for live thread-count tracking. Pass {@code null} for {@code runtime} when
-     * constructing workers in unit tests that do not need this feature.
+     * for live thread-count tracking and an optional {@link IngestionWindowTracker}
+     * for windowed rate reporting (issue #453). Pass {@code null} for either when
+     * constructing workers in unit tests that do not need those features.
      */
     public IngestionWorker(Config config, BlockingQueue<float[]> queue, AtomicBoolean done, AtomicLong rowId,
                            MetricsCollector metrics, AtomicReference<String> statusLine, long ingestStartNanos,
                            AtomicLong commitsTotal, AtomicLong commitsRecovered, AtomicLong rowsCommitted,
                            IngestRateLimiterGroup rateLimiterGroup, int rateLimiterIndex,
-                           BenchRuntime runtime) {
+                           BenchRuntime runtime, IngestionWindowTracker windowTracker) {
         this.config = config;
         this.queue = queue;
         this.done = done;
@@ -131,6 +142,7 @@ public class IngestionWorker implements Runnable {
         this.rateLimiterGroup = rateLimiterGroup;
         this.rateLimiterIndex = rateLimiterIndex;
         this.runtime = runtime;
+        this.windowTracker = windowTracker;
     }
 
     /** Package-private so {@link VectorBench}'s progress thread can format ETA consistently. */
@@ -514,6 +526,9 @@ public class IngestionWorker implements Runnable {
                 long latencyNanos = commitTransactionWithRetry(
                         ps, conn, pendingBatch, rowsInCurrentSubBatch, transactionStartNanos);
                 metrics.record(latencyNanos);
+                if (windowTracker != null) {
+                    windowTracker.recordCommit(latencyNanos, txnRows);
+                }
                 rowsIngested += txnRows;
                 pendingBatch.clear();
                 rowsInCurrentSubBatch = 0;
@@ -538,9 +553,13 @@ public class IngestionWorker implements Runnable {
         // commit whatever remains in the transaction. The commit unit may be
         // smaller than the configured transaction-size — that's fine.
         if (!pendingBatch.isEmpty()) {
+            int finalRows = pendingBatch.size();
             long latencyNanos = commitTransactionWithRetry(
                     ps, conn, pendingBatch, rowsInCurrentSubBatch, transactionStartNanos);
             metrics.record(latencyNanos);
+            if (windowTracker != null) {
+                windowTracker.recordCommit(latencyNanos, finalRows);
+            }
             pendingBatch.clear();
         }
     }

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -346,6 +346,7 @@ public class VectorBench {
             AtomicLong rowsCommitted = new AtomicLong(0);
 
             long ingestStart = System.nanoTime();
+            IngestionWindowTracker windowTracker = new IngestionWindowTracker();
 
             // Shared across all ingestion workers so --ingest-max-ops is a true
             // global cap. Live-override via POST /ingestion/config/ingest-max-ops
@@ -378,7 +379,7 @@ public class VectorBench {
                         config, ingestQueue, producerDone, rowId,
                         ingestMetrics, ingestStatus, ingestStart,
                         commitsTotal, commitsRecovered, rowsCommitted,
-                        runtime.ingestRateLimiterGroup(), idx, runtime);
+                        runtime.ingestRateLimiterGroup(), idx, runtime, windowTracker);
             };
 
             runtime.setIngestContext(ingestQueue, ingestPool, ingestWorkerFactory);
@@ -410,6 +411,14 @@ public class VectorBench {
                 latency.put("p99_ms", round2(s.p99Nanos() / 1e6));
                 latency.put("max_ms", round2(s.maxNanos() / 1e6));
                 m.put("commit_latency", latency);
+                // Windowed rate and latency (issue #453): 1-minute and 5-minute
+                // sliding windows over per-commit data recorded by each worker.
+                m.put("ops_per_sec_1m", windowTracker.computeWindowedRate(
+                        IngestionWindowTracker.ONE_MIN_NANOS, ingestStart));
+                m.put("ops_per_sec_5m", windowTracker.computeWindowedRate(
+                        IngestionWindowTracker.FIVE_MIN_NANOS, ingestStart));
+                m.put("commit_latency_5m", windowTracker.computeWindowedLatencyMap(
+                        IngestionWindowTracker.FIVE_MIN_NANOS));
                 return m;
             });
 

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWindowTrackerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWindowTrackerTest.java
@@ -166,7 +166,7 @@ class IngestionWindowTrackerTest {
     }
 
     @Test
-    void onlyCurentWindowRowsCountedNotAll() {
+    void onlyCurrentWindowRowsCountedNotAll() {
         // Regression guard: commit inside 5-min but outside 1-min must appear
         // in ops_per_sec_5m but NOT in ops_per_sec_1m.
         AtomicLong clock = new AtomicLong(0L);

--- a/vector-testings/src/test/java/herddb/vectortesting/IngestionWindowTrackerTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/IngestionWindowTrackerTest.java
@@ -1,0 +1,280 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link IngestionWindowTracker} (issue #453).
+ *
+ * <p>All tests use an injectable {@link java.util.function.LongSupplier} clock so
+ * time can be advanced deterministically without sleeping — the same pattern
+ * used by {@link BenchOutput.PlainBenchOutput} for {@code currentTimeMillis()}.
+ */
+class IngestionWindowTrackerTest {
+
+    /**
+     * HdrHistogram with 3 significant digits has ~0.1 % quantization error
+     * on each recorded value. Latency assertions use this tolerance band.
+     */
+    private static final double HDR_TOLERANCE = 0.002; // 0.2 % — 2× bucket precision
+
+    private static void assertWithinTolerance(double expected, double actual, String label) {
+        double band = Math.max(0.01, expected * HDR_TOLERANCE);
+        assertTrue(Math.abs(actual - expected) <= band,
+                label + ": expected " + expected + " ±" + band + ", got " + actual);
+    }
+
+    // ---------------------------------------------------------------- rate tests
+
+    @Test
+    void emptyTrackerReturnsZeroRate() {
+        AtomicLong clock = new AtomicLong(TimeUnit.SECONDS.toNanos(30));
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        assertEquals(0.0,
+                tracker.computeWindowedRate(IngestionWindowTracker.ONE_MIN_NANOS, 0L));
+        assertEquals(0.0,
+                tracker.computeWindowedRate(IngestionWindowTracker.FIVE_MIN_NANOS, 0L));
+    }
+
+    @Test
+    void singleCommitWithinWindowGivesCorrectRate() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        long ingestStart = 0L;
+
+        // Record 200 rows at t = 30 s.
+        clock.set(TimeUnit.SECONDS.toNanos(30));
+        tracker.recordCommit(5_000_000L, 200);
+
+        // At t = 60 s the 1-min window is [0 s, 60 s]. The run started at t = 0,
+        // so the denominator is min(60 s, 60 s) = 60 s.
+        clock.set(TimeUnit.SECONDS.toNanos(60));
+        double rate = tracker.computeWindowedRate(TimeUnit.MINUTES.toNanos(1), ingestStart);
+        assertEquals(200.0 / 60.0, rate, 0.001,
+                "rate = rows / windowSeconds");
+    }
+
+    @Test
+    void multipleCommitsAccumulateRowsForRateComputation() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        long ingestStart = 0L;
+
+        // Three commits of 100 rows each, all within the 1-min window.
+        clock.set(TimeUnit.SECONDS.toNanos(10));
+        tracker.recordCommit(5_000_000L, 100);
+        clock.set(TimeUnit.SECONDS.toNanos(20));
+        tracker.recordCommit(5_000_000L, 100);
+        clock.set(TimeUnit.SECONDS.toNanos(30));
+        tracker.recordCommit(5_000_000L, 100);
+
+        // At t = 60 s: rate = 300 / 60 = 5.0 rows/s.
+        clock.set(TimeUnit.SECONDS.toNanos(60));
+        double rate = tracker.computeWindowedRate(TimeUnit.MINUTES.toNanos(1), ingestStart);
+        assertEquals(300.0 / 60.0, rate, 0.001);
+    }
+
+    @Test
+    void entryBeforeCutoffIsExcludedFromWindowedRate() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        long ingestStart = 0L;
+
+        // Record 500 rows at t = 0 — this is outside the 1-min window at t = 90 s.
+        clock.set(0L);
+        tracker.recordCommit(5_000_000L, 500);
+
+        // Record 100 rows at t = 60 s — inside the 1-min window at t = 90 s.
+        clock.set(TimeUnit.SECONDS.toNanos(60));
+        tracker.recordCommit(5_000_000L, 100);
+
+        // At t = 90 s: window = [30 s, 90 s]. The t = 0 entry is excluded.
+        // Denominator = min(60 s, 90 s) = 60 s. Rate = 100 / 60 ≈ 1.67.
+        clock.set(TimeUnit.SECONDS.toNanos(90));
+        double rate = tracker.computeWindowedRate(TimeUnit.MINUTES.toNanos(1), ingestStart);
+        assertEquals(100.0 / 60.0, rate, 0.001,
+                "entry at t=0 is outside the 1-min window at t=90s");
+    }
+
+    @Test
+    void runShorterThanWindowUsesElapsedTimeAsDenominator() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+
+        // Ingest started at t = 10 s.
+        long ingestStart = TimeUnit.SECONDS.toNanos(10);
+
+        // Record 300 rows at t = 20 s (10 s after ingestion start).
+        clock.set(TimeUnit.SECONDS.toNanos(20));
+        tracker.recordCommit(5_000_000L, 300);
+
+        // At t = 40 s, compute 5-min rate. The run has only been going for 30 s,
+        // so the denominator is 30 s (elapsed), not 300 s (window).
+        // Rate = 300 / 30 = 10.0 rows/s.
+        clock.set(TimeUnit.SECONDS.toNanos(40));
+        double rate = tracker.computeWindowedRate(IngestionWindowTracker.FIVE_MIN_NANOS, ingestStart);
+        assertEquals(300.0 / 30.0, rate, 0.001,
+                "denominator must clamp to elapsed time when run < window");
+    }
+
+    @Test
+    void expiredEntriesAreTrimmedOnWrite() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        long ingestStart = 0L;
+
+        // Record 100 rows at t = 0.
+        clock.set(0L);
+        tracker.recordCommit(5_000_000L, 100);
+
+        // Advance past MAX_WINDOW and record another commit — this triggers trimming.
+        long past5Min = IngestionWindowTracker.MAX_WINDOW_NANOS + 1L;
+        clock.set(past5Min);
+        tracker.recordCommit(5_000_000L, 50);
+
+        // The t = 0 entry has been trimmed. Only the 50-row commit remains.
+        // At the same t, the 5-min window is [1 ns, past5Min]. t = 0 is outside.
+        // Denominator = min(300 s, past5Min / 1e9) ≈ 300 s.
+        // Rate ≈ 50 / 300 ≈ 0.167.
+        double rate = tracker.computeWindowedRate(IngestionWindowTracker.FIVE_MIN_NANOS, ingestStart);
+        double expectedRate = 50.0 / (IngestionWindowTracker.MAX_WINDOW_NANOS / 1e9);
+        assertEquals(expectedRate, rate, 0.001,
+                "old entry must be trimmed; only the recent commit contributes");
+    }
+
+    @Test
+    void onlyCurentWindowRowsCountedNotAll() {
+        // Regression guard: commit inside 5-min but outside 1-min must appear
+        // in ops_per_sec_5m but NOT in ops_per_sec_1m.
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        long ingestStart = 0L;
+
+        // Commit 1000 rows at t = 2 min (inside 5-min, outside 1-min at t = 4 min).
+        clock.set(TimeUnit.MINUTES.toNanos(2));
+        tracker.recordCommit(5_000_000L, 1000);
+
+        // Commit 200 rows at t = 3 min 30 s (inside both windows at t = 4 min).
+        clock.set(TimeUnit.MINUTES.toNanos(3) + TimeUnit.SECONDS.toNanos(30));
+        tracker.recordCommit(5_000_000L, 200);
+
+        // Query at t = 4 min.
+        clock.set(TimeUnit.MINUTES.toNanos(4));
+
+        // 5-min window: both commits inside → 1200 rows / 240 s = 5.0 rows/s.
+        double rate5m = tracker.computeWindowedRate(IngestionWindowTracker.FIVE_MIN_NANOS, ingestStart);
+        assertEquals(1200.0 / 240.0, rate5m, 0.01,
+                "5-min window must include both commits");
+
+        // 1-min window: only the 200-row commit at t = 3m30s is inside → 200 rows / 60 s ≈ 3.33.
+        double rate1m = tracker.computeWindowedRate(IngestionWindowTracker.ONE_MIN_NANOS, ingestStart);
+        assertEquals(200.0 / 60.0, rate1m, 0.01,
+                "1-min window must exclude the early commit");
+    }
+
+    // -------------------------------------------------------------- latency tests
+
+    @Test
+    void windowedLatencyMapIsAllZerosWhenEmpty() {
+        AtomicLong clock = new AtomicLong(TimeUnit.SECONDS.toNanos(5));
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+
+        Map<String, Object> m = tracker.computeWindowedLatencyMap(IngestionWindowTracker.FIVE_MIN_NANOS);
+
+        assertEquals(0.0, m.get("mean_ms"), "mean_ms must be 0 when empty");
+        assertEquals(0.0, m.get("p50_ms"),  "p50_ms must be 0 when empty");
+        assertEquals(0.0, m.get("p99_ms"),  "p99_ms must be 0 when empty");
+        assertEquals(0.0, m.get("max_ms"),  "max_ms must be 0 when empty");
+    }
+
+    @Test
+    void windowedLatencyMapReflectsPercentilesForCommitsInWindow() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+
+        // Record 100 commits with latencies 1 ms … 100 ms, all at t = 0.
+        clock.set(0L);
+        for (int i = 1; i <= 100; i++) {
+            tracker.recordCommit(TimeUnit.MILLISECONDS.toNanos(i), 1);
+        }
+
+        // Query at t = 30 s (well inside the 5-min window).
+        clock.set(TimeUnit.SECONDS.toNanos(30));
+        Map<String, Object> m = tracker.computeWindowedLatencyMap(IngestionWindowTracker.FIVE_MIN_NANOS);
+
+        double p50 = (Double) m.get("p50_ms");
+        double p99 = (Double) m.get("p99_ms");
+        double max = (Double) m.get("max_ms");
+
+        assertTrue(p50 >= 49.0 && p50 <= 51.0,
+                "p50 should be ~50 ms, got " + p50);
+        assertTrue(p99 >= 98.0 && p99 <= 100.5,
+                "p99 should be ~99 ms, got " + p99);
+        assertTrue(max >= 99.0 && max <= 101.0,
+                "max should be ~100 ms, got " + max);
+    }
+
+    @Test
+    void windowedLatencyMapExcludesCommitsOutsideWindow() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+
+        // Record a very slow commit (500 ms) at t = 0 — outside the 1-min window.
+        clock.set(0L);
+        tracker.recordCommit(TimeUnit.MILLISECONDS.toNanos(500), 1);
+
+        // Record a fast commit (10 ms) at t = 60 s — inside the 1-min window at t = 90 s.
+        clock.set(TimeUnit.SECONDS.toNanos(60));
+        tracker.recordCommit(TimeUnit.MILLISECONDS.toNanos(10), 1);
+
+        // Query at t = 90 s over the 1-min window.
+        clock.set(TimeUnit.SECONDS.toNanos(90));
+        Map<String, Object> m = tracker.computeWindowedLatencyMap(TimeUnit.MINUTES.toNanos(1));
+
+        // Only the 10-ms commit should contribute; max must not be near 500 ms.
+        double max = (Double) m.get("max_ms");
+        assertWithinTolerance(10.0, max, "max_ms");
+
+        double p50 = (Double) m.get("p50_ms");
+        assertWithinTolerance(10.0, p50, "p50_ms");
+    }
+
+    @Test
+    void windowedLatencyMapHasAllRequiredKeys() {
+        AtomicLong clock = new AtomicLong(0L);
+        IngestionWindowTracker tracker = new IngestionWindowTracker(clock::get);
+        clock.set(0L);
+        tracker.recordCommit(TimeUnit.MILLISECONDS.toNanos(15), 100);
+        clock.set(TimeUnit.SECONDS.toNanos(10));
+
+        Map<String, Object> m = tracker.computeWindowedLatencyMap(IngestionWindowTracker.FIVE_MIN_NANOS);
+
+        assertTrue(m.containsKey("mean_ms"), "must contain mean_ms");
+        assertTrue(m.containsKey("p50_ms"),  "must contain p50_ms");
+        assertTrue(m.containsKey("p99_ms"),  "must contain p99_ms");
+        assertTrue(m.containsKey("max_ms"),  "must contain max_ms");
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/StatusWindowedRateTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/StatusWindowedRateTest.java
@@ -1,0 +1,176 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests verifying that {@code GET /status} exposes the windowed
+ * ingestion-rate fields added by issue #453: {@code ops_per_sec_1m},
+ * {@code ops_per_sec_5m}, and {@code commit_latency_5m}.
+ *
+ * <p>The test does not spin up actual ingest workers. Instead it pre-records
+ * commits directly into an {@link IngestionWindowTracker} and wires it into a
+ * custom status supplier set on {@link BenchRuntime}. This exercises the same
+ * code path that {@link VectorBench} uses during a live run without any JDBC
+ * dependency.
+ */
+class StatusWindowedRateTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private AdminApiServer server;
+    private HttpClient client;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() throws Exception {
+        Config cfg = new Config();
+        BenchRuntime runtime = new BenchRuntime(cfg);
+
+        // Pre-load the tracker with a few commits so the windowed fields are > 0.
+        IngestionWindowTracker tracker = new IngestionWindowTracker();
+        tracker.recordCommit(TimeUnit.MILLISECONDS.toNanos(10), 500); // 10 ms, 500 rows
+        tracker.recordCommit(TimeUnit.MILLISECONDS.toNanos(20), 500); // 20 ms, 500 rows
+
+        // Simulate an ingest phase that started 30 seconds ago.
+        long ingestStart = System.nanoTime() - TimeUnit.SECONDS.toNanos(30);
+
+        runtime.setStatusSupplier(() -> {
+            LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+            m.put("phase", "ingestion");
+            m.put("rows", 1000L);
+            // All-time average (the existing field — must remain unchanged).
+            m.put("ops_per_sec", 1000.0 / 30.0);
+            // Windowed rates (issue #453).
+            m.put("ops_per_sec_1m", tracker.computeWindowedRate(
+                    IngestionWindowTracker.ONE_MIN_NANOS, ingestStart));
+            m.put("ops_per_sec_5m", tracker.computeWindowedRate(
+                    IngestionWindowTracker.FIVE_MIN_NANOS, ingestStart));
+            m.put("commit_latency_5m", tracker.computeWindowedLatencyMap(
+                    IngestionWindowTracker.FIVE_MIN_NANOS));
+            return m;
+        });
+
+        server = new AdminApiServer(runtime, 0);
+        int port = server.start();
+        baseUrl = "http://127.0.0.1:" + port;
+        client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @AfterEach
+    void stop() {
+        server.stop();
+    }
+
+    @Test
+    void statusContainsWindowedRateFields() throws Exception {
+        JsonNode json = getStatusJson();
+
+        // New fields must be present in the response.
+        assertNotNull(json.get("ops_per_sec_1m"),
+                "ops_per_sec_1m must be present in /status response");
+        assertNotNull(json.get("ops_per_sec_5m"),
+                "ops_per_sec_5m must be present in /status response");
+        assertNotNull(json.get("commit_latency_5m"),
+                "commit_latency_5m must be present in /status response");
+    }
+
+    @Test
+    void windowedRatesArePositiveAfterCommitsRecorded() throws Exception {
+        JsonNode json = getStatusJson();
+
+        // Both windowed rates must be > 0 because we pre-loaded commits.
+        assertTrue(json.get("ops_per_sec_1m").asDouble() > 0,
+                "ops_per_sec_1m must be > 0 after commits are recorded");
+        assertTrue(json.get("ops_per_sec_5m").asDouble() > 0,
+                "ops_per_sec_5m must be > 0 after commits are recorded");
+    }
+
+    @Test
+    void commitLatency5mHasAllSubFields() throws Exception {
+        JsonNode json = getStatusJson();
+        JsonNode lat5m = json.get("commit_latency_5m");
+
+        assertNotNull(lat5m, "commit_latency_5m must be a JSON object");
+        assertNotNull(lat5m.get("mean_ms"), "commit_latency_5m.mean_ms must be present");
+        assertNotNull(lat5m.get("p50_ms"),  "commit_latency_5m.p50_ms must be present");
+        assertNotNull(lat5m.get("p99_ms"),  "commit_latency_5m.p99_ms must be present");
+        assertNotNull(lat5m.get("max_ms"),  "commit_latency_5m.max_ms must be present");
+    }
+
+    @Test
+    void commitLatency5mMeanIsPositiveAfterCommitsRecorded() throws Exception {
+        JsonNode lat5m = getStatusJson().get("commit_latency_5m");
+
+        // mean_ms must reflect the ~15 ms average of the two pre-loaded commits.
+        double mean = lat5m.get("mean_ms").asDouble();
+        assertTrue(mean > 0,
+                "commit_latency_5m.mean_ms must be > 0 after commits are recorded, got " + mean);
+    }
+
+    @Test
+    void allTimeOpsPerSecIsStillPresent() throws Exception {
+        JsonNode json = getStatusJson();
+
+        // Backward compatibility: the all-time average must not have been removed.
+        assertNotNull(json.get("ops_per_sec"),
+                "all-time ops_per_sec must still be present for backward compatibility");
+        assertTrue(json.get("ops_per_sec").asDouble() > 0,
+                "all-time ops_per_sec must be > 0");
+    }
+
+    @Test
+    void statusResponseIsHttp200() throws Exception {
+        HttpResponse<String> resp = getStatus();
+        assertEquals(200, resp.statusCode());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private HttpResponse<String> getStatus() throws Exception {
+        return client.send(HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/status"))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build(), BodyHandlers.ofString());
+    }
+
+    private JsonNode getStatusJson() throws Exception {
+        return MAPPER.readTree(getStatus().body());
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/StatusWindowedRateTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/StatusWindowedRateTest.java
@@ -94,7 +94,9 @@ class StatusWindowedRateTest {
 
     @AfterEach
     void stop() {
-        server.stop();
+        if (server != null) {
+            server.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #453.

## Changes

- **`IngestionWindowTracker` (new class)** — lock-protected sliding-window deque of per-commit `(timestamp, rowCount, latencyNanos)` entries. Entries older than 5 minutes are trimmed on every `recordCommit()` call so the deque is bounded in size. Exposes:
  - `computeWindowedRate(windowNanos, ingestStartNanos)` → `double` (rows/s), denominator clamped to elapsed time for young runs
  - `computeWindowedLatencyMap(windowNanos)` → `Map` with `mean_ms / p50_ms / p99_ms / max_ms` built from a transient HdrHistogram over the window's entries

- **`IngestionWorker`** — adds an optional `IngestionWindowTracker` field (nullable; all existing shorter constructors pass `null`). Calls `windowTracker.recordCommit(latencyNanos, txnRows)` at both commit points in `runIngestLoop()` (main loop and final drain).

- **`VectorBench`** — creates one `IngestionWindowTracker` per ingest phase, passes it to all ingest workers via the factory lambda, and adds three new fields to the `GET /status` supplier:
  - `ops_per_sec_1m`
  - `ops_per_sec_5m`
  - `commit_latency_5m` (nested object with `mean_ms / p50_ms / p99_ms / max_ms`)

  All existing all-time fields (`ops_per_sec`, `commit_latency`) remain unchanged for backward compatibility.

## Tests

- **`IngestionWindowTrackerTest`** (11 tests) — deterministic clock-injectable tests covering: empty tracker, single commit rate, multiple commits accumulating, entry-outside-window exclusion, run-shorter-than-window denominator clamping, expired-entry trimming, two-window differentiation (5m vs 1m), and windowed latency percentiles / key set.

- **`StatusWindowedRateTest`** (6 tests) — end-to-end HTTP tests against a live `AdminApiServer`: verifies `ops_per_sec_1m`, `ops_per_sec_5m`, and `commit_latency_5m` (with all four sub-fields) appear in the JSON response, are positive after commits are pre-recorded, and that the all-time `ops_per_sec` still exists.

🤖 Implemented by the `pr-worker` agent.