### PR TITLE
issue #472: run post-Phase-C block-cache warmup on a dedicated executor

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -156,6 +156,42 @@ public final class IndexingServerConfiguration {
     /** Hard-coded fallback: 32 MiB per segment. */
     public static final long PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES_DEFAULT = 32L * 1024 * 1024;
 
+    /**
+     * Whether the post-Phase-C cache warmup runs asynchronously on a dedicated
+     * single-thread executor (issue #472).
+     *
+     * <p>When {@code true} (the default) the watermark is published as soon as
+     * Phase C completes — the BFS warmup runs in parallel with subsequent
+     * search queries on a dedicated {@code indexing-warmup} thread. This
+     * removes the ~3 s blocking gap observed in the k3s-bench profile where
+     * the next checkpoint cannot start (single-thread {@code checkpointExecutor})
+     * and the watermark snapshot is held back for the duration of the warmup.
+     * Multiple in-flight requests are coalesced (the engine drops a new submit
+     * if a previous warmup is still running), so unbounded queueing cannot
+     * happen during pathological scheduling — the next post-checkpoint trigger
+     * will pick up the latest segment set.
+     *
+     * <p>When {@code false} the warmup runs inline on the
+     * {@code checkpointExecutor} thread before the watermark is saved
+     * (the original issue #322 behaviour). Useful when an operator wants the
+     * cache fully primed before WAITFORINDEXES queries can observe the new
+     * snapshot.
+     *
+     * <p>Resolved in the same priority order as
+     * {@link #PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES}: properties-file
+     * key &gt; JVM system property &gt; hard-coded default.
+     */
+    public static final String PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC =
+            "indexing.vector.segmentCacheWarmupAsync";
+    /**
+     * System-property fallback for {@link #PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC}.
+     * A value set in the properties file always wins over this system property.
+     */
+    public static final String SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC =
+            "herddb.vectorindex.segmentCacheWarmupAsync";
+    /** Hard-coded default: async warmup is enabled. */
+    public static final boolean PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC_DEFAULT = true;
+
     // Compaction (checkpoint driver — existing)
     public static final String PROPERTY_COMPACTION_INTERVAL = "indexing.compaction.interval";
     public static final long PROPERTY_COMPACTION_INTERVAL_DEFAULT = 60000L;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -815,15 +815,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
 
         // Resolve the post-Phase-C cache warmup byte budget (issue #322) and
-        // the async/sync warmup mode (issue #472). Resolved here — outside
-        // the storage-type branch — so that engine instances driving an
-        // in-memory or local-file store (test paths, plus operators using
-        // the in-memory mode for diagnostics) honour the same configuration
-        // as the production remote-file path. The warmup is a no-op against
-        // an in-memory backing reader by design (the BFS reads complete
-        // without populating any remote cache); the test value of resolving
-        // it here is that the engine wires up the warmup executor and the
-        // warmup Future, which is what these tests verify.
+        // the async/sync warmup mode (issue #472), outside the storage-type
+        // if-branch so tests that inject a custom factory producing a
+        // PersistentVectorStore (with storage_type=memory) honour the same
+        // configuration as the production remote-file path. The production
+        // in-memory mode is unaffected because InMemoryVectorStore is
+        // filtered out by the `instanceof PersistentVectorStore` check in
+        // submitWarmupAsyncOrInline().
         // Priority: properties-file key > JVM system property > hard-coded default.
         long syspropWarmupBytes = Long.getLong(
                 IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
@@ -1737,7 +1735,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     /**
      * Awaits the most recently submitted async warmup {@link Future}, if any.
      * No-op when warmup is disabled, ran inline in sync mode, or has already
-     * completed.
+     * completed.  Same {@link ExecutionException} policy as
+     * {@link #forceCheckpointAndSaveWatermark()} on the in-flight
+     * checkpoint — log at FINE and return, since the warmup task itself
+     * already logs per-store failures at WARNING in
+     * {@link #runWarmupTask}.
      *
      * @param timeoutMs maximum time to wait, in milliseconds
      * @throws java.util.concurrent.TimeoutException if the warmup does not
@@ -1753,10 +1755,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         try {
             f.get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
-            // The warmup task itself caught any RuntimeException per-store;
-            // a propagating failure is unexpected. Log and rethrow as
-            // unchecked so the test fails clearly.
-            throw new RuntimeException("warmup task failed", e.getCause());
+            // Consistent with forceCheckpointAndSaveWatermark's handling of
+            // the in-flight checkpoint Future: the warmup task already
+            // logged per-store failures at WARNING, so we just note the
+            // root cause at FINE and let the test continue. Tests that
+            // need to inspect failure state should use
+            // getLastWarmupFutureForTest() and call get() directly.
+            LOGGER.log(Level.FINE, "Async warmup ended with failure", e.getCause());
         }
     }
 
@@ -2498,13 +2503,32 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      *
      * <p>In async mode this method snapshots the current persistent vector
      * stores, submits a single task to {@link #warmupExecutor}, stores the
-     * resulting Future in {@link #lastWarmupFuture}, and returns immediately.
-     * Concurrent submits are coalesced: if a previous warmup is still running
-     * the new submit is dropped (logged at FINE) and the next checkpoint
-     * trigger will queue a fresh warmup with the latest segment list. This
-     * prevents unbounded executor queueing under pathological scheduling
-     * while guaranteeing the system converges to "warm against the latest
-     * segment set".
+     * resulting Future in {@link #lastWarmupFuture} via
+     * {@link AtomicReference#compareAndSet} (so a future refactor that
+     * introduces concurrent callers does not silently leak a Future), and
+     * returns immediately.
+     *
+     * <p>Concurrent submits are coalesced: if a previous warmup is still
+     * running, the new submit is dropped (logged at FINE) and the next
+     * checkpoint trigger will queue a fresh warmup with the then-current
+     * segment list.  This prevents unbounded executor queueing while keeping
+     * the system converging to "warm against the latest segment set".
+     *
+     * <p><b>Quiet-system corner case:</b> if checkpoint <i>N+1</i> is
+     * coalesced away because warmup <i>N</i> is still running, the segments
+     * produced by checkpoint <i>N+1</i> are warmed only when checkpoint
+     * <i>N+2</i> fires. If no further checkpoint fires (e.g. ingestion
+     * stops, replicas catch up), those segments stay cold until the first
+     * organic ANN search hits them. This is acceptable because warmup is a
+     * best-effort latency optimization; the cache will be populated lazily
+     * by query traffic, exactly as it would have been without issue #322.
+     *
+     * <p><b>Threading contract:</b> in production this method is reachable
+     * only from {@link #checkpointAndSaveWatermark()}, which itself runs
+     * exclusively on the single-thread {@link #checkpointExecutor}. The
+     * {@link #lastWarmupFuture} CAS is therefore expected to succeed every
+     * time; the loop below logs+returns on a CAS miss as a defensive guard
+     * against a future refactor that introduces a concurrent caller.
      *
      * <p>In sync mode the warmup runs inline on the caller (typically the
      * {@code indexing-checkpoint} thread), preserving the original issue #322
@@ -2512,13 +2536,19 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      * primed.
      *
      * <p>Per-store {@link RuntimeException}s are caught and logged at WARNING
-     * so a single misbehaving store cannot abort the warmup of the others.
-     * (The store-level method already swallows IOException itself.)
+     * inside {@link #runWarmupTask} so a single misbehaving store cannot
+     * abort the warmup of the others.  (The store-level
+     * {@link PersistentVectorStore#warmUpBlockCache} already swallows
+     * {@link IOException} itself.)
      */
     private void submitWarmupAsyncOrInline() {
         if (warmupBytesPerSegment <= 0) {
             return;
         }
+        // Note: `warmupExecutor.isShutdown()` is racy with concurrent
+        // close() — the executor can transition between this read and the
+        // submit() below. The race is intentionally accepted: the
+        // RejectedExecutionException catch handles the late-loser case.
         if (warmupAsync && warmupExecutor != null && !warmupExecutor.isShutdown()) {
             // Snapshot the persistent stores at submit time so the executor
             // task does not race with concurrent map mutations (createIndex /
@@ -2546,7 +2576,17 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             final long bytesPerSegment = this.warmupBytesPerSegment;
             try {
                 Future<?> f = warmupExecutor.submit(() -> runWarmupTask(snapshot, bytesPerSegment));
-                lastWarmupFuture.set(f);
+                // CAS rather than plain set: today the threading contract
+                // (single-thread checkpointExecutor) guarantees that the
+                // observed `prev` is still current here, but a concurrent
+                // caller introduced by a future refactor would otherwise
+                // silently leak a Future. On CAS failure cancel `f` to
+                // avoid leaking the executor task and log at FINE.
+                if (!lastWarmupFuture.compareAndSet(prev, f)) {
+                    f.cancel(false);
+                    LOGGER.log(Level.FINE,
+                            "Warmup submit raced with another caller; cancelling new task");
+                }
             } catch (java.util.concurrent.RejectedExecutionException e) {
                 // Executor was shut down concurrently with this submit —
                 // accept the race and skip the warmup.
@@ -4295,6 +4335,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 Thread.currentThread().interrupt();
             }
             warmupExecutor = null;
+            // If a BFS read inside the warmup task is in a non-interruptible
+            // state (e.g. blocked in a Channel that ignores Thread.interrupt),
+            // the daemon thread may outlive close(). That is safe: the thread
+            // is daemon (cannot block JVM exit), the snapshot list it captured
+            // is dropped on the next GC, and the warmup is best-effort.
             lastWarmupFuture.set(null);
             LOGGER.info("Warmup executor shut down");
         }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -68,6 +68,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -345,6 +346,40 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      */
     private long warmupBytesPerSegment;
 
+    /**
+     * Whether the post-Phase-C warmup runs on a dedicated executor
+     * ({@code true}) or inline on {@link #checkpointExecutor} ({@code false}).
+     * Resolved at {@link #start()} from
+     * {@link IndexingServerConfiguration#PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC}
+     * with the JVM system property
+     * {@link IndexingServerConfiguration#SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC}
+     * as fallback (issue #472).
+     */
+    private boolean warmupAsync;
+
+    /**
+     * Single-thread executor that runs the post-Phase-C BFS warmup off the
+     * {@link #checkpointExecutor} thread (issue #472). The warmup reads the
+     * entry-point neighbourhood of every segment via the same
+     * {@link herddb.remote.SegmentBlockCache} that search queries use; running
+     * it inline on the checkpoint thread blocks both the next checkpoint and
+     * the watermark snapshot publication for the duration of the BFS (~3 s
+     * for 21 × 33 MiB segments in the gist1m bench profile of issue #472).
+     *
+     * <p>Owned by the engine — created in {@link #start()} when warmup is
+     * enabled in async mode and shut down in {@link #close()}. {@code null}
+     * when warmup is disabled or running in synchronous mode.
+     */
+    private ExecutorService warmupExecutor;
+
+    /**
+     * Tracks the most recently submitted warmup task. Used to coalesce
+     * concurrent submits (skip a new submit if the previous warmup is still
+     * running) and to let {@link #forceCheckpointAndSaveWatermark()} await
+     * completion so test post-conditions still hold (issue #472).
+     */
+    private final AtomicReference<Future<?>> lastWarmupFuture = new AtomicReference<>();
+
     private ExecutorService[] applyWorkers;
     private int applyParallelism;
     private volatile Throwable asyncError;
@@ -513,6 +548,27 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             }
         }
         checkpointAndSaveWatermark();
+        // The synchronous checkpoint may have queued an async warmup
+        // (issue #472). Wait for it to complete so that the caller's
+        // post-condition — "after this returns, the cache has been warmed
+        // and bytes have been read through the storage manager" — still
+        // holds for tests written before async warmup existed. Production
+        // code does not call forceCheckpointAndSaveWatermark; it goes
+        // through triggerCheckpointAsync instead, which is unaffected.
+        Future<?> warmup = lastWarmupFuture.get();
+        if (warmup != null) {
+            try {
+                warmup.get(60, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOGGER.log(Level.WARNING, "Interrupted awaiting warmup in forceCheckpointAndSaveWatermark");
+            } catch (ExecutionException e) {
+                LOGGER.log(Level.FINE, "Async warmup ended with failure", e.getCause());
+            } catch (java.util.concurrent.TimeoutException e) {
+                LOGGER.log(Level.WARNING,
+                        "Async warmup did not complete within 60 s in forceCheckpointAndSaveWatermark");
+            }
+        }
     }
 
     public void setVectorStoreFactory(VectorStoreFactory factory) {
@@ -705,19 +761,6 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         .registerMetrics(this.statsLogger.scope("remote_file_client"));
             }
 
-            // Resolve the post-Phase-C cache warmup byte budget (issue #322).
-            // Priority: properties-file key > JVM system property > hard-coded default.
-            long syspropWarmupBytes = Long.getLong(
-                    IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
-                    IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES_DEFAULT);
-            this.warmupBytesPerSegment = config.getLong(
-                    IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
-                    syspropWarmupBytes);
-            LOGGER.log(Level.INFO,
-                    "vector index segmentCacheWarmupBytes: {0} ({1})",
-                    new Object[]{warmupBytesPerSegment,
-                            warmupBytesPerSegment > 0 ? "enabled" : "disabled"});
-
             final long vectorMemLimit = maxVectorMemoryBytes;
             final VectorMemoryBudget budget = this;
             final long finalSegmentPageCacheMaxBytes = segmentPageCacheMaxBytes;
@@ -771,6 +814,37 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             LOGGER.info("Using InMemoryVectorStore factory (storage type: " + storageType + ")");
         }
 
