### PR TITLE
issue #463: surface IS shard-filter rejections in tailer metrics

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -222,9 +222,19 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      *       COMMITTRANSACTION ultimately replays are themselves DML and were
      *       already classified as accepted on their original arrival.</li>
      * </ul>
+     *
+     * <p>Issue #463: {@link #tailerEntriesShardFiltered} is bumped from
+     * {@link #applyInsert(LogEntry)}, NOT from {@code classifyForMetrics} —
+     * the shard-filter decision is per-key + per-index and only knowable
+     * after schema lookup. It counts INSERT entries this replica did NOT
+     * apply because every vector index for the table rejected the key
+     * via {@link #isAcceptedLocally(Bytes, Index)}. UPDATE entries are
+     * not tracked here because their broadcast remove still mutates state
+     * on every replica, regardless of shard ownership.
      */
     private final LongAdder tailerEntriesAccepted = new LongAdder();
     private final LongAdder tailerEntriesSkipped = new LongAdder();
+    private final LongAdder tailerEntriesShardFiltered = new LongAdder();
     private final LongAdder tailerInserts = new LongAdder();
     private final LongAdder tailerUpdates = new LongAdder();
     private final LongAdder tailerDeletes = new LongAdder();
@@ -1103,6 +1113,27 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         return tailerEntriesSkipped.sum();
     }
 
+    /**
+     * Issue #463: INSERT entries this replica did not apply because every
+     * vector index defined on the entry's table rejected the key via the
+     * shard filter. Operators verify the filter is doing its job by
+     * watching this counter rise — for a balanced {@code numShards} ≥
+     * {@code numInstances} configuration it should track roughly
+     * {@code (numInstances - 1) / numInstances} of {@link #getTailerInserts()}.
+     *
+     * <p>The counter excludes:
+     * <ul>
+     *   <li>INSERTs whose table has no vector index (different reason —
+     *       not a shard-filter rejection);</li>
+     *   <li>UPDATE / DELETE entries (UPDATE always does a broadcast remove
+     *       on every replica, DELETE is broadcast unconditionally — neither
+     *       is "filtered out" the same way an INSERT can be).</li>
+     * </ul>
+     */
+    public long getTailerEntriesShardFiltered() {
+        return tailerEntriesShardFiltered.sum();
+    }
+
     /** Issue #459: INSERT entries the tailer has classified. */
     public long getTailerInserts() {
         return tailerInserts.sum();
@@ -1891,6 +1922,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
         Record record = new Record(entry.key, entry.value);
         DataAccessorForFullRecord accessor = new DataAccessorForFullRecord(table, record);
+        // Issue #463: track whether AT LEAST one vector index for this table
+        // accepted the key locally. If every applicable index rejects it via
+        // the shard filter, the entry contributes nothing to local state and
+        // we bump tailerEntriesShardFiltered so operators can confirm the
+        // filter is firing in production. Note this is strictly a "rejected
+        // by every index" counter — INSERTs on tables with no vector index
+        // hit the early return above and are NOT counted here (different
+        // reason: no vector indexing applies).
+        boolean anyIndexAcceptedKey = false;
         for (Index idx : vectorIndexes) {
             // Per-index ownership: indexes on the same table may have different
             // numInstances (e.g. a pre-rebalance index with N=2 next to a
@@ -1898,6 +1938,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             if (!isAcceptedLocally(entry.key, idx)) {
                 continue;
             }
+            anyIndexAcceptedKey = true;
             AbstractVectorStore store = vectorStores.get(storeKey(tableName, idx.name));
             if (store == null) {
                 continue;
@@ -1906,6 +1947,9 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             if (vector != null) {
                 store.addVector(entry.key, vector);
             }
+        }
+        if (!anyIndexAcceptedKey) {
+            tailerEntriesShardFiltered.increment();
         }
     }
 
@@ -3155,6 +3199,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             @Override
             public Long getSample() {
                 return tailerEntriesSkipped.sum();
+            }
+        });
+        // Issue #463: INSERT entries this replica did not apply because the
+        // shard filter rejected the key on every vector index defined on the
+        // entry's table. Operators verify cross-replica sharding is actually
+        // happening by watching this rise to ~(N-1)/N of `tailer_inserts`.
+        tailerStats.registerGauge("entries_shard_filtered", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+            @Override
+            public Long getSample() {
+                return tailerEntriesShardFiltered.sum();
             }
         });
         tailerStats.registerGauge("inserts", new Gauge<Long>() {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -36,6 +36,8 @@ import herddb.indexing.proto.IndexingServiceGrpc;
 import herddb.indexing.proto.ListIndexesRequest;
 import herddb.indexing.proto.ListIndexesResponse;
 import herddb.indexing.proto.ListPrimaryKeysRequest;
+import herddb.indexing.proto.MetricEntry;
+import herddb.indexing.proto.MetricValue;
 import herddb.indexing.proto.PrimaryKeysChunk;
 import herddb.indexing.proto.SearchRequest;
 import herddb.indexing.proto.SearchResponse;
@@ -414,30 +416,42 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             long heapUsed = heap.getUsed();
             long heapMax = heap.getMax();
             int heapPct = heapMax > 0 ? (int) Math.min(100L, (100L * heapUsed) / heapMax) : -1;
-            GetEngineStatsResponse response = GetEngineStatsResponse.newBuilder()
-                    .setUptimeMillis(uptime)
-                    .setTailerWatermarkLedger(lsn != null ? lsn.ledgerId : -1L)
-                    .setTailerWatermarkOffset(lsn != null ? lsn.offset : -1L)
-                    .setTailerEntriesProcessed(engine.getTailerEntriesProcessed())
-                    .setTailerRunning(engine.isTailerRunning())
-                    .setApplyQueueSize(engine.getApplyQueueSize())
-                    .setApplyQueueCapacity(engine.getApplyQueueCapacity())
-                    .setTotalEstimatedMemoryBytes(engine.getTotalEstimatedMemoryBytes())
-                    .setLoadedIndexCount(engine.getLoadedIndexCount())
-                    .setApplyParallelism(engine.getApplyParallelism())
-                    .setJvmHeapUsedBytes(heapUsed)
-                    .setJvmHeapMaxBytes(heapMax)
-                    .setJvmHeapUsedPct(heapPct)
-                    // Issue #459: per-operation-type tailer counters.
-                    .setTailerEntriesAccepted(engine.getTailerEntriesAccepted())
-                    .setTailerEntriesSkipped(engine.getTailerEntriesSkipped())
-                    .setTailerInserts(engine.getTailerInserts())
-                    .setTailerUpdates(engine.getTailerUpdates())
-                    .setTailerDeletes(engine.getTailerDeletes())
-                    .setTailerDdl(engine.getTailerDdl())
-                    .setTailerBatches(engine.getTailerBatchesProcessed())
-                    .build();
-            responseObserver.onNext(response);
+
+            // Issue #463: the response is a flat (key, MetricValue) list — adding
+            // a metric is now `addInt64(b, "key", value)` server-side without a
+            // proto schema change. Order matters: the indexing-admin CLI walks
+            // the list in order to render its text output, so we emit metrics
+            // in the same order they used to appear when each was a typed
+            // proto field.
+            GetEngineStatsResponse.Builder b = GetEngineStatsResponse.newBuilder();
+            addInt64(b, "uptime_millis", uptime);
+            addBool(b, "tailer_running", engine.isTailerRunning());
+            addInt64(b, "tailer_watermark_ledger", lsn != null ? lsn.ledgerId : -1L);
+            addInt64(b, "tailer_watermark_offset", lsn != null ? lsn.offset : -1L);
+            addInt64(b, "tailer_entries_processed", engine.getTailerEntriesProcessed());
+            // Issue #459: per-operation-type tailer counters.
+            addInt64(b, "tailer_entries_accepted", engine.getTailerEntriesAccepted());
+            addInt64(b, "tailer_entries_skipped", engine.getTailerEntriesSkipped());
+            // Issue #463: INSERT entries this replica did not apply because
+            // every vector index for the table rejected the key via the shard
+            // filter. Lets operators verify cross-replica sharding without
+            // having to scrape Prometheus.
+            addInt64(b, "tailer_entries_shard_filtered", engine.getTailerEntriesShardFiltered());
+            addInt64(b, "tailer_inserts", engine.getTailerInserts());
+            addInt64(b, "tailer_updates", engine.getTailerUpdates());
+            addInt64(b, "tailer_deletes", engine.getTailerDeletes());
+            addInt64(b, "tailer_ddl", engine.getTailerDdl());
+            addInt64(b, "tailer_batches", engine.getTailerBatchesProcessed());
+            addInt64(b, "apply_queue_size", engine.getApplyQueueSize());
+            addInt64(b, "apply_queue_capacity", engine.getApplyQueueCapacity());
+            addInt64(b, "apply_parallelism", engine.getApplyParallelism());
+            addInt64(b, "loaded_index_count", engine.getLoadedIndexCount());
+            addInt64(b, "total_estimated_memory_bytes", engine.getTotalEstimatedMemoryBytes());
+            addInt64(b, "jvm_heap_used_bytes", heapUsed);
+            addInt64(b, "jvm_heap_max_bytes", heapMax);
+            addInt64(b, "jvm_heap_used_pct", heapPct);
+
+            responseObserver.onNext(b.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
             LOGGER.log(Level.SEVERE, "GetEngineStats failed", e);
@@ -446,6 +460,20 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .withCause(e)
                     .asRuntimeException());
         }
+    }
+
+    private static void addInt64(GetEngineStatsResponse.Builder b, String key, long value) {
+        b.addMetrics(MetricEntry.newBuilder()
+                .setKey(key)
+                .setValue(MetricValue.newBuilder().setInt64Value(value).build())
+                .build());
+    }
+
+    private static void addBool(GetEngineStatsResponse.Builder b, String key, boolean value) {
+        b.addMetrics(MetricEntry.newBuilder()
+                .setKey(key)
+                .setValue(MetricValue.newBuilder().setBoolValue(value).build())
+                .build());
     }
 
     @Override

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -28,6 +28,8 @@ import herddb.indexing.proto.GetInstanceInfoResponse;
 import herddb.indexing.proto.GetShadowStatusResponse;
 import herddb.indexing.proto.IndexDescriptor;
 import herddb.indexing.proto.ListIndexesResponse;
