### PR TITLE
issue #468: in-flight write-byte budget for compaction/search fairness

### DIFF
--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -453,6 +453,9 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
                         configuration.getLong(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
                                 ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES_DEFAULT));
+                clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                        configuration.getLong(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                                ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES_DEFAULT));
                 RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
                 RemoteFileClient client = factory.createClient(servers, clientConfig);
                 client.registerMetrics(statsLogger.scope("remote_file_client"));
@@ -594,6 +597,9 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
                 configuration.getLong(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
                         ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES_DEFAULT));
+        clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                configuration.getLong(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                        ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES_DEFAULT));
         RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
         RemoteFileClient client = factory.createClient(servers, clientConfig);
         client.registerMetrics(statsLogger.scope("remote_file_client"));

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -113,6 +113,27 @@ public final class ServerConfiguration {
             256L * 1024 * 1024;
 
     /**
+     * Maximum number of bytes across in-flight {@code writeFile}/{@code writeFileBlock}/
+     * {@code writeMultipartFile} calls whose payloads are currently being staged
+     * into the write-plane Netty channel. Symmetric to
+     * {@link #PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES} but for the
+     * write side (issue #468). Acquired before each block-async call is launched
+     * and released when the corresponding future completes, which gives the
+     * {@code writeMultipartFile} driver thread natural backpressure: when the
+     * cap is hit, the driver blocks on {@code acquire()} instead of fanning out
+     * hundreds of in-flight blocks at once. Bounds peak write-plane network
+     * pressure so a multipart compaction write cannot starve concurrent search
+     * reads sharing the same Netty event-loop pool / file server. Default
+     * 256 MiB matches the read cap; lower this on memory-constrained pods or
+     * profiles where compaction-vs-search contention is observed (e.g. 64 MiB
+     * for the k3s-local IS profile in issue #468).
+     */
+    public static final String PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES =
+            "remote.file.client.max.inflight.write.bytes";
+    public static final long PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES_DEFAULT =
+            256L * 1024 * 1024;
+
+    /**
      * Maximum number of block uploads that a single {@code writePage} invocation
      * may keep in flight when splitting a page into multipart blocks for
      * {@link herddb.remote.RemoteFileDataStorageManager}. Larger values speed up

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -185,6 +185,9 @@ public class IndexingServer implements AutoCloseable {
                 clientConfig.put(IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
                         config.getLong(IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
                                 IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES_DEFAULT));
+                clientConfig.put(IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                        config.getLong(IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                                IndexingServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES_DEFAULT));
                 try {
                     RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
                     RemoteFileClient client = factory.createClient(servers, clientConfig);

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -404,6 +404,27 @@ public final class IndexingServerConfiguration {
             256L * 1024 * 1024;
 
     /**
+     * Maximum number of bytes across in-flight {@code writeFile}/{@code writeFileBlock}/
+     * {@code writeMultipartFile} calls whose payloads are currently being staged
+     * into the write-plane Netty channel. Symmetric to
+     * {@link #PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES} but for the
+     * write side (issue #468). Acquired before each block-async call is launched
+     * and released when the corresponding future completes; the
+     * {@code writeMultipartFile} driver thread naturally backpressures by
+     * blocking on {@code acquire()} when the cap is hit instead of fanning out
+     * hundreds of in-flight blocks at once. Bounds peak write-plane network
+     * pressure so a Phase-B compaction write cannot starve concurrent ANN
+     * search reads sharing the same Netty event-loop pool / file server.
+     * Default 256 MiB matches the read cap; lower this on memory-constrained
+     * IS pods or profiles where compaction-vs-search contention is observed
+     * (e.g. 64 MiB for the k3s-local profile in issue #468).
+     */
+    public static final String PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES =
+            "remote.file.client.max.inflight.write.bytes";
+    public static final long PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES_DEFAULT =
+            256L * 1024 * 1024;
+
+    /**
      * Maximum time (in milliseconds) to block at bootstrap waiting for at
      * least one remote file server to be discovered (via ZK) before giving up
      * and failing startup. Guards against a cold-cluster race where the

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -423,6 +423,15 @@ indexingService:
     # MaxDirectMemorySize budgets, raise only if Netty PoolArena headroom
     # is proven sufficient (see issue #246).
     remote.file.client.max.inflight.read.bytes: "268435456"
+    # Symmetric write-side cap (issue #468). Bounds bytes across in-flight
+    # writeFile/writeFileBlock/writeMultipartFile calls so a Phase B
+    # compaction write burst (graphs of 322–658 MB + maps of 159–326 MB at
+    # gist1m scale) cannot fan out hundreds of in-flight blocks at once and
+    # starve concurrent ANN reads on the shared event-loop pool / file
+    # server. Default 256 MiB matches the read cap; lower this (e.g.
+    # "67108864" = 64 MiB) on smaller pods or profiles where compaction
+    # visibly hurts query p99 latency. Set explicitly here for visibility.
+    remote.file.client.max.inflight.write.bytes: "268435456"
     # Disable segment-count back-pressure (PR #358 / issue #354).
     # Default threshold is 500 segments: when exceeded, addVectorInternal()
     # parks the apply thread in waitForSegmentCountRelief() until compaction

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -351,6 +351,14 @@ indexingService:
     # proportion to the direct-memory pressure they impose. Lower this
     # (e.g. "134217728" = 128 MiB) on tighter bench profiles.
     remote.file.client.max.inflight.read.bytes: "268435456"
+    # Caps bytes across in-flight writeFile/writeFileBlock/writeMultipartFile
+    # calls (issue #468). Set tighter than the read cap to bias the
+    # constrained k3s-local profile toward search reads: when Phase B
+    # compaction streams a 658 MB graph + 326 MB map file via 4 MiB blocks,
+    # 64 MiB caps the queue at 16 in-flight blocks (vs. ~165 unbounded)
+    # so concurrent ANN reads are not starved on the shared event-loop
+    # pool / file server.
+    remote.file.client.max.inflight.write.bytes: "67108864"
     # BookKeeper V2 wire protocol for the IS commit-log tailer (no protobuf framing
     # on readEntries). Code-level default since issue #392; kept here explicitly
     # for parity with the GKE example. Set to "false" to fall back to V3.

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -247,6 +247,16 @@ indexingService:
   #     - steady-state gRPC transport (~256 MiB)
   #   Bench-validated baseline: MaxDirectMemorySize=10g for -Xmx=24g with
   #   remote.file.client.max.inflight.read.bytes=256 MiB (issue #246).
+  #
+  # Compaction/search fairness on the write plane (issue #468):
+  #   remote.file.client.max.inflight.write.bytes caps bytes across in-flight
+  #   writeFile/writeFileBlock/writeMultipartFile calls. Symmetric to the
+  #   read cap above — when Phase B compaction streams hundreds of MB of
+  #   merged graph + map files, this knob bounds peak write-plane network
+  #   pressure so concurrent ANN search reads on the read plane are not
+  #   starved on the shared event-loop pool / file server. Default 256 MiB.
+  #   Lower this (e.g. "67108864" = 64 MiB) on profiles where compaction
+  #   visibly hurts query p99 latency.
   javaOpts: ""
   javaOptsExtra: ""
   # Optional: override /opt/herddb/conf/logging.properties inside the pod.

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -105,6 +105,20 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
      */
     public static final String CONFIG_CLIENT_MAX_INFLIGHT_READ_BYTES =
             "remote.file.client.max.inflight.read.bytes";
+    /**
+     * Configuration key for the maximum number of bytes across all in-flight
+     * {@code writeFile}/{@code writeFileBlock}/{@code writeMultipartFile}
+     * calls whose payloads are currently being staged into the write-plane
+     * Netty channel. Symmetric to
+     * {@link #CONFIG_CLIENT_MAX_INFLIGHT_READ_BYTES} but for the write side
+     * (issue #468). Acquired before each block-async call is launched and
+     * released when the corresponding future completes; bounds peak
+     * write-plane network pressure so a multipart compaction write cannot
+     * fan out hundreds of in-flight blocks at once and starve concurrent
+     * reads on the shared event-loop pool / file server.
+     */
+    public static final String CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES =
+            "remote.file.client.max.inflight.write.bytes";
 
     private static final long DEFAULT_CLIENT_TIMEOUT_SECONDS = 1800; // 30 minutes
     private static final int DEFAULT_CLIENT_RETRIES = 10;
@@ -112,6 +126,8 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     public static final int DEFAULT_BLOCK_SIZE = 4 * 1024 * 1024;
     /** Default cap on in-flight read bytes: 256 MiB (issue #246). */
     public static final long DEFAULT_CLIENT_MAX_INFLIGHT_READ_BYTES = 256L * 1024 * 1024;
+    /** Default cap on in-flight write bytes: 256 MiB (issue #468). */
+    public static final long DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES = 256L * 1024 * 1024;
     /**
      * Emit a WARNING log line if acquiring the in-flight reservation
      * blocks for longer than this threshold.
@@ -148,6 +164,8 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     private final int blockSize;
     private final long maxInflightReadBytes;
     private final Semaphore inflightReadBytes;
+    private final long maxInflightWriteBytes;
+    private final Semaphore inflightWriteBytes;
     private final ScheduledExecutorService retryScheduler;
     private final Supplier<String> oidcTokenSupplier;
 
@@ -200,6 +218,24 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                 ? Integer.MAX_VALUE
                 : (int) maxInflightReadBytes;
         this.inflightReadBytes = new Semaphore(permits);
+        long configuredMaxInflightWriteBytes = longConfig(configuration,
+                CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES);
+        if (configuredMaxInflightWriteBytes <= 0) {
+            throw new IllegalArgumentException(CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES
+                    + " must be > 0, got " + configuredMaxInflightWriteBytes);
+        }
+        if (configuredMaxInflightWriteBytes < this.blockSize) {
+            throw new IllegalArgumentException(CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES
+                    + " (" + configuredMaxInflightWriteBytes + ") must be >= "
+                    + CONFIG_CLIENT_BLOCK_SIZE + " (" + this.blockSize
+                    + ") so a single full-block write is always admissible");
+        }
+        this.maxInflightWriteBytes = configuredMaxInflightWriteBytes;
+        int writePermits = maxInflightWriteBytes > Integer.MAX_VALUE
+                ? Integer.MAX_VALUE
+                : (int) maxInflightWriteBytes;
+        this.inflightWriteBytes = new Semaphore(writePermits);
         this.retryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "remote-file-retry");
             t.setDaemon(true);
@@ -221,12 +257,16 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         if (servers.isEmpty()) {
             LOGGER.log(Level.INFO,
                     "RemoteFileServiceClient: starting with empty server list (awaiting ZK discovery), "
-                            + "timeout={0}s, retries={1}, maxInflightReadBytes={2}",
-                    new Object[]{clientTimeoutSeconds, maxRetries, maxInflightReadBytes});
+                            + "timeout={0}s, retries={1}, maxInflightReadBytes={2}, "
+                            + "maxInflightWriteBytes={3}",
+                    new Object[]{clientTimeoutSeconds, maxRetries, maxInflightReadBytes,
+                            maxInflightWriteBytes});
         } else {
             LOGGER.log(Level.INFO,
-                    "RemoteFileServiceClient: servers={0}, timeout={1}s, retries={2}, maxInflightReadBytes={3}",
-                    new Object[]{servers, clientTimeoutSeconds, maxRetries, maxInflightReadBytes});
+                    "RemoteFileServiceClient: servers={0}, timeout={1}s, retries={2}, "
+                            + "maxInflightReadBytes={3}, maxInflightWriteBytes={4}",
+                    new Object[]{servers, clientTimeoutSeconds, maxRetries, maxInflightReadBytes,
+                            maxInflightWriteBytes});
         }
     }
 
@@ -257,6 +297,14 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         return inflightReadBytes.availablePermits();
     }
 
+    public long maxInflightWriteBytes() {
+        return maxInflightWriteBytes;
+    }
+
+    public long availableInflightWriteBytes() {
+        return inflightWriteBytes.availablePermits();
+    }
+
     private void acquireInflightReadBytes(int bytes) {
         if (bytes <= 0) {
             throw new IllegalArgumentException("bytes must be > 0, got " + bytes);
@@ -282,6 +330,56 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         inflightReadBytes.release(bytes);
     }
 
+    private void acquireInflightWriteBytes(int bytes) {
+        if (bytes <= 0) {
+            throw new IllegalArgumentException("bytes must be > 0, got " + bytes);
+        }
+        if (inflightWriteBytes.tryAcquire(bytes)) {
+            return;
+        }
+        long startNanos = System.nanoTime();
+        inflightWriteBytes.acquireUninterruptibly(bytes);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        if (elapsedMs >= PERMIT_ACQUIRE_WARN_THRESHOLD_MS) {
+            LOGGER.log(Level.WARNING,
+                    "remote file client inflight-write reservation blocked for {0}ms "
+                            + "(requested={1} bytes, available={2}/{3}); consider raising "
+                            + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES
+                            + " or reducing concurrent compaction/page-write load",
+                    new Object[]{elapsedMs, bytes, inflightWriteBytes.availablePermits(),
+                            maxInflightWriteBytes});
+        }
+    }
+
+    private void releaseInflightWriteBytes(int bytes) {
+        inflightWriteBytes.release(bytes);
+    }
+
+    /**
+     * Acquires {@code bytes} from the in-flight write-bytes budget and
+     * returns an idempotent {@link Runnable} that releases the same number
+     * of permits exactly once. Callers wire the runnable into the
+     * {@code whenComplete} hook of the future returned by
+     * {@code sendRequest}, and into every synchronous failure branch (e.g.
+     * {@code writeChannelForBlock} throwing) so the reservation is always
+     * returned. Empty payloads ({@code bytes == 0}) skip both the acquire
+     * and the release — {@link #writeAsMultipart} legitimately uses
+     * {@code Unpooled.EMPTY_BUFFER} to materialise an empty file marker
+     * and would otherwise be rejected by {@link #acquireInflightWriteBytes}.
+     */
+    private Runnable reserveInflightWriteBytes(int bytes) {
+        if (bytes <= 0) {
+            return () -> { };
+        }
+        acquireInflightWriteBytes(bytes);
+        AtomicBoolean released = new AtomicBoolean(false);
+        return () -> {
+            if (released.compareAndSet(false, true)) {
+                releaseInflightWriteBytes(bytes);
+            }
+        };
+    }
+
     @Override
     public void registerMetrics(StatsLogger statsLogger) {
         if (statsLogger == null) {
@@ -303,6 +401,24 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
             @Override public Long getSample() {
                 return maxInflightReadBytes();
+            }
+        });
+        statsLogger.registerGauge("inflight_write_bytes_available", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return availableInflightWriteBytes();
+            }
+        });
+        statsLogger.registerGauge("inflight_write_bytes_max", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return maxInflightWriteBytes();
             }
         });
     }
