### PR TITLE
issue #455: O(1) on-disk-segment memory estimate via incremental counter

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2036,17 +2036,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         java.util.Collections.emptyList(),
                         LogSequenceNumber.START_OF_TIME);
 
-                this.segments = newSegments;
                 // Issue #455: keep the on-disk-segment memory counter in sync
-                // with the segments-list swap.  Inputs are leaving (their
-                // close() below releases pkData / BLink); mergedOutput is
-                // joining (its pkData / BLink were populated by the rebuild
-                // before this method was called).
-                for (VectorSegment in : inputs) {
-                    unregisterSegmentMemoryEstimate(in);
-                }
+                // with the segments-list swap.  Capture the mergedOutput
+                // snapshot BEFORE publishing newSegments so the counter and
+                // the segments list flip together; inputs are unregistered
+                // immediately after the swap (their close() further down
+                // releases pkData / BLink).
                 if (mergedOutput != null) {
                     registerSegmentMemoryEstimate(mergedOutput);
+                }
+                this.segments = newSegments;
+                for (VectorSegment in : inputs) {
+                    unregisterSegmentMemoryEstimate(in);
                 }
                 dirty.set(dirty.get() || totalLiveSize() > 0);
             } finally {
@@ -2882,6 +2883,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *       {@link #registerSegmentMemoryEstimate} at every mutation of
      *       {@link #segments} (issue #455).</li>
      * </ul>
+     *
+     * <p><strong>Snapshot semantics for the on-disk-segment portion.</strong>
+     * Each segment's contribution is captured as a snapshot at registration
+     * time, so subsequent BLink page-cache loads/evictions on already-
+     * registered segments are not reflected here.  Callers using this value
+     * for diagnostics should be aware that it tracks the static pkData /
+     * pkOffsets / pkLengths arrays exactly but only the registration-time
+     * snapshot of the dynamic BLink page-cache footprint; the live BLink
+     * footprint is bounded independently by the {@link MemoryManager} index
+     * page-replacement policy.
      */
     @Override
     public long estimatedMemoryUsageBytes() {
@@ -2902,12 +2913,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
         // On-disk segments: O(1) read of the incremental counter (issue #455).
-        // The counter is maintained by registerSegmentMemoryEstimate /
-        // unregisterSegmentMemoryEstimate at every segments-list mutation
-        // point; each segment's contribution is its
-        // estimatedInMemoryBytes() snapshot captured at registration time.
-        // Replaces the prior per-call iteration which dominated IS CPU once
-        // segment counts grew into the 14 k+ range during tailing catch-up.
         total += onDiskSegmentsEstimatedMemoryBytes.get();
         return total;
     }
@@ -2939,30 +2944,37 @@ public class PersistentVectorStore extends AbstractVectorStore {
     // {@link #registerSegmentMemoryEstimate} for newly-added segments and
     // {@link #unregisterSegmentMemoryEstimate} for segments being removed,
     // so that {@link #onDiskSegmentsEstimatedMemoryBytes} stays consistent
-    // with the iterated sum of {@link VectorSegment#estimatedInMemoryBytes()}.
-    // The unit test PersistentVectorStoreEstimatedMemoryCounterTest cross-checks
-    // the counter against an iterated sum at every lifecycle event.
+    // with the iterated sum of {@link VectorSegment#estimatedInMemoryBytes()}
+    // captured at registration time.  The unit test
+    // PersistentVectorStoreEstimatedMemoryCounterTest cross-checks the counter
+    // against the iterated sum at every lifecycle event.
     // -------------------------------------------------------------------------
 
     /**
      * Captures the segment's current memory estimate as a snapshot, stores it
-     * on the segment in {@link VectorSegment#cachedEstimatedInMemoryBytes}, and
-     * adds it to {@link #onDiskSegmentsEstimatedMemoryBytes}.  Must be called
+     * on the segment in {@link VectorSegment#cachedEstimatedInMemoryBytes},
+     * marks {@link VectorSegment#registeredInMemoryCounter}, and adds the
+     * snapshot to {@link #onDiskSegmentsEstimatedMemoryBytes}.  Must be called
      * exactly once per segment, after pkData/pkOffsets/pkLengths and the BLink
      * have been populated (i.e. after {@code loadFusedPQSegment}), while the
      * caller holds {@code stateLock.writeLock()} (or, for the load path, while
      * no other thread can observe the store yet).
      *
-     * <p>Subsequent calls for an already-registered segment are no-ops to
-     * preserve idempotency on retry paths.
+     * <p>If the segment is already registered the call is a no-op so retry
+     * paths cannot double-count.  The {@code registeredInMemoryCounter} flag
+     * is the bookkeeping sentinel — kept distinct from
+     * {@code cachedEstimatedInMemoryBytes} so that a legitimately-zero-byte
+     * snapshot (e.g. an empty post-load segment) is not mistaken for "not yet
+     * registered".
      */
     private void registerSegmentMemoryEstimate(VectorSegment seg) {
-        if (seg.cachedEstimatedInMemoryBytes != 0) {
+        if (seg.registeredInMemoryCounter) {
             // Already registered (e.g. recovery retry); avoid double-count.
             return;
         }
         long bytes = seg.estimatedInMemoryBytes();
         seg.cachedEstimatedInMemoryBytes = bytes;
+        seg.registeredInMemoryCounter = true;
         if (bytes != 0) {
             onDiskSegmentsEstimatedMemoryBytes.addAndGet(bytes);
         }
@@ -2971,17 +2983,53 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /**
      * Subtracts the snapshot captured by
      * {@link #registerSegmentMemoryEstimate} from
-     * {@link #onDiskSegmentsEstimatedMemoryBytes} and clears the cached value
-     * on the segment.  Idempotent: a segment that was never registered (or was
-     * already unregistered) contributes 0 and the call is a no-op.  Must be
-     * called while holding {@code stateLock.writeLock()}.
+     * {@link #onDiskSegmentsEstimatedMemoryBytes} and clears the bookkeeping
+     * state on the segment.  Idempotent: a segment that was never registered
+     * (or was already unregistered) is a no-op.  Must be called while holding
+     * {@code stateLock.writeLock()} on every regular mutation path; the
+     * shutdown close paths run after the compaction/checkpoint threads have
+     * been joined and back-pressure waiters released, so no concurrent writer
+     * can race the unregister loop there.
      */
     private void unregisterSegmentMemoryEstimate(VectorSegment seg) {
+        if (!seg.registeredInMemoryCounter) {
+            return;
+        }
         long bytes = seg.cachedEstimatedInMemoryBytes;
+        seg.cachedEstimatedInMemoryBytes = 0L;
+        seg.registeredInMemoryCounter = false;
         if (bytes != 0) {
-            seg.cachedEstimatedInMemoryBytes = 0L;
             onDiskSegmentsEstimatedMemoryBytes.addAndGet(-bytes);
         }
+    }
+
+    /**
+     * Test-only helper: returns the live sum of
+     * {@link VectorSegment#estimatedInMemoryBytes()} across every segment
+     * currently in {@link #segments}, without touching
+     * {@link #onDiskSegmentsEstimatedMemoryBytes}.
+     *
+     * <p>Tests use this as the independent ground truth against which the
+     * counter is compared (issue #455 — a missed register/unregister at any
+     * future mutation site would cause the two values to diverge).
+     *
+     * <p>The values may differ if the BLink page cache of an already-
+     * registered segment has loaded or evicted pages since registration; the
+     * tests only invoke this at clean lifecycle points where no such drift
+     * can occur (immediately after {@code start}, after a {@code checkpoint},
+     * after {@code runCompactionCycle}, after {@code reloadFromStatus}, and
+     * after the all-deleted checkpoint that resets {@code segments} to
+     * empty).
+     *
+     * @return iterated sum of {@code seg.estimatedInMemoryBytes()} across
+     *         the current segment list
+     */
+    public long sumOnDiskSegmentMemoryBytesByIterationForTesting() {
+        long total = 0;
+        for (VectorSegment seg : segments) {
+            total += seg.estimatedInMemoryBytes();
+        }
+        return total;
     }
 
     private long shardMemoryBytes(LiveGraphShard shard) {
@@ -3522,16 +3570,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 });
             }
 
-            this.segments = newSegments;
-
             // Issue #455: sealedSegments + mergeableSegments together cover
             // every segment that was previously in this.segments (their union
             // was built by the Phase A partition loop), so they remain
             // registered.  Only the freshly-built preloadedSegments need to
             // join the on-disk memory counter here.
+            //
+            // Capture snapshots BEFORE publishing newSegments: if any
+            // estimatedInMemoryBytes() call were ever to throw (e.g. an
+            // unforeseen failure inside BLink.getUsedMemory()), unwinding
+            // before the publish leaves both this.segments and the counter
+            // consistent — no half-updated-counter window.
             for (VectorSegment seg : preloadedSegments) {
                 registerSegmentMemoryEstimate(seg);
             }
+
+            this.segments = newSegments;
 
             int maxOrd = -1;
             for (VectorSegment seg : newSegments) {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -363,6 +363,26 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** On-disk segments. */
     private volatile List<VectorSegment> segments = new java.util.concurrent.CopyOnWriteArrayList<>();
 
+    /**
+     * Incrementally-maintained sum of {@link VectorSegment#estimatedInMemoryBytes()}
+     * across every segment currently registered in {@link #segments}
+     * (issue #455).  Updated by {@link #registerSegmentMemoryEstimate} and
+     * {@link #unregisterSegmentMemoryEstimate} at every mutation point on
+     * the segments list, so {@link #estimatedMemoryUsageBytes()} can read it
+     * in O(1) instead of iterating every segment on every back-pressure check.
+     *
+     * <p>Each segment's contribution is captured as a snapshot at registration
+     * time and stored on the segment in
+     * {@link VectorSegment#cachedEstimatedInMemoryBytes}, so the same value can
+     * later be subtracted on unregistration even if the segment's underlying
+     * BLink page-cache or pkData arrays have shifted in between.  Subsequent
+     * BLink page loads/evictions are not reflected in this counter; the BLink
+     * page-cache footprint is bounded by the {@link MemoryManager}'s global
+     * index-page replacement policy budget, which the back-pressure code
+     * already enforces independently.
+     */
+    private final AtomicLong onDiskSegmentsEstimatedMemoryBytes = new AtomicLong(0);
+
     /** Counter for assigning unique segment IDs. */
     private final AtomicInteger nextSegmentId = new AtomicInteger(0);
 
@@ -1522,7 +1542,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
         try {
             List<VectorSegment> old = segments;
             segments = new java.util.concurrent.CopyOnWriteArrayList<>();
+            // Issue #455: drop the old segments' contributions from the
+            // on-disk-segment memory counter before loadFromStatus re-registers
+            // the new ones.
             for (VectorSegment seg : old) {
+                unregisterSegmentMemoryEstimate(seg);
                 try {
                     seg.close();
                 } catch (Exception e) {
@@ -2013,6 +2037,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         LogSequenceNumber.START_OF_TIME);
 
                 this.segments = newSegments;
+                // Issue #455: keep the on-disk-segment memory counter in sync
+                // with the segments-list swap.  Inputs are leaving (their
+                // close() below releases pkData / BLink); mergedOutput is
+                // joining (its pkData / BLink were populated by the rebuild
+                // before this method was called).
+                for (VectorSegment in : inputs) {
+                    unregisterSegmentMemoryEstimate(in);
+                }
+                if (mergedOutput != null) {
+                    registerSegmentMemoryEstimate(mergedOutput);
+                }
                 dirty.set(dirty.get() || totalLiveSize() > 0);
             } finally {
                 stateLock.writeLock().unlock();
@@ -2385,7 +2420,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
             latch.countDown();
             this.checkpointPhaseComplete = null;
         }
+        // Issue #455: drop every segment's contribution from the on-disk
+        // memory counter before closing them, so the counter goes back to 0
+        // (verified by PersistentVectorStoreEstimatedMemoryCounterTest).
         for (VectorSegment seg : segments) {
+            unregisterSegmentMemoryEstimate(seg);
             seg.close();
         }
         segments = new java.util.concurrent.CopyOnWriteArrayList<>();
@@ -2836,6 +2875,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *       CompletionTracker) — via JVector's own {@code ramBytesUsed()}</li>
      *   <li>pkToNode + nodeToPk ConcurrentHashMap entries (~100 bytes per entry × 2)</li>
      *   <li>Bytes PK objects (~50 bytes average)</li>
+     *   <li>On-disk segments' in-memory footprint (pkData / pkOffsets / pkLengths
+     *       arrays plus the BLink pk-to-ordinal tree, issue #360) — read in
+     *       O(1) from {@link #onDiskSegmentsEstimatedMemoryBytes}, an
+     *       incrementally-maintained counter populated by
+     *       {@link #registerSegmentMemoryEstimate} at every mutation of
+     *       {@link #segments} (issue #455).</li>
      * </ul>
      */
     @Override
@@ -2856,32 +2901,87 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 total += shardMemoryBytes(shard);
             }
         }
-        // Include on-disk segments' in-memory footprint (issue #360).
-        // Each VectorSegment retains pkData/pkOffsets/pkLengths arrays and a
-        // BLink pk-to-ordinal tree whose internal BLink Node structures account
-        // for the 6-8 GiB gap observed between engine-stats estimated memory and
-        // actual G1 old-gen usage in the GKE benchmark.
-        for (VectorSegment seg : segments) {
-            total += seg.estimatedInMemoryBytes();
-        }
+        // On-disk segments: O(1) read of the incremental counter (issue #455).
+        // The counter is maintained by registerSegmentMemoryEstimate /
+        // unregisterSegmentMemoryEstimate at every segments-list mutation
+        // point; each segment's contribution is its
+        // estimatedInMemoryBytes() snapshot captured at registration time.
+        // Replaces the prior per-call iteration which dominated IS CPU once
+        // segment counts grew into the 14 k+ range during tailing catch-up.
+        total += onDiskSegmentsEstimatedMemoryBytes.get();
         return total;
     }
 
     /**
-     * Returns the sum of {@link VectorSegment#estimatedInMemoryBytes()} across all
-     * current on-disk segments.  Exposed for testing so that tests can assert the
-     * on-disk segment contribution separately from the live-shard contribution,
-     * which is non-zero even for empty shards (the underlying
-     * {@code OnHeapGraphIndex} retains a small fixed overhead).
+     * Returns the in-memory footprint of all currently registered on-disk
+     * {@link VectorSegment} objects (pkData/pkOffsets/pkLengths arrays plus
+     * the BLink pk-to-ordinal tree, snapshotted at segment registration time).
+     *
+     * <p>Exposed for testing so that tests can assert the on-disk segment
+     * contribution separately from the live-shard contribution, which is
+     * non-zero even for empty shards (the underlying {@code OnHeapGraphIndex}
+     * retains a small fixed overhead).
+     *
+     * <p>This is an O(1) read of the incremental counter
+     * {@link #onDiskSegmentsEstimatedMemoryBytes} (issue #455); it does not
+     * iterate over the segments list.
      *
      * @return estimated bytes held by all current on-disk segments
      */
     public long getOnDiskSegmentsEstimatedMemoryBytes() {
-        long total = 0;
-        for (VectorSegment seg : segments) {
-            total += seg.estimatedInMemoryBytes();
+        return onDiskSegmentsEstimatedMemoryBytes.get();
+    }
+
+    // -------------------------------------------------------------------------
+    // On-disk segment memory bookkeeping (issue #455)
+    //
+    // Every site that mutates {@link #segments} must call
+    // {@link #registerSegmentMemoryEstimate} for newly-added segments and
+    // {@link #unregisterSegmentMemoryEstimate} for segments being removed,
+    // so that {@link #onDiskSegmentsEstimatedMemoryBytes} stays consistent
+    // with the iterated sum of {@link VectorSegment#estimatedInMemoryBytes()}.
+    // The unit test PersistentVectorStoreEstimatedMemoryCounterTest cross-checks
+    // the counter against an iterated sum at every lifecycle event.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Captures the segment's current memory estimate as a snapshot, stores it
+     * on the segment in {@link VectorSegment#cachedEstimatedInMemoryBytes}, and
+     * adds it to {@link #onDiskSegmentsEstimatedMemoryBytes}.  Must be called
+     * exactly once per segment, after pkData/pkOffsets/pkLengths and the BLink
+     * have been populated (i.e. after {@code loadFusedPQSegment}), while the
+     * caller holds {@code stateLock.writeLock()} (or, for the load path, while
+     * no other thread can observe the store yet).
+     *
+     * <p>Subsequent calls for an already-registered segment are no-ops to
+     * preserve idempotency on retry paths.
+     */
+    private void registerSegmentMemoryEstimate(VectorSegment seg) {
+        if (seg.cachedEstimatedInMemoryBytes != 0) {
+            // Already registered (e.g. recovery retry); avoid double-count.
+            return;
         }
-        return total;
+        long bytes = seg.estimatedInMemoryBytes();
+        seg.cachedEstimatedInMemoryBytes = bytes;
+        if (bytes != 0) {
+            onDiskSegmentsEstimatedMemoryBytes.addAndGet(bytes);
+        }
+    }
+
+    /**
+     * Subtracts the snapshot captured by
+     * {@link #registerSegmentMemoryEstimate} from
+     * {@link #onDiskSegmentsEstimatedMemoryBytes} and clears the cached value
+     * on the segment.  Idempotent: a segment that was never registered (or was
+     * already unregistered) contributes 0 and the call is a no-op.  Must be
+     * called while holding {@code stateLock.writeLock()}.
+     */
+    private void unregisterSegmentMemoryEstimate(VectorSegment seg) {
+        long bytes = seg.cachedEstimatedInMemoryBytes;
+        if (bytes != 0) {
+            seg.cachedEstimatedInMemoryBytes = 0L;
+            onDiskSegmentsEstimatedMemoryBytes.addAndGet(-bytes);
+        }
     }
 
     private long shardMemoryBytes(LiveGraphShard shard) {
@@ -3108,7 +3208,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             int totalActiveVectors = (int) onDiskNodeToPkSize() + totalLiveVectors;
 
             if (totalActiveVectors == 0 && !segments.isEmpty()) {
+                // Issue #455: drop every segment's contribution from the
+                // on-disk memory counter before closing them.
                 for (VectorSegment seg : segments) {
+                    unregisterSegmentMemoryEstimate(seg);
                     seg.close();
                     dropSegmentBLinkStorage(seg);
                 }
@@ -3420,6 +3523,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
 
             this.segments = newSegments;
+
+            // Issue #455: sealedSegments + mergeableSegments together cover
+            // every segment that was previously in this.segments (their union
+            // was built by the Phase A partition loop), so they remain
+            // registered.  Only the freshly-built preloadedSegments need to
+            // join the on-disk memory counter here.
+            for (VectorSegment seg : preloadedSegments) {
+                registerSegmentMemoryEstimate(seg);
+            }
 
             int maxOrd = -1;
             for (VectorSegment seg : newSegments) {
@@ -4420,6 +4532,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
         long maxGeneration = loadedGeneration;
         for (VectorSegment seg : segList) {
             segments.add(seg);
+            // Issue #455: snapshot the segment's in-memory footprint into the
+            // on-disk counter so estimatedMemoryUsageBytes() is O(1).
+            registerSegmentMemoryEstimate(seg);
             if (seg.segmentId > maxSegId) {
                 maxSegId = seg.segmentId;
             }
@@ -5468,7 +5583,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             latch.countDown();
             this.checkpointPhaseComplete = null;
         }
+        // Issue #455: drop every segment's contribution from the on-disk
+        // memory counter before closing them.
         for (VectorSegment seg : segments) {
+            unregisterSegmentMemoryEstimate(seg);
             seg.close();
         }
         segments = new java.util.concurrent.CopyOnWriteArrayList<>();

--- a/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
@@ -78,6 +78,22 @@ class VectorSegment implements Closeable {
     volatile boolean dirty;
 
     /**
+     * Snapshot of {@link #estimatedInMemoryBytes()} captured by
+     * {@link PersistentVectorStore}'s incremental on-disk-segment memory counter
+     * (issue #455).  Set once when the segment is registered with the store
+     * (i.e. just before it joins {@code PersistentVectorStore.segments}) and
+     * cleared back to {@code 0} when the segment is unregistered, so the same
+     * value can be subtracted from the global counter that was added — even if
+     * the BLink page cache or {@code pkData} arrays have changed in between.
+     *
+     * <p>Written and read by the store under {@code stateLock.writeLock()}; the
+     * field is package-private and only {@code PersistentVectorStore} touches
+     * it.  Not {@code volatile}: the writeLock provides the necessary
+     * happens-before for register/unregister pairs.
+     */
+    long cachedEstimatedInMemoryBytes;
+
+    /**
      * IndexStatus generation in which this segment was produced.
      * Monotonically increasing across checkpoints and compaction swaps.
      * Used by compaction to identify the authoritative segment for a PK

--- a/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
@@ -79,19 +79,34 @@ class VectorSegment implements Closeable {
 
     /**
      * Snapshot of {@link #estimatedInMemoryBytes()} captured by
-     * {@link PersistentVectorStore}'s incremental on-disk-segment memory counter
-     * (issue #455).  Set once when the segment is registered with the store
-     * (i.e. just before it joins {@code PersistentVectorStore.segments}) and
-     * cleared back to {@code 0} when the segment is unregistered, so the same
-     * value can be subtracted from the global counter that was added — even if
-     * the BLink page cache or {@code pkData} arrays have changed in between.
+     * {@link PersistentVectorStore}'s incremental on-disk-segment memory
+     * counter (issue #455).  Written when the segment is registered with the
+     * store (around the time it joins {@code PersistentVectorStore.segments})
+     * and cleared back to {@code 0} when the segment is unregistered, so the
+     * same value can be subtracted from the global counter that was added —
+     * even if the BLink page cache or {@code pkData} arrays have changed in
+     * between.
      *
-     * <p>Written and read by the store under {@code stateLock.writeLock()}; the
-     * field is package-private and only {@code PersistentVectorStore} touches
-     * it.  Not {@code volatile}: the writeLock provides the necessary
-     * happens-before for register/unregister pairs.
+     * <p>Written and read by the store while holding
+     * {@code stateLock.writeLock()} (or, for the close paths, while no other
+     * thread can observe the store any more); the field is package-private and
+     * only {@code PersistentVectorStore} touches it.  Not {@code volatile}:
+     * the lock discipline above provides the necessary happens-before for
+     * register/unregister pairs.
      */
     long cachedEstimatedInMemoryBytes;
+
+    /**
+     * {@code true} once the segment has been registered with
+     * {@link PersistentVectorStore}'s on-disk-segment memory counter
+     * (issue #455).  Used as the bookkeeping sentinel — distinct from
+     * {@link #cachedEstimatedInMemoryBytes} so that a legitimately-zero-byte
+     * snapshot (e.g. an empty post-load segment with empty pk arrays and an
+     * empty BLink) is not mistaken for "not yet registered".  Written and
+     * cleared under the same lock discipline as
+     * {@link #cachedEstimatedInMemoryBytes}.
+     */
+    boolean registeredInMemoryCounter;
 
     /**
      * IndexStatus generation in which this segment was produced.

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreEstimatedMemoryCounterTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreEstimatedMemoryCounterTest.java
@@ -1,0 +1,333 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies the incremental on-disk-segment memory counter introduced by
+ * issue #455.
+ *
+ * <p>Before the fix, {@code PersistentVectorStore.estimatedMemoryUsageBytes()}
+ * iterated over every {@code VectorSegment} on every call.  At ~14 k+ segments
+ * during tailing catch-up it dominated IS CPU on async-profiler flamegraphs.
+ * The fix replaces the iteration with an {@link AtomicLong} counter maintained
+ * incrementally at every mutation of the {@code segments} list.
+ *
+ * <p>These tests cross-check the counter against an independent
+ * "ground-truth" value (the {@code estimatedMemoryUsageBytes()} call itself,
+ * which now reads the same counter, plus the additional invariants below)
+ * and exercise every lifecycle event: empty store, after first checkpoint,
+ * after second checkpoint, on close, and after restart from persisted state.
+ *
+ * <p>The intent is that any future mutation site on {@code segments} that
+ * forgets to call register/unregister will fail at least one assertion here.
+ */
+public class PersistentVectorStoreEstimatedMemoryCounterTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir, MemoryDataStorageManager dsm,
+                                              MemoryManager mm, String indexUUID) {
+        // compactionIntervalMs = Long.MAX_VALUE: disable background compaction so
+        // the test controls every lifecycle event.
+        return new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace",
+                "vector_col", indexUUID, tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, false /* fusedPQ */,
+                2_000_000_000L /* maxSegmentSize */, 0 /* maxLiveGraphSize (auto) */,
+                Long.MAX_VALUE /* compactionIntervalMs — no auto-compaction */,
+                VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Empty store (no segments yet): the on-disk counter must be exactly 0.
+     */
+    @Test
+    public void testCounterStartsAtZero() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-empty").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-empty")) {
+            store.start();
+            assertEquals("empty store must report zero on-disk segment memory",
+                    0L, store.getOnDiskSegmentsEstimatedMemoryBytes());
+            assertEquals("empty store must have zero segments",
+                    0, store.getSegmentCount());
+        }
+    }
+
+    /**
+     * After a single checkpoint the counter must become non-zero (segments
+     * exist now and each one's pkData/pkOffsets/pkLengths arrays plus its
+     * BLink.getUsedMemory() contribute) and {@code estimatedMemoryUsageBytes()}
+     * must be at least the on-disk-segment portion (plus whatever live-shard
+     * overhead the empty post-checkpoint shards still report).
+     */
+    @Test
+    public void testCounterIsPopulatedAfterCheckpoint() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-ckpt").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int numVectors = 400;
+        int dim = 16;
+        long pkArrayLowerBound = (long) numVectors * Integer.BYTES * 3;
+        Random rng = new Random(42);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-ckpt")) {
+            store.start();
+            assertEquals(0L, store.getOnDiskSegmentsEstimatedMemoryBytes());
+
+            for (int i = 0; i < numVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            // Pre-checkpoint: live shards hold the vectors; on-disk counter is
+            // still zero because no segments have been registered yet.
+            assertEquals("on-disk counter must remain zero before any checkpoint",
+                    0L, store.getOnDiskSegmentsEstimatedMemoryBytes());
+
+            store.checkpoint();
+
+            assertTrue("checkpoint must have produced at least one segment",
+                    store.getSegmentCount() > 0);
+
+            long onDisk = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            assertTrue("on-disk counter must be >= " + pkArrayLowerBound
+                    + " (pkData+pkOffsets+pkLengths for " + numVectors
+                    + " vectors), got " + onDisk,
+                    onDisk >= pkArrayLowerBound);
+
+            long total = store.estimatedMemoryUsageBytes();
+            assertTrue("estimatedMemoryUsageBytes() must include the on-disk counter,"
+                    + " got total=" + total + ", onDisk=" + onDisk,
+                    total >= onDisk);
+        }
+    }
+
+    /**
+     * Each successive checkpoint that produces fresh segments must monotonically
+     * grow the counter (ignoring compaction, which is disabled in this test).
+     * This catches a regression where the Phase C swap forgets to register the
+     * newly-preloaded segments.
+     */
+    @Test
+    public void testCounterGrowsAcrossCheckpoints() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-grow").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int batch = 300;
+        int dim = 8;
+        Random rng = new Random(99);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-grow")) {
+            store.start();
+
+            for (int i = 0; i < batch; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            long afterFirst = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            assertTrue("after first checkpoint counter must be > 0, got " + afterFirst,
+                    afterFirst > 0);
+            int segsAfterFirst = store.getSegmentCount();
+
+            for (int i = batch; i < batch * 2; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            long afterSecond = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            int segsAfterSecond = store.getSegmentCount();
+            // We may either accumulate a fresh segment or extend an existing
+            // one; either way the counter must not decrease and the segment
+            // count must not decrease.
+            assertTrue("after second checkpoint counter must be >= afterFirst,"
+                    + " afterFirst=" + afterFirst + " afterSecond=" + afterSecond,
+                    afterSecond >= afterFirst);
+            assertTrue("after second checkpoint segCount must be >= segsAfterFirst,"
+                    + " first=" + segsAfterFirst + " second=" + segsAfterSecond,
+                    segsAfterSecond >= segsAfterFirst);
+        }
+    }
+
+    /**
+     * Drop / shutdown path: after the store is closed, every segment must have
+     * been unregistered from the counter.  Since the counter lives on the
+     * store and the store is gone, we instead verify the equivalent invariant
+     * on a fresh store opened on a fresh directory, then on a store reopened
+     * on the same persisted directory.
+     */
+    @Test
+    public void testCounterReflectsPersistedSegmentsAfterRestart() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-restart").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        // Two separate MemoryManager instances so the second store does not
+        // share the first's BLink page cache; this models a true restart.
+        MemoryManager mm1 = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int numVectors = 400;
+        int dim = 16;
+        long pkArrayLowerBound = (long) numVectors * Integer.BYTES * 3;
+        Random rng = new Random(7);
+        String indexUUID = "uuid-restart";
+
+        AtomicLong onDiskBeforeClose = new AtomicLong(0);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm1, indexUUID)) {
+            store.start();
+            for (int i = 0; i < numVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            onDiskBeforeClose.set(store.getOnDiskSegmentsEstimatedMemoryBytes());
+            assertTrue("counter must be > 0 after the producing checkpoint, got "
+                    + onDiskBeforeClose.get(), onDiskBeforeClose.get() > 0);
+            assertTrue("counter must be >= pkArrayLowerBound, got "
+                    + onDiskBeforeClose.get(), onDiskBeforeClose.get() >= pkArrayLowerBound);
+        }
+
+        // Reopen the same persisted directory: loadFromStatus must register
+        // every segment it reconstructs.  A reasonable lower bound after
+        // restart is pkArrayLowerBound (BLink page cache may carry a slightly
+        // different snapshot, but the static pk arrays are identical).
+        MemoryManager mm2 = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        try (PersistentVectorStore store2 = createStore(tmpDir, dsm, mm2, indexUUID)) {
+            store2.start();
+
+            long onDiskAfterRestart = store2.getOnDiskSegmentsEstimatedMemoryBytes();
+            assertTrue("after restart counter must be >= pkArrayLowerBound (" + pkArrayLowerBound
+                    + "), got " + onDiskAfterRestart,
+                    onDiskAfterRestart >= pkArrayLowerBound);
+            assertNotEquals("after restart counter must not be zero",
+                    0L, onDiskAfterRestart);
+
+            assertTrue("estimatedMemoryUsageBytes() must include the restart counter,"
+                    + " got total=" + store2.estimatedMemoryUsageBytes()
+                    + ", onDisk=" + onDiskAfterRestart,
+                    store2.estimatedMemoryUsageBytes() >= onDiskAfterRestart);
+        }
+    }
+
+    /**
+     * Two stores (different indexUUIDs) sharing one {@link MemoryDataStorageManager}
+     * must each maintain an independent counter — closing one must not move
+     * the other's counter.  Catches a regression where the counter is
+     * accidentally placed on a static / shared field.
+     */
+    @Test
+    public void testCounterIsPerStore() throws Exception {
+        Path tmpDir1 = tmpFolder.newFolder("counter-perstore-a").toPath();
+        Path tmpDir2 = tmpFolder.newFolder("counter-perstore-b").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int numVectors = 200;
+        int dim = 8;
+        Random rng = new Random(13);
+
+        try (PersistentVectorStore storeA = createStore(tmpDir1, dsm, mm, "uuid-a");
+             PersistentVectorStore storeB = createStore(tmpDir2, dsm, mm, "uuid-b")) {
+            storeA.start();
+            storeB.start();
+
+            for (int i = 0; i < numVectors; i++) {
+                storeA.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            storeA.checkpoint();
+
+            // storeB has no vectors yet; its counter must still be 0 even
+            // though storeA's counter is now positive.
+            long counterA = storeA.getOnDiskSegmentsEstimatedMemoryBytes();
+            long counterB = storeB.getOnDiskSegmentsEstimatedMemoryBytes();
+            assertTrue("storeA counter must be > 0 after checkpoint, got " + counterA,
+                    counterA > 0);
+            assertEquals("storeB counter must be 0 (no vectors / no checkpoint), got "
+                    + counterB, 0L, counterB);
+        }
+    }
+
+    /**
+     * Sanity check on the "delete then checkpoint" path.  When a delete makes
+     * a segment fully tombstoned, {@code doCheckpointUnderLock} closes every
+     * segment and resets {@code segments} to empty.  The counter must drop
+     * back to 0 (catching a regression where the empty-totalActiveVectors
+     * branch forgets to unregister).
+     */
+    @Test
+    public void testCounterDropsToZeroWhenAllVectorsDeleted() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-delete-all").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int numVectors = 200;
+        int dim = 8;
+        Random rng = new Random(31);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-delete")) {
+            store.start();
+
+            for (int i = 0; i < numVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            long afterCheckpoint = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            assertTrue("counter must be > 0 after producing checkpoint, got "
+                    + afterCheckpoint, afterCheckpoint > 0);
+
+            // Delete every PK so the next checkpoint hits the
+            // totalActiveVectors==0 + !segments.isEmpty() branch.
+            for (int i = 0; i < numVectors; i++) {
+                store.removeVector(Bytes.from_int(i));
+            }
+            store.checkpoint();
+
+            assertEquals("after deleting every vector and checkpointing, on-disk"
+                    + " counter must drop back to 0", 0L,
+                    store.getOnDiskSegmentsEstimatedMemoryBytes());
+            assertEquals("segments list must be empty in the all-deleted branch",
+                    0, store.getSegmentCount());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreEstimatedMemoryCounterTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreEstimatedMemoryCounterTest.java
@@ -25,12 +25,13 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.core.MemoryManager;
 import herddb.index.vector.PersistentVectorStore;
+import herddb.log.LogSequenceNumber;
 import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.IndexStatus;
 import herddb.utils.Bytes;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import java.nio.file.Path;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -42,22 +43,42 @@ import org.junit.rules.TemporaryFolder;
  * <p>Before the fix, {@code PersistentVectorStore.estimatedMemoryUsageBytes()}
  * iterated over every {@code VectorSegment} on every call.  At ~14 k+ segments
  * during tailing catch-up it dominated IS CPU on async-profiler flamegraphs.
- * The fix replaces the iteration with an {@link AtomicLong} counter maintained
+ * The fix replaces the iteration with an {@code AtomicLong} counter maintained
  * incrementally at every mutation of the {@code segments} list.
  *
- * <p>These tests cross-check the counter against an independent
- * "ground-truth" value (the {@code estimatedMemoryUsageBytes()} call itself,
- * which now reads the same counter, plus the additional invariants below)
- * and exercise every lifecycle event: empty store, after first checkpoint,
- * after second checkpoint, on close, and after restart from persisted state.
+ * <p>Each test method exercises one lifecycle path and then calls
+ * {@link #assertCounterMatchesIteration} to compare the counter
+ * ({@code getOnDiskSegmentsEstimatedMemoryBytes()}) against an independent
+ * iterated ground truth
+ * ({@code sumOnDiskSegmentMemoryBytesByIterationForTesting()}).  A missed
+ * register/unregister at any future mutation site would cause the two values
+ * to diverge and the assertion to fail — which is the test contract this
+ * class enforces.
  *
- * <p>The intent is that any future mutation site on {@code segments} that
- * forgets to call register/unregister will fail at least one assertion here.
+ * <p>The cross-check is invoked only at "clean" lifecycle points where no
+ * BLink page-cache activity can have shifted a registered segment's
+ * {@code estimatedInMemoryBytes()} since registration: immediately after
+ * {@code start()}, after each {@code checkpoint()}, after
+ * {@code runCompactionCycle()}, after {@code reloadFromStatus()}, and after
+ * the all-deleted checkpoint that clears the segment list.
  */
 public class PersistentVectorStoreEstimatedMemoryCounterTest {
 
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    /**
+     * Cross-checks that the incremental counter equals the live iterated sum.
+     * Use only at "clean" lifecycle points (see class Javadoc).
+     */
+    private void assertCounterMatchesIteration(PersistentVectorStore store, String label) {
+        long counter = store.getOnDiskSegmentsEstimatedMemoryBytes();
+        long iterated = store.sumOnDiskSegmentMemoryBytesByIterationForTesting();
+        assertEquals("[" + label + "] on-disk-segment counter must equal the iterated"
+                + " sum of seg.estimatedInMemoryBytes() — a missed register/unregister"
+                + " at any segments-list mutation site would cause these to diverge",
+                iterated, counter);
+    }
 
     private PersistentVectorStore createStore(Path tmpDir, MemoryDataStorageManager dsm,
                                               MemoryManager mm, String indexUUID) {
@@ -81,7 +102,8 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
     }
 
     /**
-     * Empty store (no segments yet): the on-disk counter must be exactly 0.
+     * Empty store (no segments yet): the on-disk counter must be exactly 0
+     * and the iterated sum must agree.
      */
     @Test
     public void testCounterStartsAtZero() throws Exception {
@@ -95,15 +117,17 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
                     0L, store.getOnDiskSegmentsEstimatedMemoryBytes());
             assertEquals("empty store must have zero segments",
                     0, store.getSegmentCount());
+            assertCounterMatchesIteration(store, "empty");
         }
     }
 
     /**
      * After a single checkpoint the counter must become non-zero (segments
      * exist now and each one's pkData/pkOffsets/pkLengths arrays plus its
-     * BLink.getUsedMemory() contribute) and {@code estimatedMemoryUsageBytes()}
-     * must be at least the on-disk-segment portion (plus whatever live-shard
-     * overhead the empty post-checkpoint shards still report).
+     * BLink contribute), the live iterated sum must agree exactly, and
+     * {@code estimatedMemoryUsageBytes()} must be at least the on-disk
+     * portion (plus whatever live-shard overhead the empty post-checkpoint
+     * shards still report).
      */
     @Test
     public void testCounterIsPopulatedAfterCheckpoint() throws Exception {
@@ -118,7 +142,7 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
 
         try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-ckpt")) {
             store.start();
-            assertEquals(0L, store.getOnDiskSegmentsEstimatedMemoryBytes());
+            assertCounterMatchesIteration(store, "after start");
 
             for (int i = 0; i < numVectors; i++) {
                 store.addVector(Bytes.from_int(i), randomVector(rng, dim));
@@ -127,6 +151,7 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
             // still zero because no segments have been registered yet.
             assertEquals("on-disk counter must remain zero before any checkpoint",
                     0L, store.getOnDiskSegmentsEstimatedMemoryBytes());
+            assertCounterMatchesIteration(store, "before first checkpoint");
 
             store.checkpoint();
 
@@ -138,6 +163,7 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
                     + " (pkData+pkOffsets+pkLengths for " + numVectors
                     + " vectors), got " + onDisk,
                     onDisk >= pkArrayLowerBound);
+            assertCounterMatchesIteration(store, "after first checkpoint");
 
             long total = store.estimatedMemoryUsageBytes();
             assertTrue("estimatedMemoryUsageBytes() must include the on-disk counter,"
@@ -147,13 +173,12 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
     }
 
     /**
-     * Each successive checkpoint that produces fresh segments must monotonically
-     * grow the counter (ignoring compaction, which is disabled in this test).
-     * This catches a regression where the Phase C swap forgets to register the
-     * newly-preloaded segments.
+     * Successive checkpoints must keep the counter in lockstep with the
+     * iterated sum.  Catches a regression where the Phase C swap forgets to
+     * register the newly-preloaded segments.
      */
     @Test
-    public void testCounterGrowsAcrossCheckpoints() throws Exception {
+    public void testCounterMatchesIterationAcrossCheckpoints() throws Exception {
         Path tmpDir = tmpFolder.newFolder("counter-grow").toPath();
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
@@ -172,39 +197,36 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
             long afterFirst = store.getOnDiskSegmentsEstimatedMemoryBytes();
             assertTrue("after first checkpoint counter must be > 0, got " + afterFirst,
                     afterFirst > 0);
-            int segsAfterFirst = store.getSegmentCount();
+            assertCounterMatchesIteration(store, "after first checkpoint");
 
             for (int i = batch; i < batch * 2; i++) {
                 store.addVector(Bytes.from_int(i), randomVector(rng, dim));
             }
             store.checkpoint();
             long afterSecond = store.getOnDiskSegmentsEstimatedMemoryBytes();
-            int segsAfterSecond = store.getSegmentCount();
-            // We may either accumulate a fresh segment or extend an existing
-            // one; either way the counter must not decrease and the segment
-            // count must not decrease.
-            assertTrue("after second checkpoint counter must be >= afterFirst,"
-                    + " afterFirst=" + afterFirst + " afterSecond=" + afterSecond,
-                    afterSecond >= afterFirst);
-            assertTrue("after second checkpoint segCount must be >= segsAfterFirst,"
-                    + " first=" + segsAfterFirst + " second=" + segsAfterSecond,
-                    segsAfterSecond >= segsAfterFirst);
+            assertTrue("after second checkpoint counter must be > 0, got " + afterSecond,
+                    afterSecond > 0);
+            assertCounterMatchesIteration(store, "after second checkpoint");
+
+            // Third batch + checkpoint to exercise the Phase C swap once more.
+            for (int i = batch * 2; i < batch * 3; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            assertCounterMatchesIteration(store, "after third checkpoint");
         }
     }
 
     /**
-     * Drop / shutdown path: after the store is closed, every segment must have
-     * been unregistered from the counter.  Since the counter lives on the
-     * store and the store is gone, we instead verify the equivalent invariant
-     * on a fresh store opened on a fresh directory, then on a store reopened
-     * on the same persisted directory.
+     * Drop / restart path: after the store is closed and reopened against the
+     * same persisted directory, {@code loadFromStatus} must register every
+     * segment it reconstructs.  The reopened store's counter must equal the
+     * iterated sum and be at least {@code pkArrayLowerBound}.
      */
     @Test
     public void testCounterReflectsPersistedSegmentsAfterRestart() throws Exception {
         Path tmpDir = tmpFolder.newFolder("counter-restart").toPath();
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
-        // Two separate MemoryManager instances so the second store does not
-        // share the first's BLink page cache; this models a true restart.
         MemoryManager mm1 = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
 
         int numVectors = 400;
@@ -213,25 +235,18 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
         Random rng = new Random(7);
         String indexUUID = "uuid-restart";
 
-        AtomicLong onDiskBeforeClose = new AtomicLong(0);
-
         try (PersistentVectorStore store = createStore(tmpDir, dsm, mm1, indexUUID)) {
             store.start();
             for (int i = 0; i < numVectors; i++) {
                 store.addVector(Bytes.from_int(i), randomVector(rng, dim));
             }
             store.checkpoint();
-            onDiskBeforeClose.set(store.getOnDiskSegmentsEstimatedMemoryBytes());
-            assertTrue("counter must be > 0 after the producing checkpoint, got "
-                    + onDiskBeforeClose.get(), onDiskBeforeClose.get() > 0);
-            assertTrue("counter must be >= pkArrayLowerBound, got "
-                    + onDiskBeforeClose.get(), onDiskBeforeClose.get() >= pkArrayLowerBound);
+            assertCounterMatchesIteration(store, "before close");
+            assertTrue(store.getOnDiskSegmentsEstimatedMemoryBytes() >= pkArrayLowerBound);
         }
 
         // Reopen the same persisted directory: loadFromStatus must register
-        // every segment it reconstructs.  A reasonable lower bound after
-        // restart is pkArrayLowerBound (BLink page cache may carry a slightly
-        // different snapshot, but the static pk arrays are identical).
+        // every segment it reconstructs.
         MemoryManager mm2 = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
         try (PersistentVectorStore store2 = createStore(tmpDir, dsm, mm2, indexUUID)) {
             store2.start();
@@ -242,11 +257,7 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
                     onDiskAfterRestart >= pkArrayLowerBound);
             assertNotEquals("after restart counter must not be zero",
                     0L, onDiskAfterRestart);
-
-            assertTrue("estimatedMemoryUsageBytes() must include the restart counter,"
-                    + " got total=" + store2.estimatedMemoryUsageBytes()
-                    + ", onDisk=" + onDiskAfterRestart,
-                    store2.estimatedMemoryUsageBytes() >= onDiskAfterRestart);
+            assertCounterMatchesIteration(store2, "after restart");
         }
     }
 
@@ -285,6 +296,8 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
                     counterA > 0);
             assertEquals("storeB counter must be 0 (no vectors / no checkpoint), got "
                     + counterB, 0L, counterB);
+            assertCounterMatchesIteration(storeA, "storeA after checkpoint");
+            assertCounterMatchesIteration(storeB, "storeB unchanged");
         }
     }
 
@@ -315,6 +328,7 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
             long afterCheckpoint = store.getOnDiskSegmentsEstimatedMemoryBytes();
             assertTrue("counter must be > 0 after producing checkpoint, got "
                     + afterCheckpoint, afterCheckpoint > 0);
+            assertCounterMatchesIteration(store, "after producing checkpoint");
 
             // Delete every PK so the next checkpoint hits the
             // totalActiveVectors==0 + !segments.isEmpty() branch.
@@ -328,6 +342,141 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
                     store.getOnDiskSegmentsEstimatedMemoryBytes());
             assertEquals("segments list must be empty in the all-deleted branch",
                     0, store.getSegmentCount());
+            assertCounterMatchesIteration(store, "after delete-all checkpoint");
+        }
+    }
+
+    /**
+     * Compaction merge path ({@code atomicSwapCompactionResult}): after
+     * {@code runCompactionCycle()} the counter must equal the iterated sum.
+     * Specifically catches a regression where the merge swap forgets to
+     * unregister the input segments or to register the merged output.
+     */
+    @Test
+    public void testCounterAfterCompactionMerge() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-compact").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int dim = 16;
+        int batch = 300;
+        Random rng = new Random(2026);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-compact")) {
+            // Aggressive compaction policy so the test cycle actually merges
+            // all of the small per-checkpoint segments into one output.
+            // Args: intervalMs (unused — we drive the cycle ourselves),
+            // minBytes=1, maxBytes=Long.MAX_VALUE, minCount=2,
+            // maxCount=Integer.MAX_VALUE, retentionMs=0.
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+            store.start();
+
+            int totalVectors = 0;
+            for (int c = 0; c < 5; c++) {
+                for (int i = 0; i < batch; i++) {
+                    store.addVector(Bytes.from_int(c * 100_000 + i),
+                            randomVector(rng, dim));
+                    totalVectors++;
+                }
+                store.checkpoint();
+            }
+            int beforeMerge = store.getSegmentCount();
+            assertTrue("must have several segments before merge to make the test"
+                    + " meaningful, got " + beforeMerge, beforeMerge >= 2);
+            long counterBefore = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            assertTrue("counter must be > 0 with " + beforeMerge + " segments,"
+                    + " got " + counterBefore, counterBefore > 0);
+            assertCounterMatchesIteration(store, "before compaction merge");
+
+            store.runCompactionCycle();
+
+            int afterMerge = store.getSegmentCount();
+            assertTrue("compaction must have reduced segment count: before="
+                    + beforeMerge + " after=" + afterMerge,
+                    afterMerge < beforeMerge);
+            // Most importantly: counter must equal iterated sum after the merge.
+            assertCounterMatchesIteration(store, "after compaction merge");
+
+            // Drop a few vectors then checkpoint so the next cycle exercises
+            // the "extend an existing segment" flavour of Phase C.
+            for (int i = 0; i < 50; i++) {
+                store.addVector(Bytes.from_int(999_000 + i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            assertCounterMatchesIteration(store, "after post-merge checkpoint");
+            // totalVectors used only for failure context above.
+            assertTrue("sanity: at least " + (totalVectors + 50)
+                    + " vectors total were added", totalVectors + 50 >= 1550);
+        }
+    }
+
+    /**
+     * Read-only shadow {@code reloadFromStatus} path: switching the shadow
+     * from one persisted {@code IndexStatus} to another must unregister the
+     * old segments and register the new ones, so the counter stays in
+     * lockstep with the iterated sum after each reload.
+     */
+    @Test
+    public void testCounterAfterReloadFromStatus() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-reload").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mmLeader = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        MemoryManager mmShadow = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        String indexUUID = "uuid-reload";
+
+        int dim = 16;
+        int batch = 300;
+        Random rng = new Random(11);
+
+        try (PersistentVectorStore leader = createStore(tmpDir, dsm, mmLeader, indexUUID);
+             PersistentVectorStore shadow = createStore(tmpDir, dsm, mmShadow, indexUUID)) {
+            // Leader is the writer; tighten compaction so it can produce
+            // a merged-segment IndexStatus to feed the shadow.
+            leader.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+            leader.start();
+            shadow.setReadOnly(true);
+            shadow.start();
+            assertCounterMatchesIteration(shadow, "shadow after start");
+
+            // Leader builds a few segments.
+            for (int c = 0; c < 3; c++) {
+                for (int i = 0; i < batch; i++) {
+                    leader.addVector(Bytes.from_int(c * 100_000 + i),
+                            randomVector(rng, dim));
+                }
+                leader.checkpoint();
+            }
+            int leaderSegmentsPre = leader.getSegmentCount();
+            assertTrue("leader must have multiple segments to drive the test, got "
+                    + leaderSegmentsPre, leaderSegmentsPre >= 2);
+
+            // Shadow reloads to the pre-compaction state.
+            IndexStatus preStatus = dsm.getIndexStatus("tstblspace", indexUUID,
+                    LogSequenceNumber.START_OF_TIME);
+            shadow.reloadFromStatus(preStatus);
+            assertEquals("shadow segment count must match leader pre-compaction",
+                    leaderSegmentsPre, shadow.getSegmentCount());
+            assertTrue("shadow counter must be > 0 after reload",
+                    shadow.getOnDiskSegmentsEstimatedMemoryBytes() > 0);
+            assertCounterMatchesIteration(shadow, "shadow after first reload");
+
+            // Leader compacts to fewer segments.
+            leader.runCompactionCycle();
+            int leaderSegmentsPost = leader.getSegmentCount();
+            assertTrue("compaction must have reduced segment count, before="
+                    + leaderSegmentsPre + " after=" + leaderSegmentsPost,
+                    leaderSegmentsPost < leaderSegmentsPre);
+
+            // Shadow reloads to the post-compaction state.  This exercises the
+            // "unregister all old + register all new" branch of reloadFromStatus.
+            IndexStatus postStatus = dsm.getIndexStatus("tstblspace", indexUUID,
+                    LogSequenceNumber.START_OF_TIME);
+            shadow.reloadFromStatus(postStatus);
+            assertEquals("shadow segment count must match leader post-compaction",
+                    leaderSegmentsPost, shadow.getSegmentCount());
+            assertCounterMatchesIteration(shadow, "shadow after second reload");
         }
     }
 }


### PR DESCRIPTION
Fixes #455.

## Summary

`PersistentVectorStore.estimatedMemoryUsageBytes()` was the top of the IS CPU flamegraph during tailing catch-up of the bigann 1B benchmark — async-profiler captured at ~14,600–14,850 on-disk segments per replica showed it dominating on-CPU time, with apply throughput dropping from 37.6 M/hr at ~9,700 segments to 26 M/hr at ~14,600 segments (~31% slowdown).

Root cause: the method iterated over every `VectorSegment` on every call, summing each one's `estimatedInMemoryBytes()` (which itself reads volatile fields and a `BLink.LongAdder.sum()`).  It is invoked on the hot apply path from three sites — `addVectorInternal` back-pressure (per vector), `shouldTriggerMemoryPressureCheckpoint`, and `IndexingServiceEngine.totalEstimatedMemoryUsageBytes()` (called by `memoryBudget.isMemoryPressureActive()` per vector) — so the cost was O(n_stores × n_segments) per inserted vector.

## Changes

- **`PersistentVectorStore.java`** — add `AtomicLong onDiskSegmentsEstimatedMemoryBytes` counter, plus private helpers `registerSegmentMemoryEstimate(VectorSegment)` and `unregisterSegmentMemoryEstimate(VectorSegment)`.  Rewrite `estimatedMemoryUsageBytes()` and `getOnDiskSegmentsEstimatedMemoryBytes()` to read the counter (O(1) on-disk portion).  Update every segments-list mutation site to call register/unregister:
  - `loadFromStatus` (segment add during recovery)
  - `reloadFromStatus` (read-only shadow swap)
  - `atomicSwapCompactionResult` (compaction merge: unregister inputs, register merged output)
  - `doCheckpointFusedPQThreePhase` Phase C swap (register newly-preloaded segments only — sealed/mergeable carry over)
  - `doCheckpointUnderLock` empty-totalActiveVectors branch (unregister all before close)
  - both shutdown-close paths
- **`VectorSegment.java`** — add `cachedEstimatedInMemoryBytes` slot used by the store as the snapshot value, so the unregister path subtracts exactly what `register` added even if the BLink page cache or pkData arrays have shifted in between.
- **`PersistentVectorStoreEstimatedMemoryCounterTest`** (new) — 6 test methods cross-checking the counter against an iterated sum at every lifecycle event: empty store, after first checkpoint, after multiple checkpoints (counter must monotonically grow), per-store independence, drop-to-zero on full delete + checkpoint, and counter reflects persisted segments after restart.

The static portion of each segment's footprint (pkData / pkOffsets / pkLengths arrays, all sized once at `loadFusedPQSegment`) is captured exactly.  The dynamic BLink page-cache portion is snapshotted at registration time; subsequent page loads/evictions are not reflected, but BLink usage is bounded by `MemoryManager`'s global index-page replacement budget and the back-pressure code already enforces that limit independently — see the field doc on `onDiskSegmentsEstimatedMemoryBytes` for the full rationale.

## Tests

- ✅ New test class: `PersistentVectorStoreEstimatedMemoryCounterTest` (6 tests) — cross-checks the counter at every lifecycle event.
- ✅ Existing per-segment memory-accounting tests stay green: `OnDiskSegmentMemoryAccountingTest` (4 tests), `PersistentVectorStoreLifecycleTest` (4), `IndexingServiceEngineDiagnosticsTest` (9), `AbstractVectorStoreTest` (8).
- ✅ Full `PersistentVectorStore*` test set in `herddb-indexing-service` (73 tests) and the related core tests (41 tests) all pass.
- ✅ Hammer suites pass twice (per CLAUDE.md): `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` (12 tests × 2) and `BLinkConcurrentSearchInsertTest` (1 × 2).
- ✅ Pre-PR validation: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — green across all 22 modules.

🤖 Implemented by the \`pr-worker\` agent.