+        // Resolve the post-Phase-C cache warmup byte budget (issue #322) and
+        // the async/sync warmup mode (issue #472). Resolved here — outside
+        // the storage-type branch — so that engine instances driving an
+        // in-memory or local-file store (test paths, plus operators using
+        // the in-memory mode for diagnostics) honour the same configuration
+        // as the production remote-file path. The warmup is a no-op against
+        // an in-memory backing reader by design (the BFS reads complete
+        // without populating any remote cache); the test value of resolving
+        // it here is that the engine wires up the warmup executor and the
+        // warmup Future, which is what these tests verify.
+        // Priority: properties-file key > JVM system property > hard-coded default.
+        long syspropWarmupBytes = Long.getLong(
+                IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
+                IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES_DEFAULT);
+        this.warmupBytesPerSegment = config.getLong(
+                IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
+                syspropWarmupBytes);
+        String syspropWarmupAsync = System.getProperty(
+                IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC);
+        boolean defaultWarmupAsync = syspropWarmupAsync != null
+                ? Boolean.parseBoolean(syspropWarmupAsync)
+                : IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC_DEFAULT;
+        this.warmupAsync = config.getBoolean(
+                IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC,
+                defaultWarmupAsync);
+        LOGGER.log(Level.INFO,
+                "vector index segmentCacheWarmupBytes: {0} ({1}, mode={2})",
+                new Object[]{warmupBytesPerSegment,
+                        warmupBytesPerSegment > 0 ? "enabled" : "disabled",
+                        warmupAsync ? "async" : "sync"});
+
         // Initialize components (watermark store is loaded later, after the
         // tablespace UUID is resolved, because a remote-backed watermark store
         // addresses its S3 object by tablespace UUID).