@@ -424,15 +540,18 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     public CompletableFuture<Long> writeFileAsync(String path, byte[] buf, int offset, int length) {
         // Writes are not idempotent — no retry.
+        Runnable releaseOnce = reserveInflightWriteBytes(length);
         ServerChannel ch;
         try {
             ch = writeChannelForPath(path);
         } catch (RuntimeException e) {
+            releaseOnce.run();
             return failed(e);
         }
-        return sendRequest(ch, requestId ->
+        CompletableFuture<Long> result = sendRequest(ch, requestId ->
                         PduCodec.WriteFileRequest.write(requestId, path, buf, offset, length),
                 pdu -> PduCodec.WriteFileResponse.readWrittenSize(pdu));
+        return result.whenComplete((written, err) -> releaseOnce.run());
     }
 
     /**
@@ -440,15 +559,18 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
      * and must release after this future completes.
      */
     public CompletableFuture<Long> writeFileAsync(String path, ByteBuf content) {
+        Runnable releaseOnce = reserveInflightWriteBytes(content.readableBytes());
         ServerChannel ch;
         try {
             ch = writeChannelForPath(path);
         } catch (RuntimeException e) {
+            releaseOnce.run();
             return failed(e);
         }
-        return sendRequest(ch, requestId ->
+        CompletableFuture<Long> result = sendRequest(ch, requestId ->
                         PduCodec.WriteFileRequest.write(requestId, path, content),
                 pdu -> PduCodec.WriteFileResponse.readWrittenSize(pdu));
+        return result.whenComplete((written, err) -> releaseOnce.run());
     }
 
     public CompletableFuture<byte[]> readFileAsync(String path) {
@@ -572,39 +694,54 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
     /**
      * Writes one block of a multipart file. Not retried (not idempotent).
+     *
+     * <p>Acquires the in-flight write-bytes reservation (issue #468) before
+     * launching the RPC and releases it when the returned future completes,
+     * regardless of outcome. The acquisition is synchronous: callers fanning
+     * many blocks out at once will block here when the cap is hit, providing
+     * natural backpressure that protects concurrent reads on the shared
+     * event-loop pool.
      */
     public CompletableFuture<Void> writeFileBlockAsync(String path, long blockIndex, byte[] content) {
+        Runnable releaseOnce = reserveInflightWriteBytes(content.length);
         ServerChannel ch;
         try {
             ch = writeChannelForBlock(path, blockIndex);
         } catch (RuntimeException e) {
+            releaseOnce.run();
             return failed(e);
         }
-        return sendRequest(ch,
+        CompletableFuture<Void> result = sendRequest(ch,
                 requestId -> PduCodec.WriteFileBlockRequest.write(requestId, path, blockIndex, content),
                 pdu -> {
                     PduCodec.WriteFileBlockResponse.readWrittenSize(pdu); // ignored
                     return (Void) null;
                 });
+        return result.whenComplete((v, err) -> releaseOnce.run());
     }
 
     /**
      * Writes one block of a multipart file from a ByteBuf. Not retried.
      * Caller still owns {@code content} and must release after completion.
+     * Acquires/releases the in-flight write-bytes reservation (issue #468)
+     * symmetrically to the {@code byte[]} overload.
      */
     public CompletableFuture<Void> writeFileBlockAsync(String path, long blockIndex, ByteBuf content) {
+        Runnable releaseOnce = reserveInflightWriteBytes(content.readableBytes());
         ServerChannel ch;
         try {
             ch = writeChannelForBlock(path, blockIndex);
         } catch (RuntimeException e) {
+            releaseOnce.run();
             return failed(e);
         }
-        return sendRequest(ch,
+        CompletableFuture<Void> result = sendRequest(ch,
                 requestId -> PduCodec.WriteFileBlockRequest.write(requestId, path, blockIndex, content),
                 pdu -> {
                     PduCodec.WriteFileBlockResponse.readWrittenSize(pdu);
                     return (Void) null;
                 });
+        return result.whenComplete((v, err) -> releaseOnce.run());
     }
 
     public CompletableFuture<byte[]> readFileRangeAsync(String path, long offset, int length, int blockSizeArg) {

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
@@ -663,4 +663,286 @@ public class RemoteFileServiceClientByteBufTest {
             }
         }
     }
+
+    // ---------------------------------------------------------------------
+    // Issue #468 — in-flight write-byte budget
+    //
+    // Symmetric to the issue #246 read-byte budget above: every
+    // writeFile / writeFileBlock / writeMultipartFile call reserves bytes
+    // from a Semaphore before launching the RPC, so a multipart compaction
+    // write cannot fan out hundreds of in-flight blocks at once and starve
+    // search reads sharing the same Netty event-loop pool / file server.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Default construction exposes the documented default write-byte budget
+     * ({@link RemoteFileServiceClient#DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES}).
+     */
+    @Test
+    public void testInflightWriteBytes_defaultConfig() {
+        assertEquals("default max inflight write bytes",
+                RemoteFileServiceClient.DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                client.maxInflightWriteBytes());
+        assertEquals("all bytes available at steady state",
+                RemoteFileServiceClient.DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                client.availableInflightWriteBytes());
+    }
+
+    /**
+     * A custom {@code remote.file.client.max.inflight.write.bytes} config
+     * value is honoured, and {@code availableInflightWriteBytes()} starts
+     * equal to the cap before any write is issued.
+     */
+    @Test
+    public void testInflightWriteBytes_customConfig() throws Exception {
+        long customBytes = 16L * 1024 * 1024; // 16 MiB
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, customBytes);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            assertEquals("configured cap is applied", customBytes, tuned.maxInflightWriteBytes());
+            assertEquals("all bytes available at idle",
+                    customBytes, tuned.availableInflightWriteBytes());
+        }
+    }
+
+    /** A non-positive byte budget is rejected at construction. */
+    @Test
+    public void testInflightWriteBytes_zeroConfigRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, 0L);
+        try {
+            new RemoteFileServiceClient(
+                    Arrays.asList("localhost:" + server.getPort()), cfg).close();
+            fail("expected IllegalArgumentException for non-positive byte budget");
+        } catch (IllegalArgumentException expected) {
+            assertTrue("message names the property",
+                    expected.getMessage().contains(
+                            RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES));
+        }
+    }
+
+    /**
+     * A byte budget below {@code blockSize} is rejected: a single full-block
+     * write would immediately deadlock.
+     */
+    @Test
+    public void testInflightWriteBytes_belowBlockSizeRejected() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, 4096);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, 2048L);
+        try {
+            new RemoteFileServiceClient(
+                    Arrays.asList("localhost:" + server.getPort()), cfg).close();
+            fail("expected IllegalArgumentException when budget < blockSize");
+        } catch (IllegalArgumentException expected) {
+            assertTrue("message names the properties",
+                    expected.getMessage().contains(
+                            RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES));
+        }
+    }
+
+    /**
+     * After a successful {@code writeFile(byte[])} the byte reservation is
+     * released — a subsequent call sees the full budget again.
+     */
+    @Test
+    public void testInflightWriteBytes_releasedAfterWriteFile() throws Exception {
+        String path = "test/permits/write/file.bin";
+        long before = client.availableInflightWriteBytes();
+        client.writeFile(path, "payload".getBytes(StandardCharsets.UTF_8));
+        long after = client.availableInflightWriteBytes();
+        assertEquals("reservation is released on completion", before, after);
+    }
+
+    /**
+     * After a successful {@code writeFile(ByteBuf)} the byte reservation
+     * is released — proves the ByteBuf overload also wires the
+     * acquire/release pair.
+     */
+    @Test
+    public void testInflightWriteBytes_releasedAfterWriteFileByteBuf() throws Exception {
+        String path = "test/permits/write/file-bytebuf.bin";
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.heapBuffer(64);
+        try {
+            buf.writeBytes("payload".getBytes(StandardCharsets.UTF_8));
+            long before = client.availableInflightWriteBytes();
+            client.writeFile(path, buf);
+            long after = client.availableInflightWriteBytes();
+            assertEquals("reservation is released on completion", before, after);
+        } finally {
+            ReferenceCountUtil.safeRelease(buf);
+        }
+    }
+
+    /**
+     * After a {@code writeFileBlock(byte[])} the reservation is released —
+     * exercises the hot path that issue #468 targets.
+     */
+    @Test
+    public void testInflightWriteBytes_releasedAfterWriteFileBlock() throws Exception {
+        String path = "test/permits/write/block.bin";
+        byte[] block = new byte[4096];
+        long before = client.availableInflightWriteBytes();
+        client.writeFileBlock(path, 0L, block);
+        long after = client.availableInflightWriteBytes();
+        assertEquals("reservation is released on completion", before, after);
+    }
+
+    /**
+     * After a {@code writeMultipartFile} of N blocks the reservation is
+     * released. This is the path used by Phase B of compaction —
+     * the primary regression gate for issue #468.
+     */
+    @Test
+    public void testInflightWriteBytes_releasedAfterWriteMultipart() throws Exception {
+        String path = "test/permits/write/multipart.bin";
+        int blockSize = 4096;
+        byte[] content = new byte[blockSize * 4];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) (i % 256);
+        }
+        long before = client.availableInflightWriteBytes();
+        long written = client.writeMultipartFile(path,
+                new ByteArrayInputStream(content), blockSize);
+        assertEquals("multipart wrote all bytes", content.length, written);
+        long after = client.availableInflightWriteBytes();
+        assertEquals("every block reservation released after multipart write",
+                before, after);
+    }
+
+    /**
+     * A reasonably concurrent burst of {@code writeFileBlock} calls must
+     * never reveal a negative budget and must return the full cap by the
+     * time every call settles. Symmetric to the read-side concurrent-burst
+     * test.
+     */
+    @Test
+    public void testInflightWriteBytes_concurrentBurstReturnsReservations() throws Exception {
+        long max = client.maxInflightWriteBytes();
+        int burst = 32;
+        int payloadSize = 4096;
+        @SuppressWarnings("unchecked")
+        CompletableFuture<Void>[] futures = new CompletableFuture[burst];
+        for (int i = 0; i < burst; i++) {
+            byte[] payload = new byte[payloadSize];
+            futures[i] = client.writeFileBlockAsync(
+                    "test/permits/write/burst-" + i, 0L, payload);
+        }
+        for (CompletableFuture<Void> f : futures) {
+            f.get(30, TimeUnit.SECONDS);
+            assertTrue("available bytes must never exceed cap",
+                    client.availableInflightWriteBytes() <= max);
+            assertTrue("available bytes must never go negative",
+                    client.availableInflightWriteBytes() >= 0);
+        }
+        assertEquals("all bytes returned at the end of the burst",
+                max, client.availableInflightWriteBytes());
+    }
+
+    /**
+     * A small byte cap that still admits one full-block write restores the
+     * budget after the write settles.
+     */
+    @Test
+    public void testInflightWriteBytes_smallBudgetRoundTrip() throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        // 4 MiB budget — exactly one default block. Any smaller and the
+        // constructor refuses (see testInflightWriteBytes_belowBlockSizeRejected).
+        long budget = RemoteFileServiceClient.DEFAULT_BLOCK_SIZE;
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, budget);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            assertEquals(budget, tuned.availableInflightWriteBytes());
+            tuned.writeFile("test/permits/write/single.bin",
+                    "one".getBytes(StandardCharsets.UTF_8));
+            assertEquals("budget restored after single write completes",
+                    budget, tuned.availableInflightWriteBytes());
+        }
+    }
+
+    /**
+     * When the remote file service is unreachable the underlying RPC
+     * eventually fails — each attempt must release its reservation so the
+     * budget returns to the configured cap. Writes are not retried by the
+     * client (see {@code RemoteFileServiceClient.writeFileAsync}'s
+     * "Writes are not idempotent — no retry." comment), so a single attempt
+     * is enough; we still want to prove the failure-path release.
+     */
+    @Test
+    public void testInflightWriteBytes_releasedAfterBackendUnreachable() throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_RETRIES, 1);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_TIMEOUT, 2L);
+        // Point at a port where nothing is listening.
+        try (RemoteFileServiceClient broken = new RemoteFileServiceClient(
+                Arrays.asList("localhost:1"), cfg)) {
+            long before = broken.availableInflightWriteBytes();
+            try {
+                broken.writeFileBlockAsync("some/path", 0L, new byte[4096])
+                        .get(60, TimeUnit.SECONDS);
+                fail("expected the write to fail against an unreachable backend");
+            } catch (java.util.concurrent.ExecutionException expected) {
+                // propagated from sendRequest
+            }
+            assertEquals("reservation restored after backend-unreachable",
+                    before, broken.availableInflightWriteBytes());
+        }
+    }
+
+    /**
+     * The behaviour the bug fix promises: with a budget tight enough to
+     * admit only one block at a time, a multipart write whose total
+     * payload exceeds the budget still completes — the driver thread
+     * naturally serialises by blocking on {@code acquire()} and unblocking
+     * each time a previous block's RPC completes and releases its bytes.
+     * This is the test that regresses if the acquire/release plumbing
+     * in {@code writeFileBlockAsync} ever leaks or is bypassed.
+     */
+    @Test
+    public void testInflightWriteBytes_smallBudgetSerializesMultipartBlocks() throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        // Use a small block size so the test stays cheap; budget == one block.
+        int blockSize = 4096;
+        long budget = blockSize;
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, blockSize);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, budget);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            // Eight blocks — eight forced acquire/release round-trips.
+            byte[] content = new byte[blockSize * 8];
+            for (int i = 0; i < content.length; i++) {
+                content[i] = (byte) i;
+            }
+            long written = tuned.writeMultipartFile(
+                    "test/permits/write/serialised.bin",
+                    new ByteArrayInputStream(content), blockSize);
+            assertEquals("multipart wrote all bytes despite the tight budget",
+                    content.length, written);
+            assertEquals("budget restored after the serialised multipart write",
+                    budget, tuned.availableInflightWriteBytes());
+            // Round-trip: read back to assert the file is structurally sound.
+            byte[] firstBlock = tuned.readFileRange(
+                    "test/permits/write/serialised.bin", 0L, blockSize, blockSize);
+            assertNotNull(firstBlock);
+            assertEquals(blockSize, firstBlock.length);
+        }
+    }
+
+    /**
+     * Empty-payload writes (issue #100's fast path: an empty multipart file
+     * still creates block 0 with an empty buffer) must not decrement the
+     * write-byte budget — otherwise an idle workload that creates many
+     * empty marker files would exhaust the cap. Specifically tests the
+     * {@code Unpooled.EMPTY_BUFFER} call site in
+     * {@code RemoteFileDataStorageManager.writeAsMultipart}.
+     */
+    @Test
+    public void testInflightWriteBytes_emptyPayloadSkipsReservation() throws Exception {
+        long before = client.availableInflightWriteBytes();
+        client.writeFileBlock("test/permits/write/empty.bin", 0L,
+                io.netty.buffer.Unpooled.EMPTY_BUFFER);
+        long after = client.availableInflightWriteBytes();
+        assertEquals("empty payload neither acquires nor leaks", before, after);
+    }
 }


