### PR TITLE
issue #470: use FastThreadLocalThread for all File Server and Indexing Service threads

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -49,6 +49,7 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.IndexStatus;
 import herddb.utils.Bytes;
 import herddb.utils.XXHash64Utils;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -799,7 +800,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             applyWorkers[i] = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
                     new LinkedBlockingQueue<>(queueCapacity),
                     r -> {
-                        Thread t = new Thread(r, "indexing-apply-worker-" + idx);
+                        FastThreadLocalThread t = new FastThreadLocalThread(r, "indexing-apply-worker-" + idx);
                         t.setDaemon(true);
                         return t;
                     },
@@ -813,7 +814,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // triggerCheckpointAsync() can submit tasks as soon as the tailer
         // starts processing entries.
         checkpointExecutor = Executors.newSingleThreadExecutor(r -> {
-            Thread t = new Thread(r, "indexing-checkpoint");
+            FastThreadLocalThread t = new FastThreadLocalThread(r, "indexing-checkpoint");
             t.setDaemon(true);
             return t;
         });
@@ -1020,7 +1021,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         } else {
             tailer = new FileCommitLogTailer(logDirectory, tableSpaceUUID, tailerStart, this::processEntry);
         }
-        tailerThread = new Thread(tailer, "indexing-service-tailer");
+        tailerThread = new FastThreadLocalThread(tailer, "indexing-service-tailer");
         tailerThread.setDaemon(true);
         tailerThread.start();
 
@@ -2441,7 +2442,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         this.startTimeMillis = System.currentTimeMillis();
 
         shadowReloadExecutor = Executors.newSingleThreadExecutor(r -> {
-            Thread t = new Thread(r, "indexing-shadow-reload");
+            FastThreadLocalThread t = new FastThreadLocalThread(r, "indexing-shadow-reload");
             t.setDaemon(true);
             return t;
         });

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -20,6 +20,7 @@
 package herddb.indexing.optimizer;
 
 import herddb.indexing.segment.SegmentRegistryClient;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import java.io.FileInputStream;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -173,7 +174,7 @@ public final class IndexOptimizerMain {
                 safeModeFileDeletion);
 
         this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "index-optimizer-engine");
+            FastThreadLocalThread t = new FastThreadLocalThread(r, "index-optimizer-engine");
             t.setDaemon(true);
             return t;
         });

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
@@ -19,6 +19,7 @@
  */
 package herddb.indexing.segment;
 