@@ -818,6 +892,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             t.setDaemon(true);
             return t;
         });
+
+        // Single-thread executor that runs the post-Phase-C BFS warmup off the
+        // checkpointExecutor thread (issue #472). Created only when warmup is
+        // enabled AND in async mode, so a sync-mode engine pays no executor
+        // cost. The warmup thread is daemon so it never blocks JVM exit; on
+        // close() it is shut down with a bounded awaitTermination, then
+        // shutdownNow.
+        if (warmupBytesPerSegment > 0 && warmupAsync) {
+            warmupExecutor = Executors.newSingleThreadExecutor(r -> {
+                FastThreadLocalThread t = new FastThreadLocalThread(r, "indexing-warmup");
+                t.setDaemon(true);
+                return t;
+            });
+        }
 
         // Validate instance identity. The bootstrap numInstances is a lower
         // bound on the engine's identity range; the running value may grow
@@ -1636,6 +1724,43 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     }
 
     /**
+     * Returns the most recently submitted async warmup {@link Future}, or
+     * {@code null} if no warmup has been submitted yet OR warmup was last run
+     * inline in sync mode (used by tests to verify async dispatch and
+     * coalescing — see {@code BlockCacheWarmupAsyncTest}).
+     */
+    // package-private for testing
+    Future<?> getLastWarmupFutureForTest() {
+        return lastWarmupFuture.get();
+    }
+
+    /**
+     * Awaits the most recently submitted async warmup {@link Future}, if any.
+     * No-op when warmup is disabled, ran inline in sync mode, or has already
+     * completed.
+     *
+     * @param timeoutMs maximum time to wait, in milliseconds
+     * @throws java.util.concurrent.TimeoutException if the warmup does not
+     *         complete within {@code timeoutMs}
+     */
+    // package-private for testing
+    void awaitPendingWarmupForTest(long timeoutMs)
+            throws InterruptedException, java.util.concurrent.TimeoutException {
+        Future<?> f = lastWarmupFuture.get();
+        if (f == null) {
+            return;
+        }
+        try {
+            f.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            // The warmup task itself caught any RuntimeException per-store;
+            // a propagating failure is unexpected. Log and rethrow as
+            // unchecked so the test fails clearly.
+            throw new RuntimeException("warmup task failed", e.getCause());
+        }
+    }
+
+    /**
      * Sets the "last processed LSN" that
      * {@link #checkpointAndSaveWatermark()} will capture and persist. Used
      * by tests that drive the engine via
@@ -2275,14 +2400,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             // so the first query batch finds hot cache blocks rather than
             // issuing cold gRPC streaming reads against the file server.
             // Warmup is best-effort — failures are logged and never abort the
-            // watermark save.  A warmupBytesPerSegment of 0 disables this.
-            if (warmupBytesPerSegment > 0) {
-                for (AbstractVectorStore store : vectorStores.values()) {
-                    if (store instanceof PersistentVectorStore) {
-                        ((PersistentVectorStore) store).warmUpBlockCache(warmupBytesPerSegment);
-                    }
-                }
-            }
+            // watermark save. A warmupBytesPerSegment of 0 disables this.
+            //
+            // In async mode (default since issue #472) the warmup runs on
+            // {@link #warmupExecutor} and the watermark snapshot is published
+            // immediately below. In sync mode the warmup runs inline here,
+            // preserving the original issue #322 behaviour.
+            submitWarmupAsyncOrInline();
             // Only now — all stores have durably persisted state covering
             // checkpointLsn — is it safe to publish the watermark snapshot.
             // We capture the engine's current numInstances together with the
@@ -2363,6 +2487,132 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             publishCheckpointStateBestEffort(checkpointLsn, checkpointEntryTimestamp);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "checkpointAndSaveWatermark failed", e);
+        }
+    }
+
+    /**
+     * Runs the post-Phase-C BFS warmup (issue #322) either on a dedicated
+     * executor (async, default since issue #472) or inline on the calling
+     * thread (sync, opt-in via
+     * {@link IndexingServerConfiguration#PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC}).
+     *
+     * <p>In async mode this method snapshots the current persistent vector
+     * stores, submits a single task to {@link #warmupExecutor}, stores the
+     * resulting Future in {@link #lastWarmupFuture}, and returns immediately.
+     * Concurrent submits are coalesced: if a previous warmup is still running
+     * the new submit is dropped (logged at FINE) and the next checkpoint
+     * trigger will queue a fresh warmup with the latest segment list. This
+     * prevents unbounded executor queueing under pathological scheduling
+     * while guaranteeing the system converges to "warm against the latest
+     * segment set".
+     *
+     * <p>In sync mode the warmup runs inline on the caller (typically the
+     * {@code indexing-checkpoint} thread), preserving the original issue #322
+     * behaviour where the watermark snapshot is held back until the cache is
+     * primed.
+     *
+     * <p>Per-store {@link RuntimeException}s are caught and logged at WARNING
+     * so a single misbehaving store cannot abort the warmup of the others.
+     * (The store-level method already swallows IOException itself.)
+     */
+    private void submitWarmupAsyncOrInline() {
+        if (warmupBytesPerSegment <= 0) {
+            return;
+        }
+        if (warmupAsync && warmupExecutor != null && !warmupExecutor.isShutdown()) {
+            // Snapshot the persistent stores at submit time so the executor
+            // task does not race with concurrent map mutations (createIndex /
+            // dropIndex). The snapshot is a defensive copy of references —
+            // if a store is closed concurrently, the per-store catch below
+            // logs and continues.
+            final List<PersistentVectorStore> snapshot = new ArrayList<>();
+            for (AbstractVectorStore store : vectorStores.values()) {
+                if (store instanceof PersistentVectorStore) {
+                    snapshot.add((PersistentVectorStore) store);
+                }
+            }
+            if (snapshot.isEmpty()) {
+                return;
+            }
+            // Coalesce: if a previous warmup is still in progress, drop this
+            // submit. The next checkpoint will trigger a fresh warmup against
+            // the then-current segment list.
+            Future<?> prev = lastWarmupFuture.get();
+            if (prev != null && !prev.isDone()) {
+                LOGGER.log(Level.FINE,
+                        "Skipping warmup submit: previous warmup still in progress");
+                return;
+            }
+            final long bytesPerSegment = this.warmupBytesPerSegment;
+            try {
+                Future<?> f = warmupExecutor.submit(() -> runWarmupTask(snapshot, bytesPerSegment));
+                lastWarmupFuture.set(f);
+            } catch (java.util.concurrent.RejectedExecutionException e) {
+                // Executor was shut down concurrently with this submit —
+                // accept the race and skip the warmup.
+                LOGGER.log(Level.FINE,
+                        "Warmup executor rejected task (likely concurrent shutdown)");
+            }
+        } else {
+            // Sync mode (or async disabled at runtime): run inline.
+            for (AbstractVectorStore store : vectorStores.values()) {
+                if (store instanceof PersistentVectorStore) {
+                    ((PersistentVectorStore) store).warmUpBlockCache(warmupBytesPerSegment);
+                }
+            }
+        }
+    }
+
+    /**
+     * Test-only hook executed at the very start of the async warmup task,
+     * before any segment is touched. {@code null} (the default) means no-op.
+     * Tests use this to pause the warmup deterministically (e.g. {@code
+     * latch.await()}) so they can observe the in-flight state without
+     * interfering with the unrelated Phase A / B / C reads of the checkpoint.
+     */
+    private volatile Runnable warmupPauseHookForTest = null;
+
+    /**
+     * Installs (or clears) the test-only warmup pause hook. Package-private:
+     * production code never calls this. The hook fires on the
+     * {@code indexing-warmup} thread before the per-store BFS loop starts.
+     */
+    // package-private for testing
+    void setWarmupPauseHookForTest(Runnable hook) {
+        this.warmupPauseHookForTest = hook;
+    }
+
+    /**
+     * Body of the async warmup task: iterates the snapshot of persistent
+     * stores and calls {@link PersistentVectorStore#warmUpBlockCache} on each.
+     * Per-store {@link RuntimeException}s are caught so a single store's
+     * failure cannot prevent the others from warming.
+     */
+    private void runWarmupTask(List<PersistentVectorStore> snapshot, long bytesPerSegment) {
+        Runnable hook = warmupPauseHookForTest;
+        if (hook != null) {
+            try {
+                hook.run();
+            } catch (RuntimeException e) {
+                // Test hook misbehaved — log and continue. Production never
+                // installs a hook so this catch is purely defensive against
+                // a misuse in tests.
+                LOGGER.log(Level.WARNING, "warmupPauseHookForTest threw; continuing", e);
+            }
+        }
+        for (PersistentVectorStore store : snapshot) {
+            try {
+                store.warmUpBlockCache(bytesPerSegment);
+            } catch (RuntimeException e) {
+                // Catch RuntimeException narrowly: warmUpBlockCache itself
+                // already handles IOException internally; the only way
+                // RuntimeException propagates here is from a store closed
+                // concurrently or another unexpected programming error.
+                // Log and continue with the next store so a single bad store
+                // does not break warmup for the others.
+                LOGGER.log(Level.WARNING,
+                        "Async warmUpBlockCache failed for one store; continuing with others", e);
+            }
         }
     }
 
