### PR TITLE
issue #475: pack disk cache into a two-tier slab layout

### DIFF
--- a/REMOTE_FILE_SERVER.md
+++ b/REMOTE_FILE_SERVER.md
@@ -251,6 +251,48 @@ mvn test
 
 ---
 
+## On-disk cache layout (S3 mode, issue #475)
+
+When `storage.mode=s3`, the file server fronts the S3-compatible bucket with
+a local volatile disk cache (`CachingObjectStorage`). The on-disk layout
+is a **two-tier slab** rather than one file per cached object:
+
+- **Small tier** (`slab-small.dat`) — fixed-size cells, default 64 KiB,
+  default 25% of `cache.max.bytes`. Holds metadata, transaction records,
+  and other sub-block payloads.
+- **Large tier** (`slab-large.dat`) — fixed-size cells, default
+  `block.size` (4 MiB), default 75% of `cache.max.bytes`. Holds full
+  multipart blocks (the dominant ANN/HNSW workload).
+- **Per-file fallback** — entries larger than the largest tier's cell
+  size fall through to the original one-file-per-object path so
+  arbitrarily large objects remain cacheable.
+
+Both slab files are pre-allocated at boot and kept open as
+`AsynchronousFileChannel`s for the JVM lifetime, so admit/evict no longer
+pay `open`/`close`/`create`/`delete` syscalls per cached object. The
+in-memory index (`Map<key, Slot>`) is volatile: the slab files are
+deleted on construction and on close, and the index starts empty on every
+boot — matching the volatile-cache contract.
+
+Knobs (see `fileserver.properties`):
+
+| Key | Default |
+|---|---|
+| `cache.slab.enabled` | `true` |
+| `cache.slab.small.cell.bytes` | `65536` |
+| `cache.slab.small.fraction` | `0.25` |
+| `cache.slab.large.cell.bytes` | tracks `block.size` |
+| `cache.slab.large.fraction` | `0.75` |
+
+Setting `cache.slab.enabled=false` reverts to the legacy per-file layout.
+
+Per-tier metrics are exposed under `rfs_disk_cache_slab_small_*`,
+`rfs_disk_cache_slab_large_*` and `rfs_disk_cache_slab_fallback_*` and
+plotted by the bundled Grafana dashboard
+(`herddb-kubernetes/.../remote-file-service-dashboard.json`).
+
+---
+
 ## Limitations and known constraints
 
 - **No replication.** Each remote server stores a distinct subset of pages. If a server is lost, the pages on that server are lost. Add replication at the infrastructure level (DRBD, replicated block devices, etc.) if durability is required.

--- a/REMOTE_FILE_SERVER.md
+++ b/REMOTE_FILE_SERVER.md
@@ -267,12 +267,15 @@ is a **two-tier slab** rather than one file per cached object:
   size fall through to the original one-file-per-object path so
   arbitrarily large objects remain cacheable.
 
