### PR TITLE
issue #462: collapse stateLock.writeLock window in compaction swap and Phase C

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -683,6 +683,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private final AtomicLong totalCheckpointCount = new AtomicLong(0);
     private final AtomicLong totalFusedPQCheckpointCount = new AtomicLong(0);
     /**
+     * Wall-clock nanoseconds the most recent {@code atomicSwapCompactionResult}
+     * call held {@code stateLock.writeLock()} (issue #462). Diagnostic only — used
+     * by the lock-progress regression tests to assert the writeLock window stays
+     * tiny (≪ persist duration) so concurrent searches are not blocked behind
+     * the compaction-swap critical section.
+     */
+    private final AtomicLong lastCompactionSwapWriteLockNanos = new AtomicLong(0);
+    /**
+     * Wall-clock nanoseconds the most recent Phase C of
+     * {@code doCheckpointFusedPQThreePhase} held {@code stateLock.writeLock()}
+     * (issue #462). Diagnostic only — used by the lock-progress regression
+     * tests to assert the writeLock window stays tiny (≪ pending-deletes-apply
+     * duration) so concurrent searches are not blocked behind Phase C.
+     */
+    private final AtomicLong lastPhaseCWriteLockNanos = new AtomicLong(0);
+    /**
      * Number of times {@link #doCheckpointUnderLock} skipped a cycle because
      * the min-live-vectors gate tripped and the max-deferral bound had not
      * yet elapsed. Incremented only on the deferral path — not on the
@@ -1154,6 +1170,60 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** Sets a hook that runs during Phase B of checkpoint. For testing. */
     public void setCheckpointPhaseBHook(Runnable hook) {
         this.checkpointPhaseBHook = hook;
+    }
+
+    /**
+     * Test hook fired inside {@code atomicSwapCompactionResult} (issue #462)
+     * after Stage 1 (validate + build {@code newSegments} + queue
+     * pending-deletes) finishes and BEFORE Stage 2 ({@code
+     * persistIndexStatusMultiSegment}). Lets unit tests assert the
+     * pre-persist invariant: {@code currentIndexStatusGeneration} unchanged,
+     * {@code this.segments} still references the OLD list, {@code
+     * mergedOutput.generation} already set to {@code oldGen + 1}.
+     * Hook runs under {@code checkpointLock} but NOT under
+     * {@code stateLock.writeLock()}.
+     */
+    private volatile Runnable atomicSwapPostBuildHook;
+
+    /** Sets the test hook fired between Stage 1 and Stage 2 of
+     * {@code atomicSwapCompactionResult}. For testing. */
+    public void setAtomicSwapPostBuildHookForTest(Runnable hook) {
+        this.atomicSwapPostBuildHook = hook;
+    }
+
+    /**
+     * Test hook fired inside {@code atomicSwapCompactionResult} (issue #462)
+     * after Stage 2 ({@code persistIndexStatusMultiSegment} returned
+     * successfully) and BEFORE Stage 3 (writeLock-protected
+     * publish + memory-counter swap). Lets unit tests assert the
+     * post-persist / pre-publish invariant: {@code
+     * currentIndexStatusGeneration} is now bumped, but {@code this.segments}
+     * still references the OLD list and {@code stateLock.isWriteLocked()
+     * == false}. Hook runs under {@code checkpointLock} but NOT under
+     * {@code stateLock.writeLock()}.
+     */
+    private volatile Runnable atomicSwapPostPersistHook;
+
+    /** Sets the test hook fired between Stage 2 and Stage 3 of
+     * {@code atomicSwapCompactionResult}. For testing. */
+    public void setAtomicSwapPostPersistHookForTest(Runnable hook) {
+        this.atomicSwapPostPersistHook = hook;
+    }
+
+    /**
+     * Test hook fired inside Phase C of {@code doCheckpointFusedPQThreePhase}
+     * (issue #462) after the pending-checkpoint-deletes apply finishes and
+     * BEFORE the Stage-2 writeLock acquisition. Lets the lock-progress
+     * regression test inject a "search now" probe at the precise window where
+     * the pre-fix code was holding the writeLock for seconds. Hook runs under
+     * {@code checkpointLock} but NOT under {@code stateLock.writeLock()}.
+     */
+    private volatile Runnable phaseCPostDeletesApplyHook;
+
+    /** Sets the test hook fired after Phase C's pending-deletes apply.
+     * For testing. */
+    public void setPhaseCPostDeletesApplyHookForTest(Runnable hook) {
+        this.phaseCPostDeletesApplyHook = hook;
     }
 
     // -------------------------------------------------------------------------
@@ -2403,6 +2473,43 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * {@code vector.index.compaction.maxBytes} of remote storage per
      * occurrence — and aborts are by-design steady-state behaviour of the
      * pressure-driven local fallback when the optimizer races the IS.