### PR DESCRIPTION
Fixes #468.

## Changes

- **`RemoteFileServiceClient`** — add `CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES` / `DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES` (256 MiB), a `Semaphore inflightWriteBytes` permit pool, and `acquireInflightWriteBytes` / `releaseInflightWriteBytes` helpers that mirror the existing read-side machinery. The four async write entry points — `writeFileAsync(byte[], int, int)`, `writeFileAsync(ByteBuf)`, `writeFileBlockAsync(byte[])`, `writeFileBlockAsync(ByteBuf)` — now reserve bytes before launching the RPC and release on future completion via the same idempotent `Runnable` pattern used by `doReadFileRangeAsByteBufAsync`. Empty payloads (`Unpooled.EMPTY_BUFFER`, used to materialise empty multipart marker files) skip both acquire and release. Constructor validates `> 0` and `>= blockSize`. Two new metric gauges: `inflight_write_bytes_available` and `inflight_write_bytes_max`.
- **`ServerConfiguration` / `IndexingServerConfiguration`** — add `PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES` constants with javadoc explaining the compaction/search-fairness motivation.
- **`Server.java` (2 sites) / `IndexingServer.java` (1 site)** — pass the new property into the client config map alongside the existing read cap.
- **Helm chart** — `values.yaml` documents the new key in the `indexingService` direct-memory comment block. `examples/k3s-local/values.yaml` sets the tighter 64 MiB cap (16 in-flight blocks vs ~165 unbounded for a 658 MB graph file) to bias the constrained k3s-local profile toward search reads. `examples/gke/values.yaml` sets the default-equivalent 256 MiB explicitly so operators see the knob.