+import herddb.indexing.proto.MetricEntry;
+import herddb.indexing.proto.MetricValue;
 import herddb.indexing.proto.PrimaryKeysChunk;
 import herddb.indexing.proto.WaitForCheckpointResponse;
 import herddb.metadata.IndexingServiceInstanceDescriptor;
@@ -391,33 +393,23 @@ public final class IndexingAdminCli {
         }
         try (IndexingAdminClient client = buildClient(cli)) {
             GetEngineStatsResponse response = client.getEngineStats();
+            Map<String, Object> map = engineStatsToMap(response);
             if (cli.hasOption("json")) {
-                out.println(JsonWriter.toJson(engineStatsToMap(response)));
+                out.println(JsonWriter.toJson(map));
             } else {
+                // Issue #463: the wire response is now a generic
+                // (key, MetricValue) list, so the CLI renders the text output
+                // by walking the list in the order the server emitted it.
+                // Keys are left-padded to 31 characters: enough room for the
+                // longest current key (`tailer_entries_shard_filtered`, 29
+                // chars) plus a 2-char separator before `=`, with comfortable
+                // space for future metrics. The separator is ` = ` (space-
+                // equals-space) so a key that exactly fills the field width
+                // still has visible whitespace between key and value.
                 out.println("Engine stats:");
-                out.printf(Locale.ROOT, "  uptime_ms                   = %d%n", response.getUptimeMillis());
-                out.printf(Locale.ROOT, "  tailer_running              = %s%n", response.getTailerRunning());
-                out.printf(Locale.ROOT, "  tailer_watermark            = %d/%d%n",
-                        response.getTailerWatermarkLedger(), response.getTailerWatermarkOffset());
-                out.printf(Locale.ROOT, "  tailer_entries_processed    = %d%n", response.getTailerEntriesProcessed());
-                // Issue #459: per-operation-type breakdown of the tailer's
-                // commit-log workload. accepted = INSERT/UPDATE/DELETE; skipped =
-                // DDL + NOOP + REBALANCE + transactional control entries.
-                out.printf(Locale.ROOT, "  tailer_entries_accepted     = %d%n", response.getTailerEntriesAccepted());
-                out.printf(Locale.ROOT, "  tailer_entries_skipped      = %d%n", response.getTailerEntriesSkipped());
-                out.printf(Locale.ROOT, "  tailer_inserts              = %d%n", response.getTailerInserts());
-                out.printf(Locale.ROOT, "  tailer_updates              = %d%n", response.getTailerUpdates());
-                out.printf(Locale.ROOT, "  tailer_deletes              = %d%n", response.getTailerDeletes());
-                out.printf(Locale.ROOT, "  tailer_ddl                  = %d%n", response.getTailerDdl());
-                out.printf(Locale.ROOT, "  tailer_batches              = %d%n", response.getTailerBatches());
-                out.printf(Locale.ROOT, "  apply_queue_size/capacity   = %d / %d%n",
-                        response.getApplyQueueSize(), response.getApplyQueueCapacity());
-                out.printf(Locale.ROOT, "  apply_parallelism           = %d%n", response.getApplyParallelism());
-                out.printf(Locale.ROOT, "  loaded_index_count          = %d%n", response.getLoadedIndexCount());
-                out.printf(Locale.ROOT, "  total_estimated_memory_bytes= %d%n", response.getTotalEstimatedMemoryBytes());
-                out.printf(Locale.ROOT, "  jvm_heap                    = %d / %d bytes (%d%%)%n",
-                        response.getJvmHeapUsedBytes(), response.getJvmHeapMaxBytes(),
-                        response.getJvmHeapUsedPct());
+                for (Map.Entry<String, Object> e : map.entrySet()) {
+                    out.printf(Locale.ROOT, "  %-31s = %s%n", e.getKey(), e.getValue());
+                }
             }
         }
         return 0;
