### PR TITLE
issue #467: round out test coverage for shard-filter metric and engine-stats proto

### DIFF
--- a/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceBookKeeperShardingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceBookKeeperShardingTest.java
@@ -484,6 +484,13 @@ public class MultiInstanceBookKeeperShardingTest {
         int numRecords = 100;
         int batchSize = 50;
         long[] txIds = new long[]{42L, 43L};
+        // Issue #467: guard against silent leftover-insert data loss. The loop
+        // below iterates `numRecords / batchSize` times and drops the remainder
+        // entirely — so if someone changes numRecords to a non-multiple of
+        // batchSize, not all INSERTs are exercised and the metric assertions
+        // below will silently pass with the wrong counts.
+        assertEquals("numRecords must be an exact multiple of batchSize to avoid "
+                + "silent leftover INSERTs", 0, numRecords % batchSize);
 
         Table table = createTable();
         Index index = createIndex(numShards);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/TailerOpTypeMetricsTest.java
@@ -21,13 +21,17 @@
 package herddb.indexing;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.codec.RecordSerializer;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
 import herddb.model.Index;
+import herddb.model.Record;
 import herddb.model.Table;
 import herddb.utils.Bytes;
+import herddb.utils.XXHash64Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -275,5 +279,199 @@ public class TailerOpTypeMetricsTest {
         assertEquals("INSERT on table without vector index must NOT count "
                         + "as shard-filtered",
                 0L, engine.getTailerEntriesShardFiltered());
+    }
+
+    /**
+     * Issue #467 item 2: a table with TWO vector indexes that have
+     * <em>different</em> {@code numShards} values (2 and 3) can produce
+     * per-key split decisions — a key whose hash puts it on an odd shard
+     * for {@code numShards=2} but an even shard for {@code numShards=3}
+     * will be <em>accepted by the second index</em> even though the first
+     * rejected it. The documented contract is:
+     * <ul>
+     *   <li>{@code tailer_entries_shard_filtered} is incremented only when
+     *       <em>every</em> applicable vector index rejected the key.</li>
+     *   <li>Keys accepted by at least one index are NOT counted.</li>
+     * </ul>
+     * The test sets up instance 0 of 2 with one table + two indexes
+     * ({@code numShards=2} and {@code numShards=3}) then drives 120 INSERTs
+     * (a multiple of lcm(2,3)=6, so hash buckets are well-represented).
+     * Before driving the INSERTs it pre-classifies each key using the same
+     * {@link XXHash64Utils#hash} + {@code Math.floorMod} formula used by
+     * production, counts how many are rejected by <em>both</em> indexes,
+     * and asserts the engine counter matches. It additionally asserts that
+     * some keys triggered the "mixed acceptance" path (one index accepts,
+     * one rejects) — proving the test is not vacuous.
+     */
+    @Test
+    public void mixedAcceptanceInsertDoesNotBumpShardFiltered() throws Exception {
+        int numRecords = 120; // multiple of lcm(2, 3) = 6
+        int numShards2 = 2;
+        int numShards3 = 3;
+
+        // Instance 0 of 2 — shard filter fires for non-trivial numShards.
+        EmbeddedIndexingService multiService = new EmbeddedIndexingService(
+                folder.newFolder("ma-log").toPath(),
+                folder.newFolder("ma-data").toPath(),
+                0, 2);
+        multiService.start();
+        try {
+            IndexingServiceEngine engine = multiService.getEngine();
+            Table table = Table.builder()
+                    .name("matbl")
+                    .tablespace("local")
+                    .column("pk", ColumnTypes.STRING)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .primaryKey("pk")
+                    .build();
+
+            // Two indexes with different numShards on the same table.
+            Index idxA = Index.builder()
+                    .name("vidxA")
+                    .table("matbl")
+                    .tablespace("local")
+                    .type(Index.TYPE_VECTOR)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .property("numShards", String.valueOf(numShards2))
+                    .build();
+            Index idxB = Index.builder()
+                    .name("vidxB")
+                    .table("matbl")
+                    .tablespace("local")
+                    .type(Index.TYPE_VECTOR)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .property("numShards", String.valueOf(numShards3))
+                    .build();
+
+            // DDL via applyEntry so the schema tracker is seeded without
+            // touching the per-op metric counters we are about to assert.
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(idxA, null));
+            engine.applyEntry(new LogSequenceNumber(1, 3),
+                    LogEntryFactory.createIndex(idxB, null));
+
+            // Pre-classify every key using the same hash + floorMod formula
+            // as IndexingServiceEngine.isAcceptedLocally. n=2, instanceId=0.
+            int expectedShardFiltered = 0;
+            int mixedAcceptanceCount = 0;
+            for (int i = 0; i < numRecords; i++) {
+                Bytes key = Bytes.from_string("ma-" + i);
+                long hash = XXHash64Utils.hash(
+                        key.getBuffer(), key.getOffset(), key.getLength());
+                // idxA: numShards=2 → accepted if (hash%2)%2==0 → shard==0
+                boolean acceptedByA = Math.floorMod((int) hash, numShards2) % 2 == 0;
+                // idxB: numShards=3 → accepted if (hash%3)%2==0 → shard ∈ {0,2}
+                boolean acceptedByB = Math.floorMod((int) hash, numShards3) % 2 == 0;
+                if (!acceptedByA && !acceptedByB) {
+                    expectedShardFiltered++;
+                }
+                if (acceptedByA != acceptedByB) {
+                    mixedAcceptanceCount++;
+                }
+            }
+
+            // Sanity-check the test is actually exercising mixed decisions
+            // (otherwise the two-index setup adds nothing over a single-index
+            // test and we would not be testing the "at-least-one-accepts"
+            // branch at all).
+            assertTrue("with numShards=2 and numShards=3 across 120 keys, at "
+                    + "least one key must have divergent per-index decisions",
+                    mixedAcceptanceCount > 0);
+            // Similarly, at least one key must be rejected by both so the
+            // counter is non-trivially tested.
+            assertTrue("at least one key must be rejected by both indexes",
+                    expectedShardFiltered > 0);
+
+            // Drive all INSERTs through processEntryForTest (the path the
+            // real tailer uses) so classifyForMetrics fires on each one.
+            // The record value must be a properly serialised row (schema-aware
+            // bytes), not a raw string — applyInsert feeds it through
+            // RecordSerializer.accessRawDataFromValue to extract the vector.
+            for (int i = 0; i < numRecords; i++) {
+                Record record = RecordSerializer.makeRecord(table,
+                        "pk", "ma-" + i,
+                        "vec", new float[]{i * 1.0f, (i + 1) * 1.0f, (i + 2) * 1.0f});
+                engine.processEntryForTest(new LogSequenceNumber(1, 10 + i),
+                        LogEntryFactory.insert(table, record.key, record.value, null));
+            }
+            engine.awaitPendingWorkForTest();
+
+            assertEquals("shard-filter counter must match the pre-classified "
+                    + "both-reject count",
+                    expectedShardFiltered, engine.getTailerEntriesShardFiltered());
+            assertEquals("tailer_inserts must count every INSERT regardless of "
+                    + "shard-filter outcome",
+                    numRecords, engine.getTailerInserts());
+        } finally {
+            multiService.close();
+        }
+    }
+
+    /**
+     * Issue #467 item 5: UPDATE and DELETE entries on a sharded vector index
+     * must NOT increment {@code tailer_entries_shard_filtered}. The shard
+     * filter is INSERT-only: DELETE is always broadcast (so stale copies on
+     * non-owners are removed), and UPDATE's remove is also broadcast while
+     * only the add side is filtered — but neither bumps the counter. A
+     * focused single-instance test locks this documented scope explicitly so a
+     * future change that accidentally widens the filter to UPDATE or DELETE
+     * would fail loudly here rather than at the broader multi-instance tests.
+     */
+    @Test
+    public void updateAndDeleteOnShardedTableDoNotBumpShardFiltered() throws Exception {
+        // Instance 0 of 2, numShards=4 — shard filter is active.
+        EmbeddedIndexingService shardedService = new EmbeddedIndexingService(
+                folder.newFolder("ud-log").toPath(),
+                folder.newFolder("ud-data").toPath(),
+                0, 2);
+        shardedService.start();
+        try {
+            IndexingServiceEngine engine = shardedService.getEngine();
+            Table table = Table.builder()
+                    .name("udtbl")
+                    .tablespace("local")
+                    .column("pk", ColumnTypes.STRING)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .primaryKey("pk")
+                    .build();
+            Index index = Index.builder()
+                    .name("udidx")
+                    .table("udtbl")
+                    .tablespace("local")
+                    .type(Index.TYPE_VECTOR)
+                    .column("vec", ColumnTypes.FLOATARRAY)
+                    .property("numShards", "4")
+                    .build();
+
+            // DDL via applyEntry so counters start at zero before the DML.
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(index, null));
+
+            // Build a properly serialised record so the async applyUpdate path
+            // can decode the vector column without throwing "bad column type".
+            Record record = RecordSerializer.makeRecord(table,
+                    "pk", "ud-key",
+                    "vec", new float[]{1.0f, 2.0f, 3.0f});
+
+            // One UPDATE and one DELETE through the full tailer path.
+            engine.processEntryForTest(new LogSequenceNumber(1, 3),
+                    LogEntryFactory.update(table, record.key, record.value, null));
+            engine.processEntryForTest(new LogSequenceNumber(1, 4),
+                    LogEntryFactory.delete(table, record.key, null));
+            engine.awaitPendingWorkForTest();
+
+            assertEquals("tailer_updates must be 1", 1L, engine.getTailerUpdates());
+            assertEquals("tailer_deletes must be 1", 1L, engine.getTailerDeletes());
+            assertEquals("UPDATE and DELETE must NOT bump tailer_entries_shard_filtered",
+                    0L, engine.getTailerEntriesShardFiltered());
+            // tailer_inserts must remain zero — nothing was inserted.
+            assertEquals("tailer_inserts must remain 0", 0L, engine.getTailerInserts());
+        } finally {
+            shardedService.close();
+        }
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/admin/IndexingAdminCliMetricEntryTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/admin/IndexingAdminCliMetricEntryTest.java
@@ -1,0 +1,240 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.indexing.proto.GetEngineStatsRequest;
+import herddb.indexing.proto.GetEngineStatsResponse;
+import herddb.indexing.proto.IndexingServiceGrpc;
+import herddb.indexing.proto.MetricEntry;
+import herddb.indexing.proto.MetricValue;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Issue #467 items 3 and 4: unit-level tests for edge-cases in
+ * {@link IndexingAdminCli}'s {@code engine-stats} rendering path that cannot
+ * be triggered through a live {@link herddb.indexing.EmbeddedIndexingService}
+ * because the production server never emits duplicate keys or unset
+ * {@code MetricValue} kinds.
+ *
+ * <p>The harness pattern follows {@link IndexingAdminCliStatusLagTest}: start a
+ * minimal in-process gRPC server that returns hand-crafted
+ * {@link GetEngineStatsResponse} messages, then drive the CLI's
+ * {@link IndexingAdminCli#run(String[])} entry point and assert the resulting
+ * stdout/stderr.
+ */
+public class IndexingAdminCliMetricEntryTest {
+
+    private FakeEngineStatsServer fakeServer;
+    private ByteArrayOutputStream stdoutBytes;
+    private ByteArrayOutputStream stderrBytes;
+    private IndexingAdminCli cli;
+
+    @Before
+    public void setUp() {
+        stdoutBytes = new ByteArrayOutputStream();
+        stderrBytes = new ByteArrayOutputStream();
+        cli = new IndexingAdminCli(
+                new PrintStream(stdoutBytes, true, StandardCharsets.UTF_8),
+                new PrintStream(stderrBytes, true, StandardCharsets.UTF_8));
+    }
+
+    @After
+    public void tearDown() throws InterruptedException {
+        if (fakeServer != null) {
+            fakeServer.close();
+        }
+    }
+
+    private String stdout() {
+        return new String(stdoutBytes.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private String stderr() {
+        return new String(stderrBytes.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Issue #467 item 3: {@code IndexingAdminCli.engineStatsToMap} builds a
+     * {@link java.util.LinkedHashMap} by calling {@code put(key, value)} for
+     * each {@link MetricEntry} in the server's ordered list. When two entries
+     * share the same key, {@code LinkedHashMap.put} silently overwrites the
+     * first value with the second (last-write-wins). The current server never
+     * emits duplicate keys, but the generic {@code repeated MetricEntry} schema
+     * technically permits them, and any future consumer that adds a metric must
+     * not accidentally produce a key collision that silently truncates the
+     * earlier value in dashboards.
+     *
+     * <p>This test locks the documented last-write-wins contract:
+     * <ol>
+     *   <li>The fake server returns two {@link MetricEntry} records for the
+     *       same key ({@code dupe_metric}) with values 42 and then 99.</li>
+     *   <li>The CLI {@code --json} output must contain {@code "dupe_metric":99}
+     *       (the second value) and must NOT contain {@code "dupe_metric":42}
+     *       (the first).</li>
+     * </ol>
+     */
+    @Test
+    public void duplicateKeyInResponseLastValueWins() throws Exception {
+        GetEngineStatsResponse response = GetEngineStatsResponse.newBuilder()
+                .addMetrics(MetricEntry.newBuilder()
+                        .setKey("dupe_metric")
+                        .setValue(MetricValue.newBuilder().setInt64Value(42L).build())
+                        .build())
+                .addMetrics(MetricEntry.newBuilder()
+                        .setKey("dupe_metric")
+                        .setValue(MetricValue.newBuilder().setInt64Value(99L).build())
+                        .build())
+                .build();
+        fakeServer = new FakeEngineStatsServer(response);
+        fakeServer.start();
+
+        int rc = cli.run(new String[]{
+            "engine-stats",
+            "--server", fakeServer.address(),
+            "--json"
+        });
+        assertEquals("CLI should succeed; stderr=\n" + stderr(), 0, rc);
+        String out = stdout().trim();
+        assertTrue("output must be a JSON object, got: " + out,
+                out.startsWith("{") && out.endsWith("}"));
+        // Second (last) value must win.
+        assertTrue("last-write-wins: must contain dupe_metric:99, got: " + out,
+                out.contains("\"dupe_metric\":99"));
+        // First value must have been overwritten and must not appear separately.
+        assertFalse("first value must be overwritten: must NOT contain "
+                + "dupe_metric:42, got: " + out, out.contains("\"dupe_metric\":42"));
+    }
+
+    /**
+     * Issue #467 item 4: {@code IndexingAdminCli.engineStatsToMap} has a
+     * {@code case KIND_NOT_SET} branch that silently skips entries whose
+     * {@link MetricValue} {@code oneof kind} field is unset — forward-compat
+     * for a hypothetical future value type (e.g. {@code bytes_value}) that an
+     * older CLI does not recognise.
+     *
+     * <p>This test locks the graceful-skip contract:
+     * <ol>
+     *   <li>The fake server returns one {@code KIND_NOT_SET} entry (key
+     *       {@code future_metric}) plus one valid {@code int64} entry (key
+     *       {@code good_metric}, value 42).</li>
+     *   <li>The CLI must succeed (exit code 0), must include
+     *       {@code "good_metric":42} in the JSON output, and must NOT include
+     *       {@code future_metric} at all (skipped, not crashed on).</li>
+     * </ol>
+     */
+    @Test
+    public void kindNotSetEntryIsSkippedGracefully() throws Exception {
+        GetEngineStatsResponse response = GetEngineStatsResponse.newBuilder()
+                // KIND_NOT_SET: a MetricEntry whose MetricValue has no oneof
+                // field set — represents an unknown future value kind.
+                .addMetrics(MetricEntry.newBuilder()
+                        .setKey("future_metric")
+                        .setValue(MetricValue.newBuilder().build())  // no kind set
+                        .build())
+                // A normal int64 entry that must still appear in the output.
+                .addMetrics(MetricEntry.newBuilder()
+                        .setKey("good_metric")
+                        .setValue(MetricValue.newBuilder().setInt64Value(42L).build())
+                        .build())
+                .build();
+        fakeServer = new FakeEngineStatsServer(response);
+        fakeServer.start();
+
+        int rc = cli.run(new String[]{
+            "engine-stats",
+            "--server", fakeServer.address(),
+            "--json"
+        });
+        assertEquals("CLI must not crash on KIND_NOT_SET; stderr=\n" + stderr(), 0, rc);
+        String out = stdout().trim();
+        assertTrue("output must be a JSON object, got: " + out,
+                out.startsWith("{") && out.endsWith("}"));
+        // The valid metric must appear.
+        assertTrue("valid metric must be present in output, got: " + out,
+                out.contains("\"good_metric\":42"));
+        // The KIND_NOT_SET entry must have been silently skipped — not
+        // represented as null, zero, or any other fallback value.
+        assertFalse("KIND_NOT_SET entry must be absent from output, got: " + out,
+                out.contains("future_metric"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Harness
+    // -----------------------------------------------------------------------
+
+    private static final class FakeEngineStatsServer implements AutoCloseable {
+        private final GetEngineStatsResponse canned;
+        private Server server;
+
+        FakeEngineStatsServer(GetEngineStatsResponse canned) {
+            this.canned = canned;
+        }
+
+        void start() throws IOException {
+            server = ServerBuilder.forPort(0)
+                    .addService(new EngineStatsImpl(canned))
+                    .build()
+                    .start();
+            assertNotNull(server);
+        }
+
+        String address() {
+            return "localhost:" + server.getPort();
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            if (server != null) {
+                server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private static final class EngineStatsImpl
+            extends IndexingServiceGrpc.IndexingServiceImplBase {
+        private final GetEngineStatsResponse response;
+
+        EngineStatsImpl(GetEngineStatsResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public void getEngineStats(GetEngineStatsRequest request,
+                                   StreamObserver<GetEngineStatsResponse> responseObserver) {
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #467.

## Changes

- **`MultiInstanceBookKeeperShardingTest`** — added `assertEquals(0, numRecords % batchSize)` guard inside `testTwoInstancesTransactionalInsertsBumpShardFilteredCounter` to make any future constant-change that silently drops trailing INSERTs a loud compile-time failure rather than a silent test miscounting.

- **`TailerOpTypeMetricsTest`** (two new `@Test` methods):
  - `mixedAcceptanceInsertDoesNotBumpShardFiltered`: table with two vector indexes at `numShards=2` and `numShards=3` on instance 0 of 2. Pre-classifies all 120 keys with `XXHash64Utils` (same formula as production), then asserts the engine counter matches only the "rejected by both indexes" subset. Sanity-checks that at least one key exercised the mixed-decision path (one index accepts, one rejects) so the two-index setup is not vacuous.
  - `updateAndDeleteOnShardedTableDoNotBumpShardFiltered`: drives one UPDATE and one DELETE through `processEntryForTest` on a sharded index (numShards=4, instance 0 of 2) and asserts `tailer_entries_shard_filtered == 0` while `tailer_updates == 1` and `tailer_deletes == 1`. Makes the INSERT-only scope explicit.

- **`IndexingAdminCliMetricEntryTest`** (new file in `herddb.indexing.admin` package, fake in-process gRPC server pattern from `IndexingAdminCliStatusLagTest`):
  - `duplicateKeyInResponseLastValueWins`: server emits two `MetricEntry` with the same key. Asserts `LinkedHashMap.put` second-write-wins semantics in the CLI's JSON output.
  - `kindNotSetEntryIsSkippedGracefully`: server emits one `KIND_NOT_SET` `MetricValue` plus one valid `int64` entry. Asserts the CLI renders the valid entry and does not crash or emit the unknown entry.

## Tests

- `TailerOpTypeMetricsTest` — 7 tests (5 pre-existing + 2 new), all green locally.
- `IndexingAdminCliMetricEntryTest` — 2 new tests, green locally.
- `MultiInstanceBookKeeperShardingTest#testTwoInstancesTransactionalInsertsBumpShardFilteredCounter` — still green with the new guard.
- Pre-PR validation (`checkstyle`, Apache RAT, SpotBugs, `install -DskipTests -Pci`) — **BUILD SUCCESS**.

🤖 Implemented by the `pr-worker` agent.