## How this addresses #468

Issue #468 captured async-profiler traces during a gist1m k=100 query phase with 2 IS replicas while compaction was streaming 322–658 MB graph + 159–326 MB map files via 4 MiB blocks. The reads have a configurable byte cap (`remote.file.client.max.inflight.read.bytes`, issue #246) but writes had no analogous cap — the `writeMultipartFile` driver fired every block at once, queueing ~165 in-flight blocks per file plus contemporaneous data-page writes. Even though read- and write-plane TCP connections are separate (issue #100), they share the Netty event-loop pool, the OS network stack, and the remote file server's processing capacity, so an unbounded write burst could starve concurrent reads (39.7 s p99 vs 12.2 s p50 in the issue body). With this PR, operators who see compaction/search contention can lower the write cap independently of the read cap and the `writeMultipartFile` driver naturally backpressures by blocking on `acquire()` instead of fanning out every block at once. Q3 (segment-count steady state) and Q4 (sharding parity) in the issue are observational and need no code change.

## Tests

- 12 new methods in `RemoteFileServiceClientByteBufTest`, mirroring the issue #246 read-byte test suite: defaults / custom config / zero rejected / below-block-size rejected / released after `writeFile(byte[])` / released after `writeFile(ByteBuf)` / released after `writeFileBlock` / released after `writeMultipartFile` / concurrent-burst returns reservations / small-budget round-trip / released after backend-unreachable / **small-budget serialises multipart blocks** (the regression gate for the bug this fixes — proves backpressure works) / empty-payload skips reservation.
- All 37 tests in `RemoteFileServiceClientByteBufTest` (25 original + 12 new) pass.
- 79 related write-path tests across `RemoteFileBlockParallelismTest`, `RemoteFileServiceClientTest`, `RemoteFileServiceClientDynamicTest`, `RemoteFileDataStorageManagerBasicTest`, `RemoteFileDataStorageManagerRangeReadTest` pass — confirms no regression in the existing write paths.
- `LazyValueCacheConcurrentUpdatesSuite{No,WithNonUnique,WithUnique}IndexesTest` (12/12) — twice green, the primary regression gate for the lazy data-page write path that uses `writeFileBlockAsync(ByteBuf)`.
- `DirectMultipleConcurrentUpdatesSuite{No,WithNonUnique,WithUnique}IndexesTest` (12/12) — twice green, file-DSM hammer.
- `BLinkConcurrentSearchInsertTest` (1/1) — green, BLink primitive hammer.
- Pre-PR validation green (`mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`).

🤖 Implemented by the `pr-worker` agent.