+import io.netty.util.concurrent.FastThreadLocalThread;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -89,7 +90,7 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
                                     long refreshIntervalMs) {
         this(registry, instanceId, listener, refreshIntervalMs,
                 Executors.newSingleThreadScheduledExecutor(r -> {
-                    Thread t = new Thread(r, "segment-assignment-watcher-" + instanceId);
+                    FastThreadLocalThread t = new FastThreadLocalThread(r, "segment-assignment-watcher-" + instanceId);
                     t.setDaemon(true);
                     return t;
                 }));

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentWatcherFastThreadLocalTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentWatcherFastThreadLocalTest.java
@@ -1,0 +1,84 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.segment;
+
+import static org.junit.Assert.assertTrue;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Verifies that the dispatch-executor thread created by
+ * {@link SegmentAssignmentWatcher}'s public constructor is a
+ * {@link FastThreadLocalThread} so Netty's recyclable-object fast-path is
+ * available on watcher threads (issue #470).
+ *
+ * <p>A no-op {@link SegmentRegistryClient} is constructed with a supplier that
+ * returns {@code null}; because the watcher's constructor does not invoke any
+ * ZooKeeper operations, this is safe. We access the private {@code dispatchExecutor}
+ * field reflectively, submit a one-shot task, and capture the running thread.
+ */
+public class SegmentAssignmentWatcherFastThreadLocalTest {
+
+    private SegmentAssignmentWatcher watcher;
+
+    @After
+    public void tearDown() {
+        if (watcher != null) {
+            watcher.close();
+        }
+    }
+
+    @Test
+    public void dispatchExecutorUsesFastThreadLocal() throws Exception {
+        // A SegmentRegistryClient whose ZK supplier returns null — safe as long
+        // as no ZK operations are triggered (and the watcher constructor is ZK-free).
+        SegmentRegistryClient noopRegistry =
+                new SegmentRegistryClient(() -> null, "/herd-test-470");
+
+        watcher = new SegmentAssignmentWatcher(
+                noopRegistry,
+                /* instanceId */ 0,
+                /* listener — no-op */ new SegmentAssignmentListener() {},
+                /* refreshIntervalMs */ 60_000L);
+
+        ScheduledExecutorService exec =
+                readField(watcher, "dispatchExecutor", ScheduledExecutorService.class);
+
+        CompletableFuture<Thread> future = new CompletableFuture<>();
+        exec.execute(() -> future.complete(Thread.currentThread()));
+        Thread t = future.get(10, TimeUnit.SECONDS);
+
+        assertTrue("dispatchExecutor thread must be FastThreadLocalThread, got: " + t.getClass(),
+                t instanceof FastThreadLocalThread);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static <T> T readField(Object target, String name, Class<T> type) throws Exception {
+        Field f = target.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return type.cast(f.get(target));
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -32,6 +32,7 @@ import herddb.remote.storage.InMemoryBlockCacheObjectStorage;
 import herddb.remote.storage.LocalObjectStorage;
 import herddb.remote.storage.ObjectStorage;
 import herddb.remote.storage.S3ObjectStorage;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.net.URI;
@@ -159,7 +160,7 @@ public class RemoteFileServer implements AutoCloseable {
     public void start() throws IOException {
         AtomicInteger threadId = new AtomicInteger();
         ThreadFactory threadFactory = r -> {
-            Thread t = new Thread(r, "remote-file-meta-" + threadId.getAndIncrement());
+            FastThreadLocalThread t = new FastThreadLocalThread(r, "remote-file-meta-" + threadId.getAndIncrement());
             t.setDaemon(true);
             return t;
         };
@@ -382,7 +383,7 @@ public class RemoteFileServer implements AutoCloseable {
     private ThreadPoolExecutor buildLaneExecutor(String namePrefix, int threads) {
         AtomicInteger counter = new AtomicInteger();
         ThreadFactory factory = r -> {
-            Thread t = new Thread(r, namePrefix + counter.getAndIncrement());
+            FastThreadLocalThread t = new FastThreadLocalThread(r, namePrefix + counter.getAndIncrement());
             t.setDaemon(true);
             return t;
         };

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -201,7 +201,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                 : (int) maxInflightReadBytes;
         this.inflightReadBytes = new Semaphore(permits);
         this.retryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "remote-file-retry");
+            FastThreadLocalThread t = new FastThreadLocalThread(r, "remote-file-retry");
             t.setDaemon(true);
             return t;
         });
@@ -336,7 +336,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
 
         if (!removed.isEmpty()) {
             // Detached close so we do not block updateServers() on socket teardown.
-            Thread t = new Thread(() -> {
+            FastThreadLocalThread t = new FastThreadLocalThread(() -> {
                 for (String server : removed) {
                     ServerChannel rc = current.readChannels.get(server);
                     if (rc != null) {

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServerFastThreadLocalTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServerFastThreadLocalTest.java
@@ -1,0 +1,102 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.remote;
+
+import static org.junit.Assert.assertTrue;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import java.lang.reflect.Field;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that every executor pool created by {@link RemoteFileServer} uses
+ * {@link FastThreadLocalThread} so Netty's recyclable-object fast-path is
+ * available on all file-server threads (issue #470).
+ */
+public class RemoteFileServerFastThreadLocalTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void metadataExecutorUsesFastThreadLocal() throws Exception {
+        server = new RemoteFileServer("localhost", 0,
+                folder.newFolder("data-meta").toPath(), 1, new Properties());
+        server.start();
+
+        ThreadPoolExecutor exec = readField(server, "metadataExecutor", ThreadPoolExecutor.class);
+        Thread t = runOnExecutor(exec);
+        assertTrue("metadataExecutor thread must be FastThreadLocalThread, got: " + t.getClass(),
+                t instanceof FastThreadLocalThread);
+    }
+
+    @Test
+    public void readExecutorUsesFastThreadLocal() throws Exception {
+        server = new RemoteFileServer("localhost", 0,
+                folder.newFolder("data-read").toPath(), 1, new Properties());
+        server.start();
+
+        ThreadPoolExecutor exec = readField(server, "readExecutor", ThreadPoolExecutor.class);
+        Thread t = runOnExecutor(exec);
+        assertTrue("readExecutor thread must be FastThreadLocalThread, got: " + t.getClass(),
+                t instanceof FastThreadLocalThread);
+    }
+
+    @Test
+    public void writeExecutorUsesFastThreadLocal() throws Exception {
+        server = new RemoteFileServer("localhost", 0,
+                folder.newFolder("data-write").toPath(), 1, new Properties());
+        server.start();
+
+        ThreadPoolExecutor exec = readField(server, "writeExecutor", ThreadPoolExecutor.class);
+        Thread t = runOnExecutor(exec);
+        assertTrue("writeExecutor thread must be FastThreadLocalThread, got: " + t.getClass(),
+                t instanceof FastThreadLocalThread);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static Thread runOnExecutor(ThreadPoolExecutor exec) throws Exception {
+        CompletableFuture<Thread> future = new CompletableFuture<>();
+        exec.execute(() -> future.complete(Thread.currentThread()));
+        return future.get(10, TimeUnit.SECONDS);
+    }
+
+    private static <T> T readField(Object target, String name, Class<T> type) throws Exception {
+        Field f = target.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return type.cast(f.get(target));
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientFastThreadLocalTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientFastThreadLocalTest.java
@@ -1,0 +1,75 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.remote;
+
+import static org.junit.Assert.assertTrue;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Verifies that the retry-scheduler thread created by {@link RemoteFileServiceClient}
+ * is a {@link FastThreadLocalThread} so Netty's recyclable-object fast-path is
+ * available during retry logic (issue #470).
+ *
+ * <p>The client is constructed in cold-start mode (empty server list) so no
+ * real network connections are opened. We access the private {@code retryScheduler}
+ * field reflectively, submit a task, and capture the thread that runs it.
+ */
+public class RemoteFileServiceClientFastThreadLocalTest {
+
+    private RemoteFileServiceClient client;
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void retrySchedulerUsesFastThreadLocal() throws Exception {
+        // Empty server list — cold-start ZK-discovery mode; no network I/O.
+        client = new RemoteFileServiceClient(Collections.emptyList());
+
+        ScheduledExecutorService scheduler =
+                readField(client, "retryScheduler", ScheduledExecutorService.class);
+
+        CompletableFuture<Thread> future = new CompletableFuture<>();
+        scheduler.execute(() -> future.complete(Thread.currentThread()));
+        Thread t = future.get(10, TimeUnit.SECONDS);
+
+        assertTrue("retryScheduler thread must be FastThreadLocalThread, got: " + t.getClass(),
+                t instanceof FastThreadLocalThread);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static <T> T readField(Object target, String name, Class<T> type) throws Exception {
+        Field f = target.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return type.cast(f.get(target));
+    }
+}


### PR DESCRIPTION
Fixes #470.

## Changes
- **`RemoteFileServer`**: converted `metadataExecutor`, `readExecutor`, and `writeExecutor` thread factories to produce `FastThreadLocalThread` instances (instead of plain `Thread`).
- **`RemoteFileServiceClient`**: converted the `retryScheduler` factory and the detached `remote-file-channel-shutdown` helper thread to `FastThreadLocalThread`; the I/O event-loop and callback-executor threads were already correct.
- **`IndexingServiceEngine`**: converted all four internal thread-creation sites — `indexing-apply-worker-*`, `indexing-checkpoint`, `indexing-service-tailer`, and `indexing-shadow-reload` — to `FastThreadLocalThread`.
- **`SegmentAssignmentWatcher`**: converted the `segment-assignment-watcher-*` dispatch-scheduler factory to `FastThreadLocalThread`.
- **`IndexOptimizerMain`**: converted the `index-optimizer-engine` scheduler factory to `FastThreadLocalThread`; the JVM shutdown hook is left as a plain `Thread` (shutdown hooks are not in the hot path and do not benefit from `FastThreadLocal`).

## Tests
- **`RemoteFileServerFastThreadLocalTest`**: starts a `RemoteFileServer`, submits tasks to each of the three executor pools via reflection, and asserts all three executor-thread instances are `FastThreadLocalThread`.
- **`RemoteFileServiceClientFastThreadLocalTest`**: creates a client in cold-start mode (empty server list), accesses the private `retryScheduler` via reflection, submits a one-shot task, and asserts the thread is `FastThreadLocalThread`.
- **`SegmentAssignmentWatcherFastThreadLocalTest`**: creates a `SegmentAssignmentWatcher` backed by a no-op `SegmentRegistryClient` (no ZooKeeper needed), accesses the `dispatchExecutor` via reflection, submits a task, and asserts `FastThreadLocalThread`.

🤖 Implemented by the `pr-worker` agent.