@@ -545,28 +537,34 @@ public final class IndexingAdminCli {
     }
 
     private static Map<String, Object> engineStatsToMap(GetEngineStatsResponse r) {
+        // Issue #463: walk the server's ordered (key, MetricValue) list and
+        // unbox each oneof case to the matching boxed Java type. Insertion
+        // order is preserved so both the text renderer and JsonWriter emit
+        // metrics in the same order the server intended.
         Map<String, Object> m = new LinkedHashMap<>();
-        m.put("uptime_millis", r.getUptimeMillis());
-        m.put("tailer_running", r.getTailerRunning());
-        m.put("tailer_watermark_ledger", r.getTailerWatermarkLedger());
-        m.put("tailer_watermark_offset", r.getTailerWatermarkOffset());
-        m.put("tailer_entries_processed", r.getTailerEntriesProcessed());
-        // Issue #459: per-operation-type tailer counters.
-        m.put("tailer_entries_accepted", r.getTailerEntriesAccepted());
-        m.put("tailer_entries_skipped", r.getTailerEntriesSkipped());
-        m.put("tailer_inserts", r.getTailerInserts());
-        m.put("tailer_updates", r.getTailerUpdates());
-        m.put("tailer_deletes", r.getTailerDeletes());
-        m.put("tailer_ddl", r.getTailerDdl());
-        m.put("tailer_batches", r.getTailerBatches());
-        m.put("apply_queue_size", r.getApplyQueueSize());
-        m.put("apply_queue_capacity", r.getApplyQueueCapacity());
-        m.put("apply_parallelism", r.getApplyParallelism());
-        m.put("loaded_index_count", r.getLoadedIndexCount());
-        m.put("total_estimated_memory_bytes", r.getTotalEstimatedMemoryBytes());
-        m.put("jvm_heap_used_bytes", r.getJvmHeapUsedBytes());
-        m.put("jvm_heap_max_bytes", r.getJvmHeapMaxBytes());
-        m.put("jvm_heap_used_pct", r.getJvmHeapUsedPct());
+        for (MetricEntry e : r.getMetricsList()) {
+            MetricValue v = e.getValue();
+            switch (v.getKindCase()) {
+                case INT64_VALUE:
+                    m.put(e.getKey(), v.getInt64Value());
+                    break;
+                case DOUBLE_VALUE:
+                    m.put(e.getKey(), v.getDoubleValue());
+                    break;
+                case BOOL_VALUE:
+                    m.put(e.getKey(), v.getBoolValue());
+                    break;
+                case STRING_VALUE:
+                    m.put(e.getKey(), v.getStringValue());
+                    break;
+                case KIND_NOT_SET:
+                default:
+                    // Server emitted an empty MetricValue. Skip the entry —
+                    // safer than crashing the CLI on a forward-compat case
+                    // we don't yet handle (e.g. a future bytes_value).
+                    break;
+            }
+        }
         return m;
     }
 

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -206,37 +206,32 @@ message PrimaryKeysChunk {
 message GetEngineStatsRequest {
 }
 
+// Tagged union for engine-stats values. Issue #463: the engine-stats RPC
+// surface used to be a frozen schema of ~20 typed fields, so every new
+// counter required a proto migration. The response is now a flat
+// repeated list of (key, MetricValue) entries — adding a metric is just
+// `addInt64(builder, "new_metric", value)` server-side.
+message MetricValue {
+    oneof kind {
+        int64 int64_value = 1;
+        double double_value = 2;
+        bool bool_value = 3;
+        string string_value = 4;
+    }
+}
+
+message MetricEntry {
+    string key = 1;
+    MetricValue value = 2;
+}
+
 message GetEngineStatsResponse {
-    int64 uptime_millis = 1;
-    int64 tailer_watermark_ledger = 2;
-    int64 tailer_watermark_offset = 3;
-    int64 tailer_entries_processed = 4;
-    bool tailer_running = 5;
-    int32 apply_queue_size = 6;
-    int32 apply_queue_capacity = 7;
-    int64 total_estimated_memory_bytes = 8;
-    int32 loaded_index_count = 9;
-    int32 apply_parallelism = 10;
-    // JVM heap (issue #80): read from ManagementFactory.getMemoryMXBean()
-    int64 jvm_heap_used_bytes = 11;
-    int64 jvm_heap_max_bytes = 12;
-    int32 jvm_heap_used_pct = 13;
-    // Issue #459: per-operation-type tailer counters. All monotonically
-    // increasing since JVM start; rates are derived by the consumer.
-    // entries_accepted = INSERT + UPDATE + DELETE entries (intent to
-    // mutate the HNSW graph). entries_skipped = DDL + NOOP + REBALANCE +
-    // BEGIN/COMMIT/ROLLBACKTRANSACTION (no graph mutation).
-    int64 tailer_entries_accepted = 14;
-    int64 tailer_entries_skipped = 15;
-    int64 tailer_inserts = 16;
-    int64 tailer_updates = 17;
-    int64 tailer_deletes = 18;
-    int64 tailer_ddl = 19;
-    // Number of read batches the underlying tailer has completed: one
-    // poll/follow cycle that processed at least one entry counts as one
-    // batch. Together with tailer_entries_processed this lets operators
-    // spot pathological "many tiny batches" patterns.
-    int64 tailer_batches = 20;
+    // Ordered list of (key, MetricValue) pairs. The server emits them in a
+    // deterministic, human-readable order so the indexing-admin CLI text
+    // output stays stable across releases. Consumers MUST NOT assume any
+    // particular subset of keys is always present — tests that need a
+    // specific metric key should look it up by name, not by position.
+    repeated MetricEntry metrics = 1;
 }
 
 message GetInstanceInfoRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingAdminCliTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingAdminCliTest.java
@@ -223,8 +223,48 @@ public class IndexingAdminCliTest {
         assertEquals(0, rc);
         String out = stdout();
         assertTrue(out.contains("Engine stats:"));
-        assertTrue(out.contains("loaded_index_count          = 1"));
-        assertTrue(out.contains("tailer_running              = true"));
+        // Issue #463: keys are left-padded to 31 chars, followed by ` = `, then
+        // the value. Existing dashboards / scripts that relied on the previous
+        // 28-char alignment must be updated.
+        assertTrue("expected 31-char-padded loaded_index_count line, got:\n" + out,
+                out.contains("loaded_index_count              = 1"));
+        assertTrue("expected 31-char-padded tailer_running line, got:\n" + out,
+                out.contains("tailer_running                  = true"));
+        // Issue #463: the new shard-filter counter must appear in the
+        // human-readable text output, alongside the rest of the metrics.
+        // A freshly-started single-instance setup hasn't routed any INSERT
+        // through applyInsert, so the count must be exactly 0.
+        assertTrue("text output must include tailer_entries_shard_filtered, got:\n" + out,
+                out.contains("tailer_entries_shard_filtered   = 0"));
+    }
+
+    /**
+     * Issue #463: after refactoring {@code GetEngineStatsResponse} to a
+     * generic {@code repeated MetricEntry} list, the {@code --json} output
+     * must still produce a valid single JSON object containing every metric
+     * key. We don't pin the order — only that every expected key is present.
+     */
+    @Test
+    public void testEngineStatsJson() {
+        int rc = cli.run(new String[]{
+            "engine-stats",
+            "--server", service.getAddress(),
+            "--json"
+        });
+        assertEquals(0, rc);
+        String out = stdout().trim();
+        assertTrue("JSON output must be a single object, got:\n" + out,
+                out.startsWith("{") && out.endsWith("}"));
+        // Spot-check a few keys spanning all three value kinds the proto
+        // currently uses (int64, bool, plus the new shard-filter counter).
+        assertTrue("must include uptime_millis, got:\n" + out,
+                out.contains("\"uptime_millis\":"));
+        assertTrue("must include tailer_running, got:\n" + out,
+                out.contains("\"tailer_running\":true"));
+        assertTrue("must include loaded_index_count:1, got:\n" + out,
+                out.contains("\"loaded_index_count\":1"));
+        assertTrue("must include the new tailer_entries_shard_filtered:0, got:\n" + out,
+                out.contains("\"tailer_entries_shard_filtered\":0"));
     }
 
     @Test

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
@@ -30,13 +30,17 @@ import herddb.indexing.proto.DescribeIndexResponse;
 import herddb.indexing.proto.GetEngineStatsResponse;
 import herddb.indexing.proto.GetInstanceInfoResponse;
 import herddb.indexing.proto.ListIndexesResponse;
+import herddb.indexing.proto.MetricEntry;
+import herddb.indexing.proto.MetricValue;
 import herddb.indexing.proto.PrimaryKeysChunk;
 import herddb.model.ColumnTypes;
 import herddb.model.Index;
 import herddb.utils.Bytes;
 import io.grpc.StatusRuntimeException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
@@ -216,17 +220,43 @@ public class IndexingServiceDiagnosticsGrpcTest {
         seedIndex("docs", "idx_docs", 4);
 
         GetEngineStatsResponse response = client.getEngineStats();
-        assertTrue(response.getUptimeMillis() >= 0);
-        assertTrue(response.getTailerRunning());
-        assertEquals(1, response.getLoadedIndexCount());
-        assertTrue(response.getApplyParallelism() >= 1);
-        assertTrue(response.getApplyQueueCapacity() > 0);
-        assertTrue(response.getTotalEstimatedMemoryBytes() > 0);
+        // Issue #463: response is now a generic (key, MetricValue) list. We
+        // index it by key for assertion lookups; nothing in this test cares
+        // about ordering — that's a property the indexing-admin CLI relies on
+        // and is exercised in IndexingAdminCliTest.testEngineStatsText.
+        Map<String, MetricValue> metrics = indexMetricsByKey(response);
+        assertTrue("uptime_millis", metrics.get("uptime_millis").getInt64Value() >= 0);
+        assertTrue("tailer_running", metrics.get("tailer_running").getBoolValue());
+        assertEquals("loaded_index_count", 1L,
+                metrics.get("loaded_index_count").getInt64Value());
+        assertTrue("apply_parallelism",
+                metrics.get("apply_parallelism").getInt64Value() >= 1);
+        assertTrue("apply_queue_capacity",
+                metrics.get("apply_queue_capacity").getInt64Value() > 0);
+        assertTrue("total_estimated_memory_bytes",
+                metrics.get("total_estimated_memory_bytes").getInt64Value() > 0);
         // JVM heap fields (issue #80).
-        assertTrue("jvm_heap_used_bytes should be > 0", response.getJvmHeapUsedBytes() > 0);
-        assertTrue("jvm_heap_max_bytes should be > 0", response.getJvmHeapMaxBytes() > 0);
-        assertTrue("jvm_heap_used_pct should be in [0,100]",
-                response.getJvmHeapUsedPct() >= 0 && response.getJvmHeapUsedPct() <= 100);
+        assertTrue("jvm_heap_used_bytes should be > 0",
+                metrics.get("jvm_heap_used_bytes").getInt64Value() > 0);
+        assertTrue("jvm_heap_max_bytes should be > 0",
+                metrics.get("jvm_heap_max_bytes").getInt64Value() > 0);
+        long pct = metrics.get("jvm_heap_used_pct").getInt64Value();
+        assertTrue("jvm_heap_used_pct should be in [0,100]", pct >= 0 && pct <= 100);
+        // Issue #463: the new shard-filter counter must be present and zero
+        // for a single-instance setup that hasn't routed any INSERT through
+        // applyInsert yet.
+        assertTrue("tailer_entries_shard_filtered must be present",
+                metrics.containsKey("tailer_entries_shard_filtered"));
+        assertEquals("tailer_entries_shard_filtered", 0L,
+                metrics.get("tailer_entries_shard_filtered").getInt64Value());
+    }
+
+    private static Map<String, MetricValue> indexMetricsByKey(GetEngineStatsResponse r) {
+        Map<String, MetricValue> m = new HashMap<>();
+        for (MetricEntry e : r.getMetricsList()) {
+            m.put(e.getKey(), e.getValue());
+        }
+        return m;
     }
 
     @Test

--- a/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceBookKeeperShardingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceBookKeeperShardingTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import herddb.codec.RecordSerializer;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
+import herddb.log.LogEntryType;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
 import herddb.model.Index;
@@ -344,6 +345,280 @@ public class MultiInstanceBookKeeperShardingTest {
                         new float[]{1.0f, 2.0f, 3.0f}, numRecords);
                 assertEquals(numRecords, results.size());
             }