+     *
+     * <p><b>Three-stage local protocol (issue #462).</b> Inside the
+     * {@code checkpointLock}, the local IndexStatus persist + in-memory swap
+     * is split so the slow I/O does not hold {@code stateLock.writeLock()}.
+     * Without this split a single {@code writeLock} window spans
+     * {@link #persistIndexStatusMultiSegment} (local fsync + remote
+     * shared-metadata PUT of every segment's metadata) — at 18&nbsp;K
+     * segments that's seconds, long enough to starve concurrent searches
+     * waiting on {@code stateLock.readLock()}.
+     *
+     * <ol>
+     *   <li><b>Stage 1 (no writeLock).</b> Validate that every input is still
+     *   in {@code segments} (under {@code checkpointLock} no other writer can
+     *   be modifying it). Build {@code newSegments}; stamp
+     *   {@code mergedOutput.generation = currentIndexStatusGeneration + 1}
+     *   so the in-memory state matches what we are about to persist. Queue
+     *   inputs for retention-aware deletion (CopyOnWriteArrayList — thread
+     *   safe).</li>
+     *
+     *   <li><b>Stage 2 (no writeLock).</b> Run
+     *   {@link #persistIndexStatusMultiSegment} — the slow part. Lock-free
+     *   readers continue to see the OLD {@code this.segments} via the volatile
+     *   field; their search results are eventually consistent. {@code
+     *   currentIndexStatusGeneration} is bumped at the end of this call.</li>
+     *
+     *   <li><b>Stage 3 (writeLock — microseconds).</b> Atomically: register
+     *   the merged output's memory estimate, publish
+     *   {@code this.segments = newSegments}, unregister the inputs' memory
+     *   estimates, set {@code dirty}.</li>
+     * </ol>
+     *
+     * <p>Failure handling is preserved verbatim from the prior single-window
+     * implementation: {@code queueSegmentPendingDelete} runs <em>before</em>
+     * the persist (Stage 1), so a Stage-2 throw leaves {@code pendingDeletes}
+     * populated exactly as today and the in-memory {@code segments} is never
+     * republished. {@link #runCompactionCycle}'s existing {@code catch}
+     * blocks observe the failure and record it.
      */
     private void atomicSwapCompactionResult(List<VectorSegment> inputs,
                                             VectorSegment mergedOutput,
@@ -2488,81 +2595,92 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         checkpointLock.lock();
         try {
+            // ---------- STAGE 1 — validate + build (no writeLock). ----------
+            // checkpointLock is the outermost serialiser of segments mutations,
+            // so the volatile read of `this.segments` is stable for the
+            // duration of this method.
+            List<VectorSegment> current = this.segments;
+            Set<Integer> currentIds = new java.util.HashSet<>(current.size() * 2);
+            for (VectorSegment s : current) {
+                currentIds.add(s.segmentId);
+            }
+            for (VectorSegment in : inputs) {
+                if (!currentIds.contains(in.segmentId)) {
+                    // In-memory drift — undo the registry stage if any
+                    // and queue the merged output's bytes for cleanup so
+                    // they don't leak. Without this branch the abort path
+                    // would leak up to vector.index.compaction.maxBytes
+                    // of remote storage per occurrence.
+                    if (publisherSnapshot != null && stagedInfo != null) {
+                        try {
+                            publisherSnapshot.unstage(stagedInfo);
+                        } catch (RuntimeException ignored) {
+                            // best-effort — reconcile-on-restart will sweep
+                        }
+                    }
+                    queueMergedOutputForDeletion(mergedOutput);
+                    throw new VectorIndexCompactor.CompactionException(
+                            VectorIndexCompactor.FailureReason.ABORTED_INPUT_GONE,
+                            "input segment " + in.segmentId + " disappeared from segment list");
+                }
+            }
+
+            Set<Integer> inputIds = new java.util.HashSet<>(inputs.size() * 2);
+            for (VectorSegment in : inputs) {
+                inputIds.add(in.segmentId);
+            }
+            List<VectorSegment> newSegments =
+                    new java.util.concurrent.CopyOnWriteArrayList<>();
+            for (VectorSegment s : current) {
+                if (!inputIds.contains(s.segmentId)) {
+                    newSegments.add(s);
+                }
+            }
+            if (mergedOutput != null) {
+                // Fresh generation will be assigned by
+                // persistIndexStatusMultiSegment; we set it now so the
+                // in-memory state matches what we persist.
+                mergedOutput.generation = currentIndexStatusGeneration.get() + 1;
+                newSegments.add(mergedOutput);
+            }
+
+            // Queue inputs for retention-aware deletion. Same ordering as the
+            // pre-#462 implementation (queue BEFORE persist) so the failure
+            // semantics are unchanged.
+            for (VectorSegment in : inputs) {
+                queueSegmentPendingDelete(in, vectorIndexCompactionRetentionMs);
+            }
+
+            Runnable postBuildHook = atomicSwapPostBuildHook;
+            if (postBuildHook != null) {
+                postBuildHook.run();
+            }
+
+            // ---------- STAGE 2 — persist (no writeLock; the slow I/O). ----------
+            // checkpointLock is held; concurrent compaction/checkpoint cannot
+            // run. Concurrent searches read the OLD this.segments via the
+            // volatile field — eventually consistent until Stage 3 publishes.
+            List<VectorSegment> allSealedForPersist = new ArrayList<>(newSegments);
+            persistIndexStatusMultiSegment(
+                    allSealedForPersist,
+                    java.util.Collections.emptyList(),
+                    java.util.Collections.emptyList(),
+                    LogSequenceNumber.START_OF_TIME);
+
+            Runnable postPersistHook = atomicSwapPostPersistHook;
+            if (postPersistHook != null) {
+                postPersistHook.run();
+            }
+
+            // ---------- STAGE 3 — atomic publish (writeLock for ~µs). ----------
+            // Issue #455: keep the on-disk-segment memory counter in sync
+            // with the segments-list swap. The register/publish/unregister
+            // triple runs under one writeLock so the counter and the
+            // segments list flip together; concurrent addVector readers
+            // (which take the readLock) cannot observe a half-updated state.
+            long stage3Start = System.nanoTime();
             stateLock.writeLock().lock();
             try {
-                // Validate every input is still in the segment list.
-                List<VectorSegment> current = segments;
-                Set<Integer> currentIds = new java.util.HashSet<>();
-                for (VectorSegment s : current) {
-                    currentIds.add(s.segmentId);
-                }
-                for (VectorSegment in : inputs) {
-                    if (!currentIds.contains(in.segmentId)) {
-                        // In-memory drift — undo the registry stage if any
-                        // and queue the merged output's bytes for cleanup so
-                        // they don't leak. The pre-existing version of this
-                        // branch (before the registry stage was added) only
-                        // had the empty rebuild.orphanPaths to fall back on
-                        // — that was a latent leak that became reachable
-                        // far more often once the new registry-revalidate
-                        // abort path landed alongside it.
-                        if (publisherSnapshot != null && stagedInfo != null) {
-                            try {
-                                publisherSnapshot.unstage(stagedInfo);
-                            } catch (RuntimeException ignored) {
-                                // best-effort — reconcile-on-restart will sweep
-                            }
-                        }
-                        queueMergedOutputForDeletion(mergedOutput);
-                        throw new VectorIndexCompactor.CompactionException(
-                                VectorIndexCompactor.FailureReason.ABORTED_INPUT_GONE,
-                                "input segment " + in.segmentId + " disappeared from segment list");
-                    }
-                }
-
-                // Build new segment list.
-                List<VectorSegment> newSegments =
-                        new java.util.concurrent.CopyOnWriteArrayList<>();
-                Set<Integer> inputIds = new java.util.HashSet<>();
-                for (VectorSegment in : inputs) {
-                    inputIds.add(in.segmentId);
-                }
-                for (VectorSegment s : current) {
-                    if (!inputIds.contains(s.segmentId)) {
-                        newSegments.add(s);
-                    }
-                }
-                if (mergedOutput != null) {
-                    // Fresh generation will be assigned by
-                    // persistIndexStatusMultiSegment; we set it now so
-                    // the in-memory state matches what we persist.
-                    mergedOutput.generation = currentIndexStatusGeneration.get() + 1;
-                    newSegments.add(mergedOutput);
-                }
-
-                // Queue inputs for retention-aware deletion.
-                for (VectorSegment in : inputs) {
-                    queueSegmentPendingDelete(in, vectorIndexCompactionRetentionMs);
-                }
-
-                // Publish the new IndexStatus. Compaction reuses
-                // persistIndexStatusMultiSegment by passing sealed=all
-                // kept segments and newSegmentResults=empty (the merged
-                // output is already a VectorSegment, not a
-                // SegmentWriteResult).
-                List<VectorSegment> allSealedForPersist = new ArrayList<>(newSegments);
-                persistIndexStatusMultiSegment(
-                        allSealedForPersist,
-                        java.util.Collections.emptyList(),
-                        java.util.Collections.emptyList(),
-                        LogSequenceNumber.START_OF_TIME);
-
-                // Issue #455: keep the on-disk-segment memory counter in sync
-                // with the segments-list swap.  Capture the mergedOutput
-                // snapshot BEFORE publishing newSegments so the counter and
-                // the segments list flip together; inputs are unregistered
-                // immediately after the swap (their close() further down
-                // releases pkData / BLink).
                 if (mergedOutput != null) {
                     registerSegmentMemoryEstimate(mergedOutput);
                 }
@@ -2574,6 +2692,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
             } finally {
                 stateLock.writeLock().unlock();
             }
+            lastCompactionSwapWriteLockNanos.set(System.nanoTime() - stage3Start);
+
             // Close the inputs OUTSIDE the write lock: the searchers that
             // held a reference dropped it when we swapped `segments`.
             for (VectorSegment in : inputs) {
@@ -4107,7 +4227,65 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.provisionalMultipartFiles = null;
         consecutiveCheckpointFailures.set(0);
 
-        // Phase C: swap + cleanup (brief write lock)
+        // ---------- Phase C — two-stage protocol (issue #462). ----------
+        //
+        // Stage 1 (no writeLock; under checkpointLock):
+        //   - Build newSegments (sealed + mergeable + preloaded), reset their
+        //     dirty flags.
+        //   - Apply pendingCheckpointDeletes — O(P × N) at scale, the slow part.
+        //
+        // Stage 2 (writeLock for ~µs):
+        //   - Close snapshotShards' builders (no concurrent search references
+        //     them: the writeLock excludes readers; we also clear
+        //     frozenShards/deferredShards before releasing).
+        //   - Register memory for preloadedSegments.
+        //   - Publish this.segments = newSegments.
+        //   - Update nextNodeId, log summary, restore deferred → liveShards.
+        //   - Clear frozenShards / deferredShards / pendingCheckpointDeletes.
+        //
+        // Concurrency invariants the Stage-1 lock-free deletes-apply relies on:
+        //   - checkpointLock is held → no concurrent checkpoint/compaction
+        //     mutates `segments`.
+        //   - seg.deletePk is concurrent-safe with concurrent search readers
+        //     (BLink.delete is internally synchronized; offsets[ord]=-1 is
+        //     benign for readers, who skip ord<0 in acceptBits and
+        //     getPkForOrdinal).
+        //   - seg.deletePk is concurrent-safe with concurrent removeVector
+        //     callers (which only take readLock): BLink.delete returns the
+        //     ordinal to exactly one caller; the racing caller observes null
+        //     and skips the offsets/liveCount mutations, so liveCount is
+        //     decremented exactly once.
+
+        // Stage 1: build + apply pending deletes.
+        List<VectorSegment> newSegments = new java.util.concurrent.CopyOnWriteArrayList<>();
+        for (VectorSegment sealed : sealedSegments) {
+            sealed.dirty = false;
+            newSegments.add(sealed);
+        }
+        for (VectorSegment mergeable : mergeableSegments) {
+            mergeable.dirty = false;
+            newSegments.add(mergeable);
+        }
+        newSegments.addAll(preloadedSegments);
+
+        PagedPkSet pending = this.pendingCheckpointDeletes;
+        if (pending != null) {
+            pending.forEach(pk -> {
+                for (VectorSegment seg : newSegments) {
+                    if (seg.deletePk(pk)) {
+                        return;
+                    }
+                }
+            });
+        }
+
+        Runnable postDeletesApplyHook = phaseCPostDeletesApplyHook;
+        if (postDeletesApplyHook != null) {
+            postDeletesApplyHook.run();
+        }
+
+        // Stage 2: writeLock for the atomic state transition.
+        long stage2Start = System.nanoTime();
         stateLock.writeLock().lock();
         try {
             for (LiveGraphShard shard : snapshotShards) {
@@ -4118,31 +4296,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         // ignore
                     }
                 }
-            }
-
-            List<VectorSegment> newSegments = new java.util.concurrent.CopyOnWriteArrayList<>();
-            // Preserve existing sealed segments
-            for (VectorSegment sealed : sealedSegments) {
-                sealed.dirty = false;
-                newSegments.add(sealed);
-            }
-            // Preserve existing mergeable segments (old compaction targets)
-            for (VectorSegment mergeable : mergeableSegments) {
-                mergeable.dirty = false;
-                newSegments.add(mergeable);
-            }
-            // Add newly written segments from this checkpoint
-            newSegments.addAll(preloadedSegments);
-
-            PagedPkSet pending = this.pendingCheckpointDeletes;
-            if (pending != null) {
-                pending.forEach(pk -> {
-                    for (VectorSegment seg : newSegments) {
-                        if (seg.deletePk(pk)) {
-                            return;
-                        }
-                    }
-                });
             }
 
             // Issue #455: sealedSegments + mergeableSegments together cover
@@ -4201,6 +4354,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             CountDownLatch latch = this.checkpointPhaseComplete;
             this.checkpointPhaseComplete = null;
             stateLock.writeLock().unlock();
+            lastPhaseCWriteLockNanos.set(System.nanoTime() - stage2Start);
             if (latch != null) {
                 latch.countDown();
             }
@@ -6646,6 +6800,28 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public long getLastCheckpointVectorsProcessed() {
         return lastCheckpointVectorsProcessed.get();
+    }
+
+    /**
+     * Returns the wall-clock nanoseconds the most recent
+     * {@code atomicSwapCompactionResult} call held {@code stateLock.writeLock()}
+     * (issue #462). Used by the lock-progress regression tests to assert the
+     * writeLock window stays tiny (≪ persist duration) so concurrent searches
+     * are not blocked behind the compaction-swap critical section.
+     */
+    public long getLastCompactionSwapWriteLockNanos() {
+        return lastCompactionSwapWriteLockNanos.get();
+    }
+
+    /**
+     * Returns the wall-clock nanoseconds the most recent Phase C of
+     * {@code doCheckpointFusedPQThreePhase} held {@code stateLock.writeLock()}
+     * (issue #462). Used by the lock-progress regression tests to assert the
+     * writeLock window stays tiny (≪ pending-deletes-apply duration) so
+     * concurrent searches are not blocked behind Phase C.
+     */
+    public long getLastPhaseCWriteLockNanos() {
+        return lastPhaseCWriteLockNanos.get();
     }
 
     public long getLiveVectorsMemoryBytes() {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2600,7 +2600,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // so the volatile read of `this.segments` is stable for the
             // duration of this method.
             List<VectorSegment> current = this.segments;
-            Set<Integer> currentIds = new java.util.HashSet<>(current.size() * 2);
+            // Canonical pre-sizing: HashSet rounds up to the next power of two,
+            // so we want capacity = ceil(size / loadFactor). 0.75f is the
+            // default load factor.
+            Set<Integer> currentIds = new java.util.HashSet<>(
+                    (int) (current.size() / 0.75f) + 1);
             for (VectorSegment s : current) {
                 currentIds.add(s.segmentId);
             }
@@ -2625,7 +2629,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 }
             }
 
-            Set<Integer> inputIds = new java.util.HashSet<>(inputs.size() * 2);
+            Set<Integer> inputIds = new java.util.HashSet<>(
+                    (int) (inputs.size() / 0.75f) + 1);
             for (VectorSegment in : inputs) {
                 inputIds.add(in.segmentId);
             }
@@ -2681,7 +2686,31 @@ public class PersistentVectorStore extends AbstractVectorStore {
             long stage3Start = System.nanoTime();
             stateLock.writeLock().lock();
             try {
+                // Re-apply pendingCompactionDeletes to merged under
+                // writeLock, catching any PKs that arrived after the
+                // lock-free lateDeletes.forEach in runCompactionCycle and
+                // during Stages 1+2 of this method (issue #462, pr-reviewer
+                // pass-1 BLOCK fix). Without this re-apply: a removeVector(X)
+                // arriving during Stages 1+2 finds X in an input segment
+                // (still in this.segments until Stage 3), seg.deletePk
+                // succeeds on the input — but the input is about to be
+                // discarded, lateDeletes.forEach already ran on merged, and
+                // X stays in merged. The set is closed in
+                // runCompactionCycle's finally block right after this method
+                // returns, so this is the last opportunity to apply.
+                //
+                // Cost: O(|pendingCompactionDeletes|) BLink scans on
+                // mergedOutput. Bounded by application's delete rate ×
+                // (lock-free Stage 1+2 duration). Each seg.deletePk on a
+                // missing PK is a single BLink search returning null, so
+                // entries already absorbed by lateDeletes.forEach return
+                // quickly and only the late-arrivers do meaningful work.
                 if (mergedOutput != null) {
+                    PagedPkSet lateDeletesReapply = this.pendingCompactionDeletes;
+                    if (lateDeletesReapply != null) {
+                        VectorSegment merged = mergedOutput;
+                        lateDeletesReapply.forEach(merged::deletePk);
+                    }
                     registerSegmentMemoryEstimate(mergedOutput);
                 }
                 this.segments = newSegments;
@@ -4296,6 +4325,37 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         // ignore
                     }
                 }
+            }
+
+            // Re-apply pendingCheckpointDeletes to preloadedSegments under
+            // writeLock to catch any PKs that arrived in the BLink-backed
+            // pending set after Stage 1's lock-free forEach (issue #462,
+            // pr-reviewer pass-1 BLOCK fix). BLink.scan is weakly consistent:
+            // late-arriver inserts that land left of the iterator's current
+            // position are missed by Stage 1.
+            //
+            // We restrict the re-apply to preloadedSegments (not all
+            // newSegments) because removeVector itself directly applies the
+            // delete to existing on-disk segments via its iteration of
+            // `this.segments` (see PersistentVectorStore.removeVector). The
+            // gap is only the preloaded segments that aren't in
+            // `this.segments` until Stage 2's publish below — removeVector
+            // can't see them, so the late-arriver path through
+            // pendingCheckpointDeletes is the only mechanism.
+            //
+            // Cost: O(|pending| × |preloadedSegments|) with preloadedSegments
+            // typically 1 segment. Each seg.deletePk on a missing PK is a
+            // single BLink search that returns null quickly, so this is fast
+            // even when most pending entries were already applied in Stage 1.
+            PagedPkSet pendingForReapply = this.pendingCheckpointDeletes;
+            if (pendingForReapply != null && !preloadedSegments.isEmpty()) {
+                pendingForReapply.forEach(pk -> {
+                    for (VectorSegment seg : preloadedSegments) {
+                        if (seg.deletePk(pk)) {
+                            return;
+                        }
+                    }
+                });
             }
 
             // Issue #455: sealedSegments + mergeableSegments together cover

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionDeletePkRaceTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionDeletePkRaceTest.java
@@ -1,0 +1,283 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Race-test for the new concurrency invariant introduced by issue #462's
+ * Change&nbsp;1: {@code atomicSwapCompactionResult}'s validate/build/persist
+ * (Stages&nbsp;1 + 2) now run lock-free under {@code checkpointLock} alone.
+ *
+ * <p>The pre-fix code held {@code stateLock.writeLock()} across the entire
+ * swap, so a concurrent {@code removeVector(X)} was BLOCKED on
+ * {@code readLock} while Stages 1 + 2 ran; once the writeLock released
+ * after Stage 3's publish, {@code removeVector} would iterate the NEW
+ * {@code this.segments} (with the merged segment in place) and apply the
+ * delete to merged directly. <strong>No data loss.</strong>
+ *
+ * <p>The post-fix code's longer lock-free window (Stages 1 + 2) lets
+ * {@code removeVector(X)} run while {@code this.segments} still references
+ * the input segments. The delete lands on an input that's about to be
+ * discarded. {@code lateDeletes.forEach} (in {@code runCompactionCycle},
+ * before atomicSwap) has already finished, so {@code X} is never applied
+ * to the merged output.
+ *
+ * <p>The fix is a Stage&nbsp;3 re-apply of {@code pendingCompactionDeletes}
+ * to {@code mergedOutput} under writeLock — this test pins down that
+ * invariant by blocking Stage 2 (the persist) on a hook, racing
+ * {@code removeVector} on PKs that live in inputs, then asserting the
+ * deleted PKs are absent from the merged output once the cycle completes.
+ */
+public class PersistentVectorStoreCompactionDeletePkRaceTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore("testidx", "testtable",
+                "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+        // Aggressive compaction: any 2+ segments must merge.
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void concurrentRemoveDuringCompactionStage12IsAppliedToMerged() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("compaction-race").toPath();
+        int dim = 16;
+        Random rng = new Random(2026);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Build several sealed segments. Each batch + checkpoint
+            // produces one on-disk segment containing PKs in
+            // [c * 100, c * 100 + 100).
+            int batches = 4;
+            int batchSize = 100;
+            int totalPks = batches * batchSize;
+            for (int c = 0; c < batches; c++) {
+                for (int i = 0; i < batchSize; i++) {
+                    store.addVector(Bytes.from_int(c * batchSize + i),
+                            randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("test setup must produce >= 2 segments to make compaction"
+                    + " meaningful, got " + segmentsBefore,
+                    segmentsBefore >= 2);
+
+            // Plant the post-build hook: compaction will park BETWEEN Stage 1
+            // (validate + build + queue retention) and Stage 2 (persist).
+            // While parked: this.segments still references the input segments,
+            // and lateDeletes.forEach has already run on merged. A
+            // removeVector(X) here:
+            //   - finds X in an input segment (still in segments) and applies
+            //     deletePk to that input — but the input is about to be
+            //     discarded;
+            //   - adds X to pendingCompactionDeletes.
+            // Without the Stage-3 re-apply (the BLOCK-2 fix), X would survive
+            // in merged.
+            CountDownLatch hookEntered = new CountDownLatch(1);
+            CountDownLatch hookRelease = new CountDownLatch(1);
+            store.setAtomicSwapPostBuildHookForTest(() -> {
+                hookEntered.countDown();
+                try {
+                    hookRelease.await(120, TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            // Drive the compaction on a background thread.
+            AtomicReference<Throwable> compactionError = new AtomicReference<>();
+            Thread compactor = new Thread(() -> {
+                try {
+                    store.runCompactionCycle();
+                } catch (Throwable t) {
+                    compactionError.compareAndSet(null, t);
+                }
+            }, "compactor-under-test");
+            compactor.start();
+
+            assertTrue("compaction did not reach the post-build hook within 30s",
+                    hookEntered.await(30, TimeUnit.SECONDS));
+
+            // Hook is parked. Race a few removeVector calls. Use deterministic
+            // slices spread across all input segments to maximise the chance
+            // that the surviving-on-merged regression appears for at least
+            // one PK.
+            List<Bytes> toDelete = new ArrayList<>();
+            for (int c = 0; c < batches; c++) {
+                // Delete 10 PKs from the head of each batch's range.
+                for (int i = 0; i < 10; i++) {
+                    toDelete.add(Bytes.from_int(c * batchSize + i));
+                }
+            }
+            Set<Bytes> deletedSnapshot = new HashSet<>(toDelete);
+
+            int removeThreads = 2;
+            int searchThreads = 2;
+            int searchIterations = 50;
+            CountDownLatch racersStart = new CountDownLatch(1);
+            CountDownLatch racersDone = new CountDownLatch(searchThreads + removeThreads);
+            AtomicReference<Throwable> workerError = new AtomicReference<>();
+            AtomicInteger searchesIssued = new AtomicInteger();
+
+            // Search workers: hammer the store; nothing should crash.
+            // Catch Throwable so AssertionError surfaces via workerError.
+            for (int s = 0; s < searchThreads; s++) {
+                final long seed = 1000 + s;
+                Thread t = new Thread(() -> {
+                    try {
+                        racersStart.await();
+                        Random r = new Random(seed);
+                        for (int i = 0; i < searchIterations; i++) {
+                            List<Map.Entry<Bytes, Float>> results =
+                                    store.search(randomVector(r, dim), 10);
+                            assertNotNull("search returned null", results);
+                            searchesIssued.incrementAndGet();
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable t2) {
+                        workerError.compareAndSet(null, t2);
+                    } finally {
+                        racersDone.countDown();
+                    }
+                }, "race-search-" + s);
+                t.setDaemon(true);
+                t.start();
+            }
+
+            // Remove workers: each takes half of toDelete.
+            int half = toDelete.size() / 2;
+            for (int s = 0; s < removeThreads; s++) {
+                final int from = (s == 0) ? 0 : half;
+                final int to = (s == 0) ? half : toDelete.size();
+                Thread t = new Thread(() -> {
+                    try {
+                        racersStart.await();
+                        for (int i = from; i < to; i++) {
+                            store.removeVector(toDelete.get(i));
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable t2) {
+                        workerError.compareAndSet(null, t2);
+                    } finally {
+                        racersDone.countDown();
+                    }
+                }, "race-remove-" + s);
+                t.setDaemon(true);
+                t.start();
+            }
+
+            racersStart.countDown();
+            assertTrue("racers did not finish within 60s",
+                    racersDone.await(60, TimeUnit.SECONDS));
+
+            // Release the hook; compaction proceeds through Stages 2 + 3.
+            hookRelease.countDown();
+            compactor.join(60_000);
+            if (compactionError.get() != null) {
+                throw new AssertionError("compaction failed", compactionError.get());
+            }
+            store.setAtomicSwapPostBuildHookForTest(null);
+
+            if (workerError.get() != null) {
+                throw new AssertionError("worker surfaced an exception/assertion failure",
+                        workerError.get());
+            }
+            assertTrue("at least some searches completed during the race",
+                    searchesIssued.get() > 0);
+
+            // Compaction succeeded — the merged output is now in segments.
+            int segmentsAfter = store.getSegmentCount();
+            assertTrue("compaction must have reduced segment count: before="
+                    + segmentsBefore + " after=" + segmentsAfter,
+                    segmentsAfter < segmentsBefore);
+
+            // Headline assertion (BLOCK-2 regression check): every PK in
+            // toDelete must be ABSENT from search results, including PKs
+            // that the racing removeVector applied to an input segment
+            // (now discarded) but which were NOT in lateDeletes when the
+            // pre-atomicSwap forEach ran. Without the Stage-3 re-apply,
+            // those PKs survive in merged.
+            int probeTopK = totalPks + 100;
+            for (int q = 0; q < 20; q++) {
+                List<Map.Entry<Bytes, Float>> results =
+                        store.search(randomVector(rng, dim), probeTopK);
+                for (Map.Entry<Bytes, Float> e : results) {
+                    assertTrue("deleted PK " + e.getKey()
+                                    + " resurfaced in search results"
+                                    + " (BLOCK-2 regression: a delete that arrived"
+                                    + " during the lock-free Stages 1+2 of"
+                                    + " atomicSwap was not re-applied to merged"
+                                    + " in Stage 3)",
+                            !deletedSnapshot.contains(e.getKey()));
+                }
+            }
+
+            // Final size accounting matches.
+            long expectedSize = (long) totalPks - toDelete.size();
+            assertTrue("store size after race must equal initial - deletions"
+                            + " (got " + store.size() + ", expected " + expectedSize + ")",
+                    store.size() == expectedSize);
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSearchProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSearchProgressTest.java
@@ -175,29 +175,34 @@ public class PersistentVectorStoreCompactionSearchProgressTest {
             // starving every search. Issue searches and assert (a) they don't
             // hang and (b) several of them complete WHILE the persist is still
             // blocked — i.e., NOT just after we release the latch.
+            //
+            // Timing budgets are deliberately loose to ride out slow CI
+            // runners. The pre-fix code blocks for the full 2 s+ persist
+            // duration; we accept up to 1 s per individual search here so a
+            // jvector ANN cold-start (JIT warmup, MMU TLB miss, etc.)
+            // doesn't flake the test. The assertion still has bite because
+            // a regression that re-introduces the writeLock-around-persist
+            // would block searches for the FULL persist duration (≥ 2 s).
             float[] query = randomVector(rng, dim);
             int searchesCompletedDuringPersist = 0;
             long maxSingleSearchNanos = 0;
-            long progressDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
-            while (System.nanoTime() < progressDeadline) {
-                // The compaction must still be parked. If not, we have not
-                // proven anything.
-                if (release.getCount() == 0) {
-                    break;
-                }
+            long progressDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (System.nanoTime() < progressDeadline
+                    && searchesCompletedDuringPersist < 5
+                    && release.getCount() > 0) {
                 long t0 = System.nanoTime();
                 List<Map.Entry<Bytes, Float>> results = store.search(query, 5);
                 long elapsed = System.nanoTime() - t0;
                 maxSingleSearchNanos = Math.max(maxSingleSearchNanos, elapsed);
                 assertFalse("search returned a null result list", results == null);
                 searchesCompletedDuringPersist++;
-                // If we have proven the point with a healthy margin, stop.
-                if (searchesCompletedDuringPersist >= 5
-                        && System.nanoTime() - t0 < TimeUnit.MILLISECONDS.toNanos(50)) {
-                    // continue collecting up to a small budget to confirm
-                    // searches stay fast
-                }
             }
+
+            // Snapshot the assertion-relevant state BEFORE we release the
+            // persist latch, so the headline assertions cannot be coloured
+            // by post-release activity (e.g., the writeLock-held Stage-3
+            // micro-window that legitimately runs after release).
+            boolean compactionStillParked = release.getCount() > 0;
 
             // Release the persist; compaction completes.
             release.countDown();
@@ -212,19 +217,26 @@ public class PersistentVectorStoreCompactionSearchProgressTest {
                             + " saw " + searchesCompletedDuringPersist
                             + " (issue #462: writeLock must not be held during the persist)",
                     searchesCompletedDuringPersist >= 5);
+            assertTrue("compaction must still have been parked when the test"
+                            + " collected its progress evidence; if not, the test"
+                            + " did not actually exercise the slow-persist window",
+                    compactionStillParked);
 
-            // Latency budget: each search during the persist had to be far
-            // shorter than the persist duration itself. 200 ms is a generous
-            // bound that still proves the writeLock is not held.
+            // Latency budget: each search during the persist must be far
+            // shorter than the persist duration itself. 1 s is a generous
+            // CI-tolerant bound that still proves the writeLock is not held
+            // (the pre-fix code blocks for ≥ 2 s).
             assertTrue("max search latency during persist (" + (maxSingleSearchNanos / 1_000_000)
                             + " ms) must be far less than the persist duration ("
                             + (dsm.persistDurationNanos.get() / 1_000_000) + " ms)",
-                    maxSingleSearchNanos < TimeUnit.MILLISECONDS.toNanos(200));
+                    maxSingleSearchNanos < TimeUnit.SECONDS.toNanos(1));
 
-            // Diagnostic counter sanity: Stage 3's writeLock window is microseconds.
-            assertTrue("Stage 3 writeLock window must be tiny (issue #462 SLO);"
+            // Diagnostic counter sanity: Stage 3's writeLock window is small.
+            // Pre-fix code at scale is multi-second; the post-fix value is
+            // microseconds. 1 s is a generous CI-tolerant bound.
+            assertTrue("Stage 3 writeLock window must be small (issue #462 SLO);"
                             + " observed " + store.getLastCompactionSwapWriteLockNanos() + " ns",
-                    store.getLastCompactionSwapWriteLockNanos() < 200_000_000L);
+                    store.getLastCompactionSwapWriteLockNanos() < TimeUnit.SECONDS.toNanos(1));
 
             // Functional correctness: compaction succeeded.
             int afterMerge = store.getSegmentCount();

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSearchProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSearchProgressTest.java
@@ -1,0 +1,298 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.IndexStatus;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Headline regression test for issue #462: ANN searches must NOT be blocked
+ * while a compaction's slow {@code persistIndexStatusMultiSegment} call is
+ * in flight.
+ *
+ * <p>The pre-fix code held {@code stateLock.writeLock()} across that persist,
+ * which at 18&nbsp;K segments meant 1&ndash;4 seconds of search starvation
+ * per compaction cycle. After the three-stage refactor the writeLock window
+ * shrinks to microseconds; this test wraps the in-memory DSM so the
+ * {@code indexCheckpoint} call sleeps for &ge;&nbsp;2 seconds, drives a
+ * compaction in the background, and asserts that searches issued during the
+ * sleep complete with low latency.
+ */
+public class PersistentVectorStoreCompactionSearchProgressTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    /**
+     * Wraps {@link MemoryDataStorageManager} so that the FIRST
+     * {@code indexCheckpoint} call (the one inside Stage 2 of
+     * {@code atomicSwapCompactionResult}) blocks until a release latch is
+     * counted down. Subsequent calls run normally.
+     */
+    private static final class SlowFirstIndexCheckpoint extends ForwardingDataStorageManager {
+
+        private final CountDownLatch persistEntered = new CountDownLatch(1);
+        private final CountDownLatch persistRelease;
+        private final AtomicInteger callCount = new AtomicInteger();
+        private final AtomicLong persistDurationNanos = new AtomicLong();
+
+        SlowFirstIndexCheckpoint(DataStorageManager delegate, CountDownLatch release) {
+            super(delegate);
+            this.persistRelease = release;
+        }
+
+        @Override
+        public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String uuid,
+                IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
+            int n = callCount.incrementAndGet();
+            // Only the FIRST persist blocks — let setup checkpoints through.
+            // The compaction-cycle test triggers compaction explicitly after
+            // setup, so its Stage-2 persist is the one that hits the latch.
+            // Use callCount's value AT THIS INVOCATION to identify the first
+            // call deterministically.
+            if (n == firstBlockingCall) {
+                long start = System.nanoTime();
+                persistEntered.countDown();
+                try {
+                    persistRelease.await(120, TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new DataStorageManagerException("interrupted while sleeping in test", ie);
+                }
+                persistDurationNanos.set(System.nanoTime() - start);
+            }
+            return delegate().indexCheckpoint(tableSpace, uuid, indexStatus, pin);
+        }
+
+        // Set by the test to the call number at which we want to block.
+        // Must be set before the compaction is triggered.
+        volatile int firstBlockingCall = Integer.MAX_VALUE;
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void searchProgressDuringSlowCompactionPersist() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("compaction-search-progress").toPath();
+        int dim = 16;
+        Random rng = new Random(2026);
+
+        MemoryDataStorageManager underlying = new MemoryDataStorageManager();
+        CountDownLatch release = new CountDownLatch(1);
+        SlowFirstIndexCheckpoint dsm = new SlowFirstIndexCheckpoint(underlying, release);
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        try (PersistentVectorStore store = new PersistentVectorStore("testidx",
+                "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN)) {
+            // Aggressive compaction: any 2+ segments must merge.
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+            store.start();
+
+            // Setup: build several sealed segments without blocking the DSM.
+            for (int c = 0; c < 4; c++) {
+                for (int i = 0; i < 200; i++) {
+                    store.addVector(Bytes.from_int(c * 100_000 + i),
+                            randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int beforeMerge = store.getSegmentCount();
+            assertTrue("test setup must produce several segments, got " + beforeMerge,
+                    beforeMerge >= 2);
+
+            // From this point on, the NEXT indexCheckpoint call (Stage 2 of
+            // atomicSwapCompactionResult) blocks on the release latch.
+            int blockingCallNumber = dsm.callCount.get() + 1;
+            dsm.firstBlockingCall = blockingCallNumber;
+
+            // Drive the compaction on a background thread.
+            AtomicReference<Throwable> compactionError = new AtomicReference<>();
+            Thread compactor = new Thread(() -> {
+                try {
+                    store.runCompactionCycle();
+                } catch (Throwable t) {
+                    compactionError.compareAndSet(null, t);
+                }
+            }, "compactor-under-test");
+            compactor.start();
+
+            // Wait until the compaction has entered the persist (Stage 2).
+            assertTrue("compaction did not reach the slow persist within 30s",
+                    dsm.persistEntered.await(30, TimeUnit.SECONDS));
+
+            // The compaction is now blocked inside indexCheckpoint. The pre-fix
+            // code would have been holding stateLock.writeLock() at this point,
+            // starving every search. Issue searches and assert (a) they don't
+            // hang and (b) several of them complete WHILE the persist is still
+            // blocked — i.e., NOT just after we release the latch.
+            float[] query = randomVector(rng, dim);
+            int searchesCompletedDuringPersist = 0;
+            long maxSingleSearchNanos = 0;
+            long progressDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+            while (System.nanoTime() < progressDeadline) {
+                // The compaction must still be parked. If not, we have not
+                // proven anything.
+                if (release.getCount() == 0) {
+                    break;
+                }
+                long t0 = System.nanoTime();
+                List<Map.Entry<Bytes, Float>> results = store.search(query, 5);
+                long elapsed = System.nanoTime() - t0;
+                maxSingleSearchNanos = Math.max(maxSingleSearchNanos, elapsed);
+                assertFalse("search returned a null result list", results == null);
+                searchesCompletedDuringPersist++;
+                // If we have proven the point with a healthy margin, stop.
+                if (searchesCompletedDuringPersist >= 5
+                        && System.nanoTime() - t0 < TimeUnit.MILLISECONDS.toNanos(50)) {
+                    // continue collecting up to a small budget to confirm
+                    // searches stay fast
+                }
+            }
+
+            // Release the persist; compaction completes.
+            release.countDown();
+            compactor.join(60_000);
+            if (compactionError.get() != null) {
+                throw new AssertionError("compaction failed", compactionError.get());
+            }
+
+            // Headline assertion: at least a handful of searches completed
+            // while the compaction's persist was still in flight.
+            assertTrue("expected >= 5 searches to complete during the slow persist;"
+                            + " saw " + searchesCompletedDuringPersist
+                            + " (issue #462: writeLock must not be held during the persist)",
+                    searchesCompletedDuringPersist >= 5);
+
+            // Latency budget: each search during the persist had to be far
+            // shorter than the persist duration itself. 200 ms is a generous
+            // bound that still proves the writeLock is not held.
+            assertTrue("max search latency during persist (" + (maxSingleSearchNanos / 1_000_000)
+                            + " ms) must be far less than the persist duration ("
+                            + (dsm.persistDurationNanos.get() / 1_000_000) + " ms)",
+                    maxSingleSearchNanos < TimeUnit.MILLISECONDS.toNanos(200));
+
+            // Diagnostic counter sanity: Stage 3's writeLock window is microseconds.
+            assertTrue("Stage 3 writeLock window must be tiny (issue #462 SLO);"
+                            + " observed " + store.getLastCompactionSwapWriteLockNanos() + " ns",
+                    store.getLastCompactionSwapWriteLockNanos() < 200_000_000L);
+
+            // Functional correctness: compaction succeeded.
+            int afterMerge = store.getSegmentCount();
+            assertTrue("compaction must have reduced segment count: before="
+                    + beforeMerge + " after=" + afterMerge,
+                    afterMerge < beforeMerge);
+
+            // Search after the compaction returns valid results from the merged segment.
+            List<Map.Entry<Bytes, Float>> postCompactResults = store.search(query, 5);
+            assertFalse("search after compaction returned empty results",
+                    postCompactResults.isEmpty());
+        }
+    }
+
+    @Test
+    public void searchUnblockedAfterPersistFailureRecoversCleanly() throws Exception {
+        // Companion test: even if Stage-2 throws, the writeLock should not
+        // have been held during it. We don't sleep-block here; we just
+        // throw, and verify that searches issued AFTER recovery work.
+        Path tmpDir = tmpFolder.newFolder("compaction-search-recovery").toPath();
+        int dim = 16;
+        Random rng = new Random(11);
+
+        MemoryDataStorageManager underlying = new MemoryDataStorageManager();
+        AtomicBoolean throwOnNextIndexCheckpoint = new AtomicBoolean(false);
+        ForwardingDataStorageManager dsm = new ForwardingDataStorageManager(underlying) {
+            @Override
+            public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String uuid,
+                    IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
+                if (throwOnNextIndexCheckpoint.compareAndSet(true, false)) {
+                    throw new DataStorageManagerException("simulated S3 failure (test)");
+                }
+                return delegate().indexCheckpoint(tableSpace, uuid, indexStatus, pin);
+            }
+        };
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        try (PersistentVectorStore store = new PersistentVectorStore("testidx",
+                "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN)) {
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+            store.start();
+            for (int c = 0; c < 4; c++) {
+                for (int i = 0; i < 100; i++) {
+                    store.addVector(Bytes.from_int(c * 1000 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int before = store.getSegmentCount();
+            assertTrue("test setup", before >= 2);
+
+            // Make the next compaction's persist throw.
+            throwOnNextIndexCheckpoint.set(true);
+            store.runCompactionCycle();
+
+            // Compaction failed — segments unchanged. Searches still work.
+            float[] query = randomVector(rng, dim);
+            List<Map.Entry<Bytes, Float>> results = store.search(query, 5);
+            assertFalse("search after failed compaction returned empty",
+                    results.isEmpty());
+            // The follow-up compaction succeeds.
+            store.runCompactionCycle();
+            assertTrue("recovery compaction must reduce segments",
+                    store.getSegmentCount() < before);
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapFailureTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapFailureTest.java
@@ -111,6 +111,7 @@ public class PersistentVectorStoreCompactionSwapFailureTest {
             long genBefore = store.getCurrentIndexStatusGeneration();
             long memCounterBefore = store.getOnDiskSegmentsEstimatedMemoryBytes();
             long compactionFailuresBefore = store.getCompactionFailuresMetadataIoTotal();
+            long swapWriteLockNanosBefore = store.getLastCompactionSwapWriteLockNanos();
 
             // Trigger the failure: next indexCheckpoint throws.
             throwOnNext.set(true);
@@ -136,6 +137,16 @@ public class PersistentVectorStoreCompactionSwapFailureTest {
             // Memory counter unchanged.
             assertEquals("on-disk-segment memory counter must be unchanged after failed swap",
                     memCounterBefore, store.getOnDiskSegmentsEstimatedMemoryBytes());
+
+            // Diagnostic counter unchanged: the writeLock was never acquired
+            // because Stage 2 (the persist) threw before Stage 3. The
+            // counter must reflect either the previous successful swap's
+            // value or 0 — NOT a fresh value updated on the failed cycle.
+            // Catches a future regression that incorrectly stamps the
+            // counter on the abort path.
+            assertEquals("lastCompactionSwapWriteLockNanos must be unchanged when Stage 2 throws"
+                            + " (Stage 3 is never reached, no new writeLock window)",
+                    swapWriteLockNanosBefore, store.getLastCompactionSwapWriteLockNanos());
 
             // Searches still work.
             float[] query = randomVector(rng, dim);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapFailureTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapFailureTest.java
@@ -1,0 +1,165 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.IndexStatus;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Locks down the failure semantics of the three-stage
+ * {@code atomicSwapCompactionResult} protocol introduced for issue #462.
+ *
+ * <p>If the slow Stage-2 persist throws (e.g., S3 down), the in-memory
+ * state must remain UNCHANGED: {@code this.segments} still references the
+ * inputs, {@code currentIndexStatusGeneration} did not bump, and the
+ * memory counter still matches the iterated sum. A follow-up successful
+ * compaction must then succeed normally.
+ *
+ * <p>This is a regression guard for the order of Stage 1 vs. Stage 2:
+ * the queued-pending-deletes side effect happens BEFORE the persist (same
+ * as the pre-#462 code). A failure leaves {@code pendingDeletes} populated
+ * — that's the existing wart, not a regression.
+ */
+public class PersistentVectorStoreCompactionSwapFailureTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void persistFailureLeavesInMemoryStateIntact() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("compaction-failure").toPath();
+        int dim = 16;
+        Random rng = new Random(2026);
+
+        MemoryDataStorageManager underlying = new MemoryDataStorageManager();
+        AtomicBoolean throwOnNext = new AtomicBoolean(false);
+        ForwardingDataStorageManager dsm = new ForwardingDataStorageManager(underlying) {
+            @Override
+            public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String uuid,
+                    IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
+                if (throwOnNext.compareAndSet(true, false)) {
+                    throw new DataStorageManagerException("simulated S3 failure (test)");
+                }
+                return delegate().indexCheckpoint(tableSpace, uuid, indexStatus, pin);
+            }
+        };
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        try (PersistentVectorStore store = new PersistentVectorStore("testidx",
+                "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN)) {
+            // Aggressive compaction so 2+ segments merge.
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+            store.start();
+
+            for (int c = 0; c < 4; c++) {
+                for (int i = 0; i < 100; i++) {
+                    store.addVector(Bytes.from_int(c * 1000 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("test setup must have several segments, got " + segmentsBefore,
+                    segmentsBefore >= 2);
+            long genBefore = store.getCurrentIndexStatusGeneration();
+            long memCounterBefore = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            long compactionFailuresBefore = store.getCompactionFailuresMetadataIoTotal();
+
+            // Trigger the failure: next indexCheckpoint throws.
+            throwOnNext.set(true);
+            store.runCompactionCycle();
+
+            // ---------- Invariant assertions ----------
+
+            // The compaction recorded a failure (the catch block in
+            // runCompactionCycle handles DataStorageManagerException as
+            // METADATA_IO).
+            assertEquals("compaction failure was not recorded as METADATA_IO",
+                    compactionFailuresBefore + 1L,
+                    store.getCompactionFailuresMetadataIoTotal());
+
+            // Segments list unchanged: the Stage-3 publish never ran.
+            assertEquals("this.segments must be unchanged after a failed compaction swap",
+                    segmentsBefore, store.getSegmentCount());
+
+            // Generation unchanged: the persist threw before bumping it.
+            assertEquals("currentIndexStatusGeneration must NOT have bumped on failure",
+                    genBefore, store.getCurrentIndexStatusGeneration());
+
+            // Memory counter unchanged.
+            assertEquals("on-disk-segment memory counter must be unchanged after failed swap",
+                    memCounterBefore, store.getOnDiskSegmentsEstimatedMemoryBytes());
+
+            // Searches still work.
+            float[] query = randomVector(rng, dim);
+            List<Map.Entry<Bytes, Float>> results = store.search(query, 5);
+            assertNotNull("search returned null after failed compaction", results);
+            assertFalse("search after failed compaction returned empty results",
+                    results.isEmpty());
+
+            // A follow-up compaction with a healthy DSM succeeds.
+            store.runCompactionCycle();
+            assertTrue("recovery compaction must have reduced segment count: before="
+                    + segmentsBefore + " after=" + store.getSegmentCount(),
+                    store.getSegmentCount() < segmentsBefore);
+
+            // The recovery compaction bumped the generation.
+            assertTrue("recovery compaction must have bumped the generation past "
+                    + genBefore,
+                    store.getCurrentIndexStatusGeneration() > genBefore);
+
+            // Memory counter matches reality after the recovery compaction.
+            long counterAfter = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            long iteratedSumAfter = store.sumOnDiskSegmentMemoryBytesByIterationForTesting();
+            assertEquals("memory counter must equal iterated sum after recovery",
+                    iteratedSumAfter, counterAfter);
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapStagesTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapStagesTest.java
@@ -1,0 +1,242 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Locks down the three-stage protocol of
+ * {@code atomicSwapCompactionResult} introduced for issue #462.
+ *
+ * <p>The test plants the two intra-method hooks
+ * ({@code atomicSwapPostBuildHook} and {@code atomicSwapPostPersistHook})
+ * to inspect state at the precise stage boundaries:
+ *
+ * <ul>
+ *   <li>Post-Stage 1 (after build, before persist): the segment list
+ *       still references the OLD segments; {@code currentIndexStatusGeneration}
+ *       has NOT bumped.
+ *   <li>Post-Stage 2 (after persist, before publish): the
+ *       {@code currentIndexStatusGeneration} has bumped; the segment list
+ *       still references the OLD segments because the writeLock-guarded
+ *       publish has not run yet; {@code stateLock.isWriteLocked()} is
+ *       {@code false} (the slow persist truly ran outside the writeLock).
+ *   <li>Post-completion: the segment list contains the merged output;
+ *       {@code currentIndexStatusGeneration} matches the new value;
+ *       memory counter is consistent with the iterated sum.
+ * </ul>
+ */
+public class PersistentVectorStoreCompactionSwapStagesTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+        // Aggressive compaction so the test cycle actually merges segments.
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Reflection accessor for the private {@code stateLock} so the hook can
+     * assert its state. The ABI is intentionally not exposed publicly; this
+     * is a test-only invariant check.
+     */
+    private static ReentrantReadWriteLock stateLockOf(PersistentVectorStore store) throws Exception {
+        Field f = PersistentVectorStore.class.getDeclaredField("stateLock");
+        f.setAccessible(true);
+        return (ReentrantReadWriteLock) f.get(store);
+    }
+
+    @Test
+    public void testStageBoundariesAndFinalState() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("stages").toPath();
+        int dim = 16;
+        Random rng = new Random(2026);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Build several sealed segments by checkpoint-per-batch so the
+            // compaction has meaningful inputs.
+            for (int c = 0; c < 5; c++) {
+                for (int i = 0; i < 200; i++) {
+                    store.addVector(Bytes.from_int(c * 100_000 + i),
+                            randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int beforeMerge = store.getSegmentCount();
+            assertTrue("must have several segments before merge to make the test"
+                    + " meaningful, got " + beforeMerge, beforeMerge >= 2);
+            long genBefore = store.getCurrentIndexStatusGeneration();
+
+            ReentrantReadWriteLock stateLock = stateLockOf(store);
+
+            // Capture state at each stage boundary so the test can fail if
+            // ANY of the stage invariants is violated.
+            AtomicLong genAtPostBuild = new AtomicLong(-1);
+            AtomicLong genAtPostPersist = new AtomicLong(-1);
+            AtomicReference<Boolean> writeLockedAtPostBuild = new AtomicReference<>();
+            AtomicReference<Boolean> writeLockedAtPostPersist = new AtomicReference<>();
+            AtomicReference<Throwable> hookFailure = new AtomicReference<>();
+            AtomicLong segmentCountAtPostBuild = new AtomicLong(-1);
+            AtomicLong segmentCountAtPostPersist = new AtomicLong(-1);
+
+            store.setAtomicSwapPostBuildHookForTest(() -> {
+                try {
+                    genAtPostBuild.set(store.getCurrentIndexStatusGeneration());
+                    writeLockedAtPostBuild.set(stateLock.isWriteLocked());
+                    segmentCountAtPostBuild.set(store.getSegmentCount());
+                } catch (Throwable t) {
+                    hookFailure.compareAndSet(null, t);
+                }
+            });
+            store.setAtomicSwapPostPersistHookForTest(() -> {
+                try {
+                    genAtPostPersist.set(store.getCurrentIndexStatusGeneration());
+                    writeLockedAtPostPersist.set(stateLock.isWriteLocked());
+                    segmentCountAtPostPersist.set(store.getSegmentCount());
+                } catch (Throwable t) {
+                    hookFailure.compareAndSet(null, t);
+                }
+            });
+
+            // Drive the compaction; the hooks fire in-thread.
+            store.runCompactionCycle();
+
+            store.setAtomicSwapPostBuildHookForTest(null);
+            store.setAtomicSwapPostPersistHookForTest(null);
+
+            if (hookFailure.get() != null) {
+                throw new AssertionError("hook threw", hookFailure.get());
+            }
+
+            // Stage 1 (post-build, pre-persist) invariants:
+            assertNotEquals("post-build hook never fired — compaction did "
+                    + "not actually merge anything", -1L, genAtPostBuild.get());
+            assertEquals("currentIndexStatusGeneration must NOT have bumped before persist",
+                    genBefore, genAtPostBuild.get());
+            assertEquals("segments list still references the OLD segments at post-build",
+                    (long) beforeMerge, segmentCountAtPostBuild.get());
+            assertEquals("stateLock.writeLock MUST NOT be held during the post-build hook"
+                            + " (Stage 1 runs under checkpointLock alone, so concurrent searches"
+                            + " can grab readLock)",
+                    Boolean.FALSE, writeLockedAtPostBuild.get());
+
+            // Stage 2 (post-persist, pre-publish) invariants:
+            assertNotEquals("post-persist hook never fired", -1L, genAtPostPersist.get());
+            assertEquals("currentIndexStatusGeneration MUST have bumped during persist",
+                    genBefore + 1, genAtPostPersist.get());
+            assertEquals("segments list STILL references the OLD segments after persist —"
+                            + " publish happens in Stage 3 under writeLock",
+                    (long) beforeMerge, segmentCountAtPostPersist.get());
+            assertEquals("stateLock.writeLock MUST NOT be held during the post-persist hook"
+                            + " (the slow persist must run lock-free; this is the entire point of"
+                            + " issue #462)",
+                    Boolean.FALSE, writeLockedAtPostPersist.get());
+
+            // Final state: compaction completed, in-memory state matches persisted state.
+            int afterMerge = store.getSegmentCount();
+            assertTrue("compaction must have reduced segment count: before="
+                    + beforeMerge + " after=" + afterMerge,
+                    afterMerge < beforeMerge);
+            assertEquals("currentIndexStatusGeneration must equal the value observed at"
+                            + " post-persist (no further bump)",
+                    genAtPostPersist.get(), store.getCurrentIndexStatusGeneration());
+
+            // Diagnostic counter sanity: writeLock window is bounded — far
+            // less than the typical multi-second persist would have taken.
+            // Even on a heavily loaded CI node, microseconds-scale work
+            // should complete within 200 ms.
+            assertTrue("Stage 3 writeLock window must be small (issue #462 SLO);"
+                            + " observed " + store.getLastCompactionSwapWriteLockNanos() + " ns",
+                    store.getLastCompactionSwapWriteLockNanos() < 200_000_000L);
+        }
+    }
+
+    @Test
+    public void testNullHooksAreSafe() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("null-hooks").toPath();
+        int dim = 16;
+        Random rng = new Random(7);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            for (int c = 0; c < 3; c++) {
+                for (int i = 0; i < 100; i++) {
+                    store.addVector(Bytes.from_int(c * 1000 + i), randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int before = store.getSegmentCount();
+            assertTrue("test setup must produce >= 2 segments", before >= 2);
+
+            // Null hooks must not throw — the swap protocol is the same as
+            // when the hooks are not configured (production behaviour).
+            assertNull(noOp(store));
+
+            store.runCompactionCycle();
+
+            assertTrue("compaction reduced segments after null-hook cycle",
+                    store.getSegmentCount() < before);
+        }
+    }
+
+    private static Object noOp(PersistentVectorStore store) {
+        store.setAtomicSwapPostBuildHookForTest(null);
+        store.setAtomicSwapPostPersistHookForTest(null);
+        return null;
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapStagesTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreCompactionSwapStagesTest.java
@@ -21,7 +21,6 @@ package herddb.indexing;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import herddb.core.MemoryManager;
 import herddb.index.vector.PersistentVectorStore;
@@ -225,18 +224,13 @@ public class PersistentVectorStoreCompactionSwapStagesTest {
 
             // Null hooks must not throw — the swap protocol is the same as
             // when the hooks are not configured (production behaviour).
-            assertNull(noOp(store));
+            store.setAtomicSwapPostBuildHookForTest(null);
+            store.setAtomicSwapPostPersistHookForTest(null);
 
             store.runCompactionCycle();
 
             assertTrue("compaction reduced segments after null-hook cycle",
                     store.getSegmentCount() < before);
         }
-    }
-
-    private static Object noOp(PersistentVectorStore store) {
-        store.setAtomicSwapPostBuildHookForTest(null);
-        store.setAtomicSwapPostPersistHookForTest(null);
-        return null;
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCDeletePkRaceTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCDeletePkRaceTest.java
@@ -1,0 +1,291 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Race-test for the new concurrency invariant introduced by issue #462's
+ * Change&nbsp;2: Phase&nbsp;C's pending-checkpoint-deletes apply now runs
+ * lock-free under {@code checkpointLock} alone, so concurrent
+ * {@code search} (read-locked) and concurrent {@code removeVector}
+ * (read-locked) calls can hit the same segments at the same time.
+ *
+ * <p>Two concurrent paths both call {@code seg.deletePk(pk)} — Phase C
+ * applying its accumulated pending set, and {@code removeVector} from
+ * client traffic. Both must produce a consistent final state:
+ * <ul>
+ *   <li>Every PK that was added and then deleted must NOT appear in any
+ *       search.</li>
+ *   <li>{@code seg.size()} accounting (via {@code liveCount}) must match
+ *       the actual live entries.</li>
+ *   <li>The on-disk-segment memory counter must equal the iterated sum.</li>
+ *   <li>No exceptions surface from the search threads.</li>
+ * </ul>
+ */
+public class PersistentVectorStorePhaseCDeletePkRaceTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void concurrentSearchAndRemoveDuringPhaseC() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("phase-c-race").toPath();
+        int dim = 16;
+        Random rng = new Random(2026);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Build sealed segments containing a known set of PKs.
+            int totalPks = 600;
+            for (int i = 0; i < totalPks; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+            assertTrue("setup must produce at least one on-disk segment",
+                    store.getSegmentCount() >= 1);
+
+            // Trigger a NEW checkpoint cycle. Phase A → frozenShards
+            // populated; Phase B writes new on-disk segments; Phase C
+            // applies pending deletes that have arrived since Phase A
+            // started.
+            //
+            // We'll inject the pause at Phase C's post-deletes-apply hook,
+            // then race remove + search calls in the open window.
+            CountDownLatch hookEntered = new CountDownLatch(1);
+            CountDownLatch hookRelease = new CountDownLatch(1);
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                hookEntered.countDown();
+                try {
+                    hookRelease.await(120, TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            // We need new live state for Phase C to do work. Add some new
+            // vectors so the next checkpoint produces a new segment.
+            int newLiveStart = totalPks;
+            int newLiveCount = 50;
+            for (int i = 0; i < newLiveCount; i++) {
+                store.addVector(Bytes.from_int(newLiveStart + i),
+                        randomVector(rng, dim));
+            }
+
+            AtomicReference<Throwable> checkpointError = new AtomicReference<>();
+            Thread checkpointer = new Thread(() -> {
+                try {
+                    store.checkpoint();
+                } catch (Throwable t) {
+                    checkpointError.compareAndSet(null, t);
+                }
+            }, "checkpoint-under-test");
+            checkpointer.start();
+
+            assertTrue("Phase C did not reach the hook within 30s",
+                    hookEntered.await(30, TimeUnit.SECONDS));
+
+            // Hook is parked. The writeLock is NOT held. Race a few
+            // remove-vector and search calls.
+            //
+            // Pick a deterministic, disjoint slice of PKs for each thread
+            // so we can verify final state precisely.
+            List<Bytes> toDelete = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                toDelete.add(Bytes.from_int(i));
+            }
+            Set<Bytes> deletedSnapshot = new HashSet<>(toDelete);
+
+            int searchThreads = 4;
+            int removeThreads = 2;
+            int searchIterations = 100;
+            CountDownLatch racersStart = new CountDownLatch(1);
+            CountDownLatch racersDone = new CountDownLatch(searchThreads + removeThreads);
+            AtomicInteger searchExceptions = new AtomicInteger();
+            AtomicInteger searchesIssued = new AtomicInteger();
+
+            // Search workers: hammer the store with searches that should
+            // never crash and never include deleted PKs.
+            for (int s = 0; s < searchThreads; s++) {
+                final long seed = 1000 + s;
+                Thread t = new Thread(() -> {
+                    try {
+                        racersStart.await();
+                        Random r = new Random(seed);
+                        for (int i = 0; i < searchIterations; i++) {
+                            try {
+                                List<Map.Entry<Bytes, Float>> results =
+                                        store.search(randomVector(r, dim), 10);
+                                assertNotNull("search returned null",
+                                        results);
+                                searchesIssued.incrementAndGet();
+                            } catch (RuntimeException re) {
+                                searchExceptions.incrementAndGet();
+                            }
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        racersDone.countDown();
+                    }
+                }, "race-search-" + s);
+                t.setDaemon(true);
+                t.start();
+            }
+
+            // Remove workers: half delete the lower half, half delete the upper half.
+            int half = toDelete.size() / 2;
+            for (int s = 0; s < removeThreads; s++) {
+                final int from = (s == 0) ? 0 : half;
+                final int to = (s == 0) ? half : toDelete.size();
+                Thread t = new Thread(() -> {
+                    try {
+                        racersStart.await();
+                        for (int i = from; i < to; i++) {
+                            store.removeVector(toDelete.get(i));
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        racersDone.countDown();
+                    }
+                }, "race-remove-" + s);
+                t.setDaemon(true);
+                t.start();
+            }
+
+            // Kick off the race.
+            racersStart.countDown();
+
+            // Wait for racers, then release the hook.
+            assertTrue("racers did not finish within 60s",
+                    racersDone.await(60, TimeUnit.SECONDS));
+            hookRelease.countDown();
+
+            checkpointer.join(60_000);
+            if (checkpointError.get() != null) {
+                throw new AssertionError("checkpoint failed", checkpointError.get());
+            }
+
+            store.setPhaseCPostDeletesApplyHookForTest(null);
+
+            // ---------- Race-result invariants ----------
+
+            // No exceptions from search threads.
+            assertEquals("search threads must not have surfaced any exceptions",
+                    0, searchExceptions.get());
+            assertTrue("at least some searches completed during the race",
+                    searchesIssued.get() > 0);
+
+            // Final state: every deleted PK is GONE.
+            // Run several searches with random queries; deleted PKs must never appear.
+            for (int q = 0; q < 20; q++) {
+                List<Map.Entry<Bytes, Float>> results =
+                        store.search(randomVector(rng, dim), 100);
+                for (Map.Entry<Bytes, Float> e : results) {
+                    assertTrue("deleted PK " + e.getKey()
+                                    + " resurfaced in search results",
+                            !deletedSnapshot.contains(e.getKey()));
+                }
+            }
+
+            // Final size accounting matches: total - deletes - any deletes
+            // applied via pendingCheckpointDeletes in this cycle. We
+            // deleted exactly `toDelete.size()` PKs across both threads.
+            // Allow for `removeVector` racing with checkpoint Phase B-only
+            // ingestion: the precise size depends on whether the live
+            // newLive PKs are added to live-shard counts.
+            // Expected size: totalPks (sealed, on-disk) + newLiveCount - toDelete.size()
+            long expectedSize = (long) totalPks + newLiveCount - toDelete.size();
+            assertEquals("store size after race must equal initial - deletions",
+                    expectedSize, store.size());
+
+            // Memory counter sanity. We do NOT require strict counter ==
+            // iteratedSum here because BLink.getUsedMemory() shrinks as
+            // entries are deleted while the cached estimate the counter
+            // recorded at register-time stays the same — that drift is a
+            // pre-existing property of partial-delete-without-rebuild,
+            // not a regression introduced by Change 2 of issue #462.
+            // What we DO require:
+            //   - the counter is non-negative,
+            //   - it is at least as large as the iterated sum (because the
+            //     iterated sum reflects the post-delete actual memory and
+            //     the counter reflects the at-register-time estimate),
+            //   - both are within a reasonable bound of each other.
+            long counter = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            long iteratedSum = store.sumOnDiskSegmentMemoryBytesByIterationForTesting();
+            assertTrue("counter must be non-negative, was " + counter, counter >= 0);
+            assertTrue("counter must be >= iterated sum (deletes shrink BLink memory"
+                            + " under the iterated sum but not the cached counter);"
+                            + " counter=" + counter + " iteratedSum=" + iteratedSum,
+                    counter >= iteratedSum);
+            // The drift should be bounded: with at most a few hundred deletes
+            // and a 16-dim vector index, the per-segment BLink memory delta
+            // is small relative to the segment's total estimated memory.
+            // 4× is a generous bound that catches a pathological leak (e.g.,
+            // a bug that registered the same segment twice) without
+            // tripping on the legitimate post-delete drift.
+            assertTrue("counter (" + counter + ") must be within 4x of iterated sum ("
+                            + iteratedSum + ") — a larger gap would indicate"
+                            + " a double-register/missed-unregister bug",
+                    iteratedSum > 0 && counter <= 4L * iteratedSum);
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCDeletePkRaceTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCDeletePkRaceTest.java
@@ -146,10 +146,28 @@ public class PersistentVectorStorePhaseCDeletePkRaceTest {
             // remove-vector and search calls.
             //
             // Pick a deterministic, disjoint slice of PKs for each thread
-            // so we can verify final state precisely.
+            // so we can verify final state precisely. The slice DELIBERATELY
+            // includes both:
+            //   - sealed-segment PKs (in [0, totalPks)) — removeVector
+            //     applies these directly via `for (seg : this.segments)`,
+            //   - frozen-shard / preloaded-segment PKs (in
+            //     [newLiveStart, newLiveStart + newLiveCount)) — these go
+            //     ONLY through pendingCheckpointDeletes, exercising the
+            //     pr-reviewer pass-1 BLOCK-1 silent-delete-loss path that
+            //     the Stage-2 re-apply guards against.
             List<Bytes> toDelete = new ArrayList<>();
-            for (int i = 0; i < 100; i++) {
+            int sealedSliceSize = 100;
+            for (int i = 0; i < sealedSliceSize; i++) {
                 toDelete.add(Bytes.from_int(i));
+            }
+            // Add the entire newLive slice — every one of these PKs landed
+            // in a frozen shard at Phase A, then in a preloaded segment
+            // after Phase B; deletes for them MUST be observed via the
+            // pendingCheckpointDeletes path (BLOCK-1 coverage).
+            int preloadedSliceStart = newLiveStart;
+            int preloadedSliceSize = newLiveCount;
+            for (int i = 0; i < preloadedSliceSize; i++) {
+                toDelete.add(Bytes.from_int(preloadedSliceStart + i));
             }
             Set<Bytes> deletedSnapshot = new HashSet<>(toDelete);
 
@@ -158,11 +176,15 @@ public class PersistentVectorStorePhaseCDeletePkRaceTest {
             int searchIterations = 100;
             CountDownLatch racersStart = new CountDownLatch(1);
             CountDownLatch racersDone = new CountDownLatch(searchThreads + removeThreads);
-            AtomicInteger searchExceptions = new AtomicInteger();
+            AtomicReference<Throwable> workerError = new AtomicReference<>();
             AtomicInteger searchesIssued = new AtomicInteger();
 
             // Search workers: hammer the store with searches that should
             // never crash and never include deleted PKs.
+            // Catch Throwable (not just RuntimeException) so an AssertionError
+            // from assertNotNull/assertTrue on the worker thread is captured
+            // and surfaced via workerError instead of being silently
+            // swallowed by the framework after the finally{}-block resolves.
             for (int s = 0; s < searchThreads; s++) {
                 final long seed = 1000 + s;
                 Thread t = new Thread(() -> {
@@ -170,18 +192,16 @@ public class PersistentVectorStorePhaseCDeletePkRaceTest {
                         racersStart.await();
                         Random r = new Random(seed);
                         for (int i = 0; i < searchIterations; i++) {
-                            try {
-                                List<Map.Entry<Bytes, Float>> results =
-                                        store.search(randomVector(r, dim), 10);
-                                assertNotNull("search returned null",
-                                        results);
-                                searchesIssued.incrementAndGet();
-                            } catch (RuntimeException re) {
-                                searchExceptions.incrementAndGet();
-                            }
+                            List<Map.Entry<Bytes, Float>> results =
+                                    store.search(randomVector(r, dim), 10);
+                            assertNotNull("search returned null",
+                                    results);
+                            searchesIssued.incrementAndGet();
                         }
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
+                    } catch (Throwable t2) {
+                        workerError.compareAndSet(null, t2);
                     } finally {
                         racersDone.countDown();
                     }
@@ -228,30 +248,42 @@ public class PersistentVectorStorePhaseCDeletePkRaceTest {
 
             // ---------- Race-result invariants ----------
 
-            // No exceptions from search threads.
-            assertEquals("search threads must not have surfaced any exceptions",
-                    0, searchExceptions.get());
+            // No exceptions or assertion failures from search workers.
+            if (workerError.get() != null) {
+                throw new AssertionError("search worker surfaced an exception/assertion failure",
+                        workerError.get());
+            }
             assertTrue("at least some searches completed during the race",
                     searchesIssued.get() > 0);
 
             // Final state: every deleted PK is GONE.
-            // Run several searches with random queries; deleted PKs must never appear.
+            //
+            // Run searches with topK large enough to materialise EVERY live
+            // PK across multiple random queries. With totalPks + newLiveCount
+            // ≈ 650 and topK = 1000, the ANN search exhausts the index so any
+            // deleted PK that wrongly survived in a segment WOULD appear in
+            // at least one of these results. This is the regression check
+            // for the BLOCK-1 fix (Stage 2 re-apply on preloaded segments)
+            // and the BLOCK-2 fix (Stage 3 re-apply on merged output).
+            int probeTopK = totalPks + newLiveCount + 100;
             for (int q = 0; q < 20; q++) {
                 List<Map.Entry<Bytes, Float>> results =
-                        store.search(randomVector(rng, dim), 100);
+                        store.search(randomVector(rng, dim), probeTopK);
                 for (Map.Entry<Bytes, Float> e : results) {
                     assertTrue("deleted PK " + e.getKey()
-                                    + " resurfaced in search results",
+                                    + " resurfaced in search results"
+                                    + " (BLOCK-1/BLOCK-2 regression: a delete"
+                                    + " that arrived during the lock-free apply"
+                                    + " survived in a preloaded/merged segment)",
                             !deletedSnapshot.contains(e.getKey()));
                 }
             }
 
             // Final size accounting matches: total - deletes - any deletes
-            // applied via pendingCheckpointDeletes in this cycle. We
-            // deleted exactly `toDelete.size()` PKs across both threads.
-            // Allow for `removeVector` racing with checkpoint Phase B-only
-            // ingestion: the precise size depends on whether the live
-            // newLive PKs are added to live-shard counts.
+            // applied via pendingCheckpointDeletes in this cycle. We deleted
+            // exactly `toDelete.size()` PKs across both threads (sealed slice
+            // [0, sealedSliceSize) PLUS preloaded slice
+            // [preloadedSliceStart, preloadedSliceStart + preloadedSliceSize)).
             // Expected size: totalPks (sealed, on-disk) + newLiveCount - toDelete.size()
             long expectedSize = (long) totalPks + newLiveCount - toDelete.size();
             assertEquals("store size after race must equal initial - deletions",

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCDeletePkRaceTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCDeletePkRaceTest.java
@@ -211,6 +211,10 @@ public class PersistentVectorStorePhaseCDeletePkRaceTest {
             }
 
             // Remove workers: half delete the lower half, half delete the upper half.
+            // Catch Throwable (not just InterruptedException) so any
+            // unchecked exception or assertion failure inside removeVector
+            // is captured via workerError instead of being swallowed by
+            // the JVM's default uncaught-exception handler.
             int half = toDelete.size() / 2;
             for (int s = 0; s < removeThreads; s++) {
                 final int from = (s == 0) ? 0 : half;
@@ -223,6 +227,8 @@ public class PersistentVectorStorePhaseCDeletePkRaceTest {
                         }
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
+                    } catch (Throwable t2) {
+                        workerError.compareAndSet(null, t2);
                     } finally {
                         racersDone.countDown();
                     }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCSearchProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCSearchProgressTest.java
@@ -1,0 +1,191 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Headline regression test for Change&nbsp;2 of issue #462: ANN searches
+ * must NOT be blocked while Phase&nbsp;C of {@code doCheckpointFusedPQThreePhase}
+ * applies pending-checkpoint deletes.
+ *
+ * <p>The pre-fix code applied {@code pendingCheckpointDeletes.forEach} ×
+ * {@code seg.deletePk} <em>under</em> {@code stateLock.writeLock()}. With
+ * many deletes accumulated during Phase&nbsp;B and 18&nbsp;K segments to
+ * scan per delete, that critical section runs for seconds — long enough to
+ * starve concurrent searches. After the two-stage refactor the deletes-apply
+ * runs lock-free under {@code checkpointLock} alone; only the brief state
+ * swap holds the writeLock.
+ *
+ * <p>This test plants the {@code phaseCPostDeletesApplyHook} so the test
+ * thread can pause Phase&nbsp;C between Stage&nbsp;1 (deletes apply) and
+ * Stage&nbsp;2 (writeLock-protected publish) and assert that searches issued
+ * during that pause complete with low latency.
+ */
+public class PersistentVectorStorePhaseCSearchProgressTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void searchProgressDuringSlowPhaseCDeletesApply() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("phase-c-search-progress").toPath();
+        int dim = 16;
+        Random rng = new Random(2026);
+
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Establish on-disk segments via initial checkpoints so a
+            // subsequent checkpoint exercises Phase C with non-empty
+            // sealed/mergeable lists.
+            for (int c = 0; c < 3; c++) {
+                for (int i = 0; i < 200; i++) {
+                    store.addVector(Bytes.from_int(c * 100_000 + i),
+                            randomVector(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("test setup must have segments, got " + segmentsBefore,
+                    segmentsBefore >= 1);
+
+            // Add a few more inserts so the next checkpoint actually has
+            // dirty state to flush.
+            for (int i = 0; i < 50; i++) {
+                store.addVector(Bytes.from_int(999_000 + i), randomVector(rng, dim));
+            }
+
+            // Plant the hook: Phase C will park BETWEEN the lock-free
+            // deletes-apply (Stage 1) and the writeLock-protected publish
+            // (Stage 2). The test simulates the slow deletes-apply at scale.
+            CountDownLatch hookEntered = new CountDownLatch(1);
+            CountDownLatch hookRelease = new CountDownLatch(1);
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                hookEntered.countDown();
+                try {
+                    hookRelease.await(120, TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            // Drive the checkpoint on a background thread.
+            AtomicReference<Throwable> checkpointError = new AtomicReference<>();
+            Thread checkpointer = new Thread(() -> {
+                try {
+                    store.checkpoint();
+                } catch (Throwable t) {
+                    checkpointError.compareAndSet(null, t);
+                }
+            }, "checkpoint-under-test");
+            checkpointer.start();
+
+            // Wait until Phase C reached the hook (= deletes-apply done,
+            // about to acquire writeLock for Stage 2).
+            assertTrue("Phase C did not reach the post-deletes-apply hook within 30s",
+                    hookEntered.await(30, TimeUnit.SECONDS));
+
+            // The pre-fix code held the writeLock during the deletes-apply.
+            // After the fix, the hook fires WITHOUT the writeLock held —
+            // so searches issued from THIS thread complete immediately.
+            float[] query = randomVector(rng, dim);
+            int searchesCompleted = 0;
+            long maxSingleSearchNanos = 0;
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            while (System.nanoTime() < deadline) {
+                long t0 = System.nanoTime();
+                List<Map.Entry<Bytes, Float>> results = store.search(query, 5);
+                long elapsed = System.nanoTime() - t0;
+                maxSingleSearchNanos = Math.max(maxSingleSearchNanos, elapsed);
+                assertFalse("search returned null", results == null);
+                searchesCompleted++;
+            }
+
+            // Release the hook; checkpoint completes.
+            hookRelease.countDown();
+            checkpointer.join(60_000);
+            if (checkpointError.get() != null) {
+                throw new AssertionError("checkpoint failed", checkpointError.get());
+            }
+
+            store.setPhaseCPostDeletesApplyHookForTest(null);
+
+            // Headline assertions: searches ran without blocking on Phase C.
+            assertTrue("expected >= 5 searches to complete during the Phase C pause;"
+                            + " saw " + searchesCompleted
+                            + " (issue #462: writeLock must not be held during deletes apply)",
+                    searchesCompleted >= 5);
+            assertTrue("max search latency during Phase C pause ("
+                            + (maxSingleSearchNanos / 1_000_000) + " ms) must be small",
+                    maxSingleSearchNanos < TimeUnit.MILLISECONDS.toNanos(200));
+
+            // Diagnostic counter sanity: Stage 2's writeLock window is microseconds.
+            assertTrue("Phase C Stage 2 writeLock window must be tiny (issue #462 SLO);"
+                            + " observed " + store.getLastPhaseCWriteLockNanos() + " ns",
+                    store.getLastPhaseCWriteLockNanos() < 200_000_000L);
+
+            // Functional correctness: checkpoint succeeded and produced new on-disk state.
+            int segmentsAfter = store.getSegmentCount();
+            assertTrue("checkpoint must have produced at least one new segment "
+                    + "(before=" + segmentsBefore + " after=" + segmentsAfter + ")",
+                    segmentsAfter > segmentsBefore);
+
+            // Search after the checkpoint returns valid results.
+            List<Map.Entry<Bytes, Float>> postResults = store.search(query, 5);
+            assertFalse("search after checkpoint returned empty",
+                    postResults.isEmpty());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCSearchProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStorePhaseCSearchProgressTest.java
@@ -139,12 +139,19 @@ public class PersistentVectorStorePhaseCSearchProgressTest {
 
             // The pre-fix code held the writeLock during the deletes-apply.
             // After the fix, the hook fires WITHOUT the writeLock held —
-            // so searches issued from THIS thread complete immediately.
+            // so searches issued from THIS thread complete normally.
+            //
+            // Timing budgets are deliberately loose to ride out slow CI
+            // runners (jvector ANN cold-start can be hundreds of ms before
+            // the JIT warms up). The regression assertion is still meaningful
+            // because the pre-fix code blocks for >>1 s when there are many
+            // pending deletes at scale; here we only need to demonstrate
+            // that searches make progress concurrently with a parked Phase C.
             float[] query = randomVector(rng, dim);
             int searchesCompleted = 0;
             long maxSingleSearchNanos = 0;
-            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-            while (System.nanoTime() < deadline) {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (System.nanoTime() < deadline && searchesCompleted < 5) {
                 long t0 = System.nanoTime();
                 List<Map.Entry<Bytes, Float>> results = store.search(query, 5);
                 long elapsed = System.nanoTime() - t0;
@@ -167,14 +174,20 @@ public class PersistentVectorStorePhaseCSearchProgressTest {
                             + " saw " + searchesCompleted
                             + " (issue #462: writeLock must not be held during deletes apply)",
                     searchesCompleted >= 5);
+            // Per-search latency: pre-fix code blocks for >>1 s when there
+            // are many pending deletes at scale; we accept up to 1 s here to
+            // avoid CI flakes while still proving the writeLock isn't held.
             assertTrue("max search latency during Phase C pause ("
                             + (maxSingleSearchNanos / 1_000_000) + " ms) must be small",
-                    maxSingleSearchNanos < TimeUnit.MILLISECONDS.toNanos(200));
+                    maxSingleSearchNanos < TimeUnit.SECONDS.toNanos(1));
 
-            // Diagnostic counter sanity: Stage 2's writeLock window is microseconds.
-            assertTrue("Phase C Stage 2 writeLock window must be tiny (issue #462 SLO);"
+            // Diagnostic counter sanity: Stage 2's writeLock window is small.
+            // Pre-fix code at scale is multi-second; even at this tiny test
+            // scale the post-fix value is microseconds. 1 s is a generous
+            // CI-tolerant bound.
+            assertTrue("Phase C Stage 2 writeLock window must be small (issue #462 SLO);"
                             + " observed " + store.getLastPhaseCWriteLockNanos() + " ns",
-                    store.getLastPhaseCWriteLockNanos() < 200_000_000L);
+                    store.getLastPhaseCWriteLockNanos() < TimeUnit.SECONDS.toNanos(1));
 
             // Functional correctness: checkpoint succeeded and produced new on-disk state.
             int segmentsAfter = store.getSegmentCount();


### PR DESCRIPTION
Fixes #462.

ANN searches block on `stateLock.readLock` for seconds during compaction
and checkpoint at the 18 K-segment scale. Two write-side critical
sections in `PersistentVectorStore` hold `stateLock.writeLock()` across
slow operations:

1. `atomicSwapCompactionResult` holds it across
   `persistIndexStatusMultiSegment` — local fsync + remote
   shared-metadata PUT for ~18 K segments, multi-second.
2. Phase C of `doCheckpointFusedPQThreePhase` holds it across the
   `pendingCheckpointDeletes` apply — `O(P × N)` `seg.deletePk` calls,
   seconds at scale.

Phase A's writeLock and Phase B (lock-free) are not the bottleneck.

## Changes

Both critical sections are restructured so the slow work runs under
`checkpointLock` alone (still serialised against other writers) while
only microsecond-scale state-flips remain under `writeLock`.

### `atomicSwapCompactionResult` — three-stage protocol
- **Stage 1 (no writeLock)**: validate inputs, build `newSegments`, queue
  retention deletes. On `ABORTED_INPUT_GONE`, also unstage from the
  segment registry (when wired) and `queueMergedOutputForDeletion` —
  same registry-cleanup semantics as the previous single-window
  implementation.
- **Stage 2 (no writeLock)**: `persistIndexStatusMultiSegment` — the
  slow I/O.
- **Stage 3 (writeLock for ~µs)**: register/unregister memory estimates,
  publish `this.segments = newSegments`, set `dirty`.

The pre-lock and post-lock segment-registry coordination introduced by
PR #357 is preserved verbatim around the new three-stage block.

### Phase C — two-stage protocol
- **Stage 1 (no writeLock)**: build `newSegments`, reset
  sealed/mergeable `dirty` flags, apply `pendingCheckpointDeletes` to
  `newSegments`. `seg.deletePk` is concurrent-safe with concurrent
  search readers (BLink delete is internally synchronized;
  `offsets[ord] = -1` is benign for readers — `acceptBits` and
  `getPkForOrdinal` skip negative offsets) and with concurrent
  `removeVector` callers (`BLink.delete` returns the ordinal to a single
  caller, so `liveCount` is decremented exactly once).
- **Stage 2 (writeLock for ~µs)**: close `snapshotShards` builders
  (writeLock excludes readers from iterating `frozenShards`/
  `deferredShards` here), register memory for preloaded, publish
  segments, restore deferred shards, clear frozen/deferred/pending.

### Diagnostics + test hooks
- Two `AtomicLong` counters with public getters:
  `getLastCompactionSwapWriteLockNanos()` and
  `getLastPhaseCWriteLockNanos()`. Used by the regression tests to
  assert the writeLock window has actually shrunk.
- Three test-only hooks (`atomicSwapPostBuildHook`,
  `atomicSwapPostPersistHook`, `phaseCPostDeletesApplyHook`) for stage-
  boundary inspection — same pattern as the existing
  `checkpointPhaseBHook`.

## Tests

Five new tests, all in `herddb-indexing-service`:

- **`PersistentVectorStoreCompactionSwapStagesTest`** — locks down the
  Stage-1/Stage-2/Stage-3 contract via the post-build / post-persist
  hooks: `currentIndexStatusGeneration`, `this.segments`, and
  `stateLock.isWriteLocked()` are inspected at each boundary; final
  state asserted post-compaction.
- **`PersistentVectorStoreCompactionSearchProgressTest`** — headline
  regression: a `ForwardingDataStorageManager` blocks `indexCheckpoint`
  for ≥ 2 s; ≥ 5 concurrent searches must complete during the block,
  each in < 200 ms; `lastCompactionSwapWriteLockNanos < 200 ms`.
- **`PersistentVectorStoreCompactionSwapFailureTest`** — failure
  semantics: `indexCheckpoint` throws; in-memory `segments`,
  `currentIndexStatusGeneration`, and memory counter are unchanged;
  follow-up cycle succeeds.
- **`PersistentVectorStorePhaseCSearchProgressTest`** — same shape for
  Phase C.
- **`PersistentVectorStorePhaseCDeletePkRaceTest`** — concurrent search
  + `removeVector` + Phase C deletes all running on the same segments
  must leave a consistent final state with no exceptions and a non-
  paradoxical memory counter.

All 5 new tests + 56 adjacent regression tests pass.

The hammer suite (`DirectMultipleConcurrentUpdatesSuite × 3`,
`BLinkConcurrentSearchInsertTest`, `LazyValueCacheConcurrentUpdatesSuite × 3`)
is green on two consecutive runs. The 33 segmented-v2 / local-compaction
tests added in PR #357 also pass on the merged code path.

`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`
runs clean across the entire reactor.

## Honest assessment

After this fix, `stateLock.writeLock()` hold time across every
write-side critical section is microseconds. Concurrent searches no
longer wait *seconds* behind a queued writer's persist — issue #462's
stated expectation ("Searches should be served concurrently with Phase A
checkpoint and compaction") is met for the lock-contention dimension.

Per-query scan time over 18 K segments is unchanged. If individual
queries are slow because each has to touch 18 K segment files, this PR
does not change that — that's a separate, structural problem that
warrants its own issue (hierarchical segment index, per-segment bloom
filter, etc.).

🤖 Implemented by the `pr-worker` agent.