### PR TITLE
issue #459: per-operation-type tailer metrics + Grafana panels

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperCommitLogTailer.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperCommitLogTailer.java
@@ -52,6 +52,7 @@ public class BookKeeperCommitLogTailer implements CommitLogTailing {
     private volatile LogSequenceNumber watermark;
     private volatile boolean running = true;
     private long entriesProcessed;
+    private long batchesProcessed;
     private int consecutiveErrors;
 
     private ZookeeperMetadataStorageManager metadataManager;
@@ -118,6 +119,7 @@ public class BookKeeperCommitLogTailer implements CommitLogTailing {
                 consecutiveErrors = 0;
                 while (running) {
                     try {
+                        long entriesBefore = entriesProcessed;
                         commitLog.followTheLeader(watermark, (lsn, entry) -> {
                             if (!running) {
                                 return false;
@@ -127,6 +129,13 @@ public class BookKeeperCommitLogTailer implements CommitLogTailing {
                             entriesProcessed++;
                             return running;
                         }, context);
+                        // One follow cycle that produced at least one entry
+                        // counts as one read batch (issue #459). Surfaced via
+                        // getBatchesProcessed() so engine-stats / Prometheus
+                        // can spot pathological "many tiny batches" patterns.
+                        if (entriesProcessed > entriesBefore) {
+                            batchesProcessed++;
+                        }
                         consecutiveErrors = 0;
                     } catch (LogNotAvailableException e) {
                         if (!running) {
@@ -280,6 +289,11 @@ public class BookKeeperCommitLogTailer implements CommitLogTailing {
     @Override
     public long getEntriesProcessed() {
         return entriesProcessed;
+    }
+
+    @Override
+    public long getBatchesProcessed() {
+        return batchesProcessed;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/log/CommitLogTailing.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLogTailing.java
@@ -47,11 +47,27 @@ public interface CommitLogTailing extends Runnable, AutoCloseable {
 
     /**
      * Returns the total number of "read batches" the tailer has completed
-     * since it was created, where a batch is one underlying poll/follow cycle
-     * that processed at least one entry. A consumer can correlate this with
-     * {@link #getEntriesProcessed()} to spot pathological "many small batches"
-     * vs "few large batches" patterns. Defaults to {@code 0} so legacy
-     * implementations that do not track batches stay source-compatible.
+     * since it was created, where a batch is one underlying poll/follow
+     * cycle that <em>completed normally</em> after processing at least one
+     * entry. A consumer can correlate this with {@link #getEntriesProcessed()}
+     * to spot pathological "many small batches" vs "few large batches"
+     * patterns. Defaults to {@code 0} so legacy implementations that do
+     * not track batches stay source-compatible.
+     *
+     * <p><b>Caveat:</b> only completed cycles count. A poll/follow cycle
+     * that drained some entries and then threw (e.g.
+     * {@code LogNotAvailableException} from a transient BookKeeper hiccup
+     * inside {@code followTheLeader}, or an I/O error on a {@code .txlog}
+     * read) is <em>not</em> counted as a batch even though
+     * {@link #getEntriesProcessed()} already reflects the entries that
+     * landed before the throw. As a consequence,
+     * {@code entries_processed / batches_processed} is an
+     * <em>approximation</em> of the average batch size and may overshoot
+     * when the tailer is hitting transient errors. The reads themselves
+     * are also eventually-consistent across threads (the underlying
+     * counter is a plain non-volatile long updated only on the tailer
+     * thread), so a remote scrape may briefly observe a value lagging by
+     * one increment.
      */
     default long getBatchesProcessed() {
         return 0L;

--- a/herddb-core/src/main/java/herddb/log/CommitLogTailing.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLogTailing.java
@@ -46,6 +46,18 @@ public interface CommitLogTailing extends Runnable, AutoCloseable {
     long getEntriesProcessed();
 
     /**
+     * Returns the total number of "read batches" the tailer has completed
+     * since it was created, where a batch is one underlying poll/follow cycle
+     * that processed at least one entry. A consumer can correlate this with
+     * {@link #getEntriesProcessed()} to spot pathological "many small batches"
+     * vs "few large batches" patterns. Defaults to {@code 0} so legacy
+     * implementations that do not track batches stay source-compatible.
+     */
+    default long getBatchesProcessed() {
+        return 0L;
+    }
+
+    /**
      * Returns whether the tailer is currently running.
      */
     boolean isRunning();

--- a/herddb-indexing-service/src/main/java/herddb/indexing/FileCommitLogTailer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/FileCommitLogTailer.java
@@ -61,6 +61,7 @@ public class FileCommitLogTailer implements CommitLogTailing {
     private CommitFileReader activeReader;
     private Path activeReaderPath;
     private long entriesProcessed;
+    private long batchesProcessed;
 
     public FileCommitLogTailer(Path logDirectory, String tableSpaceUUID, LogSequenceNumber startFrom, EntryConsumer consumer) {
         this.logDirectory = logDirectory;
@@ -81,6 +82,12 @@ public class FileCommitLogTailer implements CommitLogTailing {
                 boolean processedAny = scanAndProcess();
                 long entriesThisPoll = entriesProcessed - entriesBefore;
                 if (processedAny) {
+                    // One poll cycle that produced at least one entry counts
+                    // as one read batch (issue #459). Surfaced via
+                    // getBatchesProcessed() and used by Prometheus / engine-stats
+                    // to distinguish "many tiny batches" (high per-cycle
+                    // overhead) from "few large batches" (efficient catch-up).
+                    batchesProcessed++;
                     totalEntriesProcessed += entriesThisPoll;
                     LOGGER.info("Poll #" + pollCount + ": processed " + entriesThisPoll
                             + " entries (total=" + totalEntriesProcessed + "), watermark=" + watermark);
@@ -285,6 +292,11 @@ public class FileCommitLogTailer implements CommitLogTailing {
     @Override
     public long getEntriesProcessed() {
         return entriesProcessed;
+    }
+
+    @Override
+    public long getBatchesProcessed() {
+        return batchesProcessed;
     }
 
     @Override

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1209,6 +1209,17 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
     }
 
+    /**
+     * Replays the buffered entries of a transaction whose
+     * {@code COMMITTRANSACTION} we just observed.
+     *
+     * <p>Issue #459: each buffered entry was already classified by
+     * {@link #classifyForMetrics(LogEntry)} when it first arrived from the
+     * tailer (back when {@code processEntry()} placed it in the
+     * {@link TransactionBuffer}); replaying through {@code applySingleEntry}
+     * here MUST NOT re-classify, otherwise every transactional INSERT/UPDATE/
+     * DELETE would silently double-count.
+     */
     private void applyBufferedEntries(List<TransactionBuffer.BufferedLogEntry> entries) {
         for (TransactionBuffer.BufferedLogEntry be : entries) {
             applySingleEntry(be.getLsn(), be.getEntry());

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -67,6 +67,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -189,6 +190,45 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      */
     private volatile long lastDurableEntryTimestamp;
     private long entriesSinceLastCheckpoint;
+
+    /**
+     * Per-operation-type counters for the commit-log tailer (issue #459).
+     * Together with the existing {@code tailer.entries_processed} gauge, these
+     * let dashboards and supervision agents distinguish "the tailer is busy
+     * applying real vector writes" from "the tailer is mostly skipping
+     * non-vector traffic" or "the tailer is catching up on DDL". All counters
+     * are monotonically increasing since JVM start; rate is derived by
+     * Prometheus / consumers.
+     *
+     * <p>Counters are written from a single thread (the tailer thread) inside
+     * {@link #processEntry(LogSequenceNumber, LogEntry)} but read from
+     * arbitrary threads via the Prometheus gauge samples and gRPC handlers.
+     * {@link LongAdder} gives lock-free striped writes and a consistent
+     * (eventually-consistent) read.
+     *
+     * <p>Classification:
+     * <ul>
+     *   <li>INSERT/UPDATE/DELETE → bumps the matching per-op counter and
+     *       {@link #tailerEntriesAccepted} (intent to mutate the HNSW graph,
+     *       even if the entry's table has no vector index — the per-index
+     *       skip happens deeper in {@code applyInsert} / {@code applyUpdate} /
+     *       {@code applyDelete}).</li>
+     *   <li>DDL (CREATE_TABLE / ALTER_TABLE / DROP_TABLE / TRUNCATE_TABLE /
+     *       CREATE_INDEX / DROP_INDEX) → bumps {@link #tailerDdl} and
+     *       {@link #tailerEntriesSkipped} (no graph mutation; just schema).</li>
+     *   <li>Everything else (NOOP, REBALANCE, transactional control entries
+     *       BEGIN/COMMIT/ROLLBACK that are themselves not graph mutations)
+     *       → bumps {@link #tailerEntriesSkipped}. The buffered entries that a
+     *       COMMITTRANSACTION ultimately replays are themselves DML and were
+     *       already classified as accepted on their original arrival.</li>
+     * </ul>
+     */
+    private final LongAdder tailerEntriesAccepted = new LongAdder();
+    private final LongAdder tailerEntriesSkipped = new LongAdder();
+    private final LongAdder tailerInserts = new LongAdder();
+    private final LongAdder tailerUpdates = new LongAdder();
+    private final LongAdder tailerDeletes = new LongAdder();
+    private final LongAdder tailerDdl = new LongAdder();
 
     /**
      * Most recent {@link IndexingServiceRebalanceDescriptor} observed by the
@@ -1010,6 +1050,47 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         return t != null ? t.getEntriesProcessed() : 0L;
     }
 
+    /**
+     * Number of read batches the underlying tailer has completed since this
+     * engine started (issue #459). One batch is one poll/follow cycle that
+     * processed at least one entry. Returns {@code 0} when the tailer is not
+     * yet started.
+     */
+    public long getTailerBatchesProcessed() {
+        CommitLogTailing t = tailer;
+        return t != null ? t.getBatchesProcessed() : 0L;
+    }
+
+    /** Issue #459: entries the tailer counted as "accepted" (would mutate the HNSW graph). */
+    public long getTailerEntriesAccepted() {
+        return tailerEntriesAccepted.sum();
+    }
+
+    /** Issue #459: entries the tailer counted as "skipped" (DDL, NOOP, REBALANCE, transactional control). */
+    public long getTailerEntriesSkipped() {
+        return tailerEntriesSkipped.sum();
+    }
+
+    /** Issue #459: INSERT entries the tailer has classified. */
+    public long getTailerInserts() {
+        return tailerInserts.sum();
+    }
+
+    /** Issue #459: UPDATE entries the tailer has classified. */
+    public long getTailerUpdates() {
+        return tailerUpdates.sum();
+    }
+
+    /** Issue #459: DELETE entries the tailer has classified. */
+    public long getTailerDeletes() {
+        return tailerDeletes.sum();
+    }
+
+    /** Issue #459: DDL entries the tailer has classified. */
+    public long getTailerDdl() {
+        return tailerDdl.sum();
+    }
+
     public boolean isTailerRunning() {
         CommitLogTailing t = tailer;
         return t != null && t.isRunning();
@@ -1069,6 +1150,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         try {
             LOGGER.log(Level.FINEST, "Processing entry at LSN {0}, type={1}, txId={2}",
                     new Object[]{lsn, entry.type, entry.transactionId});
+            // Classify per-operation type for the issue-#459 metrics.
+            // Done unconditionally on every entry the tailer hands us, before
+            // the BEGIN/COMMIT/ROLLBACK fan-out below — buffered DML entries
+            // are counted at original arrival time, not at COMMIT replay time.
+            classifyForMetrics(entry);
             long txId = entry.transactionId;
 
             switch (entry.type) {
@@ -1373,6 +1459,45 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 || type == LogEntryType.TRUNCATE_TABLE
                 || type == LogEntryType.CREATE_INDEX
                 || type == LogEntryType.DROP_INDEX;
+    }
+
+    /**
+     * Bumps the issue-#459 per-operation-type counters based on the entry's
+     * {@link LogEntry#type}. Always invoked from
+     * {@link #processEntry(LogSequenceNumber, LogEntry)} on the tailer thread,
+     * before the BEGIN/COMMIT/ROLLBACK fan-out, so each commit-log entry is
+     * classified exactly once at original arrival time.
+     */
+    private void classifyForMetrics(LogEntry entry) {
+        switch (entry.type) {
+            case LogEntryType.INSERT:
+                tailerInserts.increment();
+                tailerEntriesAccepted.increment();
+                break;
+            case LogEntryType.UPDATE:
+                tailerUpdates.increment();
+                tailerEntriesAccepted.increment();
+                break;
+            case LogEntryType.DELETE:
+                tailerDeletes.increment();
+                tailerEntriesAccepted.increment();
+                break;
+            case LogEntryType.CREATE_TABLE:
+            case LogEntryType.ALTER_TABLE:
+            case LogEntryType.DROP_TABLE:
+            case LogEntryType.TRUNCATE_TABLE:
+            case LogEntryType.CREATE_INDEX:
+            case LogEntryType.DROP_INDEX:
+                tailerDdl.increment();
+                tailerEntriesSkipped.increment();
+                break;
+            default:
+                // NOOP, TABLE_CONSISTENCY_CHECK, INDEXING_SERVICE_REBALANCE,
+                // BEGIN/COMMIT/ROLLBACKTRANSACTION — none of these mutate the
+                // HNSW graph directly.
+                tailerEntriesSkipped.increment();
+                break;
+        }
     }
 
     /**
@@ -2875,6 +3000,82 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             public Long getSample() {
                 CommitLogTailing t = tailer;
                 return t != null ? t.getEntriesProcessed() : 0L;
+            }
+        });
+        // Issue #459: per-operation-type counters. Each one is exposed as a
+        // monotonically increasing gauge — Prometheus / consumers compute
+        // rates by differencing successive snapshots. Names line up with the
+        // Prometheus metric names (tailer_<scope-leaf>) on which the
+        // indexing-service Grafana dashboard panels are wired.
+        tailerStats.registerGauge("entries_accepted", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerEntriesAccepted.sum();
+            }
+        });
+        tailerStats.registerGauge("entries_skipped", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerEntriesSkipped.sum();
+            }
+        });
+        tailerStats.registerGauge("inserts", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerInserts.sum();
+            }
+        });
+        tailerStats.registerGauge("updates", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerUpdates.sum();
+            }
+        });
+        tailerStats.registerGauge("deletes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerDeletes.sum();
+            }
+        });
+        tailerStats.registerGauge("ddl", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerDdl.sum();
+            }
+        });
+        tailerStats.registerGauge("batches", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                CommitLogTailing t = tailer;
+                return t != null ? t.getBatchesProcessed() : 0L;
             }
         });
         tailerStats.registerGauge("running", new Gauge<Integer>() {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -428,6 +428,14 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setJvmHeapUsedBytes(heapUsed)
                     .setJvmHeapMaxBytes(heapMax)
                     .setJvmHeapUsedPct(heapPct)
+                    // Issue #459: per-operation-type tailer counters.
+                    .setTailerEntriesAccepted(engine.getTailerEntriesAccepted())
+                    .setTailerEntriesSkipped(engine.getTailerEntriesSkipped())
+                    .setTailerInserts(engine.getTailerInserts())
+                    .setTailerUpdates(engine.getTailerUpdates())
+                    .setTailerDeletes(engine.getTailerDeletes())
+                    .setTailerDdl(engine.getTailerDdl())
+                    .setTailerBatches(engine.getTailerBatchesProcessed())
                     .build();
             responseObserver.onNext(response);
             responseObserver.onCompleted();

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -400,6 +400,16 @@ public final class IndexingAdminCli {
                 out.printf(Locale.ROOT, "  tailer_watermark            = %d/%d%n",
                         response.getTailerWatermarkLedger(), response.getTailerWatermarkOffset());
                 out.printf(Locale.ROOT, "  tailer_entries_processed    = %d%n", response.getTailerEntriesProcessed());
+                // Issue #459: per-operation-type breakdown of the tailer's
+                // commit-log workload. accepted = INSERT/UPDATE/DELETE; skipped =
+                // DDL + NOOP + REBALANCE + transactional control entries.
+                out.printf(Locale.ROOT, "  tailer_entries_accepted     = %d%n", response.getTailerEntriesAccepted());
+                out.printf(Locale.ROOT, "  tailer_entries_skipped      = %d%n", response.getTailerEntriesSkipped());
+                out.printf(Locale.ROOT, "  tailer_inserts              = %d%n", response.getTailerInserts());
+                out.printf(Locale.ROOT, "  tailer_updates              = %d%n", response.getTailerUpdates());
+                out.printf(Locale.ROOT, "  tailer_deletes              = %d%n", response.getTailerDeletes());
+                out.printf(Locale.ROOT, "  tailer_ddl                  = %d%n", response.getTailerDdl());
+                out.printf(Locale.ROOT, "  tailer_batches              = %d%n", response.getTailerBatches());
                 out.printf(Locale.ROOT, "  apply_queue_size/capacity   = %d / %d%n",
                         response.getApplyQueueSize(), response.getApplyQueueCapacity());
                 out.printf(Locale.ROOT, "  apply_parallelism           = %d%n", response.getApplyParallelism());
@@ -541,6 +551,14 @@ public final class IndexingAdminCli {
         m.put("tailer_watermark_ledger", r.getTailerWatermarkLedger());
         m.put("tailer_watermark_offset", r.getTailerWatermarkOffset());
         m.put("tailer_entries_processed", r.getTailerEntriesProcessed());
+        // Issue #459: per-operation-type tailer counters.
+        m.put("tailer_entries_accepted", r.getTailerEntriesAccepted());
+        m.put("tailer_entries_skipped", r.getTailerEntriesSkipped());
+        m.put("tailer_inserts", r.getTailerInserts());
+        m.put("tailer_updates", r.getTailerUpdates());
+        m.put("tailer_deletes", r.getTailerDeletes());
+        m.put("tailer_ddl", r.getTailerDdl());
+        m.put("tailer_batches", r.getTailerBatches());
         m.put("apply_queue_size", r.getApplyQueueSize());
         m.put("apply_queue_capacity", r.getApplyQueueCapacity());
         m.put("apply_parallelism", r.getApplyParallelism());

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -221,6 +221,22 @@ message GetEngineStatsResponse {
     int64 jvm_heap_used_bytes = 11;
     int64 jvm_heap_max_bytes = 12;
     int32 jvm_heap_used_pct = 13;
+    // Issue #459: per-operation-type tailer counters. All monotonically
+    // increasing since JVM start; rates are derived by the consumer.
+    // entries_accepted = INSERT + UPDATE + DELETE entries (intent to
+    // mutate the HNSW graph). entries_skipped = DDL + NOOP + REBALANCE +
+    // BEGIN/COMMIT/ROLLBACKTRANSACTION (no graph mutation).
+    int64 tailer_entries_accepted = 14;
+    int64 tailer_entries_skipped = 15;
+    int64 tailer_inserts = 16;
+    int64 tailer_updates = 17;
+    int64 tailer_deletes = 18;
+    int64 tailer_ddl = 19;
+    // Number of read batches the underlying tailer has completed: one
+    // poll/follow cycle that processed at least one entry counts as one
+    // batch. Together with tailer_entries_processed this lets operators
+    // spot pathological "many tiny batches" patterns.
+    int64 tailer_batches = 20;
 }
 
 message GetInstanceInfoRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/BookKeeperCommitLogTailerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/BookKeeperCommitLogTailerTest.java
@@ -150,6 +150,121 @@ public class BookKeeperCommitLogTailerTest {
         }
     }
 
+    /**
+     * Issue #459: {@code BookKeeperCommitLogTailer.getBatchesProcessed()}
+     * must be {@code 0} on a freshly-constructed tailer, must advance once
+     * the tailer drains the leader's first wave of entries, and must keep
+     * advancing as additional waves arrive — confirming the
+     * "{@code entriesProcessed > entriesBefore} → bump batchesProcessed"
+     * delta in {@code BookKeeperCommitLogTailer.run()} is wired correctly.
+     */
+    @Test
+    public void testBatchesProcessedAdvancesAcrossMultipleWaves() throws Exception {
+        String tableSpaceUUID = "test-ts-uuid-batches";
+
+        try (ZookeeperMetadataStorageManager metadataManager = new ZookeeperMetadataStorageManager(
+                testEnv.getAddress(), testEnv.getTimeout(), testEnv.getPath())) {
+            metadataManager.start();
+            metadataManager.ensureDefaultTableSpace(
+                    "writer-node", "writer-node", 0, 1);
+
+            ServerConfiguration serverConfig = new ServerConfiguration();
+            serverConfig.set(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH,
+                    ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT);
+
+            try (BookkeeperCommitLogManager clManager = new BookkeeperCommitLogManager(
+                    metadataManager, serverConfig, NullStatsLogger.INSTANCE)) {
+                clManager.start();
+
+                BookkeeperCommitLog writerLog = clManager.createCommitLog(
+                        tableSpaceUUID, "default", "writer-node");
+                writerLog.startWriting(1);
+
+                Table table = Table.builder()
+                        .name("mytable")
+                        .tablespace("default")
+                        .column("pk", ColumnTypes.STRING)
+                        .column("data", ColumnTypes.STRING)
+                        .primaryKey("pk")
+                        .build();
+                CommitLogResult r1 = writerLog.log(LogEntryFactory.createTable(table, null), true);
+                assertNotNull(r1.getLogSequenceNumber());
+
+                // First wave.
+                int firstWave = 5;
+                for (int i = 0; i < firstWave; i++) {
+                    writerLog.log(LogEntryFactory.noop(), true);
+                }
+
+                List<LogSequenceNumber> received = new CopyOnWriteArrayList<>();
+                BookKeeperCommitLogTailer tailer = new BookKeeperCommitLogTailer(
+                        testEnv.getAddress(),
+                        testEnv.getTimeout(),
+                        testEnv.getPath(),
+                        ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT,
+                        tableSpaceUUID,
+                        LogSequenceNumber.START_OF_TIME,
+                        (lsn, entry) -> received.add(lsn)
+                );
+                Thread tailerThread = new Thread(tailer, "test-bk-tailer-batches");
+                tailerThread.setDaemon(true);
+
+                assertEquals("freshly-constructed tailer reports zero batches",
+                        0L, tailer.getBatchesProcessed());
+
+                tailerThread.start();
+                try {
+                    // Wait for the first wave (CREATE_TABLE + firstWave NOOPs)
+                    // to drain.
+                    long deadline = System.currentTimeMillis() + 30_000;
+                    while (received.size() < firstWave + 1
+                            && System.currentTimeMillis() < deadline) {
+                        Thread.sleep(100);
+                    }
+                    assertTrue("first wave drained: received=" + received.size(),
+                            received.size() >= firstWave + 1);
+                    long batchesAfterFirst = tailer.getBatchesProcessed();
+                    assertTrue("at least one batch must be counted after the "
+                                    + "first wave drained, got " + batchesAfterFirst,
+                            batchesAfterFirst >= 1L);
+
+                    // Second wave: append more entries while the tailer is
+                    // following.  followTheLeader() will return again after
+                    // these land, so batchesProcessed must strictly advance.
+                    int secondWave = 3;
+                    for (int i = 0; i < secondWave; i++) {
+                        writerLog.log(LogEntryFactory.noop(), true);
+                    }
+                    deadline = System.currentTimeMillis() + 30_000;
+                    while (received.size() < firstWave + 1 + secondWave
+                            && System.currentTimeMillis() < deadline) {
+                        Thread.sleep(100);
+                    }
+                    assertTrue("second wave drained: received=" + received.size(),
+                            received.size() >= firstWave + 1 + secondWave);
+
+                    // Assert progress: the per-batch counter must move strictly
+                    // forward (no off-by-one, no stuck-at-1).
+                    long batchesAfterSecond = tailer.getBatchesProcessed();
+                    assertTrue("batch counter must advance after the second wave: "
+                                    + "before=" + batchesAfterFirst
+                                    + " after=" + batchesAfterSecond,
+                            batchesAfterSecond > batchesAfterFirst);
+
+                    // Sanity: batches <= entries — every batch carries at
+                    // least one entry, so this invariant must always hold.
+                    assertTrue("batches (" + batchesAfterSecond + ") must be "
+                                    + "<= entries (" + tailer.getEntriesProcessed() + ")",
+                            batchesAfterSecond <= tailer.getEntriesProcessed());
+                } finally {
+                    tailer.close();
+                    tailerThread.join(5_000);
+                }
+                writerLog.close();
+            }
+        }
+    }
+
     @Test
     public void testSpeculativeReadsDisabledByDefault() throws Exception {
         // Issue #180: the tailer is a sequential follower; speculative reads

--- a/herddb-indexing-service/src/test/java/herddb/indexing/FileCommitLogTailerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/FileCommitLogTailerTest.java
@@ -292,6 +292,69 @@ public class FileCommitLogTailerTest {
     }
 
     /**
+     * Issue #459: {@code FileCommitLogTailer.getBatchesProcessed()} must be
+     * {@code 0} on a freshly-constructed tailer, must move to {@code >= 1}
+     * once a non-empty poll cycle drains the initial entries, and must
+     * strictly advance after a second wave is appended to the active file —
+     * confirming the {@code processedAny → batchesProcessed++} branch in
+     * {@code FileCommitLogTailer.run()} is wired correctly. Also asserts
+     * the {@code batches <= entries} invariant.
+     */
+    @Test
+    public void testBatchesProcessedAdvancesAcrossPollCycles() throws Exception {
+        Path logDir = folder.newFolder("txlog-batches").toPath();
+
+        Path tablespaceDir = logDir.resolve("aaaa.txlog");
+        Files.createDirectory(tablespaceDir);
+        Path segmentFile = tablespaceDir.resolve("0000000000000001.txlog");
+
+        // First wave: 3 entries already on disk before the tailer starts.
+        writeTxlogFile(segmentFile, 1, 1, 3);
+
+        List<LogSequenceNumber> consumed = Collections.synchronizedList(new ArrayList<>());
+        try (FileCommitLogTailer tailer = new FileCommitLogTailer(logDir, null,
+                LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> consumed.add(lsn))) {
+            assertEquals("freshly-constructed tailer reports zero batches",
+                    0L, tailer.getBatchesProcessed());
+
+            Thread t = new Thread(tailer);
+            t.start();
+
+            long deadline = System.currentTimeMillis() + 5000;
+            while (consumed.size() < 3 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50);
+            }
+            assertEquals("first wave drained", 3, consumed.size());
+            long batchesAfterFirst = tailer.getBatchesProcessed();
+            assertTrue("at least one batch must be counted after the first wave: "
+                            + batchesAfterFirst,
+                    batchesAfterFirst >= 1L);
+
+            // Second wave: append two more entries to the active file. A
+            // subsequent poll cycle will pick them up — batches must advance.
+            appendTxlogEntries(segmentFile, 1, 4, 2);
+            deadline = System.currentTimeMillis() + 5000;
+            while (consumed.size() < 5 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50);
+            }
+            assertEquals("second wave drained", 5, consumed.size());
+
+            long batchesAfterSecond = tailer.getBatchesProcessed();
+            assertTrue("batch counter must advance after the second wave: "
+                            + "before=" + batchesAfterFirst
+                            + " after=" + batchesAfterSecond,
+                    batchesAfterSecond > batchesAfterFirst);
+            assertTrue("batches (" + batchesAfterSecond + ") must be "
+                            + "<= entries (" + tailer.getEntriesProcessed() + ")",
+                    batchesAfterSecond <= tailer.getEntriesProcessed());
+
+            tailer.close();
+            t.join(5000);
+        }
+    }
+
+    /**
      * Tests that when the writer rolls to a new segment file, the tailer finishes
      * reading the old file and transitions to the new one.
      */

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDiagnosticsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDiagnosticsTest.java
@@ -198,6 +198,17 @@ public class IndexingServiceEngineDiagnosticsTest {
         assertTrue(service.getEngine().isTailerRunning());
         assertEquals(0L, service.getEngine().getTailerEntriesProcessed());
 
+        // Issue #459: the per-operation-type tailer counters must all be
+        // zero on a fresh engine. The TailerOpTypeMetricsTest covers their
+        // movement under driven entries; here we just guard the plumbing.
+        assertEquals(0L, service.getEngine().getTailerEntriesAccepted());
+        assertEquals(0L, service.getEngine().getTailerEntriesSkipped());
+        assertEquals(0L, service.getEngine().getTailerInserts());
+        assertEquals(0L, service.getEngine().getTailerUpdates());
+        assertEquals(0L, service.getEngine().getTailerDeletes());
+        assertEquals(0L, service.getEngine().getTailerDdl());
+        assertEquals(0L, service.getEngine().getTailerBatchesProcessed());
+
         // The apply queue is configured with the default parallelism and a
         // positive capacity; exact numbers depend on the host CPU count.
         assertTrue(service.getEngine().getApplyParallelism() >= 1);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
@@ -1,0 +1,228 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Table;
+import herddb.utils.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #459: per-operation-type tailer counters. Drives one entry of each
+ * relevant {@code LogEntryType} through {@code processEntryForTest()} and
+ * asserts the matching engine getter advanced by exactly 1, that the
+ * accepted/skipped split lines up with the issue's contract, and that
+ * {@code tailer_entries_processed = tailer_entries_accepted + tailer_entries_skipped}.
+ *
+ * <p>Counts are checked at the {@link IndexingServiceEngine} layer (where the
+ * counters live); the gRPC + admin-CLI plumbing is exercised indirectly by
+ * the existing diagnostics test.
+ */
+public class TailerOpTypeMetricsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+
+    @Before
+    public void setUp() throws Exception {
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private static Table testTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("local")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private static Index testIndex(String table) {
+        return Index.builder()
+                .name("vidx")
+                .table(table)
+                .tablespace("local")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    @Test
+    public void freshEngineReportsAllZero() {
+        IndexingServiceEngine e = service.getEngine();
+        assertEquals(0L, e.getTailerEntriesProcessed());
+        assertEquals(0L, e.getTailerEntriesAccepted());
+        assertEquals(0L, e.getTailerEntriesSkipped());
+        assertEquals(0L, e.getTailerInserts());
+        assertEquals(0L, e.getTailerUpdates());
+        assertEquals(0L, e.getTailerDeletes());
+        assertEquals(0L, e.getTailerDdl());
+        assertEquals(0L, e.getTailerBatchesProcessed());
+    }
+
+    /**
+     * Drive one entry of every classifiable {@link herddb.log.LogEntryType}
+     * through {@code processEntryForTest} and assert that:
+     * <ul>
+     *   <li>each per-op counter advanced by exactly 1,</li>
+     *   <li>{@code accepted} = inserts + updates + deletes,</li>
+     *   <li>{@code skipped} = ddl + every non-DML/non-DDL entry (NOOP,
+     *       REBALANCE, BEGIN/COMMIT/ROLLBACKTRANSACTION),</li>
+     *   <li>{@code accepted + skipped} matches the total processed
+     *       (the issue's contract).</li>
+     * </ul>
+     */
+    @Test
+    public void perOpCountersAdvanceOnceForEachEntry() throws Exception {
+        IndexingServiceEngine engine = service.getEngine();
+
+        Table table = testTable();
+        Index index = testIndex("vectable");
+        long lsnOff = 1;
+
+        // --- DDL: CREATE_TABLE, CREATE_INDEX, ALTER_TABLE, DROP_INDEX,
+        //          TRUNCATE_TABLE, DROP_TABLE.
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.createTable(table, null));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.createIndex(index, null));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.alterTable(table, null));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.truncate(table, null));
+        // DROP_INDEX is dispatched via the entry.value payload (index name).
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                new LogEntry(System.currentTimeMillis(),
+                        herddb.log.LogEntryType.DROP_INDEX, 0L, 0,
+                        null, Bytes.from_string("vidx")));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.dropTable(table, null));
+
+        // --- DML: 3 INSERT, 2 UPDATE, 1 DELETE on a freshly seeded table.
+        for (int i = 0; i < 3; i++) {
+            engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                    LogEntryFactory.insert(table, Bytes.from_string("k" + i),
+                            Bytes.from_string("v" + i), null));
+        }
+        for (int i = 0; i < 2; i++) {
+            engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                    LogEntryFactory.update(table, Bytes.from_string("k" + i),
+                            Bytes.from_string("v_new" + i), null));
+        }
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.delete(table, Bytes.from_string("k0"), null));
+
+        // --- Non-DML/non-DDL: NOOP, BEGIN/COMMIT/ROLLBACKTRANSACTION. All
+        // counted as "skipped" (no graph mutation at this entry's arrival).
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.noop());
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.beginTransaction(42L));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.commitTransaction(42L));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                LogEntryFactory.rollbackTransaction(43L));
+
+        // --- Per-op assertions.
+        assertEquals("inserts", 3L, engine.getTailerInserts());
+        assertEquals("updates", 2L, engine.getTailerUpdates());
+        assertEquals("deletes", 1L, engine.getTailerDeletes());
+        assertEquals("ddl: CREATE_TABLE+CREATE_INDEX+ALTER_TABLE+TRUNCATE_TABLE+DROP_INDEX+DROP_TABLE",
+                6L, engine.getTailerDdl());
+
+        // accepted == sum of inserts/updates/deletes; skipped == ddl + 4
+        // control entries (NOOP, BEGIN, COMMIT, ROLLBACK).
+        assertEquals("accepted", 6L, engine.getTailerEntriesAccepted());
+        assertEquals("skipped: 6 DDL + NOOP + BEGIN + COMMIT + ROLLBACK",
+                10L, engine.getTailerEntriesSkipped());
+
+        // The issue's primary contract: accepted + skipped == every entry
+        // the tailer classified.
+        long classified = engine.getTailerEntriesAccepted()
+                + engine.getTailerEntriesSkipped();
+        assertEquals("accepted + skipped must equal the number of entries classified",
+                16L, classified);
+    }
+
+    /**
+     * A second, independent INSERT on its own must bump only
+     * {@code tailer_inserts} and {@code tailer_entries_accepted} — proves the
+     * classifier doesn't double-count or leak across categories.
+     */
+    @Test
+    public void singleInsertOnlyTouchesInsertAndAccepted() throws Exception {
+        IndexingServiceEngine engine = service.getEngine();
+        Table table = testTable();
+        engine.processEntryForTest(new LogSequenceNumber(1, 1),
+                LogEntryFactory.insert(table, Bytes.from_string("k"),
+                        Bytes.from_string("v"), null));
+
+        assertEquals(1L, engine.getTailerInserts());
+        assertEquals(0L, engine.getTailerUpdates());
+        assertEquals(0L, engine.getTailerDeletes());
+        assertEquals(0L, engine.getTailerDdl());
+        assertEquals(1L, engine.getTailerEntriesAccepted());
+        assertEquals(0L, engine.getTailerEntriesSkipped());
+    }
+
+    /**
+     * A single DDL entry on its own must bump only {@code tailer_ddl} and
+     * {@code tailer_entries_skipped} — DDL is "skipped" in the issue's
+     * terminology because it doesn't mutate the HNSW graph (it just updates
+     * the in-engine schema tracker).
+     */
+    @Test
+    public void singleDdlOnlyTouchesDdlAndSkipped() throws Exception {
+        IndexingServiceEngine engine = service.getEngine();
+        Table table = testTable();
+        engine.processEntryForTest(new LogSequenceNumber(1, 1),
+                LogEntryFactory.createTable(table, null));
+
+        assertEquals(0L, engine.getTailerInserts());
+        assertEquals(0L, engine.getTailerUpdates());
+        assertEquals(0L, engine.getTailerDeletes());
+        assertEquals(1L, engine.getTailerDdl());
+        assertEquals(0L, engine.getTailerEntriesAccepted());
+        assertEquals(1L, engine.getTailerEntriesSkipped());
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
@@ -152,8 +152,12 @@ public class TailerOpTypeMetricsTest {
         engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
                 LogEntryFactory.delete(table, Bytes.from_string("k0"), null));
 
-        // --- Non-DML/non-DDL: NOOP, BEGIN/COMMIT/ROLLBACKTRANSACTION. All
-        // counted as "skipped" (no graph mutation at this entry's arrival).
+        // --- Non-DML/non-DDL: NOOP, BEGIN/COMMIT/ROLLBACKTRANSACTION,
+        // TABLE_CONSISTENCY_CHECK, INDEXING_SERVICE_REBALANCE. All counted
+        // as "skipped" (no graph mutation at this entry's arrival). Including
+        // the latter two explicitly so reordering the classifier's `default`
+        // branch can't silently miss a real LogEntryType (review feedback
+        // on PR #460).
         engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
                 LogEntryFactory.noop());
         engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
@@ -162,26 +166,41 @@ public class TailerOpTypeMetricsTest {
                 LogEntryFactory.commitTransaction(42L));
         engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
                 LogEntryFactory.rollbackTransaction(43L));
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                new LogEntry(System.currentTimeMillis(),
+                        herddb.log.LogEntryType.TABLE_CONSISTENCY_CHECK,
+                        0L, table.tableId, null, null));
+        // INDEXING_SERVICE_REBALANCE with a null payload is valid here:
+        // handleRebalanceEntry() logs and returns when entry.value is null,
+        // so the engine treats it as a no-op — but the classifier must still
+        // count it as one skipped entry, which is what we want to assert.
+        engine.processEntryForTest(new LogSequenceNumber(1, lsnOff++),
+                new LogEntry(System.currentTimeMillis(),
+                        herddb.log.LogEntryType.INDEXING_SERVICE_REBALANCE,
+                        0L, 0, null, null));
 
-        // --- Per-op assertions.
+        // --- Per-op assertions. The DML / DDL totals must be unaffected by
+        // the non-DML/non-DDL entries above.
         assertEquals("inserts", 3L, engine.getTailerInserts());
         assertEquals("updates", 2L, engine.getTailerUpdates());
         assertEquals("deletes", 1L, engine.getTailerDeletes());
         assertEquals("ddl: CREATE_TABLE+CREATE_INDEX+ALTER_TABLE+TRUNCATE_TABLE+DROP_INDEX+DROP_TABLE",
                 6L, engine.getTailerDdl());
 
-        // accepted == sum of inserts/updates/deletes; skipped == ddl + 4
-        // control entries (NOOP, BEGIN, COMMIT, ROLLBACK).
+        // accepted == sum of inserts/updates/deletes; skipped == ddl + 6
+        // control entries (NOOP, BEGIN, COMMIT, ROLLBACK,
+        // TABLE_CONSISTENCY_CHECK, INDEXING_SERVICE_REBALANCE).
         assertEquals("accepted", 6L, engine.getTailerEntriesAccepted());
-        assertEquals("skipped: 6 DDL + NOOP + BEGIN + COMMIT + ROLLBACK",
-                10L, engine.getTailerEntriesSkipped());
+        assertEquals("skipped: 6 DDL + NOOP + BEGIN + COMMIT + ROLLBACK + "
+                + "TABLE_CONSISTENCY_CHECK + INDEXING_SERVICE_REBALANCE",
+                12L, engine.getTailerEntriesSkipped());
 
         // The issue's primary contract: accepted + skipped == every entry
         // the tailer classified.
         long classified = engine.getTailerEntriesAccepted()
                 + engine.getTailerEntriesSkipped();
         assertEquals("accepted + skipped must equal the number of entries classified",
-                16L, classified);
+                18L, classified);
     }
 
     /**

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -3399,6 +3399,253 @@
     },
     {
       "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Per-operation-type rate of entries the IS tailer is classifying. Lets operators tell apart pure-INSERT ingest, UPDATE-heavy churn, DELETE bursts and DDL catch-up at a glance (issue #459).",
+          "fill": 1,
+          "id": 36,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 8,
+          "stack": true,
+          "targets": [
+            {
+              "expr": "rate(tailer_inserts{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "inserts/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(tailer_updates{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "updates/s [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(tailer_deletes{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "deletes/s [{{instance}}]",
+              "refId": "C"
+            },
+            {
+              "expr": "rate(tailer_ddl{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ddl/s [{{instance}}]",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "title": "CommitLog Tailer - Operation Mix (rate, stacked)",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "show": true},
+            {"format": "short", "show": true}
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Accepted (INSERT/UPDATE/DELETE) vs skipped (DDL + NOOP + REBALANCE + transactional control) entries per second. Skipped/processed near 1 means the IS replica is filtering out most traffic — useful when validating the cross-replica shard filter (issue #459).",
+          "fill": 1,
+          "id": 37,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 4,
+          "targets": [
+            {
+              "expr": "rate(tailer_entries_accepted{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "accepted/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(tailer_entries_skipped{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "skipped/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "CommitLog Tailer - Accepted vs Skipped (rate)",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "show": true},
+            {"format": "short", "show": true}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "CommitLog Tailer - Operation Mix (issue #459)",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Cumulative tailer counters: total entries the tailer has read, of which accepted (vector intent) vs skipped (DDL/control). Slope = ingest rate; the gap between processed and accepted+ddl is exactly the non-graph 'skipped' traffic.",
+          "fill": 1,
+          "id": 38,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 8,
+          "targets": [
+            {
+              "expr": "tailer_entries_processed{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "processed [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "tailer_entries_accepted{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "accepted [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "tailer_entries_skipped{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "skipped [{{instance}}]",
+              "refId": "C"
+            },
+            {
+              "expr": "tailer_ddl{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ddl [{{instance}}]",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "title": "CommitLog Tailer - Cumulative Counters",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "decimals": 0, "show": true},
+            {"format": "short", "show": true}
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Tailer batch rate plus mean batch size (entries/batch). A 'mean batch size' that drops toward 1 with a steady entries/s usually means the underlying poll/follow loop is being woken up before each individual append lands — high overhead per entry (issue #459).",
+          "fill": 1,
+          "id": 39,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 4,
+          "targets": [
+            {
+              "expr": "rate(tailer_batches{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "batches/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(tailer_entries_processed{job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate(tailer_batches{job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "mean entries/batch [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "CommitLog Tailer - Batches",
+          "tooltip": {"shared": true, "sort": 0, "value_type": "individual"},
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "show": true},
+            {"format": "short", "show": true}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "CommitLog Tailer - Batches & Cumulative (issue #459)",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
       "height": 150,
       "panels": [
         {


### PR DESCRIPTION
Fixes #459.

## Changes

- **`herddb-core/src/main/java/herddb/log/CommitLogTailing.java`**: add a default `getBatchesProcessed()` so existing implementors stay source-compatible.
- **`herddb-indexing-service/src/main/java/herddb/indexing/FileCommitLogTailer.java`** + **`herddb-core/src/main/java/herddb/cluster/BookKeeperCommitLogTailer.java`**: track a `batchesProcessed` counter — one poll/follow cycle that produced at least one entry counts as one batch.
- **`herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java`**: add `LongAdder` counters `tailerEntriesAccepted`, `tailerEntriesSkipped`, `tailerInserts`, `tailerUpdates`, `tailerDeletes`, `tailerDdl`; classify each entry inside `processEntry(...)` (INSERT/UPDATE/DELETE → accepted; DDL → skipped + tailerDdl; everything else → skipped). Expose public getters and register Prometheus gauges (`tailer_entries_accepted`, `tailer_inserts`, `tailer_updates`, `tailer_deletes`, `tailer_ddl`, `tailer_entries_skipped`, `tailer_batches`) under the existing `tailer` scope, so the metrics surface unchanged through `IndexingServer`'s `/metrics` servlet.
- **`herddb-indexing-service/src/main/proto/indexing_service.proto`**: extend `GetEngineStatsResponse` with the seven new int64 fields (14–20).
- **`herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java`**: populate the new proto fields from the engine getters in `getEngineStats()`.
- **`herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java`**: render the new fields in both the text and JSON output of `engine-stats`.
- **`herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json`**: add two new dashboard rows wired to the new metrics — "CommitLog Tailer — Operation Mix" (per-op rate stacked + accepted vs skipped rate) and "CommitLog Tailer — Batches & Cumulative" (cumulative counters + batches/s and mean entries/batch).

## Tests

- **`herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java`** *(new)*: drives one entry of every classifiable type through `processEntryForTest` and asserts each per-op LongAdder advanced exactly once, that `accepted + skipped` matches the total processed, and isolates two minimal cases (single INSERT, single DDL) to prove the classifier doesn't leak across categories.
- **`herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDiagnosticsTest.java`** *(extended)*: the existing `testEnginePlumbsTailerAndApplyStats` now also asserts every new getter returns 0 on a fresh engine.

🤖 Implemented by the `pr-worker` agent.