+
+        } finally {
+            for (EmbeddedIndexingService eis : services) {
+                try {
+                    eis.close();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    /**
+     * Issue #463: with 2 instances and {@code numShards=4}, every replica
+     * sees every INSERT entry (so {@code tailer_inserts} matches the workload
+     * size on each), but the shard filter rejects roughly half of them on
+     * each instance — those rejections must show up in the new
+     * {@code tailer_entries_shard_filtered} counter and the totals across
+     * the cluster must add up to exactly the workload size (every INSERT was
+     * rejected on exactly one of the two replicas). Drives the
+     * non-transactional fast path (each INSERT applied directly via
+     * {@code applySingleEntryForTest}) to keep this test isolated from the
+     * transaction-buffer code path covered by
+     * {@link #testTwoInstancesTransactionalInsertsBumpShardFilteredCounter}.
+     */
+    @Test
+    public void testTwoInstancesNonTransactionalInsertsBumpShardFilteredCounter()
+            throws Exception {
+        int numInstances = 2;
+        int numShards = 4;
+        int numRecords = 100;
+
+        Table table = createTable();
+        Index index = createIndex(numShards);
+
+        List<IndexingServiceEngine> engines = new ArrayList<>();
+        List<EmbeddedIndexingService> services = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < numInstances; i++) {
+                Path logDir = folder.newFolder("sf-nontx-log-" + i).toPath();
+                Path dataDir = folder.newFolder("sf-nontx-data-" + i).toPath();
+                EmbeddedIndexingService eis = new EmbeddedIndexingService(
+                        logDir, dataDir, i, numInstances);
+                eis.start();
+                services.add(eis);
+                engines.add(eis.getEngine());
+            }
+
+            // DDL on every replica.
+            LogEntry createTableEntry = LogEntryFactory.createTable(table, null);
+            LogEntry createIndexEntry = LogEntryFactory.createIndex(index, null);
+            for (IndexingServiceEngine engine : engines) {
+                engine.applyEntry(new LogSequenceNumber(1, 1), createTableEntry);
+                engine.applyEntry(new LogSequenceNumber(1, 2), createIndexEntry);
+            }
+
+            // 100 non-transactional INSERTs delivered to BOTH replicas via
+            // processEntryForTest — same entrypoint the real tailer thread
+            // uses. processEntry() runs classifyForMetrics() (bumps
+            // tailer_inserts) AND dispatches to the apply pipeline (where
+            // applyInsert() bumps tailer_entries_shard_filtered for entries
+            // the shard filter rejects). Going through applySingleEntryForTest
+            // would bypass classifyForMetrics and leave tailer_inserts at 0.
+            for (int i = 0; i < numRecords; i++) {
+                Record record = RecordSerializer.makeRecord(table,
+                        "pk", "sf-nontx-" + i,
+                        "vec", new float[]{i * 1.0f, (i + 1) * 1.0f, (i + 2) * 1.0f});
+                LogEntry insert = LogEntryFactory.insert(table,
+                        record.key, record.value, null);
+                LogSequenceNumber lsn = new LogSequenceNumber(1, 10 + i);
+                for (IndexingServiceEngine engine : engines) {
+                    engine.processEntryForTest(lsn, insert);
+                }
+            }
+            for (IndexingServiceEngine engine : engines) {
+                engine.awaitPendingWorkForTest();
+            }
+
+            long sf0 = engines.get(0).getTailerEntriesShardFiltered();
+            long sf1 = engines.get(1).getTailerEntriesShardFiltered();
+            assertEquals(
+                    "every INSERT must have been shard-filtered on exactly one replica",
+                    numRecords, sf0 + sf1);
+            assertTrue("instance 0 must shard-filter at least one INSERT, got " + sf0,
+                    sf0 > 0);
+            assertTrue("instance 0 must accept at least one INSERT (sf0 < " + numRecords + "), got " + sf0,
+                    sf0 < numRecords);
+            assertTrue("instance 1 must shard-filter at least one INSERT, got " + sf1,
+                    sf1 > 0);
+            assertTrue("instance 1 must accept at least one INSERT (sf1 < " + numRecords + "), got " + sf1,
+                    sf1 < numRecords);
+            // tailer_inserts is bumped at classifyForMetrics time (intent) so
+            // it should match the workload size on EVERY replica regardless
+            // of the shard filter outcome.
+            assertEquals("instance 0 must see every INSERT in tailer_inserts",
+                    numRecords, engines.get(0).getTailerInserts());
+            assertEquals("instance 1 must see every INSERT in tailer_inserts",
+                    numRecords, engines.get(1).getTailerInserts());
+
+        } finally {
+            for (EmbeddedIndexingService eis : services) {
+                try {
+                    eis.close();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    /**
+     * Issue #463: VectorBench commits each batch of INSERTs in a single
+     * transaction (BEGIN + many transactional INSERTs + COMMIT), which routes
+     * through {@code transactionBuffer} → {@code applyBufferedEntries} →
+     * {@code submitDmlAsync} → {@code applyEntry} → {@code applyInsert}. This
+     * is a different code path from
+     * {@link #testTwoInstancesNonTransactionalInsertsBumpShardFilteredCounter},
+     * which exercises the non-tx fast path. We need to verify the shard
+     * filter (and its new {@code tailer_entries_shard_filtered} counter)
+     * still fire correctly when the entries arrive inside a transaction
+     * envelope — which is what the VectorBench production path actually does.
+     *
+     * <p>Splits 100 INSERTs across two transactions of 50 each, with keys
+     * deliberately chosen so each transaction contains a mix of shard-0/1/2/3
+     * keys (sequential PKs do this naturally). Drives the full BEGIN → 50
+     * INSERTs → COMMIT envelope through {@code processEntryForTest} on both
+     * replicas, then asserts the same cluster-level invariants as the non-tx
+     * test plus a search-fan-out check that proves the on-disk state is
+     * actually disjoint (i.e., the actual filter ran, not just the metric).
+     */
+    @Test
+    public void testTwoInstancesTransactionalInsertsBumpShardFilteredCounter()
+            throws Exception {
+        int numInstances = 2;
+        int numShards = 4;
+        int numRecords = 100;
+        int batchSize = 50;
+        long[] txIds = new long[]{42L, 43L};
+
+        Table table = createTable();
+        Index index = createIndex(numShards);
+
+        List<IndexingServiceEngine> engines = new ArrayList<>();
+        List<EmbeddedIndexingService> services = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < numInstances; i++) {
+                Path logDir = folder.newFolder("sf-tx-log-" + i).toPath();
+                Path dataDir = folder.newFolder("sf-tx-data-" + i).toPath();
+                EmbeddedIndexingService eis = new EmbeddedIndexingService(
+                        logDir, dataDir, i, numInstances);
+                eis.start();
+                services.add(eis);
+                engines.add(eis.getEngine());
+            }
+
+            // DDL on every replica. CREATE_TABLE / CREATE_INDEX flow through
+            // applyEntry directly, not the transactional path — they're not
+            // part of the transaction envelope we're testing.
+            LogEntry createTableEntry = LogEntryFactory.createTable(table, null);
+            LogEntry createIndexEntry = LogEntryFactory.createIndex(index, null);
+            for (IndexingServiceEngine engine : engines) {
+                engine.applyEntry(new LogSequenceNumber(1, 1), createTableEntry);
+                engine.applyEntry(new LogSequenceNumber(1, 2), createIndexEntry);
+            }
+
+            // Drive 100 INSERTs across 2 transactions (50 each). Each INSERT
+            // has txId == txIds[batch], wrapped in BEGINTRANSACTION/COMMIT.
+            // Routed through processEntryForTest on BOTH replicas — same
+            // entrypoint the real BookKeeper tailer uses, so the
+            // transactionBuffer + applyBufferedEntries + submitDmlAsync path
+            // is exercised end-to-end.
+            long lsnOff = 10;
+            Set<String> allKeys = new HashSet<>();
+            for (int batch = 0; batch < numRecords / batchSize; batch++) {
+                long txId = txIds[batch];
+                LogEntry begin = LogEntryFactory.beginTransaction(txId);
+                LogSequenceNumber beginLsn = new LogSequenceNumber(1, lsnOff++);
+                for (IndexingServiceEngine engine : engines) {
+                    engine.processEntryForTest(beginLsn, begin);
+                }
+                for (int j = 0; j < batchSize; j++) {
+                    int globalIdx = batch * batchSize + j;
+                    String pk = "sf-tx-" + globalIdx;
+                    allKeys.add(pk);
+                    Record record = RecordSerializer.makeRecord(table,
+                            "pk", pk,
+                            "vec", new float[]{globalIdx * 1.0f,
+                                    (globalIdx + 1) * 1.0f, (globalIdx + 2) * 1.0f});
+                    // Build a transactional INSERT directly — LogEntryFactory.insert
+                    // takes a herddb.model.Transaction, but we only need the txId
+                    // for the tailer's BEGIN/COMMIT fan-out, so we construct the
+                    // LogEntry ourselves with a non-zero transactionId.
+                    LogEntry insert = new LogEntry(System.currentTimeMillis(),
+                            LogEntryType.INSERT, txId, table.tableId,
+                            record.key, record.value);
+                    LogSequenceNumber insertLsn = new LogSequenceNumber(1, lsnOff++);
+                    for (IndexingServiceEngine engine : engines) {
+                        engine.processEntryForTest(insertLsn, insert);
+                    }
+                }
+                LogEntry commit = LogEntryFactory.commitTransaction(txId);
+                LogSequenceNumber commitLsn = new LogSequenceNumber(1, lsnOff++);
+                for (IndexingServiceEngine engine : engines) {
+                    engine.processEntryForTest(commitLsn, commit);
+                }
+            }
+            // Drain the async DML pipeline on both replicas — applyBufferedEntries
+            // submits work to submitDmlAsync, which runs on the apply-worker pool.
+            for (IndexingServiceEngine engine : engines) {
+                engine.awaitPendingWorkForTest();
+            }
+
+            // Metric invariants — same shape as the non-tx test, proves the
+            // shard filter fires from the transactional code path too.
+            long sf0 = engines.get(0).getTailerEntriesShardFiltered();
+            long sf1 = engines.get(1).getTailerEntriesShardFiltered();
+            assertEquals(
+                    "every transactional INSERT must have been shard-filtered "
+                            + "on exactly one replica (got sf0=" + sf0 + ", sf1=" + sf1 + ")",
+                    numRecords, sf0 + sf1);
+            assertTrue("instance 0 must shard-filter at least one INSERT, got " + sf0,
+                    sf0 > 0);
+            assertTrue("instance 0 must accept at least one INSERT, got " + sf0,
+                    sf0 < numRecords);
+            assertTrue("instance 1 must shard-filter at least one INSERT, got " + sf1,
+                    sf1 > 0);
+            assertTrue("instance 1 must accept at least one INSERT, got " + sf1,
+                    sf1 < numRecords);
+            assertEquals("instance 0 must see every INSERT in tailer_inserts",
+                    numRecords, engines.get(0).getTailerInserts());
+            assertEquals("instance 1 must see every INSERT in tailer_inserts",
+                    numRecords, engines.get(1).getTailerInserts());
+
+            // Storage-level invariant: each replica's local index must
+            // physically hold ONLY the keys it accepted (i.e., not the
+            // shard-filtered ones), and the union across replicas must equal
+            // every key we inserted. Proves the actual filter — not just the
+            // metric — ran through the transaction-buffer path.
+            Set<String> keys0 = new HashSet<>();
+            for (Map.Entry<Bytes, Float> e : engines.get(0).search(
+                    "default", "mytable", "vidx",
+                    new float[]{1.0f, 2.0f, 3.0f}, numRecords)) {
+                keys0.add(new String(e.getKey().to_array(),
+                        java.nio.charset.StandardCharsets.UTF_8));
+            }
+            Set<String> keys1 = new HashSet<>();
+            for (Map.Entry<Bytes, Float> e : engines.get(1).search(
+                    "default", "mytable", "vidx",
+                    new float[]{1.0f, 2.0f, 3.0f}, numRecords)) {
+                keys1.add(new String(e.getKey().to_array(),
+                        java.nio.charset.StandardCharsets.UTF_8));
+            }
+            // |keys0| + |keys1| == numRecords ⇒ disjoint union (no key was
+            // accepted by both replicas — which would mean the shard filter
+            // failed open).
+            assertEquals(
+                    "no key may be present on both replicas (shard filter must "
+                            + "send each key to exactly one owner)",
+                    numRecords, keys0.size() + keys1.size());
+            Set<String> union = new HashSet<>(keys0);
+            union.addAll(keys1);
+            assertEquals(
+                    "union of per-replica keys must cover every inserted key",
+                    allKeys, union);
+            // Per-replica counts must match the negation of the shard-filter
+            // counter on the same replica: locally accepted == numRecords - shardFiltered.
+            assertEquals(
+                    "instance 0 local key set size must equal numRecords - shardFiltered0",
+                    numRecords - sf0, keys0.size());
+            assertEquals(
+                    "instance 1 local key set size must equal numRecords - shardFiltered1",
+                    numRecords - sf1, keys1.size());
 
         } finally {
             for (EmbeddedIndexingService eis : services) {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
@@ -93,6 +93,7 @@ public class TailerOpTypeMetricsTest {
         assertEquals(0L, e.getTailerEntriesProcessed());
         assertEquals(0L, e.getTailerEntriesAccepted());
         assertEquals(0L, e.getTailerEntriesSkipped());
+        assertEquals(0L, e.getTailerEntriesShardFiltered());
         assertEquals(0L, e.getTailerInserts());
         assertEquals(0L, e.getTailerUpdates());
         assertEquals(0L, e.getTailerDeletes());
@@ -243,5 +244,36 @@ public class TailerOpTypeMetricsTest {
         assertEquals(1L, engine.getTailerDdl());
         assertEquals(0L, engine.getTailerEntriesAccepted());
         assertEquals(1L, engine.getTailerEntriesSkipped());
+    }
+
+    /**
+     * Issue #463: an INSERT on a table with no vector index must NOT bump
+     * {@code tailer_entries_shard_filtered}. The early return inside
+     * {@code applyInsert} (before the per-index shard-filter loop) signals a
+     * different reason than shard-filter rejection — operators distinguish
+     * "this replica chose not to index because it doesn't own the shard"
+     * (counted) from "the table is non-vector" (not counted).
+     */
+    @Test
+    public void singleInsertOnTableWithNoVectorIndexDoesNotBumpShardFiltered()
+            throws Exception {
+        IndexingServiceEngine engine = service.getEngine();
+        Table table = testTable();
+
+        // Register the table so applyInsert resolves the schema, but do NOT
+        // create a vector index for it. The applyInsert() body will hit the
+        // `vectorIndexes.isEmpty()` early return.
+        engine.processEntryForTest(new LogSequenceNumber(1, 1),
+                LogEntryFactory.createTable(table, null));
+        engine.processEntryForTest(new LogSequenceNumber(1, 2),
+                LogEntryFactory.insert(table, Bytes.from_string("k"),
+                        Bytes.from_string("v"), null));
+        engine.awaitPendingWorkForTest();
+
+        assertEquals("INSERT must still bump tailer_inserts",
+                1L, engine.getTailerInserts());
+        assertEquals("INSERT on table without vector index must NOT count "
+                        + "as shard-filtered",
+                0L, engine.getTailerEntriesShardFiltered());
     }
 }


### PR DESCRIPTION
Fixes #463.

## Changes

- `herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java`: add `tailerEntriesShardFiltered` LongAdder + `getTailerEntriesShardFiltered()` getter. Bump it inside `applyInsert()` when the table has at least one vector index defined AND every applicable index rejected the key via `isAcceptedLocally`. Register the corresponding `tailer.entries_shard_filtered` Prometheus gauge.
- `herddb-indexing-service/src/main/proto/indexing_service.proto`: drop every typed scalar field on `GetEngineStatsResponse` and replace with a single `repeated MetricEntry { string key; MetricValue value }` list. `MetricValue` is a typed-union `oneof { int64 | double | bool | string }`. Adding a metric is now a one-line server-side change without a proto migration.
- `herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java`: replace the per-field `set*()` chain with `addInt64(...)` / `addBool(...)` helpers that append `MetricEntry` records. Emits every metric the previous schema carried plus the new `tailer_entries_shard_filtered`.
- `herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java`: walk `response.getMetricsList()` and switch on the `MetricValue.kind` oneof to populate a `LinkedHashMap<String, Object>`; reuse it for both the text and JSON renderings. Text format widened to 31-char alignment to comfortably fit the longest current key.
- Test updates: `IndexingServiceDiagnosticsGrpcTest.testGetEngineStats` migrated from per-field accessors to the new `MetricEntry`-list shape via a per-key lookup map. `IndexingAdminCliTest.testEngineStatsText` updated for the new alignment + asserts the new key is present; new `testEngineStatsJson` exercises the JSON renderer.

## Tests

- `TailerOpTypeMetricsTest.freshEngineReportsAllZero` — extended to also cover `getTailerEntriesShardFiltered()`.
- `TailerOpTypeMetricsTest.singleInsertOnTableWithNoVectorIndexDoesNotBumpShardFiltered` — drives a single INSERT on a table without a vector index and asserts the new counter stays at `0` (different early-return path than shard-filter rejection — operators distinguish the two reasons).
- `MultiInstanceBookKeeperShardingTest.testTwoInstancesNonTransactionalInsertsBumpShardFilteredCounter` — 2 instances, `numShards=4`, 100 non-transactional INSERTs delivered to both replicas via `processEntryForTest`. Asserts `sf0 + sf1 == 100`, each strictly between 0 and 100, and `tailer_inserts == 100` on each replica (per-op counter still counts intent).
- `MultiInstanceBookKeeperShardingTest.testTwoInstancesTransactionalInsertsBumpShardFilteredCounter` — same shape but routes the 100 INSERTs through two `BEGIN → 50× INSERT(tx) → COMMIT` envelopes, exercising the `transactionBuffer → applyBufferedEntries → submitDmlAsync` chain that VectorBench actually drives in production. Adds a search-fan-out check that the per-replica on-disk key sets are disjoint and union to every inserted key — proves the actual filter (not just the metric) runs through the transactional code path.
- `IndexingAdminCliTest.testEngineStatsText` — extended to assert the new shard-filter key is present and `0` on a fresh single-instance setup.
- `IndexingAdminCliTest.testEngineStatsJson` — new test that runs `engine-stats --json` against the embedded service and verifies the JSON output is a single object containing every expected key (covering all three currently-used `MetricValue` kinds: int64, bool, plus the new shard-filter entry).

🤖 Implemented by the `pr-worker` agent.