@@ -4024,6 +4274,29 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             // AbstractVectorStore instances) are eligible for GC.
             pendingDropTasks.clear();
             LOGGER.info("Checkpoint executor shut down");
+        }
+
+        // Shut down the warmup executor AFTER the checkpoint executor
+        // (issue #472) so the final synchronous checkpoint above could still
+        // queue a warmup. The warmup is best-effort and never holds invariants
+        // — we wait briefly for an in-flight warmup to finish, then force
+        // shutdownNow. The thread is daemon so it never blocks JVM exit even
+        // if shutdownNow is interrupted.
+        if (warmupExecutor != null) {
+            warmupExecutor.shutdown();
+            try {
+                if (!warmupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    LOGGER.log(Level.FINE,
+                            "In-flight warmup did not complete within 5s of shutdown; forcing shutdownNow");
+                    warmupExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                warmupExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+            warmupExecutor = null;
+            lastWarmupFuture.set(null);
+            LOGGER.info("Warmup executor shut down");
         }
 
         // Drain and shut down apply workers

--- a/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupAsyncTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupAsyncTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import herddb.codec.RecordSerializer;
@@ -545,12 +546,13 @@ public class BlockCacheWarmupAsyncTest {
             // before — the second submit was dropped because the previous
             // warmup was still running.
             Future<?> stillFirstWarmup = te.engine.getLastWarmupFutureForTest();
-            assertTrue("second checkpoint must not pile up a new warmup while one is in progress",
-                    stillFirstWarmup == firstWarmup);
+            assertSame(
+                    "second checkpoint must not pile up a new warmup while one is in progress",
+                    firstWarmup, stillFirstWarmup);
 
             // Release the hook; the in-flight warmup now completes.
             hookRelease.countDown();
-            firstWarmup.get(30, TimeUnit.SECONDS);
+            te.engine.awaitPendingWarmupForTest(30_000);
             assertTrue("first warmup must have completed after hook release",
                     firstWarmup.isDone());
 
@@ -659,7 +661,7 @@ public class BlockCacheWarmupAsyncTest {
             // Release the hook; the warmup completes normally and reads
             // bytes through the storage manager.
             hookRelease.countDown();
-            warmup.get(30, TimeUnit.SECONDS);
+            te.engine.awaitPendingWarmupForTest(30_000);
             assertTrue("warmup must have read bytes after release",
                     te.dsm.totalBytesRead.get() > 0);
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupAsyncTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupAsyncTest.java
@@ -1,0 +1,737 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.codec.RecordSerializer;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.storage.DataStorageManagerException;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for the asynchronous post-Phase-C block-cache warmup introduced by
+ * issue #472.
+ *
+ * <p>Issue #322 added a synchronous warmup that holds the
+ * {@code indexing-checkpoint} thread until the entry-point neighbourhood of
+ * every segment has been BFS-walked (~3 s for 21 × 33 MiB segments in the
+ * gist1m k3s-bench profile). Issue #472 moves that warmup onto a dedicated
+ * {@code indexing-warmup} executor so the watermark snapshot is published
+ * immediately and the next checkpoint cycle is not blocked.
+ *
+ * <p>The tests in this class verify:
+ * <ol>
+ *   <li>Async mode (default): the engine submits the warmup to a separate
+ *       executor and returns a non-null {@link Future}; the warmup completes
+ *       and reads bytes.</li>
+ *   <li>Sync mode (opt-in): the warmup runs inline on the calling thread and
+ *       no async {@link Future} is published — backward-compatibility with
+ *       the original issue #322 behaviour.</li>
+ *   <li>Coalescing: while a warmup is in flight a second submit is dropped,
+ *       preventing unbounded executor queueing.</li>
+ *   <li>Shutdown: an in-flight warmup does not prevent {@link
+ *       IndexingServiceEngine#close()} from returning within a sane bound.</li>
+ *   <li>Non-blocking ordering: with a slow data-storage manager the watermark
+ *       is saved <em>before</em> the warmup future completes, proving the
+ *       checkpoint thread is not blocked on the warmup.</li>
+ *   <li>System-property fallback: the JVM property
+ *       {@link IndexingServerConfiguration#SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC}
+ *       is honoured when the properties-file key is absent.</li>
+ * </ol>
+ *
+ * @see BlockCacheWarmupTest existing tests for the warmup byte-budget logic
+ *      and the per-segment BFS, which are unchanged by issue #472.
+ */
+public class BlockCacheWarmupAsyncTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private int savedMinLive;
+
+    @Before
+    public void lowerMinLiveGate() {
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        // Allow checkpoints to run even with a small vector batch.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreMinLiveGate() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers (intentionally duplicated from BlockCacheWarmupTest — keeping
+    // this test self-contained so it can be run in isolation without the
+    // other warmup tests being on the classpath).
+    // -------------------------------------------------------------------------
+
+    /** In-memory watermark store that records every {@code save()} call. */
+    private static final class RecordingWatermarkStore implements WatermarkStore {
+
+        private final AtomicReference<WatermarkSnapshot> saved = new AtomicReference<>();
+        private int saveCount;
+
+        @Override
+        public synchronized WatermarkSnapshot load() {
+            WatermarkSnapshot v = saved.get();
+            return v != null ? v : WatermarkSnapshot.START_OF_TIME;
+        }
+
+        @Override
+        public synchronized void save(WatermarkSnapshot snapshot) throws IOException {
+            saved.set(snapshot);
+            saveCount++;
+        }
+
+        synchronized int getSaveCount() {
+            return saveCount;
+        }
+    }
+
+    private static float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private static Table buildTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private static MemoryMetadataStorageManager createTestMetadata() throws Exception {
+        MemoryMetadataStorageManager m = new MemoryMetadataStorageManager();
+        m.start();
+        m.ensureDefaultTableSpace("local", "local", 0, 1);
+        return m;
+    }
+
+    /**
+     * A {@link MemoryDataStorageManager} that wraps every
+     * {@link ReaderSupplier} in a counting + optionally-blocking shim so
+     * tests can both observe how many bytes were read and gate the warmup on
+     * a {@link CountDownLatch}.
+     */
+    private static final class ControllableMemoryDataStorageManager extends MemoryDataStorageManager {
+
+        final AtomicLong totalBytesRead = new AtomicLong();
+        /** Sleeps this many ms before each read when {@code slowReads} is on. */
+        final AtomicLong perReadDelayMs = new AtomicLong(0);
+        /**
+         * If non-null, every read awaits this latch BEFORE issuing the
+         * underlying read. Tests use this to "freeze" the warmup so they can
+         * observe interim state (watermark already saved while warmup
+         * remains in flight).
+         */
+        volatile CountDownLatch readGate = null;
+
+        @Override
+        public ReaderSupplier multipartIndexReaderSupplier(
+                String tableSpace, String uuid, String fileType, long fileSize)
+                throws DataStorageManagerException {
+            ReaderSupplier original = super.multipartIndexReaderSupplier(
+                    tableSpace, uuid, fileType, fileSize);
+            return new CountingReaderSupplier(original, this);
+        }
+    }
+
+    private static final class CountingReaderSupplier implements ReaderSupplier {
+
+        private final ReaderSupplier delegate;
+        private final ControllableMemoryDataStorageManager owner;
+
+        CountingReaderSupplier(ReaderSupplier delegate, ControllableMemoryDataStorageManager owner) {
+            this.delegate = delegate;
+            this.owner = owner;
+        }
+
+        @Override
+        public RandomAccessReader get() throws IOException {
+            return new CountingReader(delegate.get(), owner);
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+
+    private static final class CountingReader implements RandomAccessReader {
+
+        private final RandomAccessReader delegate;
+        private final ControllableMemoryDataStorageManager owner;
+
+        CountingReader(RandomAccessReader delegate, ControllableMemoryDataStorageManager owner) {
+            this.delegate = delegate;
+            this.owner = owner;
+        }
+
+        private void preReadGateAndDelay() throws IOException {
+            CountDownLatch gate = owner.readGate;
+            if (gate != null) {
+                try {
+                    if (!gate.await(60, TimeUnit.SECONDS)) {
+                        throw new IOException("read gate timed out");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("interrupted at read gate", e);
+                }
+            }
+            long delayMs = owner.perReadDelayMs.get();
+            if (delayMs > 0) {
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("interrupted in slow read", e);
+                }
+            }
+        }
+
+        @Override
+        public void readFully(byte[] dest) throws IOException {
+            preReadGateAndDelay();
+            delegate.readFully(dest);
+            owner.totalBytesRead.addAndGet(dest.length);
+        }
+
+        @Override
+        public void readFully(ByteBuffer buffer) throws IOException {
+            preReadGateAndDelay();
+            int before = buffer.remaining();
+            delegate.readFully(buffer);
+            owner.totalBytesRead.addAndGet((long) (before - buffer.remaining()));
+        }
+
+        @Override
+        public void readFully(long[] longs) throws IOException {
+            preReadGateAndDelay();
+            delegate.readFully(longs);
+            owner.totalBytesRead.addAndGet((long) longs.length * Long.BYTES);
+        }
+
+        @Override
+        public void read(int[] ints, int offset, int count) throws IOException {
+            preReadGateAndDelay();
+            delegate.read(ints, offset, count);
+            owner.totalBytesRead.addAndGet((long) count * Integer.BYTES);
+        }
+
+        @Override
+        public void read(float[] floats, int offset, int count) throws IOException {
+            preReadGateAndDelay();
+            delegate.read(floats, offset, count);
+            owner.totalBytesRead.addAndGet((long) count * Float.BYTES);
+        }
+
+        @Override
+        public void seek(long offset) throws IOException {
+            delegate.seek(offset);
+        }
+
+        @Override
+        public long getPosition() throws IOException {
+            return delegate.getPosition();
+        }
+
+        @Override
+        public int readInt() throws IOException {
+            preReadGateAndDelay();
+            int v = delegate.readInt();
+            owner.totalBytesRead.addAndGet(Integer.BYTES);
+            return v;
+        }
+
+        @Override
+        public float readFloat() throws IOException {
+            preReadGateAndDelay();
+            float v = delegate.readFloat();
+            owner.totalBytesRead.addAndGet(Float.BYTES);
+            return v;
+        }
+
+        @Override
+        public long readLong() throws IOException {
+            preReadGateAndDelay();
+            long v = delegate.readLong();
+            owner.totalBytesRead.addAndGet(Long.BYTES);
+            return v;
+        }
+
+        @Override
+        public long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+
+    /**
+     * Builds a configured {@link IndexingServiceEngine} ready for the
+     * checkpoint-and-warmup flow.
+     *
+     * @param props pre-populated properties (storage type, warmup byte
+     *     budget, async mode flag) — the helper adds nothing more
+     */
+    private TestEngine newEngine(Properties props) throws Exception {
+        Path logDir = folder.newFolder().toPath();
+        Path dataDir = folder.newFolder().toPath();
+
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, config);
+        engine.setMetadataStorageManager(createTestMetadata());
+
+        RecordingWatermarkStore watermark = new RecordingWatermarkStore();
+        engine.setWatermarkStore(watermark);
+
+        ControllableMemoryDataStorageManager dsm = new ControllableMemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        AtomicReference<PersistentVectorStore> storeRef = new AtomicReference<>();
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName, dataDirectory, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, "tstblspace", vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            storeRef.set(pvs);
+            return pvs;
+        });
+
+        return new TestEngine(engine, dsm, watermark, storeRef);
+    }
+
+    /** Bundle of references the tests need from a built engine. */
+    private static final class TestEngine implements AutoCloseable {
+
+        final IndexingServiceEngine engine;
+        final ControllableMemoryDataStorageManager dsm;
+        final RecordingWatermarkStore watermark;
+        final AtomicReference<PersistentVectorStore> storeRef;
+
+        TestEngine(IndexingServiceEngine engine,
+                   ControllableMemoryDataStorageManager dsm,
+                   RecordingWatermarkStore watermark,
+                   AtomicReference<PersistentVectorStore> storeRef) {
+            this.engine = engine;
+            this.dsm = dsm;
+            this.watermark = watermark;
+            this.storeRef = storeRef;
+        }
+
+        @Override
+        public void close() throws Exception {
+            engine.close();
+        }
+    }
+
+    /**
+     * Brings the engine to the point where it has 1 PersistentVectorStore
+     * containing 512 random vectors (one FusedPQ-eligible segment after the
+     * upcoming checkpoint).
+     */
+    private LogSequenceNumber bootstrapWithVectors(TestEngine te, long seed) throws Exception {
+        te.engine.start();
+        Table table = buildTable();
+        te.engine.applyEntry(new LogSequenceNumber(1, 1),
+                LogEntryFactory.createTable(table, null));
+        Index index = Index.builder()
+                .name("vidx")
+                .table("vectable")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+        te.engine.applyEntry(new LogSequenceNumber(1, 2),
+                LogEntryFactory.createIndex(index, null));
+        assertNotNull("store must have been created by DDL", te.storeRef.get());
+
+        Random rng = new Random(seed);
+        int dim = 32;
+        long baseLsn = 100;
+        LogSequenceNumber lastLsn = null;
+        for (int i = 0; i < 512; i++) {
+            Record record = RecordSerializer.makeRecord(table,
+                    "pk", "k" + i,
+                    "vec", randomVector(rng, dim));
+            LogEntry insert = LogEntryFactory.insert(table, record.key, record.value, null);
+            lastLsn = new LogSequenceNumber(1, baseLsn + i);
+            te.engine.applySingleEntryForTest(lastLsn, insert);
+        }
+        te.engine.awaitPendingWorkForTest();
+        te.engine.setLastProcessedLsnForTest(lastLsn);
+        return lastLsn;
+    }
+
+    private Properties baseProps(boolean async, long warmupBytes) {
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
+                String.valueOf(warmupBytes));
+        props.setProperty(IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC,
+                String.valueOf(async));
+        return props;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Async mode (default): after a force-checkpoint a non-null warmup
+     * Future has been submitted, eventually completes, and bytes are read
+     * through the storage manager.
+     */
+    @Test
+    public void testAsyncWarmupSubmitsToSeparateExecutor() throws Exception {
+        try (TestEngine te = newEngine(baseProps(true, 32L * 1024 * 1024))) {
+            bootstrapWithVectors(te, 42);
+            te.dsm.totalBytesRead.set(0);
+
+            te.engine.forceCheckpointAndSaveWatermark();
+
+            assertEquals("watermark must be saved", 1, te.watermark.getSaveCount());
+            Future<?> warmup = te.engine.getLastWarmupFutureForTest();
+            assertNotNull("async mode must publish a warmup Future", warmup);
+            // forceCheckpointAndSaveWatermark awaits the warmup before
+            // returning, so the Future must already be done.
+            assertTrue("warmup must be done after forceCheckpointAndSaveWatermark",
+                    warmup.isDone());
+            assertTrue("warmup must have read bytes from the segment",
+                    te.dsm.totalBytesRead.get() > 0);
+        }
+    }
+
+    /**
+     * Sync mode (opt-in): after a force-checkpoint no async warmup Future is
+     * published — the warmup ran inline. Bytes are still read.
+     */
+    @Test
+    public void testSyncWarmupRunsInline() throws Exception {
+        try (TestEngine te = newEngine(baseProps(false, 32L * 1024 * 1024))) {
+            bootstrapWithVectors(te, 43);
+            te.dsm.totalBytesRead.set(0);
+
+            te.engine.forceCheckpointAndSaveWatermark();
+
+            assertEquals("watermark must be saved", 1, te.watermark.getSaveCount());
+            assertNull("sync mode must NOT publish a warmup Future",
+                    te.engine.getLastWarmupFutureForTest());
+            assertTrue("inline warmup must have read bytes from the segment",
+                    te.dsm.totalBytesRead.get() > 0);
+        }
+    }
+
+    /**
+     * Coalescing: while a warmup is paused at the test hook a second
+     * checkpoint trigger does NOT pile up a second Future on the executor —
+     * it sees the in-flight Future and skips the submit. Once the hook is
+     * released the in-flight warmup completes; the next checkpoint after
+     * that queues a fresh warmup with the latest segments.
+     *
+     * <p>Uses {@link IndexingServiceEngine#setWarmupPauseHookForTest} rather
+     * than the read-gate so that Phase A / B / C reads (which run on the
+     * checkpoint thread, not the warmup thread) are not blocked by the
+     * pause — only the warmup itself is.
+     */
+    @Test
+    public void testAsyncWarmupCoalescing() throws Exception {
+        try (TestEngine te = newEngine(baseProps(true, 32L * 1024 * 1024))) {
+            bootstrapWithVectors(te, 44);
+
+            // Hook installed BEFORE the first checkpoint trigger so the
+            // warmup task pauses at the very start of its run.
+            CountDownLatch hookRelease = new CountDownLatch(1);
+            te.engine.setWarmupPauseHookForTest(() -> {
+                try {
+                    if (!hookRelease.await(60, TimeUnit.SECONDS)) {
+                        throw new RuntimeException("warmup pause hook timed out");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            });
+
+            // First checkpoint: Phase A → B → C runs unhindered, then the
+            // warmup is dispatched and immediately blocks at the hook.
+            te.engine.triggerCheckpointAsyncForTest();
+
+            Future<?> firstCheckpoint = te.engine.getInflightCheckpointFutureForTest();
+            assertNotNull(firstCheckpoint);
+            firstCheckpoint.get(30, TimeUnit.SECONDS);
+            assertEquals("first checkpoint must have saved the watermark",
+                    1, te.watermark.getSaveCount());
+
+            Future<?> firstWarmup = waitForWarmupFuture(te, 5_000);
+            assertNotNull("first checkpoint must have submitted a warmup", firstWarmup);
+            assertFalse("warmup is paused at the test hook and must still be in progress",
+                    firstWarmup.isDone());
+
+            // While the first warmup is still paused, fire another checkpoint.
+            te.engine.triggerCheckpointAsyncForTest();
+            Future<?> secondCheckpoint = te.engine.getInflightCheckpointFutureForTest();
+            assertNotNull(secondCheckpoint);
+            secondCheckpoint.get(30, TimeUnit.SECONDS);
+
+            // Coalescing assertion: the warmup Future is the SAME instance as
+            // before — the second submit was dropped because the previous
+            // warmup was still running.
+            Future<?> stillFirstWarmup = te.engine.getLastWarmupFutureForTest();
+            assertTrue("second checkpoint must not pile up a new warmup while one is in progress",
+                    stillFirstWarmup == firstWarmup);
+
+            // Release the hook; the in-flight warmup now completes.
+            hookRelease.countDown();
+            firstWarmup.get(30, TimeUnit.SECONDS);
+            assertTrue("first warmup must have completed after hook release",
+                    firstWarmup.isDone());
+
+            // Clear the hook so subsequent submits run uninterrupted.
+            te.engine.setWarmupPauseHookForTest(null);
+        }
+    }
+
+    /**
+     * Shutdown: a paused-at-hook warmup does not prevent
+     * {@link IndexingServiceEngine#close()} from completing within a sane
+     * bound. The warmup executor is shut down cleanly via shutdownNow with
+     * a 5 s awaitTermination cap; the daemon thread is then interrupted and
+     * the close() returns.
+     */
+    @Test
+    public void testAsyncWarmupCloseDoesNotHang() throws Exception {
+        TestEngine te = newEngine(baseProps(true, 32L * 1024 * 1024));
+        boolean closed = false;
+        try {
+            bootstrapWithVectors(te, 45);
+
+            // Park the warmup indefinitely at the test hook. close() must
+            // interrupt the daemon thread within the bounded window.
+            CountDownLatch parkForever = new CountDownLatch(1);
+            te.engine.setWarmupPauseHookForTest(() -> {
+                try {
+                    // Wait essentially forever; close() will interrupt this
+                    // thread, propagating an InterruptedException that the
+                    // hook converts to RuntimeException — which the engine
+                    // catches and logs at WARNING.
+                    parkForever.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            });
+
+            te.engine.triggerCheckpointAsyncForTest();
+            // Wait until the warmup has been submitted (so close() actually
+            // exercises the in-flight-shutdown path).
+            assertNotNull(waitForWarmupFuture(te, 10_000));
+
+            long t0 = System.currentTimeMillis();
+            te.engine.close();
+            closed = true;
+            long elapsed = System.currentTimeMillis() - t0;
+            // 30 s for the checkpoint executor + 5 s for the warmup executor
+            // + a generous safety margin.
+            assertTrue("engine.close() must complete in a bounded time, got " + elapsed + " ms",
+                    elapsed < 45_000);
+            // Sanity: cancellation flag gets set so the parked hook unblocks
+            // (the daemon thread itself is gone after close() anyway).
+            parkForever.countDown();
+        } finally {
+            if (!closed) {
+                te.engine.close();
+            }
+        }
+    }
+
+    /**
+     * Non-blocking ordering: with the warmup paused at the test hook, the
+     * checkpoint Future completes (and the watermark is saved) while the
+     * warmup is still in flight. Proves that the checkpoint thread is
+     * decoupled from the warmup — the whole point of issue #472.
+     */
+    @Test
+    public void testAsyncWarmupDoesNotBlockWatermarkSave() throws Exception {
+        try (TestEngine te = newEngine(baseProps(true, 32L * 1024 * 1024))) {
+            bootstrapWithVectors(te, 46);
+
+            // Pause the warmup at its very first instruction. Phase A / B / C
+            // run unhindered (they execute on the checkpoint thread, not the
+            // warmup thread).
+            CountDownLatch hookRelease = new CountDownLatch(1);
+            te.engine.setWarmupPauseHookForTest(() -> {
+                try {
+                    if (!hookRelease.await(60, TimeUnit.SECONDS)) {
+                        throw new RuntimeException("warmup pause hook timed out");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            });
+
+            te.engine.triggerCheckpointAsyncForTest();
+            Future<?> checkpoint = te.engine.getInflightCheckpointFutureForTest();
+            assertNotNull(checkpoint);
+            // The checkpoint Future returns once the watermark is saved
+            // (and the async warmup has been dispatched but is paused).
+            checkpoint.get(30, TimeUnit.SECONDS);
+
+            assertEquals("watermark must be saved as soon as checkpoint Future returns",
+                    1, te.watermark.getSaveCount());
+
+            Future<?> warmup = waitForWarmupFuture(te, 5_000);
+            assertNotNull("warmup must have been submitted", warmup);
+            // CRITICAL ASSERTION: the watermark is already saved (above) but
+            // the warmup is NOT done — proving the watermark save did not
+            // wait for the warmup to finish.
+            assertFalse("warmup must still be running while watermark is saved",
+                    warmup.isDone());
+
+            // Release the hook; the warmup completes normally and reads
+            // bytes through the storage manager.
+            hookRelease.countDown();
+            warmup.get(30, TimeUnit.SECONDS);
+            assertTrue("warmup must have read bytes after release",
+                    te.dsm.totalBytesRead.get() > 0);
+
+            te.engine.setWarmupPauseHookForTest(null);
+        }
+    }
+
+    /**
+     * The system property
+     * {@link IndexingServerConfiguration#SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC}
+     * is honoured as a default when the properties-file key is absent.
+     * Setting it to {@code false} via system property must run the warmup
+     * inline (no async Future published).
+     */
+    @Test
+    public void testSystemPropertyDisablesAsyncMode() throws Exception {
+        String originalValue = System.getProperty(
+                IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC);
+        try {
+            System.setProperty(
+                    IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC, "false");
+
+            // Build properties WITHOUT the async key so the engine falls
+            // back to the system property.
+            Properties props = new Properties();
+            props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+            props.setProperty(IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_BYTES,
+                    String.valueOf(32L * 1024 * 1024));
+            // Note: PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC intentionally absent.
+
+            try (TestEngine te = newEngine(props)) {
+                bootstrapWithVectors(te, 47);
+                te.dsm.totalBytesRead.set(0);
+                te.engine.forceCheckpointAndSaveWatermark();
+                assertEquals("watermark saved", 1, te.watermark.getSaveCount());
+                assertNull("system property forced sync mode — no async Future expected",
+                        te.engine.getLastWarmupFutureForTest());
+                assertTrue("inline warmup must have read bytes",
+                        te.dsm.totalBytesRead.get() > 0);
+            }
+        } finally {
+            if (originalValue == null) {
+                System.clearProperty(
+                        IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC);
+            } else {
+                System.setProperty(
+                        IndexingServerConfiguration.SYSPROP_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC,
+                        originalValue);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Polling helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Polls {@link IndexingServiceEngine#getLastWarmupFutureForTest()} until
+     * a non-null Future appears or {@code timeoutMs} elapses.
+     */
+    private static Future<?> waitForWarmupFuture(TestEngine te, long timeoutMs)
+            throws InterruptedException, TimeoutException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            Future<?> f = te.engine.getLastWarmupFutureForTest();
+            if (f != null) {
+                return f;
+            }
+            Thread.sleep(10);
+        }
+        fail("warmup Future never appeared within " + timeoutMs + " ms");
+        // unreachable
+        throw new TimeoutException();
+    }
+}


### PR DESCRIPTION
Fixes part of #472 — the **Block cache warm-up cost** point. The other
discussion points in #472 (redundant `deleteByPrefix` sweeps, Phase B /
search contention, k=10 vs k=100 latency, ingest-query round behaviour)
are out of scope for this PR.

## Why

The k3s-bench profile attached to #472 shows the post-Phase-C BFS warmup
running inline on the `indexing-checkpoint` thread — costing ~2.9 s per
cycle for 21 × 33 MiB segments — and blocking both the next checkpoint
trigger (single-thread executor) and the watermark snapshot publication
for that whole window.  At k=10 the warmup cost is non-trivial vs the
p50 query latency (4.5 s).

## What

- New daemon executor `indexing-warmup` dispatches the BFS warmup off
  the checkpoint thread.  The watermark is saved as soon as Phase C
  completes; the warmup runs in parallel with subsequent ANN searches.
- Concurrent submits are coalesced via a `CAS`-on-Future so unbounded
  executor queueing cannot happen — the next checkpoint trigger picks up
  the latest segment set.
- New config flag `indexing.vector.segmentCacheWarmupAsync` (default
  `true`, with `herddb.vectorindex.segmentCacheWarmupAsync` system-
  property fallback) lets operators fall back to the original synchronous
  behaviour from issue #322.
- `PersistentVectorStore.warmUpBlockCache` itself is unchanged — only
  the engine-level dispatch moves.
- The warmup config init is also moved out of the storage-type if-branch
  so memory-storage tests honour the same configuration as the
  production remote-file path.
- `forceCheckpointAndSaveWatermark()` (test-only entry point) awaits the
  async warmup before returning, so existing tests that assert
  "bytes-read > 0 after force-checkpoint" keep working without changes.

## Tests

`BlockCacheWarmupAsyncTest` (new) — six tests:
- `testAsyncWarmupSubmitsToSeparateExecutor` — async mode publishes a
  Future, completes, reads bytes.
- `testSyncWarmupRunsInline` — sync mode does not publish a Future; old
  inline behaviour is preserved.
- `testAsyncWarmupCoalescing` — second checkpoint trigger does not pile
  up a second warmup while the first is still running (uses the new
  `setWarmupPauseHookForTest` test seam).
- `testAsyncWarmupCloseDoesNotHang` — `close()` returns within a sane
  bound even with a parked warmup hook.
- `testAsyncWarmupDoesNotBlockWatermarkSave` — with the warmup paused at
  the test hook, the checkpoint Future completes and the watermark is
  saved BEFORE the warmup Future is done — proves the decoupling.
- `testSystemPropertyDisablesAsyncMode` — `-D` system-property fallback
  works when the properties-file key is absent.

Existing `BlockCacheWarmupTest` continues to pass without changes
(6 tests).

## Test plan

- [x] `mvn -pl herddb-indexing-service -Dtest='BlockCacheWarmupAsyncTest,BlockCacheWarmupTest,CheckpointAndSaveWatermarkTest,IndexingServiceEngineDurableLsnTest,JoiningRestartTest,RestartUnreachableStartOfTimeTest,DropTableIndexCleanupRemoteFileTest' test` (28 tests, all green)
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` (full reactor green)
- [ ] CI green

🤖 Implemented by the `pr-worker` agent.