-Both slab files are pre-allocated at boot and kept open as
-`AsynchronousFileChannel`s for the JVM lifetime, so admit/evict no longer
-pay `open`/`close`/`create`/`delete` syscalls per cached object. The
-in-memory index (`Map<key, Slot>`) is volatile: the slab files are
-deleted on construction and on close, and the index starts empty on every
-boot — matching the volatile-cache contract.
+Both slab files are sized at boot to `totalCells * cellSize` (sparse file
+on extent-based filesystems) and kept open as `AsynchronousFileChannel`s
+for the JVM lifetime, so admit/evict no longer pay
+`open`/`close`/`create`/`delete` syscalls per cached object — the
+syscall savings come from the kept-open channel, not from any layout
+guarantee on the underlying filesystem. The in-memory index
+(`Map<key, Slot>`) is volatile: the slab files are deleted on
+construction and on close, and the index starts empty on every boot —
+matching the volatile-cache contract.
 
 Knobs (see `fileserver.properties`):
 

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/remote-file-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/remote-file-service-dashboard.json
@@ -2442,6 +2442,340 @@
       "showTitle": true,
       "title": "Disk Cache Size Row",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 220,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rfs_disk_cache_slab_small_live_cells{instance=~\"$instance\"} / clamp_min(rfs_disk_cache_slab_small_total_cells{instance=~\"$instance\"}, 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "small fill ratio [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_disk_cache_slab_large_live_cells{instance=~\"$instance\"} / clamp_min(rfs_disk_cache_slab_large_total_cells{instance=~\"$instance\"}, 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "large fill ratio [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Slab Live Cells (small vs large, % full)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "logBase": 1,
+              "max": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 221,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rfs_disk_cache_slab_small_bytes_in_use{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "small [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rfs_disk_cache_slab_large_bytes_in_use{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "large [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "rfs_disk_cache_slab_fallback_bytes{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fallback (per-file) [{{instance}}]",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "title": "Slab Bytes in Use (per tier)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Disk Cache Slab Tiers",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 222,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_disk_cache_slab_small_admit_count{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "small admits/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(rfs_disk_cache_slab_large_admit_count{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "large admits/s [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(rfs_disk_cache_slab_small_admit_full_count{instance=~\"$instance\"}[1m]) + rate(rfs_disk_cache_slab_large_admit_full_count{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "tier-full fall-through/s [{{instance}}]",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "title": "Slab Admit Rate (1m)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 223,
+          "legend": {
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/fallback file count/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(rfs_disk_cache_slab_small_evict_count{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "small evictions/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(rfs_disk_cache_slab_large_evict_count{instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "large evictions/s [{{instance}}]",
+              "refId": "B"
+            },
+            {
+              "expr": "rfs_disk_cache_slab_fallback_files{instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fallback file count [{{instance}}]",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "title": "Slab Evict Rate (1m) & Fallback Files",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Disk Cache Slab Admit/Evict",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -32,6 +32,7 @@ import herddb.remote.storage.InMemoryBlockCacheObjectStorage;
 import herddb.remote.storage.LocalObjectStorage;
 import herddb.remote.storage.ObjectStorage;
 import herddb.remote.storage.S3ObjectStorage;
+import herddb.remote.storage.SlabCacheFileStore;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
@@ -811,7 +812,7 @@ public class RemoteFileServer implements AutoCloseable {
      * way.
      */
     private static void registerSlabGauges(StatsLogger scope, String tierName,
-                                           herddb.remote.storage.SlabCacheFileStore slab) {
+                                           SlabCacheFileStore slab) {
         registerLongGauge(scope, tierName + "_cell_bytes",
                 () -> slab == null ? 0L : (long) slab.cellSize());
         registerLongGauge(scope, tierName + "_total_cells",

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServer.java
@@ -113,6 +113,18 @@ public class RemoteFileServer implements AutoCloseable {
      */
     public static final String CONFIG_METADATA_EXECUTOR_THREADS = "fileserver.metadata.executor.threads";
 
+    // -- Slab disk cache config (issue #475) -----------------------------------------
+    /** Config key: master switch for the slab disk-cache layout (default: enabled). */
+    public static final String CONFIG_CACHE_SLAB_ENABLED = "cache.slab.enabled";
+    /** Config key: cell size of the small slab tier in bytes (default: 64 KiB). */
+    public static final String CONFIG_CACHE_SLAB_SMALL_CELL_BYTES = "cache.slab.small.cell.bytes";
+    /** Config key: fraction of {@code cache.max.bytes} given to the small slab tier (default: 0.25). */
+    public static final String CONFIG_CACHE_SLAB_SMALL_FRACTION = "cache.slab.small.fraction";
+    /** Config key: cell size of the large slab tier in bytes (default: {@code block.size}, i.e. 4 MiB). */
+    public static final String CONFIG_CACHE_SLAB_LARGE_CELL_BYTES = "cache.slab.large.cell.bytes";
+    /** Config key: fraction of {@code cache.max.bytes} given to the large slab tier (default: 0.75). */
+    public static final String CONFIG_CACHE_SLAB_LARGE_FRACTION = "cache.slab.large.fraction";
+
     private final String host;
     private final int port;
     private final Path dataDirectory;
@@ -517,14 +529,58 @@ public class RemoteFileServer implements AutoCloseable {
 
         S3ObjectStorage s3Storage = new S3ObjectStorage(s3Client, bucket, s3Prefix, statsLogger);
         try {
+            CachingObjectStorage.SlabConfig slabConfig = buildSlabConfig(cacheMaxBytes);
             CachingObjectStorage cache = new CachingObjectStorage(
-                    s3Storage, cacheDirPath, metadataExecutor, cacheMaxBytes);
+                    s3Storage, cacheDirPath, metadataExecutor, cacheMaxBytes, slabConfig);
             diskCache = cache;
             return cache;
         } catch (IOException e) {
             s3Client.close();
             throw e;
         }
+    }
+
+    /**
+     * Builds the slab-tier configuration from the server {@code config} (issue #475).
+     * Defaults: 64 KiB small cells getting 25% of the budget, 4 MiB (or {@link #blockSize})
+     * large cells getting 75%. Setting {@code cache.slab.enabled=false} reverts to the
+     * legacy per-file disk-cache layout.
+     */
+    private CachingObjectStorage.SlabConfig buildSlabConfig(long totalBudgetBytes) {
+        boolean slabEnabled = Boolean.parseBoolean(
+                config.getProperty(CONFIG_CACHE_SLAB_ENABLED, "true"));
+        if (!slabEnabled) {
+            LOGGER.log(Level.INFO, "Slab disk cache layout disabled — using legacy per-file path.");
+            return CachingObjectStorage.SlabConfig.disabled();
+        }
+        int smallCell = Integer.parseInt(
+                config.getProperty(CONFIG_CACHE_SLAB_SMALL_CELL_BYTES, "65536"));
+        double smallFraction = Double.parseDouble(
+                config.getProperty(CONFIG_CACHE_SLAB_SMALL_FRACTION, "0.25"));
+        // buildSlabConfig is called from buildS3ObjectStorage, which runs BEFORE
+        // start() assigns this.blockSize. Read block.size from config directly so the
+        // large-cell default tracks the configured block size.
+        int configuredBlockSize = Integer.parseInt(
+                config.getProperty("block.size", String.valueOf(DEFAULT_BLOCK_SIZE)));
+        int largeCellDefault = configuredBlockSize > 0 ? configuredBlockSize : DEFAULT_BLOCK_SIZE;
+        int largeCell = Integer.parseInt(
+                config.getProperty(CONFIG_CACHE_SLAB_LARGE_CELL_BYTES, String.valueOf(largeCellDefault)));
+        double largeFraction = Double.parseDouble(
+                config.getProperty(CONFIG_CACHE_SLAB_LARGE_FRACTION, "0.75"));
+        if (smallCell <= 0 || largeCell <= 0) {
+            throw new IllegalArgumentException("slab cell size must be > 0; got smallCell="
+                    + smallCell + " largeCell=" + largeCell);
+        }
+        if (smallFraction < 0 || largeFraction < 0 || smallFraction + largeFraction > 1.0001d) {
+            throw new IllegalArgumentException("slab fractions must be >= 0 and sum <= 1.0; got smallFraction="
+                    + smallFraction + " largeFraction=" + largeFraction);
+        }
+        long smallTier = (long) (totalBudgetBytes * smallFraction);
+        long largeTier = (long) (totalBudgetBytes * largeFraction);
+        LOGGER.log(Level.INFO,
+                "Slab disk cache: smallCell={0} smallTier={1} largeCell={2} largeTier={3}",
+                new Object[]{smallCell, smallTier, largeCell, largeTier});
+        return new CachingObjectStorage.SlabConfig(true, smallCell, smallTier, largeCell, largeTier);
     }
 
     /**
@@ -715,6 +771,76 @@ public class RemoteFileServer implements AutoCloseable {
             @Override
             public Long getSample() {
                 return cache.getMissBytes();
+            }
+        });
+        // Slab tier metrics (issue #475) — exposed under the same rfs_disk_cache_*
+        // namespace so the existing Grafana dashboard can pick them up alongside
+        // the legacy hit/miss/eviction counters. When the slab layout is disabled
+        // (cache.slab.enabled=false), the slab getters return null and the gauges
+        // simply report zero — keeping the dashboard rendering benign.
+        registerSlabGauges(scope, "slab_small", cache.getSmallSlab());
+        registerSlabGauges(scope, "slab_large", cache.getLargeSlab());
+        scope.registerGauge("slab_fallback_files", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.getFallbackFileCount();
+            }
+        });
+        scope.registerGauge("slab_fallback_bytes", new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return cache.getFallbackBytes();
+            }
+        });
+    }
+
+    /**
+     * Registers the eight per-tier gauges for one slab store ({@code slab_small} or
+     * {@code slab_large}). When {@code slab} is null (slab layout disabled), the
+     * gauges still register but report zero — the dashboard renders cleanly either
+     * way.
+     */
+    private static void registerSlabGauges(StatsLogger scope, String tierName,
+                                           herddb.remote.storage.SlabCacheFileStore slab) {
+        registerLongGauge(scope, tierName + "_cell_bytes",
+                () -> slab == null ? 0L : (long) slab.cellSize());
+        registerLongGauge(scope, tierName + "_total_cells",
+                () -> slab == null ? 0L : (long) slab.totalCells());
+        registerLongGauge(scope, tierName + "_live_cells",
+                () -> slab == null ? 0L : (long) slab.liveCells());
+        registerLongGauge(scope, tierName + "_free_cells",
+                () -> slab == null ? 0L : (long) slab.freeCells());
+        registerLongGauge(scope, tierName + "_bytes_in_use",
+                () -> slab == null ? 0L : slab.bytesInUse());
+        registerLongGauge(scope, tierName + "_admit_count",
+                () -> slab == null ? 0L : slab.admitCount());
+        registerLongGauge(scope, tierName + "_admit_full_count",
+                () -> slab == null ? 0L : slab.admitFullCount());
+        registerLongGauge(scope, tierName + "_evict_count",
+                () -> slab == null ? 0L : slab.evictCount());
+    }
+
+    private static void registerLongGauge(StatsLogger scope, String name,
+                                          java.util.function.LongSupplier supplier) {
+        scope.registerGauge(name, new Gauge<Long>() {
+            @Override
+            public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override
+            public Long getSample() {
+                return supplier.getAsLong();
             }
         });
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
@@ -24,9 +24,9 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
-import com.google.common.util.concurrent.Striped;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
@@ -42,7 +42,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -50,38 +49,104 @@ import java.util.stream.Stream;
 /**
  * Decorator that wraps an inner {@link ObjectStorage} (e.g. S3) with a local disk cache.
  * <p>
- * The cache is a pure on-disk LRU: byte[] values are NOT retained on the JVM heap.
- * Hot-data speed comes from the OS page cache, which manages its own memory pressure.
- * A Caffeine {@link Cache} indexes the disk tier: keys are object paths, values are the
- * on-disk file size in bytes. The cache is weight-bounded by {@code maxCacheBytes}
- * (the <b>disk</b> budget), and its eviction listener deletes the backing file.
+ * Issue #475 reworked the on-disk layout to avoid the per-object
+ * {@code open}/{@code close}/{@code create}/{@code delete} syscalls that the original
+ * one-file-per-object layout incurred. The cache now writes payloads into two
+ * {@link SlabCacheFileStore} tiers — a small-cell tier and a large-cell tier — kept
+ * open for the JVM lifetime, with an in-memory index. Anything larger than the largest
+ * tier's cell falls through to a per-file fallback (the original code path), which is
+ * required for the rare case of metadata objects bigger than the configured large cell.
  * <p>
- * Concurrent readers for the same missing key are deduplicated via an in-flight map so
- * only one {@code inner.read()} fires. Stripe-based read/write locks serialise disk
- * reads against evictions so that a deletion never races a concurrent reader.
+ * The cache is volatile: slab files are deleted on construction and on close, the cache
+ * directory is wiped on construction, and there is no persistent on-disk index — the
+ * Caffeine LRU starts empty on every boot. Caffeine's {@code maximumWeight} bounds the
+ * <b>logical</b> bytes resident in the cache (aggregated across both slab tiers and the
+ * fallback); the slab files themselves are pre-allocated to their per-tier byte budget.
  * <p>
- * The cache directory is cleared on construction. Cache files are stored flat in
- * {@code cacheDir} with {@code /} replaced by {@code _} in filenames.
+ * Concurrent readers for the same missing key are deduplicated via {@code inFlightReads}
+ * so only one {@code inner.read()} fires. Concurrent writers are deduplicated via
+ * {@code inFlightWrites}.
  * <p>
  * Metrics (issue #336): Caffeine {@code recordStats()} is enabled so callers can query
  * hit/miss/eviction counts via {@link #diskLruStats()}. Byte-level hit/miss counters are
- * maintained via {@link AtomicLong} fields incremented in {@link #readRange}. The maximum
- * cache weight can be changed at runtime via {@link #setMaxCacheBytes(long)}.
+ * maintained via {@link AtomicLong} fields incremented in {@link #readRange}. Slab-tier
+ * stats (issue #475) are exposed via {@link #getSmallSlab()} / {@link #getLargeSlab()}
+ * and the fallback-tier stats via {@link #getFallbackFileCount()} /
+ * {@link #getFallbackBytes()}. The maximum cache weight can be changed at runtime via
+ * {@link #setMaxCacheBytes(long)}.
  *
  * @author enrico.olivelli
  */
 public class CachingObjectStorage implements ObjectStorage {
 
     private static final Logger LOGGER = Logger.getLogger(CachingObjectStorage.class.getName());
-    private static final int STRIPES = 256;
+
+    /** Tier tag stored in {@link CacheEntry}. */
+    static final byte TIER_SMALL_SLAB = 0;
+    static final byte TIER_LARGE_SLAB = 1;
+    static final byte TIER_FALLBACK = 2;
+
+    /**
+     * Configuration knob for slab tiers (issue #475). When {@link #slabEnabled} is
+     * {@code false}, every admit goes through the per-file fallback path — the
+     * original layout from before the slab refactor.
+     */
+    public static final class SlabConfig {
+        public final boolean slabEnabled;
+        public final int smallCellBytes;
+        public final long smallTierBytes;
+        public final int largeCellBytes;
+        public final long largeTierBytes;
+
+        public SlabConfig(boolean slabEnabled, int smallCellBytes, long smallTierBytes,
+                          int largeCellBytes, long largeTierBytes) {
+            this.slabEnabled = slabEnabled;
+            this.smallCellBytes = smallCellBytes;
+            this.smallTierBytes = smallTierBytes;
+            this.largeCellBytes = largeCellBytes;
+            this.largeTierBytes = largeTierBytes;
+        }
+
+        /** Default config: slab enabled, 64 KiB small cells (25%), 4 MiB large cells (75%). */
+        public static SlabConfig defaultsFor(long totalBudgetBytes, int defaultLargeCellBytes) {
+            int smallCell = 64 * 1024;
+            long smallTier = Math.max(0L, totalBudgetBytes / 4);
+            long largeTier = Math.max(0L, totalBudgetBytes - smallTier);
+            int largeCell = defaultLargeCellBytes > 0 ? defaultLargeCellBytes : 4 * 1024 * 1024;
+            return new SlabConfig(true, smallCell, smallTier, largeCell, largeTier);
+        }
+
+        /** Disabled config: every admit goes through the legacy per-file path. */
+        public static SlabConfig disabled() {
+            return new SlabConfig(false, 0, 0L, 0, 0L);
+        }
+    }
+
+    /** In-LRU value: identifies which tier holds the payload. */
+    static final class CacheEntry {
+        final byte tier;
+        final int payloadLength;
+
+        CacheEntry(byte tier, int payloadLength) {
+            this.tier = tier;
+            this.payloadLength = payloadLength;
+        }
+    }
 
     private final ObjectStorage inner;
     private final Path cacheDir;
     private final ExecutorService executor;
-    private final Cache<String, Long> diskLru;
-    private final Striped<ReadWriteLock> locks = Striped.lazyWeakReadWriteLock(STRIPES);
+    private final Cache<String, CacheEntry> diskLru;
     private final ConcurrentHashMap<String, CompletableFuture<ByteBuf>> inFlightReads = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlightWrites = new ConcurrentHashMap<>();
+
+    private final boolean slabEnabled;
+    private final SlabCacheFileStore smallSlab;
+    private final SlabCacheFileStore largeSlab;
+    /** Number of live entries currently held in the per-file fallback tier. */
+    private final AtomicLong fallbackFileCount = new AtomicLong();
+    /** Bytes held in the per-file fallback tier (sum of payload sizes). */
+    private final AtomicLong fallbackBytes = new AtomicLong();
 
     /**
      * Bytes served from the on-disk cache in {@link #readRange} calls.
@@ -95,34 +160,71 @@ public class CachingObjectStorage implements ObjectStorage {
      */
     private final AtomicLong missBytes = new AtomicLong();
 
+    /**
+     * Legacy constructor: defaults the slab layout from {@code maxCacheBytes} (small
+     * tier 25%, large tier 75%, large cell 4 MiB). Kept for binary-compat with
+     * existing tests and the {@code RemoteFileServer} reflection wiring.
+     */
     public CachingObjectStorage(ObjectStorage inner, Path cacheDir, ExecutorService executor,
                                 long maxCacheBytes) throws IOException {
+        this(inner, cacheDir, executor, maxCacheBytes,
+                SlabConfig.defaultsFor(maxCacheBytes, 4 * 1024 * 1024));
+    }
+
+    public CachingObjectStorage(ObjectStorage inner, Path cacheDir, ExecutorService executor,
+                                long maxCacheBytes, SlabConfig slabConfig) throws IOException {
         this.inner = inner;
         this.cacheDir = cacheDir;
         this.executor = executor;
         clearCacheDir();
         Files.createDirectories(cacheDir);
 
+        this.slabEnabled = slabConfig.slabEnabled;
+        if (slabConfig.slabEnabled) {
+            int smallCells = slabConfig.smallCellBytes > 0
+                    ? (int) Math.min(Integer.MAX_VALUE, slabConfig.smallTierBytes / slabConfig.smallCellBytes)
+                    : 0;
+            int largeCells = slabConfig.largeCellBytes > 0
+                    ? (int) Math.min(Integer.MAX_VALUE, slabConfig.largeTierBytes / slabConfig.largeCellBytes)
+                    : 0;
+            this.smallSlab = new SlabCacheFileStore(cacheDir.resolve("slab-small.dat"),
+                    slabConfig.smallCellBytes > 0 ? slabConfig.smallCellBytes : 1, smallCells);
+            this.largeSlab = new SlabCacheFileStore(cacheDir.resolve("slab-large.dat"),
+                    slabConfig.largeCellBytes > 0 ? slabConfig.largeCellBytes : 1, largeCells);
+        } else {
+            this.smallSlab = null;
+            this.largeSlab = null;
+        }
+
         this.diskLru = Caffeine.newBuilder()
                 .maximumWeight(maxCacheBytes)
-                .weigher((String key, Long size) -> {
-                    long s = size == null ? 0L : size;
-                    return s > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) s;
+                .weigher((String key, CacheEntry entry) -> {
+                    if (entry == null) {
+                        return 0;
+                    }
+                    return entry.payloadLength;
                 })
                 // recordStats() is required for hit/miss/eviction counters exposed via
                 // diskLruStats(). The cost is negligible (a few AtomicLong increments
                 // per cache operation).
                 .recordStats()
-                .evictionListener((RemovalListener<String, Long>) (key, value, cause) -> {
-                    // Synchronous, best-effort delete. Runs on Caffeine's maintenance thread
-                    // (or inline on a put() that triggers eviction) — does NOT take the stripe
-                    // lock, because the stripe lock might already be held by the same thread
-                    // inside admitToDisk. Concurrent readers that lose the race get
-                    // NoSuchFileException and fall through to inner.read() via the
-                    // tryReadFromDisk / tryReadSliceFromDisk null-return contract.
-                    if (key != null) {
-                        deleteCacheFile(key);
+                // evictionListener fires ONLY for size/time-based eviction — not for
+                // explicit invalidate(...). This matches the original CachingObjectStorage
+                // contract: explicit invalidations call onEviction synchronously from
+                // invalidateAndDelete() so isInCache(...) and the slab/fallback gauges
+                // are immediately consistent. Using removalListener here would fire for
+                // explicit invalidations too and double-decrement the fallback counters.
+                .evictionListener((RemovalListener<String, CacheEntry>) (key, entry, cause) -> {
+                    // Best-effort cleanup of slab/fallback resources. For slab tiers,
+                    // markEvicted is fast (atomic ops + map.remove + free-list push);
+                    // for the fallback tier, we unlink the cache file. Concurrent
+                    // readers that lose the race get a null/miss and fall through to
+                    // inner.read() via the slab pin contract or via the
+                    // NoSuchFileException catch in the per-file path.
+                    if (key == null || entry == null) {
+                        return;
                     }
+                    onEviction(key, entry);
                 })
                 .build();
     }
@@ -140,54 +242,24 @@ public class CachingObjectStorage implements ObjectStorage {
         return diskLru.stats();
     }
 
-    /**
-     * Bytes served from the on-disk cache across all {@link #readRange} calls since pod start.
-     * Incremented once per successful disk-cache hit, before the I/O completes, so the counter
-     * counts <em>intended</em> hit bytes (matching the {@code length} parameter of readRange).
-     */
     public long getHitBytes() {
         return hitBytes.get();
     }
 
-    /**
-     * Bytes fetched from the inner storage (GCS / S3 fallback) across all {@link #readRange}
-     * calls since pod start. Incremented on every cache miss.
-     */
     public long getMissBytes() {
         return missBytes.get();
     }
 
-    /**
-     * Approximate number of entries currently tracked in the disk-LRU index.
-     * Safe to call from gauge samplers (Caffeine's {@code estimatedSize()} is thread-safe).
-     */
     public long estimatedEntries() {
         return diskLru.estimatedSize();
     }
 
-    /**
-     * Returns the current maximum weight (bytes) of the disk-cache LRU as reported
-     * by Caffeine's eviction policy. Returns 0 if the policy is not weight-based.
-     */
     public long getMaxCacheBytes() {
         return diskLru.policy().eviction()
                 .map(e -> e.getMaximum())
                 .orElse(0L);
     }
 
-    /**
-     * Dynamically resizes the disk-cache LRU to {@code newMaxBytes}.
-     * <p>
-     * The change is applied immediately via Caffeine's live policy API.
-     * If {@code newMaxBytes} is smaller than the current total weight, Caffeine will
-     * evict excess entries lazily on the next cache access or maintenance cycle.
-     * <p>
-     * <b>This change is NOT persistent</b>: a pod restart will revert to the value
-     * configured in {@code fileserver.properties} / Helm values (issue #336).
-     *
-     * @param newMaxBytes new maximum weight in bytes; must be &gt; 0
-     * @return the previous maximum, or 0 if the policy is not available
-     */
     public long setMaxCacheBytes(long newMaxBytes) {
         if (newMaxBytes <= 0) {
             throw new IllegalArgumentException("newMaxBytes must be > 0, got: " + newMaxBytes);
@@ -201,6 +273,38 @@ public class CachingObjectStorage implements ObjectStorage {
                 "Disk cache resized: previousMax={0} bytes, newMax={1} bytes",
                 new Object[]{prev[0], newMaxBytes});
         return prev[0];
+    }
+
+    // -----------------------------------------------------------------------
+    // Slab-tier introspection (issue #475)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the small-cell slab tier, or {@code null} when {@code cache.slab.enabled=false}.
+     * Exposed primarily for Prometheus gauge wiring (see {@code RemoteFileServer}).
+     */
+    public SlabCacheFileStore getSmallSlab() {
+        return smallSlab;
+    }
+
+    /**
+     * Returns the large-cell slab tier, or {@code null} when {@code cache.slab.enabled=false}.
+     */
+    public SlabCacheFileStore getLargeSlab() {
+        return largeSlab;
+    }
+
+    public long getFallbackFileCount() {
+        return fallbackFileCount.get();
+    }
+
+    public long getFallbackBytes() {
+        return fallbackBytes.get();
+    }
+
+    /** Returns true if {@code path} is currently resident in any tier. */
+    public boolean isInCache(String path) {
+        return diskLru.getIfPresent(path) != null;
     }
 
     // -----------------------------------------------------------------------
@@ -223,16 +327,60 @@ public class CachingObjectStorage implements ObjectStorage {
         }
     }
 
+    /**
+     * Returns the fallback-tier cache-file path for {@code path}. Only meaningful
+     * for entries admitted via the fallback (per-file) path; slab-tier entries do
+     * not have an individual cache file. Used by {@link #onEviction} to unlink
+     * fallback files and by tests that explicitly verify fallback semantics.
+     */
     Path cacheFilePath(String path) {
         String safeName = path.replace('/', '_').replace('\\', '_');
         return cacheDir.resolve(safeName);
     }
 
+    private void onEviction(String key, CacheEntry entry) {
+        switch (entry.tier) {
+            case TIER_SMALL_SLAB:
+                if (smallSlab != null) {
+                    smallSlab.markEvicted(key);
+                }
+                break;
+            case TIER_LARGE_SLAB:
+                if (largeSlab != null) {
+                    largeSlab.markEvicted(key);
+                }
+                break;
+            case TIER_FALLBACK:
+                deleteFallbackFile(key, entry.payloadLength);
+                break;
+            default:
+                LOGGER.log(Level.WARNING, "Unknown cache tier {0} for key {1}",
+                        new Object[]{entry.tier, key});
+        }
+    }
+
+    private void deleteFallbackFile(String path, int payloadLength) {
+        try {
+            if (Files.deleteIfExists(cacheFilePath(path))) {
+                fallbackFileCount.decrementAndGet();
+                fallbackBytes.addAndGet(-payloadLength);
+            } else {
+                // File already gone (e.g. cache cleared); still drop the counters so
+                // the gauges don't drift. Use a CAS-loop pattern via getAndUpdate to
+                // avoid going negative on duplicate eviction notifications.
+                fallbackFileCount.updateAndGet(v -> v > 0 ? v - 1 : 0);
+                fallbackBytes.updateAndGet(v -> v - payloadLength >= 0 ? v - payloadLength : 0);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to delete fallback cache file: " + path, e);
+        }
+    }
+
     /**
-     * Asynchronously writes {@code bytes} to a cache file using {@link AsynchronousFileChannel}.
-     * Writes to a temp file then atomically renames it.
+     * Asynchronously writes {@code bytes} to a fallback cache file using
+     * {@link AsynchronousFileChannel}. Writes to a temp file then atomically renames.
      */
-    private CompletableFuture<Void> writeCacheFileAsync(String path, byte[] bytes) {
+    private CompletableFuture<Void> writeFallbackFileAsync(String path, byte[] bytes) {
         CompletableFuture<Void> result = new CompletableFuture<>();
         Path target = cacheFilePath(path);
         Path tmp = cacheDir.resolve(target.getFileName() + ".tmp");
@@ -248,9 +396,9 @@ public class CachingObjectStorage implements ObjectStorage {
                         channel.close();
                         Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
                         result.complete(null);
-                    } catch (Throwable t) {
-                        deleteCacheFile(path);
-                        result.completeExceptionally(t);
+                    } catch (IOException e) {
+                        bestEffortDelete(target);
+                        result.completeExceptionally(e);
                     }
                 }
 
@@ -259,105 +407,58 @@ public class CachingObjectStorage implements ObjectStorage {
                     try {
                         channel.close();
                     } catch (IOException ignored) {
+                        // Channel close failure during error handling: safe to ignore.
                     }
-                    deleteCacheFile(path);
+                    bestEffortDelete(target);
                     result.completeExceptionally(exc);
                 }
             });
-        } catch (Throwable t) {
-            deleteCacheFile(path);
+        } catch (IOException t) {
+            bestEffortDelete(target);
             result.completeExceptionally(t);
         }
 
         return result;
     }
 
-    /**
-     * Asynchronously writes {@code buf}'s readable bytes to a cache file using
-     * {@link AsynchronousFileChannel}. The caller must hold a refcount on
-     * {@code buf}; this method releases that refcount when the write completes
-     * (success or failure). The buffer's reader/writer indices are not modified.
-     */
-    private CompletableFuture<Void> writeCacheFileAsync(String path, ByteBuf buf) {
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        Path target = cacheFilePath(path);
-        Path tmp = cacheDir.resolve(target.getFileName() + ".tmp");
-        int len = buf.readableBytes();
-
+    private void bestEffortDelete(Path target) {
         try {
-            AsynchronousFileChannel channel = AsynchronousFileChannel.open(
-                    tmp, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-            // nioBuffer on a direct pooled ByteBuf returns a view, no copy.
-            ByteBuffer nio = buf.nioBuffer(buf.readerIndex(), len);
-            channel.write(nio, 0, null, new CompletionHandler<Integer, Void>() {
-                @Override
-                public void completed(Integer bytesWritten, Void attachment) {
-                    try {
-                        channel.close();
-                        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-                        result.complete(null);
-                    } catch (Throwable t) {
-                        deleteCacheFile(path);
-                        result.completeExceptionally(t);
-                    } finally {
-                        buf.release();
-                    }
-                }
-
-                @Override
-                public void failed(Throwable exc, Void attachment) {
-                    try {
-                        channel.close();
-                    } catch (IOException ignored) {
-                    }
-                    deleteCacheFile(path);
-                    buf.release();
-                    result.completeExceptionally(exc);
-                }
-            });
-        } catch (Throwable t) {
-            deleteCacheFile(path);
-            buf.release();
-            result.completeExceptionally(t);
-        }
-
-        return result;
-    }
-
-    private void deleteCacheFile(String path) {
-        try {
-            Files.deleteIfExists(cacheFilePath(path));
+            Files.deleteIfExists(target);
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to delete cache file for path: " + path, e);
+            LOGGER.log(Level.WARNING, "Failed to delete fallback file: " + target, e);
         }
     }
 
     /**
-     * Asynchronously stores {@code content} on disk and registers it in the disk LRU.
+     * Asynchronously stores {@code content} in the cache and registers it in the disk LRU.
      * Returns a CompletableFuture that completes when the write is done.
      * Deduplicates concurrent writes to the same path via an in-flight map.
+     * <p>
+     * Tier selection (when {@code slabEnabled}):
+     * <ol>
+     *   <li>If {@code len &lt;= smallSlab.cellSize()} → try small slab first.</li>
+     *   <li>Otherwise / on small-tier-full: if {@code len &lt;= largeSlab.cellSize()} → try large slab.</li>
+     *   <li>Otherwise / on large-tier-full: fall through to the per-file fallback.</li>
+     * </ol>
+     * When {@code !slabEnabled}, every admit uses the per-file fallback.
      */
     private CompletableFuture<Void> admitToDisk(String path, byte[] content) {
         CompletableFuture<Void> pending = new CompletableFuture<>();
         CompletableFuture<Void> existing = inFlightWrites.putIfAbsent(path, pending);
         if (existing != null) {
-            // Another thread is already writing this path; attach to their future
             return existing;
         }
-
-        writeCacheFileAsync(path, content).whenComplete((v, err) -> {
+        admitChooseTier(path, content).whenComplete((v, err) -> {
             try {
                 if (err != null) {
                     pending.completeExceptionally(err);
                     return;
                 }
-                diskLru.put(path, (long) content.length);
                 pending.complete(null);
             } finally {
                 inFlightWrites.remove(path, pending);
             }
         });
-
         return pending;
     }
 
@@ -371,26 +472,148 @@ public class CachingObjectStorage implements ObjectStorage {
         CompletableFuture<Void> pending = new CompletableFuture<>();
         CompletableFuture<Void> existing = inFlightWrites.putIfAbsent(path, pending);
         if (existing != null) {
-            // Another thread is already writing this path; release our retain and attach.
             buf.release();
             return existing;
         }
-
-        int size = buf.readableBytes();
-        writeCacheFileAsync(path, buf).whenComplete((v, err) -> {
+        admitChooseTier(path, buf).whenComplete((v, err) -> {
             try {
                 if (err != null) {
                     pending.completeExceptionally(err);
                     return;
                 }
-                diskLru.put(path, (long) size);
                 pending.complete(null);
             } finally {
                 inFlightWrites.remove(path, pending);
             }
         });
-
         return pending;
+    }
+
+    private CompletableFuture<Void> admitChooseTier(String path, byte[] content) {
+        if (!slabEnabled) {
+            return admitToFallback(path, content);
+        }
+        int len = content.length;
+        // Try small tier if it fits.
+        if (smallSlab != null && len <= smallSlab.cellSize()) {
+            ByteBuf bufForSmall = wrapHeap(content);
+            return smallSlab.tryStore(path, bufForSmall).thenCompose(slot -> {
+                if (slot != null) {
+                    putEntry(path, new CacheEntry(TIER_SMALL_SLAB, len));
+                    return CompletableFuture.completedFuture(null);
+                }
+                return tryLargeOrFallback(path, content);
+            });
+        }
+        return tryLargeOrFallback(path, content);
+    }
+
+    private CompletableFuture<Void> tryLargeOrFallback(String path, byte[] content) {
+        int len = content.length;
+        if (largeSlab != null && len <= largeSlab.cellSize()) {
+            ByteBuf bufForLarge = wrapHeap(content);
+            return largeSlab.tryStore(path, bufForLarge).thenCompose(slot -> {
+                if (slot != null) {
+                    putEntry(path, new CacheEntry(TIER_LARGE_SLAB, len));
+                    return CompletableFuture.completedFuture(null);
+                }
+                return admitToFallback(path, content);
+            });
+        }
+        return admitToFallback(path, content);
+    }
+
+    /**
+     * Wraps a heap byte[] into a {@link ByteBuf} suitable for {@link SlabCacheFileStore#tryStore}.
+     * The slab path takes ownership of the refcount (releases when the async write
+     * completes). Using {@link Unpooled#wrappedBuffer(byte[])} avoids a heap→direct copy
+     * here; AsynchronousFileChannel internally stages a direct buffer for the actual write.
+     */
+    private static ByteBuf wrapHeap(byte[] content) {
+        return Unpooled.wrappedBuffer(content);
+    }
+
+    /**
+     * Inserts {@code entry} into the LRU under {@code path}, recycling any prior tier
+     * resources from the previous entry under the same key (e.g. an admit that
+     * promotes a fallback entry into a slab tier on rewrite).
+     */
+    private void putEntry(String path, CacheEntry entry) {
+        CacheEntry prev = diskLru.asMap().put(path, entry);
+        if (prev != null && prev != entry) {
+            // Recycle prior tier resources for this path. For slab tiers, the slab's
+            // own put() already overwrote the slot atomically — onEviction is a no-op.
+            // For the fallback tier this unlinks the prior cache file.
+            onEviction(path, prev);
+        }
+    }
+
+    private CompletableFuture<Void> admitChooseTier(String path, ByteBuf buf) {
+        int len = buf.readableBytes();
+        if (!slabEnabled) {
+            // Slab disabled: copy out and feed to the fallback path.
+            byte[] heap = new byte[len];
+            buf.getBytes(buf.readerIndex(), heap);
+            buf.release();
+            return admitToFallback(path, heap);
+        }
+        if (smallSlab != null && len <= smallSlab.cellSize()) {
+            ByteBuf retainedForSmall = buf.retainedDuplicate();
+            return smallSlab.tryStore(path, retainedForSmall).thenCompose(slot -> {
+                if (slot != null) {
+                    putEntry(path, new CacheEntry(TIER_SMALL_SLAB, len));
+                    buf.release();
+                    return CompletableFuture.completedFuture(null);
+                }
+                return tryLargeOrFallbackBuf(path, buf);
+            });
+        }
+        return tryLargeOrFallbackBuf(path, buf);
+    }
+
+    private CompletableFuture<Void> tryLargeOrFallbackBuf(String path, ByteBuf buf) {
+        int len = buf.readableBytes();
+        if (largeSlab != null && len <= largeSlab.cellSize()) {
+            ByteBuf retainedForLarge = buf.retainedDuplicate();
+            return largeSlab.tryStore(path, retainedForLarge).thenCompose(slot -> {
+                if (slot != null) {
+                    putEntry(path, new CacheEntry(TIER_LARGE_SLAB, len));
+                    buf.release();
+                    return CompletableFuture.completedFuture(null);
+                }
+                return copyAndFallback(path, buf);
+            });
+        }
+        return copyAndFallback(path, buf);
+    }
+
+    private CompletableFuture<Void> copyAndFallback(String path, ByteBuf buf) {
+        int len = buf.readableBytes();
+        byte[] heap = new byte[len];
+        buf.getBytes(buf.readerIndex(), heap);
+        buf.release();
+        return admitToFallback(path, heap);
+    }
+
+    private CompletableFuture<Void> admitToFallback(String path, byte[] content) {
+        return writeFallbackFileAsync(path, content).thenApply(v -> {
+            CacheEntry entry = new CacheEntry(TIER_FALLBACK, content.length);
+            CacheEntry prev = diskLru.asMap().put(path, entry);
+            if (prev == null || prev.tier != TIER_FALLBACK) {
+                // Either there was no prior entry, or it was held in a slab tier.
+                // The new file occupies one fallback slot and contributes its bytes.
+                fallbackFileCount.incrementAndGet();
+                fallbackBytes.addAndGet(content.length);
+                if (prev != null) {
+                    // Recycle the prior slab slot.
+                    onEviction(path, prev);
+                }
+            } else {
+                // Same-tier overwrite — only adjust bytes by the delta.
+                fallbackBytes.addAndGet((long) content.length - prev.payloadLength);
+            }
+            return null;
+        });
     }
 
     // -----------------------------------------------------------------------
@@ -420,27 +643,40 @@ public class CachingObjectStorage implements ObjectStorage {
     }
 
     /**
-     * Asynchronously attempts to read the full file from the on-disk cache using
-     * {@link AsynchronousFileChannel}. Returns a future that completes with {@code null}
-     * on miss (including {@link NoSuchFileException} from a concurrent eviction).
-     * Uses an optimistic lock-free approach: open the file directly; if it doesn't exist
-     * or is being evicted, fall through to the inner storage.
-     *
-     * Uses Netty pooled direct ByteBuf for zero-copy I/O. Caller MUST call
-     * {@link ReadResult#release()} when done to return the buffer to the pool.
+     * Asynchronously attempts to read the full file from the on-disk cache (any
+     * tier). Returns a future that completes with {@code null} on miss or
+     * concurrent eviction. Caller MUST call {@link ReadResult#release()} when done
+     * to return the buffer to the pool.
      */
     private CompletableFuture<ReadResult> tryReadFromDiskAsync(String path) {
-        if (diskLru.getIfPresent(path) == null) {
+        CacheEntry entry = diskLru.getIfPresent(path);
+        if (entry == null) {
             return CompletableFuture.completedFuture(null);
         }
+        switch (entry.tier) {
+            case TIER_SMALL_SLAB:
+                if (smallSlab == null) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return smallSlab.read(path).thenApply(buf -> buf == null ? null : ReadResult.found(buf));
+            case TIER_LARGE_SLAB:
+                if (largeSlab == null) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return largeSlab.read(path).thenApply(buf -> buf == null ? null : ReadResult.found(buf));
+            case TIER_FALLBACK:
+                return tryReadFromFallbackAsync(path);
+            default:
+                return CompletableFuture.completedFuture(null);
+        }
+    }
 
+    private CompletableFuture<ReadResult> tryReadFromFallbackAsync(String path) {
         CompletableFuture<ReadResult> result = new CompletableFuture<>();
         try {
             Path filePath = cacheFilePath(path);
-            // Open file directly; catch NoSuchFileException for eviction races
             AsynchronousFileChannel channel = AsynchronousFileChannel.open(filePath, StandardOpenOption.READ);
             long fileSize = channel.size();
-            // Allocate direct pooled ByteBuf for zero-copy efficient I/O
             ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.directBuffer((int) fileSize);
             ByteBuffer nioBuffer = byteBuf.nioBuffer(0, (int) fileSize);
 
@@ -450,6 +686,7 @@ public class CachingObjectStorage implements ObjectStorage {
                     try {
                         channel.close();
                     } catch (IOException ignored) {
+                        // Channel close best-effort: data already in the buffer.
                     }
                     byteBuf.writerIndex(bytesRead);
                     result.complete(ReadResult.found(byteBuf));
@@ -460,18 +697,18 @@ public class CachingObjectStorage implements ObjectStorage {
                     try {
                         channel.close();
                     } catch (IOException ignored) {
+                        // Channel close best-effort during error handling.
                     }
-                    // Release pooled buffer on failure
                     byteBuf.release();
-                    // Treat as cache miss; fall through to inner storage
+                    // Treat as cache miss; fall through to inner storage.
                     result.complete(null);
                 }
             });
         } catch (NoSuchFileException e) {
-            // File was evicted after the getIfPresent check; treat as cache miss
+            // File was evicted after the LRU lookup; treat as cache miss.
             result.complete(null);
-        } catch (Throwable t) {
-            LOGGER.log(Level.WARNING, "Failed to read cache file for path: " + path, t);
+        } catch (IOException t) {
+            LOGGER.log(Level.WARNING, "Failed to read fallback cache file for path: " + path, t);
             result.complete(null);
         }
 
@@ -480,12 +717,8 @@ public class CachingObjectStorage implements ObjectStorage {
 
     /**
      * Loads {@code path} from the inner storage, deduplicating concurrent loads of the
-     * same key. On a successful load the bytes are written to disk and registered in
-     * the LRU before being returned.
-     * <p>
-     * The pooled {@link ByteBuf} from the inner storage is kept end-to-end: it is
-     * shared by the disk-write path and by every concurrent caller (each gets a
-     * {@code retainedDuplicate} via {@code pending.thenApply}). No heap copy.
+     * same key. On a successful load the bytes are written to the cache and registered
+     * before being returned.
      */
     private CompletableFuture<ReadResult> loadAndCache(String path) {
         CompletableFuture<ByteBuf> pending = new CompletableFuture<>();
@@ -520,7 +753,7 @@ public class CachingObjectStorage implements ObjectStorage {
             }
             ByteBuf buf = result.byteBuf();
             // Two extra retains:
-            //   +1 for admitToDisk (released inside writeCacheFileAsync when the disk write finishes).
+            //   +1 for admitToDisk (released inside the tier write when finished).
             //   +1 to keep buf alive across pending.complete so all dependents
             //      (original caller + any in-flight followers) can retainedDuplicate.
             // The original `result`'s refcount is dropped right after.
@@ -538,8 +771,6 @@ public class CachingObjectStorage implements ObjectStorage {
                             return;
                         }
                         try {
-                            // pending.complete fires all dependents synchronously here:
-                            // each does retainedDuplicate(buf), bumping refcount per caller.
                             pending.complete(buf);
                         } finally {
                             inFlightReads.remove(path, pending);
@@ -587,35 +818,42 @@ public class CachingObjectStorage implements ObjectStorage {
                 });
     }
 
-    /**
-     * Asynchronously reads only the requested slice from the on-disk block file using
-     * {@link AsynchronousFileChannel}. Returns a future that completes with {@code null}
-     * on miss (including {@link NoSuchFileException} from a concurrent eviction).
-     * Uses an optimistic lock-free approach: open the file directly; if it doesn't exist,
-     * fall through to the inner storage.
-     *
-     * Uses Netty pooled direct ByteBuf for zero-copy I/O. Caller MUST call
-     * {@link ReadResult#release()} when done to return the buffer to the pool.
-     */
     private CompletableFuture<ReadResult> tryReadSliceFromDiskAsync(String blockPath, int offsetInBlock, int length) {
-        Long size = diskLru.getIfPresent(blockPath);
-        if (size == null) {
+        CacheEntry entry = diskLru.getIfPresent(blockPath);
+        if (entry == null) {
             return CompletableFuture.completedFuture(null);
         }
+        switch (entry.tier) {
+            case TIER_SMALL_SLAB:
+                if (smallSlab == null) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return smallSlab.readRange(blockPath, offsetInBlock, length)
+                        .thenApply(buf -> buf == null ? null : ReadResult.found(buf));
+            case TIER_LARGE_SLAB:
+                if (largeSlab == null) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return largeSlab.readRange(blockPath, offsetInBlock, length)
+                        .thenApply(buf -> buf == null ? null : ReadResult.found(buf));
+            case TIER_FALLBACK:
+                return tryReadSliceFromFallbackAsync(blockPath, offsetInBlock, length, entry.payloadLength);
+            default:
+                return CompletableFuture.completedFuture(null);
+        }
+    }
 
-        long blockLength = size;
+    private CompletableFuture<ReadResult> tryReadSliceFromFallbackAsync(
+            String blockPath, int offsetInBlock, int length, int blockLength) {
         if (offsetInBlock >= blockLength) {
             return CompletableFuture.completedFuture(ReadResult.notFound());
         }
-
-        int readable = (int) Math.min(length, blockLength - offsetInBlock);
+        int readable = Math.min(length, blockLength - offsetInBlock);
         CompletableFuture<ReadResult> result = new CompletableFuture<>();
 
         try {
             Path filePath = cacheFilePath(blockPath);
-            // Open file directly; catch NoSuchFileException for eviction races
             AsynchronousFileChannel channel = AsynchronousFileChannel.open(filePath, StandardOpenOption.READ);
-            // Allocate direct pooled ByteBuf for zero-copy efficient I/O
             ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(readable);
             ByteBuffer nioBuffer = byteBuf.nioBuffer(0, readable);
 
@@ -625,6 +863,7 @@ public class CachingObjectStorage implements ObjectStorage {
                     try {
                         channel.close();
                     } catch (IOException ignored) {
+                        // Channel close best-effort: data already in the buffer.
                     }
                     byteBuf.writerIndex(bytesRead);
                     result.complete(ReadResult.found(byteBuf));
@@ -635,18 +874,17 @@ public class CachingObjectStorage implements ObjectStorage {
                     try {
                         channel.close();
                     } catch (IOException ignored) {
+                        // Channel close best-effort during error handling.
                     }
-                    // Release pooled buffer on failure
                     byteBuf.release();
-                    // Treat as cache miss; fall through to inner storage
                     result.complete(null);
                 }
             });
         } catch (NoSuchFileException e) {
-            // File was evicted after the size check; treat as cache miss
             result.complete(null);
-        } catch (Throwable t) {
-            LOGGER.log(Level.WARNING, "Failed to read slice from cache file for path: " + blockPath, t);
+        } catch (IOException t) {
+            LOGGER.log(Level.WARNING,
+                    "Failed to read slice from fallback cache file for path: " + blockPath, t);
             result.complete(null);
         }
 
@@ -666,7 +904,6 @@ public class CachingObjectStorage implements ObjectStorage {
             }
             int to = Math.min(offsetInBlock + length, blockLength);
             int sliceLength = to - offsetInBlock;
-            // retainedSlice shares the underlying memory; no copy.
             return ReadResult.found(blockBuf.retainedSlice(blockBuf.readerIndex() + offsetInBlock, sliceLength));
         } finally {
             full.release();
@@ -684,13 +921,17 @@ public class CachingObjectStorage implements ObjectStorage {
     }
 
     /**
-     * Explicit invalidation path: removes the entry from the LRU and deletes the on-disk file.
-     * Caffeine's {@code evictionListener} only fires for size/time-based eviction, not for
-     * explicit {@code invalidate()}, so we must unlink the file ourselves here.
+     * Explicit invalidation path: removes the entry from the LRU and synchronously
+     * runs the per-tier cleanup. We do not rely on Caffeine's removal listener for
+     * explicit invalidations because it may fire asynchronously on Caffeine's
+     * default ForkJoinPool, which would leave the slab/fallback counters stale
+     * relative to {@code isInCache(path)}.
      */
     private void invalidateAndDelete(String path) {
-        diskLru.invalidate(path);
-        deleteCacheFile(path);
+        CacheEntry removed = diskLru.asMap().remove(path);
+        if (removed != null) {
+            onEviction(path, removed);
+        }
     }
 
     @Override
@@ -730,6 +971,29 @@ public class CachingObjectStorage implements ObjectStorage {
 
     @Override
     public void close() throws Exception {
-        inner.close();
+        try {
+            inner.close();
+        } finally {
+            IOException pending = null;
+            if (smallSlab != null) {
+                try {
+                    smallSlab.close();
+                } catch (IOException e) {
+                    pending = e;
+                }
+            }
+            if (largeSlab != null) {
+                try {
+                    largeSlab.close();
+                } catch (IOException e) {
+                    if (pending == null) {
+                        pending = e;
+                    }
+                }
+            }
+            if (pending != null) {
+                throw pending;
+            }
+        }
     }
 }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/CachingObjectStorage.java
@@ -365,9 +365,10 @@ public class CachingObjectStorage implements ObjectStorage {
                 fallbackFileCount.decrementAndGet();
                 fallbackBytes.addAndGet(-payloadLength);
             } else {
-                // File already gone (e.g. cache cleared); still drop the counters so
-                // the gauges don't drift. Use a CAS-loop pattern via getAndUpdate to
-                // avoid going negative on duplicate eviction notifications.
+                // File already gone (e.g. clearCacheDir on construction racing with
+                // a stale eviction notification, or a manual filesystem-level delete).
+                // Clamp the counters at zero to keep the gauges non-negative under
+                // any unexpected double-eviction.
                 fallbackFileCount.updateAndGet(v -> v > 0 ? v - 1 : 0);
                 fallbackBytes.updateAndGet(v -> v - payloadLength >= 0 ? v - payloadLength : 0);
             }
@@ -379,6 +380,9 @@ public class CachingObjectStorage implements ObjectStorage {
     /**
      * Asynchronously writes {@code bytes} to a fallback cache file using
      * {@link AsynchronousFileChannel}. Writes to a temp file then atomically renames.
+     * On any failure we delete BOTH the partially-written temp file and the target
+     * (the rename may have run before {@code completed} threw); leaving either
+     * behind would be a per-cache-lifetime leak.
      */
     private CompletableFuture<Void> writeFallbackFileAsync(String path, byte[] bytes) {
         CompletableFuture<Void> result = new CompletableFuture<>();
@@ -397,6 +401,7 @@ public class CachingObjectStorage implements ObjectStorage {
                         Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
                         result.complete(null);
                     } catch (IOException e) {
+                        bestEffortDelete(tmp);
                         bestEffortDelete(target);
                         result.completeExceptionally(e);
                     }
@@ -409,11 +414,13 @@ public class CachingObjectStorage implements ObjectStorage {
                     } catch (IOException ignored) {
                         // Channel close failure during error handling: safe to ignore.
                     }
+                    bestEffortDelete(tmp);
                     bestEffortDelete(target);
                     result.completeExceptionally(exc);
                 }
             });
         } catch (IOException t) {
+            bestEffortDelete(tmp);
             bestEffortDelete(target);
             result.completeExceptionally(t);
         }
@@ -559,14 +566,25 @@ public class CachingObjectStorage implements ObjectStorage {
         }
         if (smallSlab != null && len <= smallSlab.cellSize()) {
             ByteBuf retainedForSmall = buf.retainedDuplicate();
-            return smallSlab.tryStore(path, retainedForSmall).thenCompose(slot -> {
-                if (slot != null) {
-                    putEntry(path, new CacheEntry(TIER_SMALL_SLAB, len));
-                    buf.release();
-                    return CompletableFuture.completedFuture(null);
-                }
-                return tryLargeOrFallbackBuf(path, buf);
-            });
+            // whenComplete fires on BOTH success and exceptional completion so the
+            // outer buf retain (held alongside the retainedDuplicate handed to the
+            // slab) is released exactly once even when tryStore completes
+            // exceptionally — thenCompose only runs on successful completion and
+            // would otherwise leak the pooled direct buffer.
+            return smallSlab.tryStore(path, retainedForSmall)
+                    .whenComplete((slot, err) -> {
+                        if (err != null) {
+                            buf.release();
+                        }
+                    })
+                    .thenCompose(slot -> {
+                        if (slot != null) {
+                            putEntry(path, new CacheEntry(TIER_SMALL_SLAB, len));
+                            buf.release();
+                            return CompletableFuture.completedFuture(null);
+                        }
+                        return tryLargeOrFallbackBuf(path, buf);
+                    });
         }
         return tryLargeOrFallbackBuf(path, buf);
     }
@@ -575,14 +593,23 @@ public class CachingObjectStorage implements ObjectStorage {
         int len = buf.readableBytes();
         if (largeSlab != null && len <= largeSlab.cellSize()) {
             ByteBuf retainedForLarge = buf.retainedDuplicate();
-            return largeSlab.tryStore(path, retainedForLarge).thenCompose(slot -> {
-                if (slot != null) {
-                    putEntry(path, new CacheEntry(TIER_LARGE_SLAB, len));
-                    buf.release();
-                    return CompletableFuture.completedFuture(null);
-                }
-                return copyAndFallback(path, buf);
-            });
+            // Same exceptional-completion guard as admitChooseTier(ByteBuf): release
+            // the outer buf retain whether tryStore resolves with a slot, returns
+            // null (tier-full), or completes exceptionally.
+            return largeSlab.tryStore(path, retainedForLarge)
+                    .whenComplete((slot, err) -> {
+                        if (err != null) {
+                            buf.release();
+                        }
+                    })
+                    .thenCompose(slot -> {
+                        if (slot != null) {
+                            putEntry(path, new CacheEntry(TIER_LARGE_SLAB, len));
+                            buf.release();
+                            return CompletableFuture.completedFuture(null);
+                        }
+                        return copyAndFallback(path, buf);
+                    });
         }
         return copyAndFallback(path, buf);
     }

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
@@ -41,7 +41,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * One slab file with fixed-size cells, kept open for the JVM lifetime (issue #475).
+ * One slab file with fixed-size cells, kept open for the JVM lifetime
+ * (issue #475).
  * <p>
  * Replaces the per-object cache file in {@link CachingObjectStorage} with a single,
  * pre-allocated container divided into {@code cellSize}-sized slots. Each cached

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -123,6 +124,14 @@ public class SlabCacheFileStore implements AutoCloseable {
      * (the cache is volatile). The file is pre-allocated to {@code totalCells * cellSize}
      * bytes so the OS can pick contiguous extents.
      *
+     * Note: the file is sized to {@code totalCells * cellSize} via a one-byte tail
+     * write. On ext4/xfs/apfs and other extent-based filesystems this creates a
+     * sparse file (the holes materialise as the slab is written into); we do not
+     * attempt to force contiguous on-disk extents. The kept-open
+     * {@link AsynchronousFileChannel} is what avoids the per-admit
+     * {@code open}/{@code close}/{@code create}/{@code delete} syscall cost — not
+     * any layout guarantee of the underlying filesystem.
+     *
      * @param slabFile path of the slab file (parent dir must exist)
      * @param cellSize cell size in bytes; must be {@code > 0}
      * @param totalCells number of cells; must be {@code >= 0} (zero is legal — the
@@ -146,8 +155,10 @@ public class SlabCacheFileStore implements AutoCloseable {
                 StandardOpenOption.CREATE_NEW, StandardOpenOption.READ, StandardOpenOption.WRITE);
         if (totalCells > 0) {
             try {
-                // Note: AsynchronousFileChannel does not have a truncate-up operation,
-                // so we extend the file by writing one byte at the last position.
+                // Size the file to totalCells * cellSize via a one-byte tail write.
+                // AsynchronousFileChannel does not have a truncate-up operation; on
+                // common extent-based filesystems this creates a sparse file (holes
+                // are realised as the slab is written into).
                 ByteBuffer one = ByteBuffer.allocate(1);
                 CompletableFuture<Integer> latch = new CompletableFuture<>();
                 channel.write(one, (long) totalCells * cellSize - 1, null,
@@ -163,16 +174,25 @@ public class SlabCacheFileStore implements AutoCloseable {
                             }
                         });
                 latch.get();
-            } catch (Exception e) {
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
                 try {
                     channel.close();
                 } catch (IOException ignored) {
                     // Best-effort; we're already throwing.
                 }
-                if (e instanceof IOException) {
-                    throw (IOException) e;
+                throw new IOException("Interrupted while pre-allocating slab file " + slabFile, ie);
+            } catch (ExecutionException ee) {
+                try {
+                    channel.close();
+                } catch (IOException ignored) {
+                    // Best-effort; we're already throwing.
                 }
-                throw new IOException("Failed to pre-allocate slab file " + slabFile, e);
+                Throwable cause = ee.getCause();
+                if (cause instanceof IOException) {
+                    throw (IOException) cause;
+                }
+                throw new IOException("Failed to pre-allocate slab file " + slabFile, ee);
             }
         }
         for (int i = 0; i < totalCells; i++) {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
@@ -1,0 +1,490 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * One slab file with fixed-size cells, kept open for the JVM lifetime (issue #475).
+ * <p>
+ * Replaces the per-object cache file in {@link CachingObjectStorage} with a single,
+ * pre-allocated container divided into {@code cellSize}-sized slots. Each cached
+ * payload occupies exactly one cell; the in-memory {@code liveSlots} map records
+ * the cell index, the actual payload length, and pin/eviction state. Free cells
+ * are tracked in a lock-free deque. The file is opened once at construction and
+ * closed only at shutdown — no per-object {@code open}/{@code close}/{@code create}/
+ * {@code delete} syscalls happen during steady-state operation.
+ * <p>
+ * The cache is volatile: the slab file is deleted both on construction (a fresh
+ * file is created with {@code CREATE_NEW}) and on {@link #close()}. There is no
+ * persistent on-disk index, matching the issue's "cache is volatile and rebuilt
+ * at every boot" requirement.
+ * <p>
+ * <b>Concurrency.</b> Reads and evictions race safely without holding any lock
+ * across the async I/O. Each {@link Slot} carries a {@code pinCount}
+ * ({@link AtomicInteger}) and a {@code volatile boolean evicted} flag.
+ * Readers {@code tryPin} (CAS-increment that bails if {@code evicted == true},
+ * then re-checks {@code evicted} after the increment); eviction sets
+ * {@code evicted = true} <em>before</em> checking {@code pinCount}. The cell is
+ * recycled by whichever path observes "{@code pinCount == 0} after the eviction
+ * flag is set" — guarded by an {@link AtomicBoolean} so exactly one thread
+ * recycles. This guarantees a recycled cell never serves stale bytes to an
+ * in-flight reader.
+ * <p>
+ * <b>Caller contract.</b> {@link #tryStore} takes ownership of one refcount on
+ * the supplied {@link ByteBuf} and releases it when the async write completes
+ * (success or failure). Callers must serialize concurrent stores under the same
+ * key (e.g. via {@link CachingObjectStorage}'s {@code inFlightWrites} dedup);
+ * this class does not perform per-key dedup itself.
+ *
+ * @author enrico.olivelli
+ */
+public class SlabCacheFileStore implements AutoCloseable {
+
+    private static final Logger LOGGER = Logger.getLogger(SlabCacheFileStore.class.getName());
+
+    /**
+     * Live entry handle — one per cached payload. Public so tests can introspect
+     * {@link #cellIndex()} / {@link #payloadLength()}; pin/eviction state is
+     * package-private (enforced via {@link SlabCacheFileStore} methods).
+     */
+    public static final class Slot {
+
+        final int cellIndex;
+        final int payloadLength;
+        final AtomicInteger pinCount = new AtomicInteger();
+        volatile boolean evicted;
+        final AtomicBoolean recycled = new AtomicBoolean();
+
+        Slot(int cellIndex, int payloadLength) {
+            this.cellIndex = cellIndex;
+            this.payloadLength = payloadLength;
+        }
+
+        public int cellIndex() {
+            return cellIndex;
+        }
+
+        public int payloadLength() {
+            return payloadLength;
+        }
+    }
+
+    private final Path slabFile;
+    private final int cellSize;
+    private final int totalCells;
+    private final AsynchronousFileChannel channel;
+    private final ConcurrentLinkedDeque<Integer> freeCells = new ConcurrentLinkedDeque<>();
+    private final ConcurrentHashMap<String, Slot> liveSlots = new ConcurrentHashMap<>();
+    private final AtomicLong bytesInUse = new AtomicLong();
+    private final AtomicLong admitCount = new AtomicLong();
+    private final AtomicLong admitFullCount = new AtomicLong();
+    private final AtomicLong evictCount = new AtomicLong();
+    private volatile boolean closed;
+
+    /**
+     * Creates a fresh slab file at {@code slabFile} with {@code totalCells} cells of
+     * {@code cellSize} bytes each. Any pre-existing file at the path is deleted first
+     * (the cache is volatile). The file is pre-allocated to {@code totalCells * cellSize}
+     * bytes so the OS can pick contiguous extents.
+     *
+     * @param slabFile path of the slab file (parent dir must exist)
+     * @param cellSize cell size in bytes; must be {@code > 0}
+     * @param totalCells number of cells; must be {@code >= 0} (zero is legal — the
+     *                   tier will simply admit nothing and report full)
+     */
+    public SlabCacheFileStore(Path slabFile, int cellSize, int totalCells) throws IOException {
+        if (cellSize <= 0) {
+            throw new IllegalArgumentException("cellSize must be > 0, got " + cellSize);
+        }
+        if (totalCells < 0) {
+            throw new IllegalArgumentException("totalCells must be >= 0, got " + totalCells);
+        }
+        this.slabFile = slabFile;
+        this.cellSize = cellSize;
+        this.totalCells = totalCells;
+        if (slabFile.getParent() != null) {
+            Files.createDirectories(slabFile.getParent());
+        }
+        Files.deleteIfExists(slabFile);
+        this.channel = AsynchronousFileChannel.open(slabFile,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        if (totalCells > 0) {
+            try {
+                // Note: AsynchronousFileChannel does not have a truncate-up operation,
+                // so we extend the file by writing one byte at the last position.
+                ByteBuffer one = ByteBuffer.allocate(1);
+                CompletableFuture<Integer> latch = new CompletableFuture<>();
+                channel.write(one, (long) totalCells * cellSize - 1, null,
+                        new CompletionHandler<Integer, Void>() {
+                            @Override
+                            public void completed(Integer res, Void att) {
+                                latch.complete(res);
+                            }
+
+                            @Override
+                            public void failed(Throwable exc, Void att) {
+                                latch.completeExceptionally(exc);
+                            }
+                        });
+                latch.get();
+            } catch (Exception e) {
+                try {
+                    channel.close();
+                } catch (IOException ignored) {
+                    // Best-effort; we're already throwing.
+                }
+                if (e instanceof IOException) {
+                    throw (IOException) e;
+                }
+                throw new IOException("Failed to pre-allocate slab file " + slabFile, e);
+            }
+        }
+        for (int i = 0; i < totalCells; i++) {
+            freeCells.add(i);
+        }
+        LOGGER.log(Level.INFO,
+                "SlabCacheFileStore opened: file={0} cellSize={1} totalCells={2} totalBytes={3}",
+                new Object[]{slabFile, cellSize, totalCells, (long) totalCells * cellSize});
+    }
+
+    public int cellSize() {
+        return cellSize;
+    }
+
+    public int totalCells() {
+        return totalCells;
+    }
+
+    public long bytesInUse() {
+        return bytesInUse.get();
+    }
+
+    public long admitCount() {
+        return admitCount.get();
+    }
+
+    public long admitFullCount() {
+        return admitFullCount.get();
+    }
+
+    public long evictCount() {
+        return evictCount.get();
+    }
+
+    public int liveCells() {
+        return liveSlots.size();
+    }
+
+    public int freeCells() {
+        return freeCells.size();
+    }
+
+    /**
+     * Tries to admit {@code content} under {@code key}.
+     * <p>
+     * Resolves to:
+     * <ul>
+     *   <li>The newly-published {@link Slot} on success.</li>
+     *   <li>{@code null} when the content is larger than {@link #cellSize()} (caller
+     *       should fall through to a larger tier or to a per-file fallback).</li>
+     *   <li>{@code null} when the tier is full ({@link #admitFullCount()} is incremented
+     *       so operators can observe the rate of fall-through).</li>
+     *   <li>Exceptionally on I/O failure; the cell is returned to the free list and
+     *       the in-memory index is not updated.</li>
+     * </ul>
+     * The supplied {@link ByteBuf}'s refcount is released when the async write
+     * completes (success or failure). Callers must serialize concurrent stores under
+     * the same key — see class javadoc.
+     */
+    public CompletableFuture<Slot> tryStore(String key, ByteBuf content) {
+        int len = content.readableBytes();
+        if (len > cellSize) {
+            content.release();
+            return CompletableFuture.completedFuture(null);
+        }
+        if (closed) {
+            content.release();
+            CompletableFuture<Slot> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IOException("SlabCacheFileStore is closed: " + slabFile));
+            return failed;
+        }
+        Integer cellIndexBoxed = freeCells.pollFirst();
+        if (cellIndexBoxed == null) {
+            admitFullCount.incrementAndGet();
+            content.release();
+            return CompletableFuture.completedFuture(null);
+        }
+        final int cellIndex = cellIndexBoxed;
+        final long offset = (long) cellIndex * cellSize;
+        final Slot newSlot = new Slot(cellIndex, len);
+        final CompletableFuture<Slot> result = new CompletableFuture<>();
+
+        try {
+            ByteBuffer nio = content.nioBuffer(content.readerIndex(), len);
+            channel.write(nio, offset, null, new CompletionHandler<Integer, Void>() {
+                @Override
+                public void completed(Integer bytesWritten, Void attachment) {
+                    try {
+                        // Publish AFTER the bytes are durable on the channel so a
+                        // concurrent reader that wins the race against the index put
+                        // can never observe stale or partial bytes from a previously
+                        // freed cell.
+                        Slot prev = liveSlots.put(key, newSlot);
+                        if (prev != null) {
+                            // Caller didn't dedup — the previous slot under this key
+                            // is now orphaned. Mark it evicted so its cell returns to
+                            // the free list (lazily, after any in-flight readers
+                            // unpin).
+                            markEvictedSlot(prev);
+                        }
+                        admitCount.incrementAndGet();
+                        bytesInUse.addAndGet(len);
+                        result.complete(newSlot);
+                    } finally {
+                        content.release();
+                    }
+                }
+
+                @Override
+                public void failed(Throwable exc, Void attachment) {
+                    try {
+                        // Roll back: never published, just return the cell.
+                        freeCells.add(cellIndex);
+                        result.completeExceptionally(exc);
+                    } finally {
+                        content.release();
+                    }
+                }
+            });
+        } catch (RuntimeException t) {
+            // Synchronous failure (e.g. NonWritableChannelException / IllegalArgumentException
+            // from AsynchronousFileChannel). ClosedChannelException is reported via the
+            // handler's failed() callback, not thrown. Roll back inline.
+            freeCells.add(cellIndex);
+            content.release();
+            result.completeExceptionally(t);
+        }
+        return result;
+    }
+
+    /**
+     * Reads the full payload for {@code key}.
+     * <p>
+     * Resolves to a pooled direct {@link ByteBuf} carrying the payload bytes
+     * (caller must release), or {@code null} on miss / concurrent eviction.
+     * Resolves exceptionally on I/O failure.
+     */
+    public CompletableFuture<ByteBuf> read(String key) {
+        Slot slot = liveSlots.get(key);
+        if (slot == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (!tryPin(slot)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return readPinned(slot, 0, slot.payloadLength);
+    }
+
+    /**
+     * Reads at most {@code length} bytes starting at {@code offset} within the
+     * payload for {@code key}.
+     * <p>
+     * Resolves to a pooled direct {@link ByteBuf} carrying the slice (caller
+     * must release), or {@code null} on miss / concurrent eviction / out-of-range
+     * offset. Resolves exceptionally on I/O failure.
+     */
+    public CompletableFuture<ByteBuf> readRange(String key, int offset, int length) {
+        if (offset < 0 || length < 0) {
+            CompletableFuture<ByteBuf> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IllegalArgumentException(
+                    "offset/length must be >= 0, got offset=" + offset + " length=" + length));
+            return failed;
+        }
+        Slot slot = liveSlots.get(key);
+        if (slot == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (!tryPin(slot)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (offset >= slot.payloadLength) {
+            unpin(slot);
+            return CompletableFuture.completedFuture(null);
+        }
+        int readable = Math.min(length, slot.payloadLength - offset);
+        return readPinned(slot, offset, readable);
+    }
+
+    private CompletableFuture<ByteBuf> readPinned(Slot slot, int offsetInPayload, int length) {
+        long fileOffset = (long) slot.cellIndex * cellSize + offsetInPayload;
+        ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(length);
+        ByteBuffer nio = byteBuf.nioBuffer(0, length);
+        CompletableFuture<ByteBuf> result = new CompletableFuture<>();
+        try {
+            channel.read(nio, fileOffset, null, new CompletionHandler<Integer, Void>() {
+                @Override
+                public void completed(Integer bytesRead, Void attachment) {
+                    try {
+                        if (bytesRead != null && bytesRead > 0) {
+                            byteBuf.writerIndex(bytesRead);
+                        }
+                        result.complete(byteBuf);
+                    } finally {
+                        unpin(slot);
+                    }
+                }
+
+                @Override
+                public void failed(Throwable exc, Void attachment) {
+                    try {
+                        byteBuf.release();
+                        result.completeExceptionally(exc);
+                    } finally {
+                        unpin(slot);
+                    }
+                }
+            });
+        } catch (RuntimeException t) {
+            try {
+                byteBuf.release();
+                result.completeExceptionally(t);
+            } finally {
+                unpin(slot);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Marks {@code key} as evicted. Pinned readers continue; the cell is recycled
+     * at the last unpin (or immediately if no readers are pinned).
+     *
+     * @return {@code true} if the key was resident and is now scheduled for recycle;
+     *         {@code false} if the key was not in the index.
+     */
+    public boolean markEvicted(String key) {
+        Slot slot = liveSlots.remove(key);
+        if (slot == null) {
+            return false;
+        }
+        markEvictedSlot(slot);
+        return true;
+    }
+
+    private void markEvictedSlot(Slot slot) {
+        slot.evicted = true;
+        if (slot.pinCount.get() == 0) {
+            recycle(slot);
+        }
+    }
+
+    private boolean tryPin(Slot slot) {
+        while (true) {
+            if (slot.evicted) {
+                return false;
+            }
+            int curr = slot.pinCount.get();
+            if (slot.pinCount.compareAndSet(curr, curr + 1)) {
+                if (slot.evicted) {
+                    // Eviction won the race; back out our increment. The decrement
+                    // may now observe pinCount == 0 with evicted == true and trigger
+                    // the recycle.
+                    unpin(slot);
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+
+    private void unpin(Slot slot) {
+        int now = slot.pinCount.decrementAndGet();
+        if (now == 0 && slot.evicted) {
+            recycle(slot);
+        }
+    }
+
+    private void recycle(Slot slot) {
+        if (!slot.recycled.compareAndSet(false, true)) {
+            return;
+        }
+        bytesInUse.addAndGet(-slot.payloadLength);
+        evictCount.incrementAndGet();
+        freeCells.add(slot.cellIndex);
+    }
+
+    /** Returns true if {@code key} is currently resident (non-evicted) in this slab. */
+    public boolean contains(String key) {
+        return liveSlots.containsKey(key);
+    }
+
+    /**
+     * Snapshot of the live keys. Test-only helper; the returned set is a live view
+     * into the underlying concurrent map and is not stable across concurrent ops.
+     */
+    Set<String> liveKeys() {
+        return liveSlots.keySet();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        IOException pending = null;
+        try {
+            channel.close();
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Error closing slab channel: " + slabFile, e);
+            pending = e;
+        }
+        try {
+            Files.deleteIfExists(slabFile);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Could not delete slab file on close: " + slabFile, e);
+            if (pending == null) {
+                pending = e;
+            }
+        }
+        if (pending != null) {
+            throw pending;
+        }
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/SlabCacheFileStore.java
@@ -380,33 +380,42 @@ public class SlabCacheFileStore implements AutoCloseable {
             channel.read(nio, fileOffset, null, new CompletionHandler<Integer, Void>() {
                 @Override
                 public void completed(Integer bytesRead, Void attachment) {
+                    // Order matters: unpin BEFORE completing the future so when a
+                    // caller's read.get() returns, the slot's pinCount has already
+                    // decremented and any racing markEvicted observes it as
+                    // unpinned (and recycles synchronously). Otherwise a single-
+                    // threaded test that evicts immediately after a successful read
+                    // can race the JDK callback's unpin and observe the slot still
+                    // pinned, deferring the recycle to a later async unpin and
+                    // leaving the next admit with no free cell.
                     try {
                         if (bytesRead != null && bytesRead > 0) {
                             byteBuf.writerIndex(bytesRead);
                         }
-                        result.complete(byteBuf);
                     } finally {
                         unpin(slot);
                     }
+                    result.complete(byteBuf);
                 }
 
                 @Override
                 public void failed(Throwable exc, Void attachment) {
+                    // Same unpin-before-complete contract as the success path.
                     try {
                         byteBuf.release();
-                        result.completeExceptionally(exc);
                     } finally {
                         unpin(slot);
                     }
+                    result.completeExceptionally(exc);
                 }
             });
         } catch (RuntimeException t) {
             try {
                 byteBuf.release();
-                result.completeExceptionally(t);
             } finally {
                 unpin(slot);
             }
+            result.completeExceptionally(t);
         }
         return result;
     }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageSlabMetricsTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageSlabMetricsTest.java
@@ -1,0 +1,164 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.remote.storage.CachingObjectStorageTest.FakeObjectStorage;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that the slab/fallback introspection methods on
+ * {@link CachingObjectStorage} report values matching what the Prometheus
+ * gauges in {@code RemoteFileServer} will sample (issue #475). Anything that
+ * makes a gauge regress would cause the Grafana dashboard to display stale
+ * data, so we hammer the lifecycle here.
+ *
+ * @author enrico.olivelli
+ */
+public class CachingObjectStorageSlabMetricsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        executor = Executors.newFixedThreadPool(4);
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    private CachingObjectStorage build(FakeObjectStorage inner, long maxBytes,
+                                       CachingObjectStorage.SlabConfig slabConfig) throws Exception {
+        Path cacheDir = folder.newFolder().toPath();
+        return new CachingObjectStorage(inner, cacheDir, executor, maxBytes, slabConfig);
+    }
+
+    @Test
+    public void testSlabAndFallbackStatsLifecycle() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        // Small: 1 KiB cells x 2 cells; Large: 16 KiB cells x 2 cells; budget 1 MiB.
+        CachingObjectStorage.SlabConfig cfg =
+                new CachingObjectStorage.SlabConfig(true, 1024, 2 * 1024, 16 * 1024, 32 * 1024);
+        try (CachingObjectStorage caching = build(inner, 1024 * 1024, cfg)) {
+            SlabCacheFileStore small = caching.getSmallSlab();
+            SlabCacheFileStore large = caching.getLargeSlab();
+            assertNotNull(small);
+            assertNotNull(large);
+
+            // Initial state.
+            assertEquals(1024, small.cellSize());
+            assertEquals(2, small.totalCells());
+            assertEquals(2, small.freeCells());
+            assertEquals(0, small.liveCells());
+            assertEquals(0, small.bytesInUse());
+            assertEquals(0, small.admitCount());
+            assertEquals(0, small.admitFullCount());
+            assertEquals(0, small.evictCount());
+            assertEquals(0L, caching.getFallbackFileCount());
+            assertEquals(0L, caching.getFallbackBytes());
+
+            // Admit one small.
+            caching.write("a", new byte[800]).get();
+            assertEquals(1, small.liveCells());
+            assertEquals(1, small.freeCells());
+            assertEquals(800, small.bytesInUse());
+            assertEquals(1, small.admitCount());
+            assertEquals(0, small.admitFullCount());
+
+            // Admit one large.
+            caching.write("b", new byte[8 * 1024]).get();
+            assertEquals(1, large.liveCells());
+            assertEquals(8 * 1024, large.bytesInUse());
+
+            // Admit one fallback.
+            caching.write("c", new byte[64 * 1024]).get();
+            assertEquals(1L, caching.getFallbackFileCount());
+            assertEquals(64L * 1024, caching.getFallbackBytes());
+
+            // Saturate the small tier so a third small admit falls through.
+            caching.write("a2", new byte[800]).get();
+            assertEquals(2, small.liveCells());
+            assertEquals(0, small.freeCells());
+            // Force a small-tier-full admit: this will fall through to the large tier
+            // (since 800 ≤ largeCell). admit_full_count on small must increment.
+            long smallFullBefore = small.admitFullCount();
+            caching.write("a3", new byte[800]).get();
+            assertEquals("small admit_full_count must increment on tier-full",
+                    smallFullBefore + 1, small.admitFullCount());
+            assertEquals(2, large.liveCells());
+
+            // Evict everything via delete.
+            caching.delete("a").get();
+            caching.delete("a2").get();
+            caching.delete("a3").get();
+            caching.delete("b").get();
+            caching.delete("c").get();
+
+            // After cleanup, slab counters must be zero and fallback gauges drained.
+            assertEquals(0, small.liveCells());
+            assertEquals(2, small.freeCells());
+            assertEquals(0, small.bytesInUse());
+            assertEquals(0, large.liveCells());
+            assertEquals(2, large.freeCells());
+            assertEquals(0, large.bytesInUse());
+            assertEquals(0L, caching.getFallbackFileCount());
+            assertEquals(0L, caching.getFallbackBytes());
+
+            // Evict counters must be monotonic and reflect the actual evicts. Two
+            // small entries (a, a2), two large entries (b plus the fall-through admit
+            // of a3) — so we expect at least 2 small + 2 large evicts.
+            assertTrue("small.evictCount() must reflect deletes; got " + small.evictCount(),
+                    small.evictCount() >= 2);
+            assertTrue("large.evictCount() must reflect deletes; got " + large.evictCount(),
+                    large.evictCount() >= 2);
+        }
+    }
+
+    @Test
+    public void testSlabDisabledReportsNullSlabsAndZeroSlabStats() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        try (CachingObjectStorage caching = build(inner, 64 * 1024,
+                CachingObjectStorage.SlabConfig.disabled())) {
+            assertNull("slab disabled => no small slab", caching.getSmallSlab());
+            assertNull("slab disabled => no large slab", caching.getLargeSlab());
+            // Fallback counters must still work.
+            caching.write("a", new byte[100]).get();
+            caching.write("b", new byte[200]).get();
+            assertEquals(2L, caching.getFallbackFileCount());
+            assertEquals(300L, caching.getFallbackBytes());
+        }
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageSlabTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageSlabTest.java
@@ -26,10 +26,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.remote.storage.CachingObjectStorageTest.FakeObjectStorage;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -285,6 +290,58 @@ public class CachingObjectStorageSlabTest {
         assertFalse(caching.isInCache("ts1/huge"));
         assertTrue(caching.isInCache("ts2/small"));
         assertEquals(0L, caching.getFallbackFileCount());
+    }
+
+    @Test
+    public void testInnerBufferReleasedWhenSlabAdmitFailsOnLoadAndCache() throws Exception {
+        // Regression test for the refcount-leak path called out by pr-reviewer:
+        // when CachingObjectStorage.loadAndCache hands a pooled direct ByteBuf to
+        // admitChooseTier(ByteBuf) and the slab admit completes EXCEPTIONALLY (e.g.
+        // closed channel, disk-full, I/O error), the outer buf retain held alongside
+        // the retainedDuplicate handed to the slab must still be released exactly
+        // once. Without the whenComplete-on-error guard, that retain leaked because
+        // thenCompose only fires on successful completion.
+        AtomicReference<ByteBuf> capturedBuf = new AtomicReference<>();
+        FakeObjectStorage inner = new FakeObjectStorage() {
+            @Override
+            public CompletableFuture<ReadResult> read(String path) {
+                readCalls.incrementAndGet();
+                byte[] bytes = data.get(path);
+                if (bytes == null) {
+                    return CompletableFuture.completedFuture(ReadResult.notFound());
+                }
+                ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(bytes.length);
+                buf.writeBytes(bytes);
+                capturedBuf.set(buf);
+                return CompletableFuture.completedFuture(ReadResult.found(buf));
+            }
+        };
+        byte[] payload = "payload bytes for slab admit failure".getBytes();
+        inner.data.put("k1", payload);
+
+        try (CachingObjectStorage caching = build(inner, 1024 * 1024, defaultTestSlabConfig())) {
+            // Close both slabs so any tryStore call resolves exceptionally.
+            caching.getSmallSlab().close();
+            caching.getLargeSlab().close();
+
+            // Trigger the slab admit failure via loadAndCache. The future returned
+            // by caching.read should fail (admitToDisk's whenComplete propagates
+            // the exception to the read future).
+            ExecutionException thrown = null;
+            try {
+                ReadResult result = caching.read("k1").get();
+                if (result != null) {
+                    result.release();
+                }
+            } catch (ExecutionException expected) {
+                thrown = expected;
+            }
+            assertNotNull("read must propagate the slab admit failure", thrown);
+            assertNotNull("inner.read must have been called", capturedBuf.get());
+            assertEquals(
+                    "inner pooled ByteBuf must be fully released after slab admit failure",
+                    0, capturedBuf.get().refCnt());
+        }
     }
 
     @Test

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageSlabTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageSlabTest.java
@@ -1,0 +1,316 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.remote.storage.CachingObjectStorageTest.FakeObjectStorage;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end tests for the slab disk cache layout in {@link CachingObjectStorage}
+ * (issue #475). Verifies tier selection across small / large / fallback, eviction
+ * across tiers under a tight budget, the {@code isInCache} introspection helper,
+ * and the {@link CachingObjectStorage#setMaxCacheBytes} resize path.
+ *
+ * @author enrico.olivelli
+ */
+public class CachingObjectStorageSlabTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        executor = Executors.newFixedThreadPool(4);
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    private CachingObjectStorage build(FakeObjectStorage inner, long maxBytes,
+                                       CachingObjectStorage.SlabConfig slabConfig) throws Exception {
+        Path cacheDir = folder.newFolder().toPath();
+        return new CachingObjectStorage(inner, cacheDir, executor, maxBytes, slabConfig);
+    }
+
+    /** Reasonable defaults tuned for unit testing: small 4 KiB cells, large 64 KiB cells. */
+    private static CachingObjectStorage.SlabConfig defaultTestSlabConfig() {
+        // smallCell=4K, smallTier=8K (=> 2 cells); largeCell=64K, largeTier=128K (=> 2 cells).
+        return new CachingObjectStorage.SlabConfig(true, 4 * 1024, 8 * 1024, 64 * 1024, 128 * 1024);
+    }
+
+    @Test
+    public void testTierSelectionByPayloadSize() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024, defaultTestSlabConfig());
+
+        byte[] tiny = new byte[1024];
+        byte[] mid = new byte[16 * 1024];
+        byte[] huge = new byte[256 * 1024]; // > 64K largeCell -> fallback
+
+        caching.write("a/tiny.page", tiny).get();
+        caching.write("b/mid.page", mid).get();
+        caching.write("c/huge.page", huge).get();
+
+        // All three must be reachable via read().
+        assertTrue(caching.isInCache("a/tiny.page"));
+        assertTrue(caching.isInCache("b/mid.page"));
+        assertTrue(caching.isInCache("c/huge.page"));
+
+        // Slab counters should reflect tier assignment.
+        assertNotNull(caching.getSmallSlab());
+        assertNotNull(caching.getLargeSlab());
+        assertEquals(1, caching.getSmallSlab().liveCells());
+        assertEquals(1, caching.getLargeSlab().liveCells());
+        assertEquals(1L, caching.getFallbackFileCount());
+        assertEquals(huge.length, caching.getFallbackBytes());
+    }
+
+    @Test
+    public void testRoundTripFromEachTier() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024, defaultTestSlabConfig());
+
+        byte[] tiny = new byte[100];
+        Arrays.fill(tiny, (byte) 0x11);
+        byte[] mid = new byte[5000];
+        Arrays.fill(mid, (byte) 0x22);
+        byte[] huge = new byte[80 * 1024];
+        Arrays.fill(huge, (byte) 0x33);
+
+        caching.write("tiny", tiny).get();
+        caching.write("mid", mid).get();
+        caching.write("huge", huge).get();
+
+        ReadResult t = caching.read("tiny").get();
+        try {
+            assertEquals(ReadResult.Status.FOUND, t.status());
+            assertArrayEquals(tiny, t.content());
+        } finally {
+            t.release();
+        }
+        ReadResult m = caching.read("mid").get();
+        try {
+            assertArrayEquals(mid, m.content());
+        } finally {
+            m.release();
+        }
+        ReadResult h = caching.read("huge").get();
+        try {
+            assertArrayEquals(huge, h.content());
+        } finally {
+            h.release();
+        }
+    }
+
+    @Test
+    public void testReadRangeFromSlabTier() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024, defaultTestSlabConfig());
+
+        byte[] block = new byte[5000];
+        for (int i = 0; i < block.length; i++) {
+            block[i] = (byte) (i & 0xFF);
+        }
+        caching.writeBlock("big.page", 0, block).get();
+
+        // The block fits in the large tier (5000 < 64K) but not in the small tier (5000 > 4K).
+        // It MUST go into the large tier — verify by reading a slice and checking the bytes.
+        int innerReadsBefore = inner.readCalls.get();
+        ReadResult slice = caching.readRange("big.page", 1000, 64, 4096).get();
+        try {
+            assertEquals(ReadResult.Status.FOUND, slice.status());
+            assertEquals("inner.read must NOT be called for a slab-cached slice",
+                    innerReadsBefore, inner.readCalls.get());
+            byte[] sliceBytes = slice.content();
+            // readRange uses blockSize=4096 here, so blockIndex=0, offsetInBlock=1000;
+            // length=64 bytes -> the cached block is at multipart/0 with the 5000 bytes.
+            byte[] expected = Arrays.copyOfRange(block, 1000, 1064);
+            assertArrayEquals(expected, sliceBytes);
+        } finally {
+            slice.release();
+        }
+    }
+
+    @Test
+    public void testEvictionAcrossTiersUnderTightBudget() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        // Tight budget: small tier 4 cells of 1 KiB, large tier 4 cells of 4 KiB. Caffeine
+        // bytes budget = 8 KiB so the LRU must evict to keep total bytes bounded.
+        CachingObjectStorage.SlabConfig cfg =
+                new CachingObjectStorage.SlabConfig(true, 1024, 4 * 1024, 4096, 16 * 1024);
+        CachingObjectStorage caching = build(inner, 8 * 1024, cfg);
+
+        // Admit 8 entries of 3 KiB each → 24 KiB > 8 KiB budget, so Caffeine must
+        // evict at least 5 of them to respect the budget.
+        for (int i = 0; i < 8; i++) {
+            caching.write("k" + i, new byte[3 * 1024]).get();
+        }
+        caching.cleanUp();
+
+        long resident = 0;
+        for (int i = 0; i < 8; i++) {
+            if (caching.isInCache("k" + i)) {
+                resident++;
+            }
+        }
+        assertTrue("at most 3 entries should fit under the 8 KiB budget, got " + resident,
+                resident <= 3);
+        assertTrue("at least one entry should still be resident, got " + resident,
+                resident >= 1);
+        // Bytes-in-use across slab tiers must respect the budget.
+        long slabBytes = caching.getSmallSlab().bytesInUse() + caching.getLargeSlab().bytesInUse()
+                + caching.getFallbackBytes();
+        assertTrue("slab+fallback bytes must respect Caffeine budget",
+                slabBytes <= 8 * 1024 + 3 * 1024); // tolerate one in-flight admit
+    }
+
+    @Test
+    public void testTierFullFallsThroughToNextTier() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        // Small tier: 1 cell of 1 KiB (room for one small entry only); large tier: 8 cells of
+        // 16 KiB (plenty of headroom). Caffeine budget large enough to keep both resident.
+        CachingObjectStorage.SlabConfig cfg =
+                new CachingObjectStorage.SlabConfig(true, 1024, 1024, 16 * 1024, 128 * 1024);
+        CachingObjectStorage caching = build(inner, 256 * 1024, cfg);
+
+        byte[] payload = new byte[800]; // fits small tier
+        caching.write("a", payload).get();
+        assertEquals(1, caching.getSmallSlab().liveCells());
+        assertEquals(0, caching.getLargeSlab().liveCells());
+
+        // Second admit can't fit in the small tier (only one cell), should fall through
+        // to the large tier (which has plenty of cells).
+        caching.write("b", payload).get();
+        assertEquals(1, caching.getSmallSlab().liveCells());
+        assertEquals(1, caching.getLargeSlab().liveCells());
+        assertEquals("admit-full counter must record the fall-through",
+                1, caching.getSmallSlab().admitFullCount());
+    }
+
+    @Test
+    public void testDeleteInvalidatesAcrossTiers() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024, defaultTestSlabConfig());
+
+        caching.write("small/x", new byte[1024]).get();
+        caching.write("large/y", new byte[16 * 1024]).get();
+        caching.write("huge/z", new byte[200 * 1024]).get(); // fallback
+
+        assertTrue(caching.isInCache("small/x"));
+        assertTrue(caching.isInCache("large/y"));
+        assertTrue(caching.isInCache("huge/z"));
+
+        caching.delete("small/x").get();
+        caching.delete("large/y").get();
+        caching.delete("huge/z").get();
+
+        assertFalse(caching.isInCache("small/x"));
+        assertFalse(caching.isInCache("large/y"));
+        assertFalse(caching.isInCache("huge/z"));
+        assertEquals(0L, caching.getFallbackFileCount());
+        assertEquals(0L, caching.getFallbackBytes());
+    }
+
+    @Test
+    public void testSetMaxCacheBytesAffectsCaffeineBudget() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 8 * 1024, defaultTestSlabConfig());
+        assertEquals(8 * 1024L, caching.getMaxCacheBytes());
+
+        caching.setMaxCacheBytes(64 * 1024L);
+        assertEquals(64 * 1024L, caching.getMaxCacheBytes());
+
+        // Verify entries that previously would have been evicted now stay resident.
+        for (int i = 0; i < 4; i++) {
+            caching.write("k" + i, new byte[8 * 1024]).get();
+        }
+        caching.cleanUp();
+        // 4 * 8 KiB = 32 KiB, well within the 64 KiB budget; all four should be present.
+        for (int i = 0; i < 4; i++) {
+            assertTrue("k" + i + " should still be resident under expanded budget",
+                    caching.isInCache("k" + i));
+        }
+    }
+
+    @Test
+    public void testDeleteByPrefixInvalidatesAllTiers() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024, defaultTestSlabConfig());
+
+        caching.write("ts1/small", new byte[500]).get();
+        caching.write("ts1/big", new byte[20 * 1024]).get();
+        caching.write("ts1/huge", new byte[200 * 1024]).get();
+        caching.write("ts2/small", new byte[500]).get();
+
+        int deleted = caching.deleteByPrefix("ts1/").get();
+        assertEquals(3, deleted);
+
+        assertFalse(caching.isInCache("ts1/small"));
+        assertFalse(caching.isInCache("ts1/big"));
+        assertFalse(caching.isInCache("ts1/huge"));
+        assertTrue(caching.isInCache("ts2/small"));
+        assertEquals(0L, caching.getFallbackFileCount());
+    }
+
+    @Test
+    public void testSlabDisabledRoutesEverythingToFallback() throws Exception {
+        FakeObjectStorage inner = new FakeObjectStorage();
+        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024,
+                CachingObjectStorage.SlabConfig.disabled());
+        // No slab tiers should be present.
+        assertEquals(null, caching.getSmallSlab());
+        assertEquals(null, caching.getLargeSlab());
+
+        caching.write("small/x", new byte[100]).get();
+        caching.write("medium/y", new byte[10 * 1024]).get();
+        caching.write("big/z", new byte[200 * 1024]).get();
+
+        // All three go to the fallback.
+        assertEquals(3L, caching.getFallbackFileCount());
+        assertEquals(100L + 10 * 1024 + 200 * 1024, caching.getFallbackBytes());
+
+        // Reads still work end-to-end.
+        ReadResult r = caching.read("medium/y").get();
+        try {
+            assertEquals(ReadResult.Status.FOUND, r.status());
+            assertEquals(10 * 1024, r.content().length);
+        } finally {
+            r.release();
+        }
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/CachingObjectStorageTest.java
@@ -170,6 +170,18 @@ public class CachingObjectStorageTest {
         return new CachingObjectStorage(inner, cacheDir, executor, maxBytes);
     }
 
+    /**
+     * Builds a {@link CachingObjectStorage} forced into the legacy per-file mode
+     * (slab disabled). Used by tests that exercise the {@link Files#exists}-based
+     * cache-file-on-disk semantics — those scenarios only apply to the fallback
+     * tier with the slab layout in place (issue #475).
+     */
+    private CachingObjectStorage buildLegacy(FakeObjectStorage inner, long maxBytes) throws Exception {
+        Path cacheDir = folder.newFolder("cache").toPath();
+        return new CachingObjectStorage(inner, cacheDir, executor, maxBytes,
+                CachingObjectStorage.SlabConfig.disabled());
+    }
+
     @Test
     public void testWriteReadFromCache() throws Exception {
         FakeObjectStorage inner = new FakeObjectStorage();
@@ -221,9 +233,8 @@ public class CachingObjectStorageTest {
             result.release();
         }
 
-        // Local cache file should have been written
-        Path cacheFile = caching.cacheFilePath("ts1/x.page");
-        assertTrue("cache file should exist", Files.exists(cacheFile));
+        // Entry should now be resident in the cache (in some tier).
+        assertTrue("cache entry should be resident", caching.isInCache("ts1/x.page"));
     }
 
     @Test
@@ -257,8 +268,7 @@ public class CachingObjectStorageTest {
             result.release();
         }
 
-        Path cacheFile = caching.cacheFilePath("del/1.page");
-        assertFalse("local cache file should be gone", Files.exists(cacheFile));
+        assertFalse("cache entry should no longer be resident", caching.isInCache("del/1.page"));
     }
 
     @Test
@@ -294,8 +304,8 @@ public class CachingObjectStorageTest {
             rc.release();
         }
 
-        assertFalse(Files.exists(caching.cacheFilePath("pfx/a.page")));
-        assertFalse(Files.exists(caching.cacheFilePath("pfx/b.page")));
+        assertFalse(caching.isInCache("pfx/a.page"));
+        assertFalse(caching.isInCache("pfx/b.page"));
     }
 
     @Test
@@ -315,12 +325,9 @@ public class CachingObjectStorageTest {
         caching.cleanUp();
         flushExecutor();
 
-        Path fileA = caching.cacheFilePath("blobs/a");
-        Path fileB = caching.cacheFilePath("blobs/b");
-        Path fileC = caching.cacheFilePath("blobs/c");
-        assertFalse("oldest entry should have been evicted and unlinked", Files.exists(fileA));
-        assertTrue("newer entry should remain on disk", Files.exists(fileB));
-        assertTrue("newest entry should remain on disk", Files.exists(fileC));
+        assertFalse("oldest entry should have been evicted", caching.isInCache("blobs/a"));
+        assertTrue("newer entry should remain", caching.isInCache("blobs/b"));
+        assertTrue("newest entry should remain", caching.isInCache("blobs/c"));
     }
 
     @Test
@@ -335,8 +342,8 @@ public class CachingObjectStorageTest {
         caching.cleanUp();
         flushExecutor();
 
-        Path cacheFile = caching.cacheFilePath("evict/big.page");
-        assertFalse("evicted entry's local file should be deleted", Files.exists(cacheFile));
+        assertFalse("evicted entry should no longer be resident",
+                caching.isInCache("evict/big.page"));
     }
 
     @Test
@@ -412,14 +419,15 @@ public class CachingObjectStorageTest {
 
     @Test
     public void testReadSurvivesConcurrentEviction() throws Exception {
+        // Legacy-mode test: simulate the per-file fallback path having its file
+        // unlinked under the cache LRU's feet, and verify the read falls through
+        // to inner.read instead of throwing.
         FakeObjectStorage inner = new FakeObjectStorage();
-        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024);
+        CachingObjectStorage caching = buildLegacy(inner, 10 * 1024 * 1024);
 
         byte[] content = "race".getBytes();
         caching.write("race/1.page", content).get();
 
-        // Force eviction and wait for the listener to unlink the file.
-        caching.cacheFilePath("race/1.page");
         Path file = caching.cacheFilePath("race/1.page");
         Files.deleteIfExists(file);
 
@@ -471,10 +479,11 @@ public class CachingObjectStorageTest {
 
     @Test
     public void testAsyncReadFromCacheHandlesNoSuchFile() throws Exception {
-        // If a file is evicted after the cache membership check but before async open,
-        // the read should treat it as a cache miss and fall through to inner.read
+        // Legacy-mode test: simulate the per-file fallback path having its file
+        // unlinked between LRU lookup and async open. The read must treat that
+        // as a cache miss and fall through to inner.read.
         FakeObjectStorage inner = new FakeObjectStorage();
-        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024);
+        CachingObjectStorage caching = buildLegacy(inner, 10 * 1024 * 1024);
 
         byte[] data = "race".getBytes();
         caching.write("race/1.page", data).get();
@@ -498,9 +507,9 @@ public class CachingObjectStorageTest {
 
     @Test
     public void testAsyncReadSliceFromCacheHandlesNoSuchFile() throws Exception {
-        // Similar to above but for readRange
+        // Similar to above but for readRange — also legacy-mode (per-file path).
         FakeObjectStorage inner = new FakeObjectStorage();
-        CachingObjectStorage caching = build(inner, 10 * 1024 * 1024);
+        CachingObjectStorage caching = buildLegacy(inner, 10 * 1024 * 1024);
 
         byte[] block = new byte[4096];
         for (int i = 0; i < block.length; i++) {
@@ -543,11 +552,9 @@ public class CachingObjectStorageTest {
         caching.writeBlock("multi.page", 0, block0).get();
         caching.writeBlock("multi.page", 1, block1).get();
 
-        // Verify cache files were written
-        Path file0 = caching.cacheFilePath("multi.page.multipart/0");
-        Path file1 = caching.cacheFilePath("multi.page.multipart/1");
-        assertTrue("block 0 cache file should exist", Files.exists(file0));
-        assertTrue("block 1 cache file should exist", Files.exists(file1));
+        // Verify both blocks are resident in the cache (in some tier).
+        assertTrue("block 0 should be cached", caching.isInCache("multi.page.multipart/0"));
+        assertTrue("block 1 should be cached", caching.isInCache("multi.page.multipart/1"));
 
         // Verify reads work
         ReadResult r0 = caching.readRange("multi.page", 0, 100, 1024).get();
@@ -620,15 +627,10 @@ public class CachingObjectStorageTest {
         caching.cleanUp();
         flushExecutor();
 
-        // Oldest blob should be evicted
-        Path fileA = caching.cacheFilePath("blobs/a");
-        assertFalse("oldest entry should have been evicted", Files.exists(fileA));
-
-        // Newer ones should remain
-        Path fileB = caching.cacheFilePath("blobs/b");
-        Path fileC = caching.cacheFilePath("blobs/c");
-        assertTrue("b should remain", Files.exists(fileB));
-        assertTrue("c should remain", Files.exists(fileC));
+        // Oldest blob should be evicted; newer ones should remain resident.
+        assertFalse("oldest entry should have been evicted", caching.isInCache("blobs/a"));
+        assertTrue("b should remain", caching.isInCache("blobs/b"));
+        assertTrue("c should remain", caching.isInCache("blobs/c"));
 
         // Verify reads still work (newer entries remain accessible)
         ReadResult rb = caching.read("blobs/b").get();
@@ -806,7 +808,7 @@ public class CachingObjectStorageTest {
         }
 
         // Data should not be cached
-        Path cacheFile = caching.cacheFilePath("fail/file.page");
-        assertFalse("cache file should not exist after failed write", Files.exists(cacheFile));
+        assertFalse("entry should not be resident after failed inner write",
+                caching.isInCache("fail/file.page"));
     }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/SlabCacheFileStoreConcurrencyTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/SlabCacheFileStoreConcurrencyTest.java
@@ -1,0 +1,327 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Hammer test for {@link SlabCacheFileStore} (issue #475). Many threads admit/read/free
+ * random keys from a shared pool. Each payload starts with a key-derived header so a
+ * read that returns bytes "from the wrong key" (a torn read against a recycled cell)
+ * fails the test loudly.
+ *
+ * @author enrico.olivelli
+ */
+public class SlabCacheFileStoreConcurrencyTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final int CELL_SIZE = 4096;
+    private static final int TOTAL_CELLS = 64;
+    private static final int KEY_POOL = 200;
+    private static final int THREADS = 8;
+    private static final int OPS_PER_THREAD = 2000;
+    private static final byte HEADER_LEN = 16;
+
+    private static byte[] payloadFor(String key, int variant) {
+        // Header: 16 bytes derived from (key,variant) so the read path can verify
+        // the bytes match the expected key. We use a SHA-1-style mix here without
+        // needing a real digest — collisions in the 16-byte prefix between different
+        // (key,variant) tuples are astronomically unlikely under the test's load.
+        long h = 0xcbf29ce484222325L;
+        for (int i = 0; i < key.length(); i++) {
+            h ^= key.charAt(i);
+            h *= 0x100000001b3L;
+        }
+        long h2 = h ^ ((long) variant * 0x9e3779b97f4a7c15L);
+        ByteBuffer header = ByteBuffer.allocate(HEADER_LEN);
+        header.putLong(h);
+        header.putLong(h2);
+        int payloadLen = 32 + ThreadLocalRandom.current().nextInt(CELL_SIZE - 32);
+        byte[] payload = new byte[payloadLen];
+        System.arraycopy(header.array(), 0, payload, 0, HEADER_LEN);
+        // Fill the rest with a deterministic pattern derived from h2 so any cross-talk
+        // between recycled cells shows up as a body mismatch even if the header
+        // happens to collide.
+        for (int i = HEADER_LEN; i < payloadLen; i++) {
+            payload[i] = (byte) ((h2 >>> ((i & 7) * 8)) & 0xFF);
+        }
+        return payload;
+    }
+
+    private static long headerHash(String key) {
+        long h = 0xcbf29ce484222325L;
+        for (int i = 0; i < key.length(); i++) {
+            h ^= key.charAt(i);
+            h *= 0x100000001b3L;
+        }
+        return h;
+    }
+
+    private static ByteBuf bufOf(byte[] bytes) {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(bytes.length);
+        buf.writeBytes(bytes);
+        return buf;
+    }
+
+    @Test
+    public void testHammerNoTornReadsAcrossRecycle() throws Exception {
+        Path slabPath = folder.newFolder().toPath().resolve("slab.dat");
+        SlabCacheFileStore slab = new SlabCacheFileStore(slabPath, CELL_SIZE, TOTAL_CELLS);
+        ExecutorService exec = Executors.newFixedThreadPool(THREADS);
+        try {
+            // Track the CURRENT (latest) variant per key. Readers compare the read
+            // header against headerHash(key); writers stamp the new variant atomically
+            // before the admit completes. The test never asserts that "what was
+            // written N steps ago is what we read now" — only that "the bytes we
+            // read for key K start with headerHash(K)" — so torn reads from a
+            // recycled cell (which would carry a different headerHash) fail loudly.
+            ConcurrentHashMap<String, AtomicInteger> variantByKey = new ConcurrentHashMap<>();
+            for (int i = 0; i < KEY_POOL; i++) {
+                variantByKey.put("k" + i, new AtomicInteger());
+            }
+            AtomicLong tornReads = new AtomicLong();
+            AtomicLong totalReads = new AtomicLong();
+            AtomicLong totalWrites = new AtomicLong();
+            AtomicLong totalEvicts = new AtomicLong();
+            CountDownLatch latch = new CountDownLatch(THREADS);
+
+            for (int t = 0; t < THREADS; t++) {
+                exec.submit(() -> {
+                    ThreadLocalRandom rnd = ThreadLocalRandom.current();
+                    try {
+                        for (int op = 0; op < OPS_PER_THREAD; op++) {
+                            String key = "k" + rnd.nextInt(KEY_POOL);
+                            int choice = rnd.nextInt(10);
+                            if (choice < 4) {
+                                // ADMIT.
+                                int variant = variantByKey.get(key).incrementAndGet();
+                                byte[] payload = payloadFor(key, variant);
+                                try {
+                                    slab.tryStore(key, bufOf(payload)).get(5, TimeUnit.SECONDS);
+                                    totalWrites.incrementAndGet();
+                                } catch (Exception e) {
+                                    // Tier-full / I/O error / interrupted: skip; counts
+                                    // are sanity-checked below.
+                                }
+                            } else if (choice < 8) {
+                                // READ.
+                                ByteBuf buf;
+                                try {
+                                    buf = slab.read(key).get(5, TimeUnit.SECONDS);
+                                } catch (Exception e) {
+                                    continue;
+                                }
+                                if (buf == null) {
+                                    continue;
+                                }
+                                try {
+                                    totalReads.incrementAndGet();
+                                    if (buf.readableBytes() < HEADER_LEN) {
+                                        tornReads.incrementAndGet();
+                                        continue;
+                                    }
+                                    long readHeader = buf.getLong(buf.readerIndex());
+                                    if (readHeader != headerHash(key)) {
+                                        tornReads.incrementAndGet();
+                                    }
+                                } finally {
+                                    buf.release();
+                                }
+                            } else {
+                                // EVICT.
+                                if (slab.markEvicted(key)) {
+                                    totalEvicts.incrementAndGet();
+                                }
+                            }
+                        }
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            assertTrue("workers must finish in time", latch.await(120, TimeUnit.SECONDS));
+
+            assertEquals("no torn read may slip through pin/evict ordering",
+                    0, tornReads.get());
+            // Sanity: we performed real work.
+            assertTrue(totalWrites.get() > 0);
+            assertTrue(totalReads.get() > 0);
+            assertTrue(totalEvicts.get() > 0);
+
+            // Drain by evicting every key, then verify counters.
+            for (int i = 0; i < KEY_POOL; i++) {
+                slab.markEvicted("k" + i);
+            }
+            assertEquals("after final cleanup all bytes must be released",
+                    0L, slab.bytesInUse());
+            assertEquals("after final cleanup all cells must be free",
+                    TOTAL_CELLS, slab.freeCells());
+        } finally {
+            exec.shutdownNow();
+            exec.awaitTermination(10, TimeUnit.SECONDS);
+            slab.close();
+        }
+    }
+
+    @Test
+    public void testConcurrentReadsOfSameKeyAreConsistent() throws Exception {
+        Path slabPath = folder.newFolder().toPath().resolve("slab.dat");
+        try (SlabCacheFileStore slab = new SlabCacheFileStore(slabPath, CELL_SIZE, 4)) {
+            byte[] payload = payloadFor("k1", 1);
+            slab.tryStore("k1", bufOf(payload)).get();
+
+            int n = 32;
+            ExecutorService exec = Executors.newFixedThreadPool(8);
+            CountDownLatch latch = new CountDownLatch(n);
+            AtomicLong mismatches = new AtomicLong();
+            try {
+                for (int i = 0; i < n; i++) {
+                    exec.submit(() -> {
+                        try {
+                            ByteBuf buf = slab.read("k1").get(5, TimeUnit.SECONDS);
+                            if (buf == null) {
+                                mismatches.incrementAndGet();
+                                return;
+                            }
+                            try {
+                                if (buf.readableBytes() != payload.length) {
+                                    mismatches.incrementAndGet();
+                                    return;
+                                }
+                                byte[] got = new byte[buf.readableBytes()];
+                                buf.getBytes(buf.readerIndex(), got);
+                                for (int j = 0; j < got.length; j++) {
+                                    if (got[j] != payload[j]) {
+                                        mismatches.incrementAndGet();
+                                        return;
+                                    }
+                                }
+                            } finally {
+                                buf.release();
+                            }
+                        } catch (Exception e) {
+                            mismatches.incrementAndGet();
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                }
+                assertTrue(latch.await(30, TimeUnit.SECONDS));
+                assertEquals("all concurrent reads must see consistent bytes",
+                        0, mismatches.get());
+            } finally {
+                exec.shutdownNow();
+                exec.awaitTermination(10, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @Test
+    public void testEvictDuringReadDoesNotTearBuffer() throws Exception {
+        // Force the read/evict race many times: thread A pins for read, thread B
+        // calls markEvicted, last unpin recycles the cell. The slab guarantees the
+        // ByteBuf returned to A still carries A's bytes regardless of B's eviction.
+        Path slabPath = folder.newFolder().toPath().resolve("slab.dat");
+        try (SlabCacheFileStore slab = new SlabCacheFileStore(slabPath, CELL_SIZE, 1)) {
+            int rounds = 400;
+            byte[] payload = payloadFor("hot", 1);
+            ExecutorService exec = Executors.newFixedThreadPool(2);
+            AtomicLong mismatches = new AtomicLong();
+            try {
+                for (int r = 0; r < rounds; r++) {
+                    slab.tryStore("hot", bufOf(payload)).get();
+                    CountDownLatch ready = new CountDownLatch(2);
+                    CountDownLatch start = new CountDownLatch(1);
+                    List<java.util.concurrent.Future<?>> tasks = new ArrayList<>();
+
+                    tasks.add(exec.submit(() -> {
+                        ready.countDown();
+                        try {
+                            start.await();
+                            ByteBuf buf = slab.read("hot").get(2, TimeUnit.SECONDS);
+                            if (buf == null) {
+                                return; // legitimate: eviction won
+                            }
+                            try {
+                                if (buf.readableBytes() != payload.length) {
+                                    mismatches.incrementAndGet();
+                                    return;
+                                }
+                                byte[] got = new byte[buf.readableBytes()];
+                                buf.getBytes(buf.readerIndex(), got);
+                                for (int j = 0; j < got.length; j++) {
+                                    if (got[j] != payload[j]) {
+                                        mismatches.incrementAndGet();
+                                        return;
+                                    }
+                                }
+                            } finally {
+                                buf.release();
+                            }
+                        } catch (Exception ignored) {
+                            // Best-effort under contention; mismatches is the real check.
+                        }
+                    }));
+                    tasks.add(exec.submit(() -> {
+                        ready.countDown();
+                        try {
+                            start.await();
+                            slab.markEvicted("hot");
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }));
+
+                    assertTrue(ready.await(5, TimeUnit.SECONDS));
+                    start.countDown();
+                    for (java.util.concurrent.Future<?> f : tasks) {
+                        f.get(5, TimeUnit.SECONDS);
+                    }
+                }
+                assertEquals("read/evict race must not return torn bytes",
+                        0, mismatches.get());
+            } finally {
+                exec.shutdownNow();
+                exec.awaitTermination(10, TimeUnit.SECONDS);
+            }
+        }
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/SlabCacheFileStoreConcurrencyTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/SlabCacheFileStoreConcurrencyTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
@@ -131,23 +132,37 @@ public class SlabCacheFileStoreConcurrencyTest {
                             String key = "k" + rnd.nextInt(KEY_POOL);
                             int choice = rnd.nextInt(10);
                             if (choice < 4) {
-                                // ADMIT.
+                                // ADMIT. tryStore returns null on tier-full (NOT an
+                                // exception) so any exceptional completion or timeout
+                                // here is a real bug — fail the test loudly. The same
+                                // applies to InterruptedException (a stuck slab admit
+                                // is a real bug, not benign).
                                 int variant = variantByKey.get(key).incrementAndGet();
                                 byte[] payload = payloadFor(key, variant);
                                 try {
                                     slab.tryStore(key, bufOf(payload)).get(5, TimeUnit.SECONDS);
                                     totalWrites.incrementAndGet();
-                                } catch (Exception e) {
-                                    // Tier-full / I/O error / interrupted: skip; counts
-                                    // are sanity-checked below.
+                                } catch (java.util.concurrent.TimeoutException te) {
+                                    throw new AssertionError("tryStore stuck for 5s on key " + key, te);
+                                } catch (ExecutionException ee) {
+                                    throw new AssertionError("tryStore failed exceptionally on key " + key, ee);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                    return;
                                 }
                             } else if (choice < 8) {
-                                // READ.
+                                // READ. Same rationale: read returns null on miss
+                                // (NOT an exception). Anything else is a bug.
                                 ByteBuf buf;
                                 try {
                                     buf = slab.read(key).get(5, TimeUnit.SECONDS);
-                                } catch (Exception e) {
-                                    continue;
+                                } catch (java.util.concurrent.TimeoutException te) {
+                                    throw new AssertionError("read stuck for 5s on key " + key, te);
+                                } catch (ExecutionException ee) {
+                                    throw new AssertionError("read failed exceptionally on key " + key, ee);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                    return;
                                 }
                                 if (buf == null) {
                                     continue;

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/SlabCacheFileStoreTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/SlabCacheFileStoreTest.java
@@ -1,0 +1,354 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for {@link SlabCacheFileStore} (issue #475).
+ *
+ * @author enrico.olivelli
+ */
+public class SlabCacheFileStoreTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private SlabCacheFileStore openSlab(int cellSize, int totalCells) throws Exception {
+        Path slab = folder.newFolder().toPath().resolve("slab.dat");
+        return new SlabCacheFileStore(slab, cellSize, totalCells);
+    }
+
+    private static ByteBuf bufOf(byte[] bytes) {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(bytes.length);
+        buf.writeBytes(bytes);
+        return buf;
+    }
+
+    private static byte[] readAll(SlabCacheFileStore slab, String key) throws Exception {
+        ByteBuf buf = slab.read(key).get();
+        if (buf == null) {
+            return null;
+        }
+        try {
+            byte[] copy = new byte[buf.readableBytes()];
+            buf.getBytes(buf.readerIndex(), copy);
+            return copy;
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void testStoreAndReadFullPayload() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(4096, 4)) {
+            byte[] payload = "hello world".getBytes();
+            SlabCacheFileStore.Slot slot = slab.tryStore("k1", bufOf(payload)).get();
+            assertNotNull(slot);
+            assertEquals(payload.length, slot.payloadLength());
+
+            assertArrayEquals(payload, readAll(slab, "k1"));
+            assertEquals(payload.length, slab.bytesInUse());
+            assertEquals(1, slab.liveCells());
+            assertEquals(3, slab.freeCells());
+            assertEquals(1, slab.admitCount());
+            assertEquals(0, slab.admitFullCount());
+            assertEquals(0, slab.evictCount());
+        }
+    }
+
+    @Test
+    public void testReadRangeReturnsCorrectSlice() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(4096, 1)) {
+            byte[] payload = new byte[2048];
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) (i & 0xFF);
+            }
+            slab.tryStore("k1", bufOf(payload)).get();
+
+            ByteBuf slice = slab.readRange("k1", 1000, 16).get();
+            try {
+                byte[] sliceBytes = new byte[slice.readableBytes()];
+                slice.getBytes(slice.readerIndex(), sliceBytes);
+                assertEquals(16, sliceBytes.length);
+                assertArrayEquals(Arrays.copyOfRange(payload, 1000, 1016), sliceBytes);
+            } finally {
+                slice.release();
+            }
+        }
+    }
+
+    @Test
+    public void testReadRangeOutOfBoundsReturnsNull() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(4096, 1)) {
+            byte[] payload = new byte[100];
+            slab.tryStore("k1", bufOf(payload)).get();
+
+            ByteBuf empty = slab.readRange("k1", 100, 16).get();
+            assertNull(empty);
+            ByteBuf empty2 = slab.readRange("k1", 1000, 16).get();
+            assertNull(empty2);
+        }
+    }
+
+    @Test
+    public void testReadRangeClampsToPayloadLength() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(4096, 1)) {
+            byte[] payload = new byte[100];
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) i;
+            }
+            slab.tryStore("k1", bufOf(payload)).get();
+
+            ByteBuf slice = slab.readRange("k1", 90, 1000).get();
+            try {
+                assertEquals(10, slice.readableBytes());
+                byte[] sliceBytes = new byte[slice.readableBytes()];
+                slice.getBytes(slice.readerIndex(), sliceBytes);
+                assertArrayEquals(Arrays.copyOfRange(payload, 90, 100), sliceBytes);
+            } finally {
+                slice.release();
+            }
+        }
+    }
+
+    @Test
+    public void testTryStoreRejectsOversizedPayload() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 4)) {
+            byte[] payload = new byte[65];
+            SlabCacheFileStore.Slot slot = slab.tryStore("k1", bufOf(payload)).get();
+            assertNull("oversize payload must return null", slot);
+            assertEquals(0, slab.liveCells());
+            assertEquals(4, slab.freeCells());
+            assertEquals(0, slab.admitCount());
+            // Oversize is NOT counted as admit-full — admit-full is for tier-full only.
+            assertEquals(0, slab.admitFullCount());
+        }
+    }
+
+    @Test
+    public void testTryStoreReportsTierFullAndIncrementsCounter() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 1)) {
+            // First admit succeeds.
+            assertNotNull(slab.tryStore("k1", bufOf(new byte[10])).get());
+            // Second admit fails because the only cell is in use.
+            SlabCacheFileStore.Slot rejected = slab.tryStore("k2", bufOf(new byte[10])).get();
+            assertNull(rejected);
+            assertEquals(1, slab.admitFullCount());
+            assertEquals(1, slab.liveCells());
+        }
+    }
+
+    @Test
+    public void testFreeRecyclesCellAndRemovesFromIndex() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 1)) {
+            slab.tryStore("k1", bufOf(new byte[10])).get();
+            assertTrue(slab.contains("k1"));
+            assertTrue(slab.markEvicted("k1"));
+            assertFalse(slab.contains("k1"));
+            assertEquals(1, slab.evictCount());
+            assertEquals(0, slab.bytesInUse());
+            assertEquals(0, slab.liveCells());
+            assertEquals(1, slab.freeCells());
+
+            // Cell can now be reused for a new key.
+            byte[] payload = "second".getBytes();
+            SlabCacheFileStore.Slot slot = slab.tryStore("k2", bufOf(payload)).get();
+            assertNotNull(slot);
+            assertArrayEquals(payload, readAll(slab, "k2"));
+        }
+    }
+
+    @Test
+    public void testRecycledCellHoldsNewBytes() throws Exception {
+        // Direct test of "no torn read after recycle" — we deliberately admit, free,
+        // and re-admit a different payload at the same key, then ensure the read
+        // returns the new bytes (and definitely not bytes from the previous admit).
+        try (SlabCacheFileStore slab = openSlab(4096, 1)) {
+            byte[] first = new byte[200];
+            Arrays.fill(first, (byte) 0x11);
+            slab.tryStore("k", bufOf(first)).get();
+            slab.markEvicted("k");
+
+            byte[] second = new byte[200];
+            Arrays.fill(second, (byte) 0x22);
+            slab.tryStore("k", bufOf(second)).get();
+            assertArrayEquals(second, readAll(slab, "k"));
+        }
+    }
+
+    @Test
+    public void testReadOfMissingKeyReturnsNull() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 1)) {
+            assertNull(slab.read("missing").get());
+            assertNull(slab.readRange("missing", 0, 10).get());
+        }
+    }
+
+    @Test
+    public void testCloseIsIdempotent() throws Exception {
+        SlabCacheFileStore slab = openSlab(64, 2);
+        slab.close();
+        slab.close(); // must not throw
+    }
+
+    @Test
+    public void testCloseDeletesSlabFile() throws Exception {
+        Path slabPath = folder.newFolder().toPath().resolve("slab.dat");
+        SlabCacheFileStore slab = new SlabCacheFileStore(slabPath, 64, 2);
+        assertTrue(Files.exists(slabPath));
+        slab.close();
+        assertFalse("close() must delete the slab file", Files.exists(slabPath));
+    }
+
+    @Test
+    public void testZeroCellsTier() throws Exception {
+        // A zero-capacity tier accepts no admissions and counts every attempt as full.
+        try (SlabCacheFileStore slab = openSlab(64, 0)) {
+            assertEquals(0, slab.totalCells());
+            assertEquals(0, slab.freeCells());
+            SlabCacheFileStore.Slot rejected = slab.tryStore("k1", bufOf(new byte[10])).get();
+            assertNull(rejected);
+            assertEquals(1, slab.admitFullCount());
+        }
+    }
+
+    @Test
+    public void testInvalidArgsThrow() throws Exception {
+        Path slabPath = folder.newFolder().toPath().resolve("slab.dat");
+        try {
+            new SlabCacheFileStore(slabPath, 0, 1).close();
+            fail("expected IllegalArgumentException for cellSize=0");
+        } catch (IllegalArgumentException expected) {
+            // Expected: cellSize must be > 0.
+            assertTrue(expected.getMessage().contains("cellSize"));
+        }
+        try {
+            new SlabCacheFileStore(slabPath, 64, -1).close();
+            fail("expected IllegalArgumentException for negative totalCells");
+        } catch (IllegalArgumentException expected) {
+            // Expected: totalCells must be >= 0.
+            assertTrue(expected.getMessage().contains("totalCells"));
+        }
+    }
+
+    @Test
+    public void testReadRangeNegativeArgs() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 1)) {
+            slab.tryStore("k1", bufOf(new byte[10])).get();
+            try {
+                slab.readRange("k1", -1, 5).get();
+                fail("expected IllegalArgumentException for negative offset");
+            } catch (ExecutionException expected) {
+                assertTrue(expected.getCause() instanceof IllegalArgumentException);
+            }
+            try {
+                slab.readRange("k1", 0, -5).get();
+                fail("expected IllegalArgumentException for negative length");
+            } catch (ExecutionException expected) {
+                assertTrue(expected.getCause() instanceof IllegalArgumentException);
+            }
+        }
+    }
+
+    @Test
+    public void testEachCellGetsDistinctSlot() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 4)) {
+            Set<Integer> seenCells = new HashSet<>();
+            for (int i = 0; i < 4; i++) {
+                byte[] payload = ("cell-" + i).getBytes();
+                SlabCacheFileStore.Slot slot = slab.tryStore("k" + i, bufOf(payload)).get();
+                assertNotNull(slot);
+                assertTrue("cells must be distinct, got duplicate: " + slot.cellIndex(),
+                        seenCells.add(slot.cellIndex()));
+            }
+            // Verify all four payloads round-trip correctly to their key.
+            for (int i = 0; i < 4; i++) {
+                assertArrayEquals(("cell-" + i).getBytes(), readAll(slab, "k" + i));
+            }
+        }
+    }
+
+    @Test
+    public void testStorePayloadOfEverySize() throws Exception {
+        // Sweep the tier with payloads of size 1, 2, 3, ..., cellSize (subject to the
+        // single-cell capacity by freeing each between admits).
+        int cellSize = 257;
+        try (SlabCacheFileStore slab = openSlab(cellSize, 1)) {
+            for (int size = 1; size <= cellSize; size++) {
+                byte[] payload = new byte[size];
+                for (int i = 0; i < size; i++) {
+                    payload[i] = (byte) ((i + size) & 0xFF);
+                }
+                SlabCacheFileStore.Slot slot = slab.tryStore("k", bufOf(payload)).get();
+                assertNotNull("size " + size + " must succeed", slot);
+                assertArrayEquals("size " + size + " round-trip", payload, readAll(slab, "k"));
+                slab.markEvicted("k");
+            }
+        }
+    }
+
+    @Test
+    public void testBytesInUseTracksLiveBytesAcrossAdmitFreeRecycle() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(4096, 4)) {
+            slab.tryStore("a", bufOf(new byte[100])).get();
+            assertEquals(100, slab.bytesInUse());
+            slab.tryStore("b", bufOf(new byte[200])).get();
+            assertEquals(300, slab.bytesInUse());
+            slab.tryStore("c", bufOf(new byte[50])).get();
+            assertEquals(350, slab.bytesInUse());
+            slab.markEvicted("b");
+            assertEquals(150, slab.bytesInUse());
+            slab.tryStore("d", bufOf(new byte[400])).get();
+            assertEquals(550, slab.bytesInUse());
+        }
+    }
+
+    @Test
+    public void testLiveKeysSnapshot() throws Exception {
+        try (SlabCacheFileStore slab = openSlab(64, 4)) {
+            slab.tryStore("a", bufOf(new byte[10])).get();
+            slab.tryStore("b", bufOf(new byte[10])).get();
+            List<String> keys = new ArrayList<>(slab.liveKeys());
+            keys.sort(String::compareTo);
+            assertEquals(Arrays.asList("a", "b"), keys);
+        }
+    }
+}

--- a/herddb-services/src/main/resources/conf/fileserver.properties
+++ b/herddb-services/src/main/resources/conf/fileserver.properties
@@ -38,6 +38,23 @@ bind.host=0.0.0.0
 # s3.prefix=
 # cache.max.bytes=1073741824
 
+# On-disk cache layout (issue #475). The disk cache is now a two-tier slab store
+# kept open for the JVM lifetime, so admit/evict no longer pay open/close/create/
+# delete syscalls per cached object. Set cache.slab.enabled=false to revert to
+# the legacy one-file-per-object layout.
+# cache.slab.enabled=true
+# Cell size of the small slab tier in bytes. Objects up to this size are admitted
+# to the small tier first.
+# cache.slab.small.cell.bytes=65536
+# Fraction of cache.max.bytes given to the small tier (0..1).
+# cache.slab.small.fraction=0.25
+# Cell size of the large slab tier in bytes. Default tracks block.size (4 MiB).
+# cache.slab.large.cell.bytes=4194304
+# Fraction of cache.max.bytes given to the large tier (0..1). Anything that does
+# not fit either slab tier falls through to the legacy per-file path so arbitrarily
+# large objects remain cacheable.
+# cache.slab.large.fraction=0.75
+
 # Block cache (fronts the object storage for readRange requests).
 # Holds whole multipart blocks as pooled direct ByteBufs so repeated random reads
 # from ANN/HNSW traversal are served without touching disk or S3.


### PR DESCRIPTION
Fixes #475.

## Why

The S3-backed disk cache (`CachingObjectStorage`) used to write one local
file per cached object. With ANN/HNSW workloads that pull millions of
4 MiB blocks plus many small metadata objects, this generated millions of
`open` / `close` / `create` / `delete` syscalls and a directory full of
tiny files. The issue asked for a layout that keeps a small number of
slab files open for the JVM's lifetime, with several tiers to limit
fragmentation between small and big logical parts. The cache is volatile
so no on-disk index is needed.

## Changes

- **`SlabCacheFileStore` (new)** — one pre-allocated slab file divided
  into fixed-size cells, kept open as `AsynchronousFileChannel`.
  In-memory `Map<key,Slot>` index, lock-free free-list of cell indices.
  Per-slot `pinCount` (`AtomicInteger`) + `volatile boolean evicted` so
  cell recycle is safe against concurrent reads without holding any lock
  across the async I/O. Per-tier counters: `bytesInUse`, `liveCells`,
  `freeCells`, `admitCount`, `admitFullCount`, `evictCount`.
- **`CachingObjectStorage` (refactor)** — two `SlabCacheFileStore`
  instances (small + large) plus a per-file fallback for oversize
  objects. Caffeine LRU value type changes from `Long` to a small
  `CacheEntry { tier, payloadLength }`. New `SlabConfig` knob and a new
  `boolean isInCache(String)` introspection helper. `evictionListener`
  routes size-based evictions to the right tier; explicit invalidations
  go through `invalidateAndDelete` which calls the cleanup synchronously
  so `isInCache` and the gauges are immediately consistent. The original
  per-file layout is preserved behind `cache.slab.enabled=false`.
- **`RemoteFileServer`** — reads `cache.slab.{enabled,small.cell.bytes,
  small.fraction,large.cell.bytes,large.fraction}` from `Properties`.
  Defaults: enabled, 64 KiB small cells (25%), 4 MiB large cells (75%).
  Registers eight Prometheus gauges per slab tier plus
  `rfs_disk_cache_slab_fallback_files` and
  `rfs_disk_cache_slab_fallback_bytes`, all under the existing
  `rfs_disk_cache_*` namespace.
- **Grafana dashboard** — two new rows (4 panels) plotting tier fill
  ratio, bytes-in-use per tier (incl. fallback), admit rate per tier
  with fall-through breakdown, and evict rate per tier alongside the
  fallback file count.
- **Docs / config** — `REMOTE_FILE_SERVER.md` describes the new layout;
  `fileserver.properties` documents the new knobs.

## Tests

- `SlabCacheFileStoreTest` — 18 unit tests covering store/retrieve at
  every payload size up to `cellSize`, free + recycle, range read,
  out-of-bounds, oversize rejection, tier-full counter, zero-cells tier,
  invalid arguments, idempotent close + slab-file deletion, distinct
  cells per key, monotonic counters.
- `SlabCacheFileStoreConcurrencyTest` — 3 hammer tests. The main one
  fires 8 threads × 2000 ops of mixed admit/read/free over 200 keys;
  every payload starts with a key-derived header so any cross-talk from
  a recycled cell fails loudly (`assertEquals(0, tornReads)`). A second
  test races concurrent reads of the same key; a third forces the
  read-vs-evict race 400 rounds in a single-cell tier and asserts no
  torn bytes.
- `CachingObjectStorageSlabTest` — 9 end-to-end tests: tier selection
  by payload size, round-trip from each tier, range read out of a slab
  cell, eviction across tiers under a tight Caffeine budget, tier-full
  fall-through, `delete` and `deleteByPrefix` invalidating across all
  tiers, `setMaxCacheBytes` resize, and `slab.enabled=false` routing
  every admit to the fallback.
- `CachingObjectStorageSlabMetricsTest` — drives the slab/fallback
  introspection getters through a full admit/read/evict lifecycle,
  ensuring the Prometheus gauges (which read these getters) report
  correct values.
- `CachingObjectStorageTest` updated — replaces `Files.exists(cacheFilePath)`
  assertions with `isInCache(...)`; the three legacy-race tests are
  routed through `SlabConfig.disabled()` so the per-file fallback path
  stays under coverage.
- `LazyValueCacheConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,
  WithUniqueIndexes}Test` — all 3 subclasses green twice in a row.
- Full `herddb-remote-file-service` test suite (353 tests) green.
- `S3RemoteFileServerTest` (MinIO via Testcontainers — true end-to-end
  through the slab) green.
- Pre-PR validation: `mvn checkstyle:check apache-rat:check
  spotbugs:check install -DskipTests -Pci` — green.

🤖 Implemented by the `pr-worker` agent.