### PR TITLE
issue #484: implement SegmentMerger SPI, aggressive policy, event-driven scheduling

### DIFF
--- a/excludeFindBugsFilter.xml
+++ b/excludeFindBugsFilter.xml
@@ -71,4 +71,19 @@
         <Class name="herddb.vectortesting.VectorBench"/>
         <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
     </Match>
+    <!--
+      IndexOptimizerMain (issue #484): the scheduler / eventDebounceMs / tablespaceUuid
+      fields are written exactly once inside the synchronized start() and then read
+      from background threads (the ZK persistent-recursive watcher thread, the
+      single-threaded scheduler) without holding the IndexOptimizerMain monitor.
+      The pattern is safe lazy publication via volatile: start() registers the
+      ZK watch as the very last step, so the reader threads cannot observe the
+      fields before start() has finished initialising them. SpotBugs' percentage
+      heuristic flags the pattern anyway because shutdown() also writes these
+      fields under the monitor.
+    -->
+    <Match>
+        <Class name="herddb.indexing.optimizer.IndexOptimizerMain"/>
+        <Bug pattern="IS2_INCONSISTENT_SYNC"/>
+    </Match>
 </FindBugsFilter>

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -110,6 +110,21 @@ public final class RemoteSegmentGraphMerger {
     /** Block size used for streaming downloads via the multipart reader. */
     private static final int DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024;
 
+    /**
+     * Sanity caps for the input map-file header values. A corrupt or partially
+     * uploaded multipart file can carry garbage int32 values; we surface those
+     * as {@link IOException} rather than letting them coerce us into giant
+     * allocations or unbounded loops (review item B.2#3 from the first
+     * pr-reviewer pass).
+     *
+     * <p>{@code MAX_ENTRIES} matches the per-segment cap used by the in-IS
+     * compactor ({@code MAX_TOMBSTONED_ORDINALS = 1<<28}); a single segment
+     * never holds more vectors than that. {@code MAX_PK_LEN} bounds the
+     * per-entry primary-key length.
+     */
+    static final int MAX_ENTRIES_PER_MAP_FILE = 1 << 28;
+    static final int MAX_PK_LEN = 1 << 16;
+
     private static final VectorTypeSupport VTS =
             VectorizationProvider.getInstance().getVectorTypeSupport();
 
@@ -274,7 +289,7 @@ public final class RemoteSegmentGraphMerger {
                 Path mapFile = mapTempFiles.get(i);
                 BitSet tombstoneSet = buildTombstoneSet(in.tombstonedOrdinals);
                 long[] perInputCounters = new long[2]; // [tombstones, duplicates]
-                accumulateAuthority(in, mapFile, tombstoneSet, authority, perInputCounters);
+                accumulateAuthority(in, mapFile, tombstoneSet, authority, perInputCounters, dim);
                 droppedTombstones += perInputCounters[0];
                 droppedDuplicates += perInputCounters[1];
             }
@@ -420,9 +435,21 @@ public final class RemoteSegmentGraphMerger {
                     while (remaining > 0L) {
                         int toRead = (int) Math.min(buf.length, remaining);
                         byte[] chunk = (toRead == buf.length) ? buf : new byte[toRead];
-                        reader.readFully(chunk);
-                        bos.write(chunk, 0, toRead);
-                        remaining -= toRead;
+                        try {
+                            reader.readFully(chunk);
+                            bos.write(chunk, 0, toRead);
+                            remaining -= toRead;
+                        } catch (java.io.EOFException eof) {
+                            // The supplied {@code in.mapFileSize} may overestimate the
+                            // actual file size for legacy znodes whose
+                            // {@link SegmentMetadata#mapFileSize} field is unset (see
+                            // {@code RemoteSegmentMerger}'s mapFileSizeHint fallback).
+                            // Treat EOF on a too-large hint as "end of file" rather than
+                            // an error — the parser layer (accumulateAuthority) will fail
+                            // fast on a truncated entryCount/pkLen if the read was actually
+                            // short.
+                            break;
+                        }
                     }
                 }
             }
@@ -463,26 +490,50 @@ public final class RemoteSegmentGraphMerger {
      * inserts the surviving (pk, vector) into the authority map or — if
      * a same-PK entry from an earlier input had a higher generation —
      * counts it as a duplicate-drop.
+     *
+     * <p>Validates every {@code int} read from the file against
+     * {@link #MAX_ENTRIES_PER_MAP_FILE} / {@link #MAX_PK_LEN} / {@code dim}
+     * so a corrupt or partially-uploaded input cannot coerce the merger
+     * into a giant allocation or a corrupt graph (review items B.1#2 and
+     * B.2#3 from the first pr-reviewer pass).
      */
     private void accumulateAuthority(RemoteSegmentInput in, Path mapFile,
                                      BitSet tombstoneSet,
                                      Map<Bytes, AuthorityEntry> authority,
-                                     long[] perInputCounters) throws IOException {
+                                     long[] perInputCounters,
+                                     int expectedDim) throws IOException {
         try (DataInputStream dis = new DataInputStream(
                 new BufferedInputStream(new FileInputStream(mapFile.toFile()),
                         DOWNLOAD_CHUNK_SIZE))) {
             int entryCount = dis.readInt();
+            if (entryCount < 0 || entryCount > MAX_ENTRIES_PER_MAP_FILE) {
+                throw new IOException("malformed map file " + mapFile
+                        + ": entryCount " + entryCount
+                        + " outside [0, " + MAX_ENTRIES_PER_MAP_FILE + "]");
+            }
             for (int i = 0; i < entryCount; i++) {
                 int ordinal = dis.readInt();
+                if (ordinal < 0) {
+                    throw new IOException("malformed map file " + mapFile
+                            + ": negative ordinal " + ordinal + " at entry " + i);
+                }
                 int pkLen = dis.readInt();
-                if (pkLen < 0) {
-                    throw new IOException("malformed map file " + mapFile + ": negative pkLen " + pkLen);
+                if (pkLen < 0 || pkLen > MAX_PK_LEN) {
+                    throw new IOException("malformed map file " + mapFile
+                            + ": pkLen " + pkLen + " outside [0, " + MAX_PK_LEN
+                            + "] at entry " + i);
                 }
                 byte[] pkBytes = new byte[pkLen];
                 dis.readFully(pkBytes);
                 int floatCount = dis.readInt();
-                if (floatCount < 0) {
-                    throw new IOException("malformed map file " + mapFile + ": negative floatCount " + floatCount);
+                if (floatCount != expectedDim) {
+                    // Dimension-mismatch: refuse to merge. Silently building a graph
+                    // with mismatched-dimension vectors would corrupt the InlineVectors
+                    // feature and tank recall on every search (review item B.1#2 from
+                    // the first pr-reviewer pass).
+                    throw new IOException("dimension mismatch in input " + mapFile
+                            + " (segment " + in.segmentUuid + "): expected " + expectedDim
+                            + ", got " + floatCount + " at entry " + i);
                 }
                 if (tombstoneSet.get(ordinal)) {
                     // Skip the floats; we still need to consume them to keep the stream aligned.

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -1,0 +1,662 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.index.vector;
+
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
+import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.quantization.PQVectors;
+import io.github.jbellis.jvector.quantization.ProductQuantization;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.IntFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Standalone graph-merge utility used by the index-optimizer service to combine
+ * a set of remote-stored {@code segmented-v2} vector segments into a single
+ * larger segment without going through {@link PersistentVectorStore}.
+ *
+ * <p>The optimizer pod has no in-memory {@link VectorSegment}s and no live
+ * {@code IndexingService}; all it has is the metadata znodes, a
+ * {@link DataStorageManager} pointing at remote storage, and a scratch
+ * directory. This class:
+ * <ol>
+ *   <li>Downloads each input's map file (which carries every {@code (ordinal,
+ *       pk, vector)} tuple as written by {@code writeFusedPQMapDataToTempFile}).</li>
+ *   <li>Drops every entry whose segment-local ordinal is in the supplied
+ *       tombstone bitset (the optimizer pre-loads each input's
+ *       {@code TombstoneOverlay} and hands the tombstoned-ordinal arrays in
+ *       through {@link RemoteSegmentInput#tombstonedOrdinals}).</li>
+ *   <li>De-duplicates surviving entries across segments by primary key,
+ *       preferring the one from the highest-generation source.</li>
+ *   <li>Builds a fresh {@code GraphIndexBuilder} over the surviving vectors,
+ *       writes a FusedPQ + InlineVectors {@code OnDiskGraphIndex}, and a
+ *       companion map file in the same wire format as
+ *       {@code writeFusedPQMapDataToTempFile}.</li>
+ *   <li>Uploads both files via {@link DataStorageManager#writeMultipartIndexFile}
+ *       under {@code multipartUuid = indexUuid + "_seg" + outputSegmentId}.</li>
+ * </ol>
+ *
+ * <p>The output is identical in every observable way to a segment produced
+ * by {@code PersistentVectorStore.writeShardAsFusedPQSegment} — same on-disk
+ * layout, same map-file format — so the indexing-service tier can load it
+ * with {@code OnDiskGraphIndex.load(...)} as it would any other segment.
+ *
+ * <p>This class is stateless and thread-hostile (every {@link #merge} call
+ * builds its own state and tears it down before returning). The caller is
+ * responsible for serialising calls if it really wants to.
+ */
+public final class RemoteSegmentGraphMerger {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoteSegmentGraphMerger.class.getName());
+
+    /**
+     * Mirror of the constant in {@code PersistentVectorStore}: shards smaller
+     * than this are written without FusedPQ (PQ training cost outweighs
+     * scoring benefit for tiny graphs, and the InlineVectors path covers
+     * search just fine). Kept at the same value for behavioural parity.
+     */
+    private static final int MIN_VECTORS_FOR_FUSED_PQ = 64 * 1024;
+
+    /** Block size used for streaming downloads via the multipart reader. */
+    private static final int DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024;
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private final DataStorageManager dataStorageManager;
+    private final Path tmpDirectory;
+    private final int graphM;
+    private final int beamWidth;
+    private final float neighborOverflow;
+    private final float alpha;
+    private final VectorSimilarityFunction similarity;
+
+    public RemoteSegmentGraphMerger(DataStorageManager dataStorageManager,
+                                    Path tmpDirectory,
+                                    int graphM,
+                                    int beamWidth,
+                                    float neighborOverflow,
+                                    float alpha,
+                                    VectorSimilarityFunction similarity) {
+        this.dataStorageManager = Objects.requireNonNull(dataStorageManager, "dataStorageManager");
+        this.tmpDirectory = Objects.requireNonNull(tmpDirectory, "tmpDirectory");
+        this.graphM = graphM;
+        this.beamWidth = beamWidth;
+        this.neighborOverflow = neighborOverflow;
+        this.alpha = alpha;
+        this.similarity = Objects.requireNonNull(similarity, "similarity");
+    }
+
+    // -------------------------------------------------------------------------
+    // Inputs / outputs
+    // -------------------------------------------------------------------------
+
+    /**
+     * Description of one input segment for {@link #merge}. The optimizer pod
+     * builds these from the registry znodes and the just-loaded tombstone
+     * overlays.
+     */
+    public static final class RemoteSegmentInput {
+
+        public final String tablespaceUuid;
+        public final String indexUuid;
+        public final String segmentUuid;
+        public final long segmentId;
+        public final long mapFileSize;
+        /**
+         * Generation as recorded in the registry znode. Used for tie-breaking
+         * when the same primary key appears in multiple input segments — the
+         * higher-generation source wins (mirrors the in-IS authority map's
+         * "highest-generation owner" rule).
+         */
+        public final long generation;
+        /**
+         * Segment-local ordinals that have been tombstoned. May be empty.
+         * Caller is expected to load the latest {@code TombstoneOverlay} for
+         * the segment (via {@code TombstoneOverlayManager.loadOverlay}) and
+         * pass {@code overlay.getTombstonedOrdinals()} here, or an empty array
+         * when no overlay exists.
+         */
+        public final int[] tombstonedOrdinals;
+
+        public RemoteSegmentInput(String tablespaceUuid, String indexUuid, String segmentUuid,
+                                  long segmentId, long mapFileSize, long generation,
+                                  int[] tombstonedOrdinals) {
+            this.tablespaceUuid = Objects.requireNonNull(tablespaceUuid, "tablespaceUuid");
+            this.indexUuid = Objects.requireNonNull(indexUuid, "indexUuid");
+            this.segmentUuid = Objects.requireNonNull(segmentUuid, "segmentUuid");
+            this.segmentId = segmentId;
+            this.mapFileSize = mapFileSize;
+            this.generation = generation;
+            this.tombstonedOrdinals = tombstonedOrdinals == null
+                    ? new int[0]
+                    : tombstonedOrdinals.clone();
+        }
+    }
+
+    /** Outcome of a successful merge — handed to the caller for znode publishing. */
+    public static final class MergeOutput {
+        public final String tablespaceUuid;
+        public final String indexUuid;
+        public final long segmentId;
+        public final String graphPath;
+        public final long graphFileSize;
+        public final String mapPath;
+        public final long mapFileSize;
+        public final long vectorCount;
+        public final long droppedTombstones;
+        public final long droppedDuplicates;
+
+        public MergeOutput(String tablespaceUuid, String indexUuid, long segmentId,
+                           String graphPath, long graphFileSize,
+                           String mapPath, long mapFileSize,
+                           long vectorCount, long droppedTombstones, long droppedDuplicates) {
+            this.tablespaceUuid = tablespaceUuid;
+            this.indexUuid = indexUuid;
+            this.segmentId = segmentId;
+            this.graphPath = graphPath;
+            this.graphFileSize = graphFileSize;
+            this.mapPath = mapPath;
+            this.mapFileSize = mapFileSize;
+            this.vectorCount = vectorCount;
+            this.droppedTombstones = droppedTombstones;
+            this.droppedDuplicates = droppedDuplicates;
+        }
+
+        /** Sum of graph and map file sizes — convenient for {@code SegmentMetadata.sizeBytes}. */
+        public long totalSizeBytes() {
+            return graphFileSize + mapFileSize;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Merge
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads every input segment's map file from remote storage, drops
+     * tombstoned entries, de-duplicates surviving entries by PK preferring the
+     * highest-generation source, builds a merged graph, and uploads both the
+     * graph and a fresh map file. Returns metadata about the produced output.
+     *
+     * <p>Returns {@code null} when after tombstone + duplicate filtering no
+     * vectors remain — the caller should treat this as "merge declined" and
+     * not publish anything (the inputs are fully obsolete and will be
+     * reaped through the normal retention path).
+     *
+     * @throws IOException                  on local I/O failures (temp file, jvector writer)
+     * @throws DataStorageManagerException  on remote storage failures
+     */
+    public MergeOutput merge(List<RemoteSegmentInput> inputs,
+                             String outputTablespaceUuid,
+                             String outputIndexUuid,
+                             long outputSegmentId,
+                             int dim) throws IOException, DataStorageManagerException {
+        Objects.requireNonNull(inputs, "inputs");
+        if (inputs.isEmpty()) {
+            throw new IllegalArgumentException("inputs must be non-empty");
+        }
+        if (dim <= 0) {
+            throw new IllegalArgumentException("dim must be positive: " + dim);
+        }
+
+        long startNanos = System.nanoTime();
+
+        // 1. Stream each input's map file to a local temp file. We never hold
+        //    every map in memory — even for a 1M-vector merge that would be
+        //    a few GiB. The temp files are all deleted at the end of merge().
+        List<Path> mapTempFiles = new ArrayList<>(inputs.size());
+        long droppedTombstones = 0;
+        long droppedDuplicates = 0;
+        try {
+            for (RemoteSegmentInput in : inputs) {
+                mapTempFiles.add(downloadMapFile(in));
+            }
+
+            // 2. First pass: walk every map file and decide which (pk, vec) to keep.
+            //    Authority map: pk -> (generation, vector). Higher generation wins.
+            //    PERF: the inner reads are sequential against the BufferedInputStream;
+            //    the de-duplication HashMap is bounded by the union of input PKs (which
+            //    is also the upper bound on the merged segment's vector count).
+            Map<Bytes, AuthorityEntry> authority = new HashMap<>();
+            for (int i = 0; i < inputs.size(); i++) {
+                RemoteSegmentInput in = inputs.get(i);
+                Path mapFile = mapTempFiles.get(i);
+                BitSet tombstoneSet = buildTombstoneSet(in.tombstonedOrdinals);
+                long[] perInputCounters = new long[2]; // [tombstones, duplicates]
+                accumulateAuthority(in, mapFile, tombstoneSet, authority, perInputCounters);
+                droppedTombstones += perInputCounters[0];
+                droppedDuplicates += perInputCounters[1];
+            }
+            int keptCount = authority.size();
+            if (keptCount == 0) {
+                LOGGER.log(Level.INFO,
+                        "RemoteSegmentGraphMerger: every input vector was tombstoned or duplicated"
+                                + " (inputs={0}, droppedTombstones={1}, droppedDuplicates={2});"
+                                + " declining merge",
+                        new Object[]{inputs.size(), droppedTombstones, droppedDuplicates});
+                return null;
+            }
+
+            // 3. Build the merged graph over the surviving (pk, vector) pairs.
+            //    We assign new ordinals 0..keptCount-1 in iteration order; the
+            //    ordering is the natural HashMap iteration order which is fine
+            //    because the consumer only cares about (pk -> ordinal -> vector)
+            //    consistency, not about a specific layout.
+            BuildArtefacts artefacts = buildGraph(authority, dim, keptCount);
+
+            // 4. Write the graph and map files locally.
+            Path graphTempFile = Files.createTempFile(tmpDirectory,
+                    "herddb-merger-graph-", ".idx");
+            Path mapOutTempFile = Files.createTempFile(tmpDirectory,
+                    "herddb-merger-map-", ".tmp");
+            boolean uploadedGraph = false;
+            boolean uploadedMap = false;
+            String graphPath = null;
+            String mapPath = null;
+            long graphSize;
+            long mapSize;
+            String multipartUuid = outputIndexUuid + "_seg" + outputSegmentId;
+            try {
+                writeGraph(artefacts, dim, graphTempFile);
+                graphSize = Files.size(graphTempFile);
+                writeMapFile(artefacts, mapOutTempFile);
+                mapSize = Files.size(mapOutTempFile);
+
+                // 5. Upload both. If the second upload fails we delete the first
+                //    so we don't leak partial output.
+                graphPath = dataStorageManager.writeMultipartIndexFile(
+                        outputTablespaceUuid, multipartUuid, "graph",
+                        graphTempFile, /* progress */ null);
+                uploadedGraph = true;
+                mapPath = dataStorageManager.writeMultipartIndexFile(
+                        outputTablespaceUuid, multipartUuid, "map",
+                        mapOutTempFile, /* progress */ null);
+                uploadedMap = true;
+            } finally {
+                Files.deleteIfExists(graphTempFile);
+                Files.deleteIfExists(mapOutTempFile);
+                // Close the builder; we no longer need any of its in-memory state.
+                try {
+                    artefacts.builder.close();
+                } catch (IOException ignored) {
+                    // Builder close is best-effort — we already wrote the graph and
+                    // there's nothing the caller can do about a close failure.
+                }
+                if (uploadedGraph && !uploadedMap) {
+                    try {
+                        dataStorageManager.deleteMultipartIndexFile(
+                                outputTablespaceUuid, multipartUuid, "graph");
+                    } catch (DataStorageManagerException cleanupErr) {
+                        // Broad catch (storage is the plugin boundary): log and continue;
+                        // the orphan file is a leak the caller must reap, not corruption.
+                        LOGGER.log(Level.WARNING,
+                                "merger orphan-graph cleanup failed for {0}: {1}",
+                                new Object[]{multipartUuid, cleanupErr.getMessage()});
+                    }
+                }
+            }
+
+            long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+            LOGGER.log(Level.INFO,
+                    "RemoteSegmentGraphMerger: merged {0} inputs into segment {1}/{2}_seg{3}"
+                            + " ({4} kept, {5} tombstoned, {6} duplicates dropped, {7} ms)",
+                    new Object[]{inputs.size(), outputTablespaceUuid, outputIndexUuid,
+                            outputSegmentId, keptCount, droppedTombstones, droppedDuplicates,
+                            elapsedMs});
+            return new MergeOutput(outputTablespaceUuid, outputIndexUuid, outputSegmentId,
+                    graphPath, graphSize, mapPath, mapSize,
+                    keptCount, droppedTombstones, droppedDuplicates);
+        } finally {
+            for (Path tmp : mapTempFiles) {
+                try {
+                    Files.deleteIfExists(tmp);
+                } catch (IOException ignored) {
+                    // Best-effort tmp cleanup; ENOENT is fine.
+                }
+            }
+        }
+    }
+
+    /**
+     * Best-effort delete of the multipart files produced by a previous
+     * {@link #merge} that the caller has decided to abandon (e.g. the
+     * post-merge revalidation aborted the run). Idempotent: missing files
+     * are not an error.
+     */
+    public void deleteOutput(MergeOutput out) {
+        if (out == null) {
+            return;
+        }
+        String multipartUuid = out.indexUuid + "_seg" + out.segmentId;
+        deleteIgnoringMissing(out.tablespaceUuid, multipartUuid, "graph");
+        deleteIgnoringMissing(out.tablespaceUuid, multipartUuid, "map");
+    }
+
+    private void deleteIgnoringMissing(String tablespaceUuid, String multipartUuid, String fileType) {
+        try {
+            dataStorageManager.deleteMultipartIndexFile(tablespaceUuid, multipartUuid, fileType);
+        } catch (DataStorageManagerException e) {
+            // Broad catch (storage layer): cleanup is best-effort. The caller
+            // is already aborting the merge run; leaking a multipart artefact
+            // is wasted bytes the next reconcile cycle can sweep.
+            LOGGER.log(Level.WARNING,
+                    "merger output cleanup failed for {0}/{1}: {2}",
+                    new Object[]{multipartUuid, fileType, e.getMessage()});
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Map file streaming + tombstone filter
+    // -------------------------------------------------------------------------
+
+    private Path downloadMapFile(RemoteSegmentInput in) throws IOException, DataStorageManagerException {
+        Path tempFile = Files.createTempFile(tmpDirectory, "herddb-merger-input-", ".tmp");
+        boolean ok = false;
+        try {
+            String multipartUuid = in.indexUuid + "_seg" + in.segmentId;
+            if (dataStorageManager.supportsDirectMultipartDownload()) {
+                dataStorageManager.downloadMultipartIndexFile(
+                        in.tablespaceUuid, multipartUuid, "map", in.mapFileSize, tempFile);
+            } else {
+                ReaderSupplier supplier = dataStorageManager.multipartIndexReaderSupplier(
+                        in.tablespaceUuid, multipartUuid, "map", in.mapFileSize);
+                try (RandomAccessReader reader = supplier.get();
+                     FileOutputStream fos = new FileOutputStream(tempFile.toFile());
+                     BufferedOutputStream bos = new BufferedOutputStream(fos, DOWNLOAD_CHUNK_SIZE)) {
+                    reader.seek(0L);
+                    byte[] buf = new byte[DOWNLOAD_CHUNK_SIZE];
+                    long remaining = in.mapFileSize;
+                    while (remaining > 0L) {
+                        int toRead = (int) Math.min(buf.length, remaining);
+                        byte[] chunk = (toRead == buf.length) ? buf : new byte[toRead];
+                        reader.readFully(chunk);
+                        bos.write(chunk, 0, toRead);
+                        remaining -= toRead;
+                    }
+                }
+            }
+            ok = true;
+            return tempFile;
+        } finally {
+            if (!ok) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (IOException ignored) {
+                    // ENOENT is fine; we never opened the file.
+                }
+            }
+        }
+    }
+
+    private static BitSet buildTombstoneSet(int[] tombstonedOrdinals) {
+        if (tombstonedOrdinals == null || tombstonedOrdinals.length == 0) {
+            return new BitSet(0);
+        }
+        int max = 0;
+        for (int o : tombstonedOrdinals) {
+            if (o > max) {
+                max = o;
+            }
+        }
+        BitSet b = new BitSet(max + 1);
+        for (int o : tombstonedOrdinals) {
+            if (o >= 0) {
+                b.set(o);
+            }
+        }
+        return b;
+    }
+
+    /**
+     * Walks one input's map file, dropping tombstoned ordinals, and either
+     * inserts the surviving (pk, vector) into the authority map or — if
+     * a same-PK entry from an earlier input had a higher generation —
+     * counts it as a duplicate-drop.
+     */
+    private void accumulateAuthority(RemoteSegmentInput in, Path mapFile,
+                                     BitSet tombstoneSet,
+                                     Map<Bytes, AuthorityEntry> authority,
+                                     long[] perInputCounters) throws IOException {
+        try (DataInputStream dis = new DataInputStream(
+                new BufferedInputStream(new FileInputStream(mapFile.toFile()),
+                        DOWNLOAD_CHUNK_SIZE))) {
+            int entryCount = dis.readInt();
+            for (int i = 0; i < entryCount; i++) {
+                int ordinal = dis.readInt();
+                int pkLen = dis.readInt();
+                if (pkLen < 0) {
+                    throw new IOException("malformed map file " + mapFile + ": negative pkLen " + pkLen);
+                }
+                byte[] pkBytes = new byte[pkLen];
+                dis.readFully(pkBytes);
+                int floatCount = dis.readInt();
+                if (floatCount < 0) {
+                    throw new IOException("malformed map file " + mapFile + ": negative floatCount " + floatCount);
+                }
+                if (tombstoneSet.get(ordinal)) {
+                    // Skip the floats; we still need to consume them to keep the stream aligned.
+                    skipFully(dis, (long) floatCount * Float.BYTES);
+                    perInputCounters[0]++;
+                    continue;
+                }
+                Bytes pk = Bytes.from_array(pkBytes);
+                AuthorityEntry existing = authority.get(pk);
+                if (existing != null && existing.generation >= in.generation) {
+                    // Earlier input already owns this PK at a higher (or equal — keep first
+                    // observation as a deterministic tiebreak) generation. Skip and record.
+                    skipFully(dis, (long) floatCount * Float.BYTES);
+                    perInputCounters[1]++;
+                    continue;
+                }
+                if (existing != null) {
+                    // We are about to replace a lower-generation owner; the previous one
+                    // becomes a "duplicate dropped".
+                    perInputCounters[1]++;
+                }
+                VectorFloat<?> vec = VTS.createFloatVector(floatCount);
+                for (int j = 0; j < floatCount; j++) {
+                    int bits = dis.readInt();
+                    vec.set(j, Float.intBitsToFloat(bits));
+                }
+                authority.put(pk, new AuthorityEntry(vec, in.generation));
+            }
+        }
+    }
+
+    private static final class AuthorityEntry {
+        final VectorFloat<?> vector;
+        final long generation;
+
+        AuthorityEntry(VectorFloat<?> vector, long generation) {
+            this.vector = vector;
+            this.generation = generation;
+        }
+    }
+
+    private static void skipFully(DataInputStream dis, long bytes) throws IOException {
+        long remaining = bytes;
+        while (remaining > 0L) {
+            long skipped = dis.skip(remaining);
+            if (skipped <= 0L) {
+                // skip() returns 0 at EOF; surface as a clean error rather than spinning.
+                if (dis.read() < 0) {
+                    throw new IOException("unexpected EOF while skipping map-file padding ("
+                            + bytes + " requested, " + (bytes - remaining) + " consumed)");
+                }
+                remaining--;
+            } else {
+                remaining -= skipped;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Graph build (in-memory) + on-disk write
+    // -------------------------------------------------------------------------
+
+    private static final class BuildArtefacts {
+        final GraphIndexBuilder builder;
+        final VectorStorage storage;
+        final VectorStorageRandomAccessVectorValues ravv;
+        final List<Bytes> ordinalToPk;
+
+        BuildArtefacts(GraphIndexBuilder builder, VectorStorage storage,
+                       VectorStorageRandomAccessVectorValues ravv, List<Bytes> ordinalToPk) {
+            this.builder = builder;
+            this.storage = storage;
+            this.ravv = ravv;
+            this.ordinalToPk = ordinalToPk;
+        }
+    }
+
+    private BuildArtefacts buildGraph(Map<Bytes, AuthorityEntry> authority, int dim, int keptCount) {
+        VectorStorage storage = new VectorStorage(keptCount);
+        VectorStorageRandomAccessVectorValues ravv =
+                new VectorStorageRandomAccessVectorValues(storage, dim, keptCount);
+        BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, similarity);
+        GraphIndexBuilder builder = new GraphIndexBuilder(
+                bsp, dim, List.of(graphM), beamWidth, neighborOverflow, alpha,
+                /* addHierarchy */ false, /* refineFinalGraph */ false,
+                ForkJoinPool.commonPool(), ForkJoinPool.commonPool(), keptCount);
+        List<Bytes> ordinalToPk = new ArrayList<>(keptCount);
+        int ord = 0;
+        for (Map.Entry<Bytes, AuthorityEntry> e : authority.entrySet()) {
+            ordinalToPk.add(e.getKey());
+            storage.set(ord, e.getValue().vector);
+            try {
+                builder.addGraphNode(ord, e.getValue().vector);
+            } catch (RuntimeException re) {
+                // The builder is the plugin boundary (jvector). Add a clear
+                // diagnostic hint rather than letting an opaque failure escape.
+                throw new IllegalStateException(
+                        "GraphIndexBuilder.addGraphNode failed at ordinal " + ord
+                                + " (" + keptCount + " total)", re);
+            }
+            ord++;
+        }
+        try {
+            builder.cleanup();
+        } catch (RuntimeException re) {
+            throw new IllegalStateException("GraphIndexBuilder.cleanup failed in merger", re);
+        }
+        return new BuildArtefacts(builder, storage, ravv, ordinalToPk);
+    }
+
+    private void writeGraph(BuildArtefacts art, int dim, Path graphTempFile) throws IOException {
+        OnHeapGraphIndex graph = (OnHeapGraphIndex) art.builder.getGraph();
+        int shardSize = art.ordinalToPk.size();
+
+        boolean useFusedPQ = shardSize >= MIN_VECTORS_FOR_FUSED_PQ;
+        int pqSubspaces = Math.max(1, dim / 4);
+        // Mirror PersistentVectorStore.getOrTrainPQ's defaults verbatim
+        // (clusterCount=256, centerData=true) so the merged segment is
+        // PQ-compatible with everything the IS-side writer produces.
+        ProductQuantization pq = useFusedPQ
+                ? ProductQuantization.compute(art.ravv, pqSubspaces,
+                        /* clusterCount */ 256, /* centerData */ true)
+                : null;
+        PQVectors pqv = (pq != null) ? pq.encodeAll(art.ravv, ForkJoinPool.commonPool()) : null;
+
+        OnDiskGraphIndexWriter.Builder writerBuilder = new OnDiskGraphIndexWriter.Builder(
+                graph, graphTempFile);
+        if (useFusedPQ) {
+            writerBuilder.with(new FusedPQ(graph.maxDegree(), pq));
+        }
+        try (OnDiskGraphIndexWriter writer = writerBuilder
+                .with(new InlineVectors(dim))
+                .build()) {
+            ImmutableGraphIndex.View view = graph.getView();
+            EnumMap<FeatureId, IntFunction<Feature.State>> suppliers =
+                    new EnumMap<>(FeatureId.class);
+            if (useFusedPQ) {
+                suppliers.put(FeatureId.FUSED_PQ,
+                        ordinal -> new FusedPQ.State(view, pqv, ordinal));
+            }
+            suppliers.put(FeatureId.INLINE_VECTORS,
+                    ordinal -> new InlineVectors.State(art.ravv.getVector(ordinal)));
+            writer.write(suppliers);
+        }
+    }
+
+    /**
+     * Writes the map file in the exact same wire format that
+     * {@code PersistentVectorStore.writeFusedPQMapDataToTempFile} produces, so
+     * the indexing-service tier can reload the merged segment with no
+     * format-detection logic.
+     */
+    private void writeMapFile(BuildArtefacts art, Path mapTempFile) throws IOException {
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapTempFile.toFile()), DOWNLOAD_CHUNK_SIZE);
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            int entryCount = art.ordinalToPk.size();
+            dos.writeInt(entryCount);
+            for (int ord = 0; ord < entryCount; ord++) {
+                Bytes pk = art.ordinalToPk.get(ord);
+                byte[] pkBytes = pk.to_array();
+                VectorFloat<?> vec = art.ravv.getVector(ord);
+                if (vec == null) {
+                    throw new IOException("merger map writer: null vector at ordinal " + ord);
+                }
+                dos.writeInt(ord);
+                dos.writeInt(pkBytes.length);
+                dos.write(pkBytes);
+                int floatCount = vec.length();
+                dos.writeInt(floatCount);
+                for (int j = 0; j < floatCount; j++) {
+                    dos.writeInt(Float.floatToIntBits(vec.get(j)));
+                }
+            }
+        }
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -430,26 +430,31 @@ public final class RemoteSegmentGraphMerger {
                      FileOutputStream fos = new FileOutputStream(tempFile.toFile());
                      BufferedOutputStream bos = new BufferedOutputStream(fos, DOWNLOAD_CHUNK_SIZE)) {
                     reader.seek(0L);
+                    // Determine the ACTUAL number of bytes to read. The supplied
+                    // {@code in.mapFileSize} may overestimate the real file
+                    // size for legacy znodes whose
+                    // {@link SegmentMetadata#mapFileSize} field is unset (the
+                    // merger then falls back to the combined {@code sizeBytes}
+                    // hint). We use {@link RandomAccessReader#length()} when
+                    // available to get the byte-accurate size; if it throws
+                    // (some implementations don't support it), we trust the
+                    // hint and let any tail-EOF surface as an
+                    // {@link IOException} the caller handles.
+                    long actualBytes;
+                    try {
+                        long readerLen = reader.length();
+                        actualBytes = Math.min(readerLen, in.mapFileSize);
+                    } catch (UnsupportedOperationException unsupported) {
+                        actualBytes = in.mapFileSize;
+                    }
                     byte[] buf = new byte[DOWNLOAD_CHUNK_SIZE];
-                    long remaining = in.mapFileSize;
+                    long remaining = actualBytes;
                     while (remaining > 0L) {
                         int toRead = (int) Math.min(buf.length, remaining);
                         byte[] chunk = (toRead == buf.length) ? buf : new byte[toRead];
-                        try {
-                            reader.readFully(chunk);
-                            bos.write(chunk, 0, toRead);
-                            remaining -= toRead;
-                        } catch (java.io.EOFException eof) {
-                            // The supplied {@code in.mapFileSize} may overestimate the
-                            // actual file size for legacy znodes whose
-                            // {@link SegmentMetadata#mapFileSize} field is unset (see
-                            // {@code RemoteSegmentMerger}'s mapFileSizeHint fallback).
-                            // Treat EOF on a too-large hint as "end of file" rather than
-                            // an error — the parser layer (accumulateAuthority) will fail
-                            // fast on a truncated entryCount/pkLen if the read was actually
-                            // short.
-                            break;
-                        }
+                        reader.readFully(chunk);
+                        bos.write(chunk, 0, toRead);
+                        remaining -= toRead;
                     }
                 }
             }

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -430,25 +430,15 @@ public final class RemoteSegmentGraphMerger {
                      FileOutputStream fos = new FileOutputStream(tempFile.toFile());
                      BufferedOutputStream bos = new BufferedOutputStream(fos, DOWNLOAD_CHUNK_SIZE)) {
                     reader.seek(0L);
-                    // Determine the ACTUAL number of bytes to read. The supplied
-                    // {@code in.mapFileSize} may overestimate the real file
-                    // size for legacy znodes whose
-                    // {@link SegmentMetadata#mapFileSize} field is unset (the
-                    // merger then falls back to the combined {@code sizeBytes}
-                    // hint). We use {@link RandomAccessReader#length()} when
-                    // available to get the byte-accurate size; if it throws
-                    // (some implementations don't support it), we trust the
-                    // hint and let any tail-EOF surface as an
-                    // {@link IOException} the caller handles.
-                    long actualBytes;
-                    try {
-                        long readerLen = reader.length();
-                        actualBytes = Math.min(readerLen, in.mapFileSize);
-                    } catch (UnsupportedOperationException unsupported) {
-                        actualBytes = in.mapFileSize;
-                    }
+                    // The caller (RemoteSegmentMerger) refuses inputs whose
+                    // mapFileSize is unset (issue #484 round 3), so by the
+                    // time we get here in.mapFileSize is the EXACT byte size
+                    // of the remote map file. Read exactly that many bytes
+                    // in chunks; readFully will throw IOException if the
+                    // remote file is shorter than advertised, which is the
+                    // right failure mode for a corrupt or truncated upload.
                     byte[] buf = new byte[DOWNLOAD_CHUNK_SIZE];
-                    long remaining = actualBytes;
+                    long remaining = in.mapFileSize;
                     while (remaining > 0L) {
                         int toRead = (int) Math.min(buf.length, remaining);
                         byte[] chunk = (toRead == buf.length) ? buf : new byte[toRead];

--- a/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerCorruptInputTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerCorruptInputTest.java
@@ -1,0 +1,203 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.index.vector;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Validates that {@link RemoteSegmentGraphMerger} fails fast on corrupt or
+ * dimension-mismatched input map files (issue #484, review items B.1#2 and
+ * B.2#3 from the first pr-reviewer pass).
+ *
+ * <p>The merger validates every {@code int} read from the input file
+ * against {@link RemoteSegmentGraphMerger#MAX_ENTRIES_PER_MAP_FILE} and
+ * {@link RemoteSegmentGraphMerger#MAX_PK_LEN}, rejects negative ordinals,
+ * and refuses any input whose vector dimension differs from the configured
+ * one. Without these checks a corrupt or partially-uploaded multipart file
+ * could either coerce the merger into a multi-GB allocation (OOM) or
+ * silently corrupt the merged graph by writing mismatched-dim vectors.
+ */
+public class RemoteSegmentGraphMergerCorruptInputTest {
+
+    private static final String TS_UUID = "ts-corrupt";
+    private static final String IDX_UUID = "idx-corrupt";
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    /** Writes a 2-input fixture where the second input is replaced by raw bytes. */
+    private List<RemoteSegmentGraphMerger.RemoteSegmentInput> twoInputsWithCorruptSecond(
+            byte[] corruptMapBytes) throws Exception {
+        // First input is healthy: 5 vectors at dim=4.
+        Path goodMap = Files.createTempFile(tmpDir, "good-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(goodMap.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(5);
+            for (int i = 0; i < 5; i++) {
+                dos.writeInt(i);
+                byte[] pk = ("good-" + i).getBytes();
+                dos.writeInt(pk.length);
+                dos.write(pk);
+                dos.writeInt(4);
+                for (int j = 0; j < 4; j++) {
+                    dos.writeInt(Float.floatToIntBits((float) (i + j)));
+                }
+            }
+        }
+        long goodSize = Files.size(goodMap);
+        dsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg1", "map", goodMap, null);
+        Files.deleteIfExists(goodMap);
+
+        // Second input: written as raw, possibly-malformed bytes.
+        Path corruptMap = Files.createTempFile(tmpDir, "corrupt-", ".tmp");
+        Files.write(corruptMap, corruptMapBytes);
+        dsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg2", "map", corruptMap, null);
+        Files.deleteIfExists(corruptMap);
+
+        return List.of(
+                new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                        TS_UUID, IDX_UUID, "good-uuid", 1L, goodSize, 1L, new int[0]),
+                new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                        TS_UUID, IDX_UUID, "corrupt-uuid", 2L, corruptMapBytes.length, 2L, new int[0]));
+    }
+
+    @Test
+    public void garbageEntryCountThrowsIOException() throws Exception {
+        // entryCount = Integer.MAX_VALUE — a sane reader must reject this rather
+        // than try to allocate an int[Integer.MAX_VALUE] or loop billions of
+        // times. The MAX_ENTRIES_PER_MAP_FILE cap (1<<28) is what stops us.
+        byte[] bytes = new byte[]{
+                (byte) 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff
+        };
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(twoInputsWithCorruptSecond(bytes), TS_UUID, IDX_UUID,
+                    /* output */ 999L, /* dim */ 4);
+            fail("expected IOException for entryCount > MAX_ENTRIES_PER_MAP_FILE");
+        } catch (IOException ok) {
+            assertTrue("message should mention entryCount: " + ok.getMessage(),
+                    ok.getMessage().contains("entryCount"));
+        }
+    }
+
+    @Test
+    public void negativeOrdinalThrowsIOException() throws Exception {
+        // entryCount=1, ordinal=-1, then no further bytes (ok — read should
+        // fail at the ordinal check before consuming pkLen).
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeInt(1);
+        dos.writeInt(-1); // negative ordinal
+        // pad with bogus pkLen / floatCount to make sure parser doesn't get
+        // confused before it hits the ordinal check
+        dos.writeInt(0);
+        dos.writeInt(0);
+        dos.flush();
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(twoInputsWithCorruptSecond(baos.toByteArray()), TS_UUID, IDX_UUID,
+                    999L, 4);
+            fail("expected IOException for negative ordinal");
+        } catch (IOException ok) {
+            assertTrue("message should mention ordinal: " + ok.getMessage(),
+                    ok.getMessage().contains("ordinal"));
+        }
+    }
+
+    @Test
+    public void oversizedPkLenThrowsIOException() throws Exception {
+        // entryCount=1, ordinal=0, pkLen=Integer.MAX_VALUE — the cap
+        // MAX_PK_LEN (1<<16) must reject this. Without the cap we'd allocate a
+        // 2 GiB byte[] and OOM.
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeInt(1);
+        dos.writeInt(0);
+        dos.writeInt(Integer.MAX_VALUE); // oversized pkLen
+        dos.flush();
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(twoInputsWithCorruptSecond(baos.toByteArray()), TS_UUID, IDX_UUID,
+                    999L, 4);
+            fail("expected IOException for oversized pkLen");
+        } catch (IOException ok) {
+            assertTrue("message should mention pkLen: " + ok.getMessage(),
+                    ok.getMessage().contains("pkLen"));
+        }
+    }
+
+    @Test
+    public void dimensionMismatchThrowsIOException() throws Exception {
+        // entryCount=1, ordinal=0, pkLen=3, "abc", floatCount=8. The merger is
+        // configured with dim=4, so the floatCount=8 mismatch must abort the
+        // merge before any vector data is consumed (silently building a graph
+        // with mismatched-dim vectors would corrupt the InlineVectors feature).
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeInt(1);
+        dos.writeInt(0);          // ordinal
+        dos.writeInt(3);          // pkLen
+        dos.write("abc".getBytes()); // pkBytes
+        dos.writeInt(8);          // floatCount = 8 (mismatch with dim=4)
+        // Do not write the floats — the merger should fail before consuming them.
+        dos.flush();
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(twoInputsWithCorruptSecond(baos.toByteArray()), TS_UUID, IDX_UUID,
+                    /* outputSegmentId */ 9999L, /* dim */ 4);
+            fail("expected IOException for dimension mismatch");
+        } catch (IOException ok) {
+            assertTrue("message should mention dimension mismatch: " + ok.getMessage(),
+                    ok.getMessage().contains("dimension mismatch"));
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerTest.java
@@ -1,0 +1,368 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.graph.GraphSearcher;
+import io.github.jbellis.jvector.graph.SearchResult;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Round-trip recall test for {@link RemoteSegmentGraphMerger} (issue #484).
+ *
+ * <p>Builds three small synthetic input segments — each one a slice of a
+ * 1500-vector dataset — written via the same FusedPQ-less map+graph layout
+ * that {@code PersistentVectorStore} produces, hands them to the merger, and
+ * verifies:
+ * <ul>
+ *   <li>the merged segment carries every PK that survived tombstoning;</li>
+ *   <li>the merged graph (loaded via {@code OnDiskGraphIndex.load}) returns
+ *       every dataset vector for an identity-vector probe (recall = 1.0
+ *       on a deterministic search-self check);</li>
+ *   <li>nearest-neighbour recall@10 against the brute-force baseline on a
+ *       held-out 50-query workload is at least 0.9 — proves the merged
+ *       graph's edge structure is healthy, not just that the vectors are
+ *       present.</li>
+ * </ul>
+ */
+public class RemoteSegmentGraphMergerTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-rsgm";
+    private static final String IDX_UUID = "idx-rsgm";
+    private static final int DIM = 64;
+    private static final int VECTORS_PER_SEGMENT = 500;
+    private static final int SEGMENT_COUNT = 3;
+    private static final int M = 16;
+    private static final int BEAM_WIDTH = 64;
+    private static final float NEIGHBOR_OVERFLOW = 1.2f;
+    private static final float ALPHA = 1.4f;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+    private VectorFloat<?>[] dataset;
+    private Bytes[] datasetPks;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+        dataset = new VectorFloat<?>[VECTORS_PER_SEGMENT * SEGMENT_COUNT];
+        datasetPks = new Bytes[dataset.length];
+        Random rng = new Random(0xCAFEBABE);
+        for (int i = 0; i < dataset.length; i++) {
+            VectorFloat<?> v = VTS.createFloatVector(DIM);
+            for (int j = 0; j < DIM; j++) {
+                v.set(j, rng.nextFloat() * 2.0f - 1.0f);
+            }
+            dataset[i] = v;
+            datasetPks[i] = Bytes.from_string("pk-" + i);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        // dsm is in-memory — nothing to clean up.
+    }
+
+    /**
+     * Slice the dataset into three segments and write each one as a real
+     * (graph + map) multipart pair via the DSM. The on-disk graph isn't used
+     * by the merger but the map file's wire format is what the merger reads.
+     */
+    private List<RemoteSegmentGraphMerger.RemoteSegmentInput> writeInputSegments() throws Exception {
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = new ArrayList<>(SEGMENT_COUNT);
+        for (int seg = 0; seg < SEGMENT_COUNT; seg++) {
+            int from = seg * VECTORS_PER_SEGMENT;
+            int to = from + VECTORS_PER_SEGMENT;
+
+            // Write the map file (the merger's only real input).
+            Path mapFile = Files.createTempFile(tmpDir, "input-map-", ".tmp");
+            try (BufferedOutputStream bos = new BufferedOutputStream(
+                    new FileOutputStream(mapFile.toFile()));
+                 DataOutputStream dos = new DataOutputStream(bos)) {
+                dos.writeInt(VECTORS_PER_SEGMENT);
+                for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                    int globalIdx = from + local;
+                    dos.writeInt(local);
+                    byte[] pkBytes = datasetPks[globalIdx].to_array();
+                    dos.writeInt(pkBytes.length);
+                    dos.write(pkBytes);
+                    VectorFloat<?> v = dataset[globalIdx];
+                    dos.writeInt(v.length());
+                    for (int j = 0; j < v.length(); j++) {
+                        dos.writeInt(Float.floatToIntBits(v.get(j)));
+                    }
+                }
+            }
+            long mapSize = Files.size(mapFile);
+            String multipartUuid = IDX_UUID + "_seg" + seg;
+            dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", mapFile, null);
+            Files.deleteIfExists(mapFile);
+
+            inputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                    TS_UUID, IDX_UUID, "seg-uuid-" + seg, seg, mapSize,
+                    /* generation */ 1L + seg, /* tombstoned */ new int[0]));
+        }
+        return inputs;
+    }
+
+    @Test
+    public void mergedSegmentContainsEveryPkAndAchievesGoodRecall() throws Exception {
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = writeInputSegments();
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, M, BEAM_WIDTH, NEIGHBOR_OVERFLOW, ALPHA,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        long outputSegmentId = 999_999_999L;
+        RemoteSegmentGraphMerger.MergeOutput output = merger.merge(
+                inputs, TS_UUID, IDX_UUID, outputSegmentId, DIM);
+        assertNotNull("merger must produce an output", output);
+        assertEquals("every input vector survives (no tombstones, no duplicates)",
+                dataset.length, output.vectorCount);
+        assertEquals(0L, output.droppedTombstones);
+        assertEquals(0L, output.droppedDuplicates);
+
+        // Re-read the merged map file: every PK from the dataset must appear.
+        Set<Bytes> mergedPks = readMapFilePks(output.tablespaceUuid,
+                output.indexUuid + "_seg" + output.segmentId, output.mapPath, output.mapFileSize);
+        assertEquals(dataset.length, mergedPks.size());
+        for (Bytes expected : datasetPks) {
+            assertTrue("merged map missing PK " + expected, mergedPks.contains(expected));
+        }
+
+        // Load the merged graph back via OnDiskGraphIndex.load and run a
+        // recall@10 sweep against the brute-force baseline. We use 50 random
+        // dataset vectors as queries; the merged graph should rediscover the
+        // same vector at rank 0 with high probability (recall >= 0.9).
+        ReaderSupplier graphSupplier = dsm.multipartIndexReaderSupplier(
+                output.tablespaceUuid, output.indexUuid + "_seg" + output.segmentId,
+                "graph", output.graphFileSize);
+        OnDiskGraphIndex graph = OnDiskGraphIndex.load(graphSupplier);
+        try {
+            // Build a deterministic ordinal-to-pk map by reading the merged map
+            // file, so we can resolve search results back to the dataset index.
+            int[] ordinalToDatasetIdx = buildOrdinalToDatasetIdx(output);
+
+            int hits = 0;
+            int trials = 50;
+            Random rng = new Random(0xABBA);
+            try (GraphSearcher searcher = new GraphSearcher(graph)) {
+                OnDiskGraphIndex.View view = (OnDiskGraphIndex.View) searcher.getView();
+                for (int t = 0; t < trials; t++) {
+                    int queryIdx = rng.nextInt(dataset.length);
+                    VectorFloat<?> q = dataset[queryIdx];
+                    Set<Integer> bruteTop10 = bruteForceTop10(q);
+
+                    ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(
+                            q, VectorSimilarityFunction.EUCLIDEAN);
+                    DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(reranker);
+                    SearchResult result = searcher.search(ssp, 10, 10, 0.0f, 0.0f, Bits.ALL);
+                    int matches = 0;
+                    for (SearchResult.NodeScore ns : result.getNodes()) {
+                        int datasetIdx = ordinalToDatasetIdx[ns.node];
+                        if (bruteTop10.contains(datasetIdx)) {
+                            matches++;
+                        }
+                    }
+                    // Each query contributes the fraction of its top-10 that
+                    // overlaps with the brute-force top-10 (max 10).
+                    hits += matches;
+                }
+            }
+            double recall = (double) hits / (trials * 10.0);
+            assertTrue("recall@10 must be >= 0.9 to prove merged graph is healthy; got " + recall,
+                    recall >= 0.9);
+        } finally {
+            graph.close();
+        }
+    }
+
+    private int[] buildOrdinalToDatasetIdx(RemoteSegmentGraphMerger.MergeOutput output) throws Exception {
+        int[] map = new int[(int) output.vectorCount];
+        ReaderSupplier supplier = dsm.multipartIndexReaderSupplier(output.tablespaceUuid,
+                output.indexUuid + "_seg" + output.segmentId, "map", output.mapFileSize);
+        try (io.github.jbellis.jvector.disk.RandomAccessReader r = supplier.get()) {
+            r.seek(0L);
+            byte[] all = new byte[(int) output.mapFileSize];
+            r.readFully(all);
+            java.io.DataInputStream dis = new java.io.DataInputStream(
+                    new java.io.ByteArrayInputStream(all));
+            int entryCount = dis.readInt();
+            for (int i = 0; i < entryCount; i++) {
+                int ordinal = dis.readInt();
+                int pkLen = dis.readInt();
+                byte[] pk = new byte[pkLen];
+                dis.readFully(pk);
+                int floatCount = dis.readInt();
+                for (int j = 0; j < floatCount; j++) {
+                    dis.readInt();
+                }
+                String pkString = new String(pk, java.nio.charset.StandardCharsets.UTF_8);
+                // pk is "pk-<datasetIdx>"
+                int datasetIdx = Integer.parseInt(pkString.substring("pk-".length()));
+                map[ordinal] = datasetIdx;
+            }
+        }
+        return map;
+    }
+
+    @Test
+    public void everyInputTombstonedYieldsNullOutput() throws Exception {
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = writeInputSegments();
+
+        // Mark every ordinal in every input as tombstoned.
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> tombstoned = new ArrayList<>(inputs.size());
+        for (RemoteSegmentGraphMerger.RemoteSegmentInput in : inputs) {
+            int[] all = new int[VECTORS_PER_SEGMENT];
+            for (int i = 0; i < VECTORS_PER_SEGMENT; i++) {
+                all[i] = i;
+            }
+            tombstoned.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                    in.tablespaceUuid, in.indexUuid, in.segmentUuid, in.segmentId,
+                    in.mapFileSize, in.generation, all));
+        }
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, M, BEAM_WIDTH, NEIGHBOR_OVERFLOW, ALPHA,
+                VectorSimilarityFunction.EUCLIDEAN);
+        RemoteSegmentGraphMerger.MergeOutput output = merger.merge(
+                tombstoned, TS_UUID, IDX_UUID, /* segmentId */ 1234L, DIM);
+        assertNull("merger must decline when every input is tombstoned", output);
+    }
+
+    @Test
+    public void deleteOutputRemovesUploadedFiles() throws Exception {
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = writeInputSegments();
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, M, BEAM_WIDTH, NEIGHBOR_OVERFLOW, ALPHA,
+                VectorSimilarityFunction.EUCLIDEAN);
+        RemoteSegmentGraphMerger.MergeOutput output = merger.merge(
+                inputs, TS_UUID, IDX_UUID, /* segmentId */ 555L, DIM);
+        assertNotNull(output);
+        merger.deleteOutput(output);
+        // Probing for the (now-deleted) graph file via the multipart reader
+        // supplier must throw DataStorageManagerException — the in-memory DSM
+        // is strict about missing keys, which is exactly the behaviour we want
+        // to verify.
+        try {
+            dsm.multipartIndexReaderSupplier(output.tablespaceUuid,
+                    output.indexUuid + "_seg" + output.segmentId, "graph", output.graphFileSize);
+            org.junit.Assert.fail("graph file should have been deleted");
+        } catch (Exception expected) {
+            // pass
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Set<Bytes> readMapFilePks(String tablespaceUuid, String multipartUuid,
+                                      String mapPath, long fileSize) throws Exception {
+        Set<Bytes> out = new HashSet<>();
+        ReaderSupplier supplier = dsm.multipartIndexReaderSupplier(
+                tablespaceUuid, multipartUuid, "map", fileSize);
+        try (io.github.jbellis.jvector.disk.RandomAccessReader r = supplier.get()) {
+            r.seek(0L);
+            byte[] all = new byte[(int) fileSize];
+            r.readFully(all);
+            java.io.DataInputStream dis = new java.io.DataInputStream(
+                    new java.io.ByteArrayInputStream(all));
+            int entryCount = dis.readInt();
+            for (int i = 0; i < entryCount; i++) {
+                int ordinal = dis.readInt();
+                int pkLen = dis.readInt();
+                byte[] pk = new byte[pkLen];
+                dis.readFully(pk);
+                int floatCount = dis.readInt();
+                for (int j = 0; j < floatCount; j++) {
+                    dis.readInt();
+                }
+                out.add(Bytes.from_array(pk));
+                org.junit.Assert.assertTrue("ordinal must be in [0, entryCount)",
+                        ordinal >= 0 && ordinal < entryCount);
+            }
+        }
+        return out;
+    }
+
+    private Set<Integer> bruteForceTop10(VectorFloat<?> query) {
+        Integer[] indices = new Integer[dataset.length];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = i;
+        }
+        Arrays.sort(indices, Comparator.comparingDouble(idx -> -score(query, dataset[idx])));
+        Set<Integer> out = new HashSet<>();
+        for (int i = 0; i < 10 && i < indices.length; i++) {
+            out.add(indices[i]);
+        }
+        return out;
+    }
+
+    /**
+     * EUCLIDEAN similarity used by jvector: score = 1 / (1 + sum-of-squared-diffs).
+     * We rank by score descending, equivalent to ranking by squared distance ascending.
+     */
+    private static double score(VectorFloat<?> a, VectorFloat<?> b) {
+        double s = 0.0;
+        for (int i = 0; i < a.length(); i++) {
+            double d = a.get(i) - b.get(i);
+            s += d * d;
+        }
+        return 1.0 / (1.0 + s);
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerTombstoneFilterTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerTombstoneFilterTest.java
@@ -1,0 +1,229 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Targeted unit test for the tombstone-filter path in
+ * {@link RemoteSegmentGraphMerger} (issue #484).
+ *
+ * <p>Builds two input segments:
+ * <ul>
+ *   <li>Input A: 100 vectors, with the first 50 ordinals tombstoned.</li>
+ *   <li>Input B: 100 vectors, untombstoned.</li>
+ * </ul>
+ *
+ * <p>Asserts that the merged segment contains exactly:
+ * <ul>
+ *   <li>The 50 surviving PKs from input A (ordinals 50..99).</li>
+ *   <li>All 100 PKs from input B.</li>
+ * </ul>
+ *
+ * <p>Tombstoned PKs from A must NOT appear in the merged map file — proving
+ * the tombstone bitset filter actually drops them rather than letting them
+ * resurrect through the merge.
+ */
+public class RemoteSegmentGraphMergerTombstoneFilterTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-tomb";
+    private static final String IDX_UUID = "idx-tomb";
+    private static final int DIM = 16;
+    private static final int VECTORS_PER_SEGMENT = 100;
+    private static final int M = 8;
+    private static final int BEAM_WIDTH = 32;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    private void writeMapForSegment(long segmentId, String pkPrefix) throws Exception {
+        Path mapFile = Files.createTempFile(tmpDir, "input-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapFile.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(VECTORS_PER_SEGMENT);
+            Random rng = new Random((int) segmentId * 0xDEADBEEFL);
+            for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                dos.writeInt(local);
+                byte[] pkBytes = Bytes.from_string(pkPrefix + "-" + local).to_array();
+                dos.writeInt(pkBytes.length);
+                dos.write(pkBytes);
+                VectorFloat<?> v = VTS.createFloatVector(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    v.set(j, rng.nextFloat() * 2.0f - 1.0f);
+                }
+                dos.writeInt(v.length());
+                for (int j = 0; j < v.length(); j++) {
+                    dos.writeInt(Float.floatToIntBits(v.get(j)));
+                }
+            }
+        }
+        long mapSize = Files.size(mapFile);
+        dsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg" + segmentId, "map", mapFile, null);
+        Files.deleteIfExists(mapFile);
+        // Side-effect: the test holds the size for later assertions.
+        sizes[(int) segmentId] = mapSize;
+    }
+
+    /** Map sizes recorded by {@link #writeMapForSegment} for later input wiring. */
+    private final long[] sizes = new long[10];
+
+    @Test
+    public void halfTombstonedSegmentLosesExactlyTombstonedPks() throws Exception {
+        // Input A: tombstones ordinals 0..49.
+        writeMapForSegment(/* segmentId */ 1L, "a");
+        // Input B: no tombstones.
+        writeMapForSegment(2L, "b");
+
+        int[] tombstonedA = new int[VECTORS_PER_SEGMENT / 2];
+        for (int i = 0; i < tombstonedA.length; i++) {
+            tombstonedA[i] = i;
+        }
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = new ArrayList<>();
+        inputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                TS_UUID, IDX_UUID, "uuid-A", 1L, sizes[1], /* generation */ 1L,
+                tombstonedA));
+        inputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                TS_UUID, IDX_UUID, "uuid-B", 2L, sizes[2], /* generation */ 2L,
+                /* tombstoned */ new int[0]));
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, M, BEAM_WIDTH, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        long outputSegmentId = 9_876_543_210L;
+        RemoteSegmentGraphMerger.MergeOutput output = merger.merge(
+                inputs, TS_UUID, IDX_UUID, outputSegmentId, DIM);
+        assertNotNull(output);
+        assertEquals("50 from A + 100 from B = 150 surviving", 150, output.vectorCount);
+        assertEquals(50L, output.droppedTombstones);
+        assertEquals(0L, output.droppedDuplicates);
+
+        Set<Bytes> mergedPks = readMergedPks(output);
+        assertEquals(150, mergedPks.size());
+        // All B PKs must be present.
+        for (int i = 0; i < VECTORS_PER_SEGMENT; i++) {
+            assertTrue("input-B PK b-" + i + " missing",
+                    mergedPks.contains(Bytes.from_string("b-" + i)));
+        }
+        // Only the un-tombstoned A PKs (ordinals 50..99) must be present.
+        for (int i = 0; i < VECTORS_PER_SEGMENT; i++) {
+            Bytes pk = Bytes.from_string("a-" + i);
+            if (i < 50) {
+                assertFalse("tombstoned PK a-" + i + " must NOT appear in merged segment",
+                        mergedPks.contains(pk));
+            } else {
+                assertTrue("surviving PK a-" + i + " missing", mergedPks.contains(pk));
+            }
+        }
+    }
+
+    @Test
+    public void allOrdinalsTombstonedDropsEntireSegment() throws Exception {
+        writeMapForSegment(1L, "a");
+        writeMapForSegment(2L, "b");
+
+        int[] allTombstoned = new int[VECTORS_PER_SEGMENT];
+        for (int i = 0; i < VECTORS_PER_SEGMENT; i++) {
+            allTombstoned[i] = i;
+        }
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = List.of(
+                new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                        TS_UUID, IDX_UUID, "uuid-A", 1L, sizes[1], 1L, allTombstoned),
+                new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                        TS_UUID, IDX_UUID, "uuid-B", 2L, sizes[2], 2L, new int[0]));
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, M, BEAM_WIDTH, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        RemoteSegmentGraphMerger.MergeOutput output = merger.merge(
+                inputs, TS_UUID, IDX_UUID, 1L, DIM);
+        assertNotNull(output);
+        assertEquals("only input-B's 100 vectors survive", 100, output.vectorCount);
+        assertEquals(VECTORS_PER_SEGMENT, output.droppedTombstones);
+        Set<Bytes> mergedPks = readMergedPks(output);
+        for (int i = 0; i < VECTORS_PER_SEGMENT; i++) {
+            assertFalse(mergedPks.contains(Bytes.from_string("a-" + i)));
+            assertTrue(mergedPks.contains(Bytes.from_string("b-" + i)));
+        }
+    }
+
+    private Set<Bytes> readMergedPks(RemoteSegmentGraphMerger.MergeOutput output) throws Exception {
+        ReaderSupplier supplier = dsm.multipartIndexReaderSupplier(
+                output.tablespaceUuid, output.indexUuid + "_seg" + output.segmentId,
+                "map", output.mapFileSize);
+        try (RandomAccessReader r = supplier.get()) {
+            r.seek(0L);
+            byte[] all = new byte[(int) output.mapFileSize];
+            r.readFully(all);
+            DataInputStream dis = new DataInputStream(new ByteArrayInputStream(all));
+            int entryCount = dis.readInt();
+            Set<Bytes> out = new HashSet<>(entryCount * 2);
+            for (int i = 0; i < entryCount; i++) {
+                dis.readInt(); // ordinal
+                int pkLen = dis.readInt();
+                byte[] pk = new byte[pkLen];
+                dis.readFully(pk);
+                int floatCount = dis.readInt();
+                for (int j = 0; j < floatCount; j++) {
+                    dis.readInt();
+                }
+                out.add(Bytes.from_array(pk));
+            }
+            return out;
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerUploadFailureTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/RemoteSegmentGraphMergerUploadFailureTest.java
@@ -1,0 +1,232 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.index.vector;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongConsumer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies the orphan-graph cleanup branch of {@link RemoteSegmentGraphMerger}:
+ * when the graph file uploads successfully but the map upload fails, the
+ * merger MUST delete the orphan graph artefact so an aborted run doesn't leak
+ * multipart files (issue #484, review item B.4 from the first pr-reviewer pass).
+ */
+public class RemoteSegmentGraphMergerUploadFailureTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-upfail";
+    private static final String IDX_UUID = "idx-upfail";
+    private static final int DIM = 8;
+    private static final int VECTORS_PER_SEGMENT = 30;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager backingDsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        backingDsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    private List<RemoteSegmentGraphMerger.RemoteSegmentInput> writeTwoInputs() throws Exception {
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = new ArrayList<>(2);
+        for (int seg = 0; seg < 2; seg++) {
+            Path mapFile = Files.createTempFile(tmpDir, "input-", ".tmp");
+            try (BufferedOutputStream bos = new BufferedOutputStream(
+                    new FileOutputStream(mapFile.toFile()));
+                 DataOutputStream dos = new DataOutputStream(bos)) {
+                dos.writeInt(VECTORS_PER_SEGMENT);
+                Random rng = new Random(seg);
+                for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                    dos.writeInt(local);
+                    byte[] pk = ("seg" + seg + "-" + local).getBytes();
+                    dos.writeInt(pk.length);
+                    dos.write(pk);
+                    VectorFloat<?> v = VTS.createFloatVector(DIM);
+                    for (int j = 0; j < DIM; j++) {
+                        v.set(j, rng.nextFloat());
+                    }
+                    dos.writeInt(v.length());
+                    for (int j = 0; j < v.length(); j++) {
+                        dos.writeInt(Float.floatToIntBits(v.get(j)));
+                    }
+                }
+            }
+            long mapSize = Files.size(mapFile);
+            backingDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg" + seg, "map", mapFile, null);
+            Files.deleteIfExists(mapFile);
+            inputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                    TS_UUID, IDX_UUID, "seg-uuid-" + seg, seg, mapSize,
+                    /* generation */ 1L + seg, new int[0]));
+        }
+        return inputs;
+    }
+
+    @Test
+    public void mapUploadFailureCleansUpOrphanGraph() throws Exception {
+        // Use a fresh throwing DSM so the merger reads inputs back from the
+        // SAME storage instance that simulates the map-upload failure. The
+        // fault is armed only AFTER the input fixtures have been seeded so
+        // the seed writes never trip the trigger.
+        List<String> deletes = new ArrayList<>();
+        ThrowingMapUploadDsm throwingDsm = new ThrowingMapUploadDsm(
+                new AtomicInteger(), deletes);
+        backingDsm = throwingDsm;
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = writeTwoInputs();
+        throwingDsm.armMapUploadFailure();
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                throwingDsm, tmpDir, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        long outputSegmentId = 555L;
+        try {
+            merger.merge(inputs, TS_UUID, IDX_UUID, outputSegmentId, DIM);
+            fail("expected DataStorageManagerException from the map-upload failure");
+        } catch (DataStorageManagerException ok) {
+            assertTrue(ok.getMessage().contains("simulated map upload failure"));
+        }
+
+        // The merger must have attempted to delete the orphan graph file on the
+        // way out (the cleanup branch in RemoteSegmentGraphMerger.merge).
+        String expectedKey = TS_UUID + "/" + IDX_UUID + "_seg" + outputSegmentId + "/graph";
+        assertTrue("orphan-graph cleanup must have been invoked, observed deletes: " + deletes,
+                deletes.contains(expectedKey));
+
+        // Belt-and-suspenders: the orphan graph file is gone from the backing
+        // DSM (the throwing decorator delegates deletes to the backing DSM).
+        try {
+            backingDsm.multipartIndexReaderSupplier(TS_UUID,
+                    IDX_UUID + "_seg" + outputSegmentId, "graph", 1L);
+            fail("orphan graph file must have been deleted");
+        } catch (DataStorageManagerException ok) {
+            // expected — the in-memory DSM throws on missing keys
+        }
+    }
+
+    @Test
+    public void deleteOutputAfterEverythingSucceededRemovesBoth() throws Exception {
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = writeTwoInputs();
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                backingDsm, tmpDir, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        RemoteSegmentGraphMerger.MergeOutput output = merger.merge(
+                inputs, TS_UUID, IDX_UUID, /* outputSegmentId */ 777L, DIM);
+        assertTrue(output != null);
+
+        merger.deleteOutput(output);
+
+        // Both files removed from the backing DSM.
+        try {
+            backingDsm.multipartIndexReaderSupplier(TS_UUID,
+                    IDX_UUID + "_seg777", "graph", 1L);
+            fail("graph file must have been deleted");
+        } catch (DataStorageManagerException ok) {
+            // expected
+        }
+        try {
+            backingDsm.multipartIndexReaderSupplier(TS_UUID,
+                    IDX_UUID + "_seg777", "map", 1L);
+            fail("map file must have been deleted");
+        } catch (DataStorageManagerException ok) {
+            // expected
+        }
+
+        // deleteOutput is idempotent — calling it again on already-deleted output
+        // must NOT throw.
+        merger.deleteOutput(output);
+    }
+
+    @Test
+    public void deleteOutputOnNullIsNoOp() throws Exception {
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                backingDsm, tmpDir, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        merger.deleteOutput(null);
+        // No exception; that's the assertion.
+    }
+
+    /**
+     * DSM decorator that delegates to a backing {@link MemoryDataStorageManager}
+     * for everything the merger touches except for the second
+     * {@code writeMultipartIndexFile} call (the map-file upload, which always
+     * follows the graph upload). That call throws to simulate a partial-upload
+     * failure so the orphan-graph cleanup branch can be exercised.
+     *
+     * <p>Subclassing {@link MemoryDataStorageManager} avoids the ~30
+     * abstract-method ceremony that subclassing
+     * {@code herddb.storage.DataStorageManager} directly would require.
+     */
+    private static final class ThrowingMapUploadDsm extends MemoryDataStorageManager {
+        private final List<String> deletes;
+        /** Set to true to enable the throw-on-next-map-upload trigger. */
+        private volatile boolean throwOnNextMapUpload = false;
+
+        ThrowingMapUploadDsm(AtomicInteger unused, List<String> deletes) {
+            this.deletes = deletes;
+        }
+
+        void armMapUploadFailure() {
+            this.throwOnNextMapUpload = true;
+        }
+
+        @Override
+        public String writeMultipartIndexFile(String tableSpace, String uuid, String fileType,
+                                              Path tempFile, LongConsumer progress)
+                throws IOException, DataStorageManagerException {
+            if ("map".equals(fileType) && throwOnNextMapUpload) {
+                throwOnNextMapUpload = false;
+                throw new DataStorageManagerException("simulated map upload failure");
+            }
+            return super.writeMultipartIndexFile(tableSpace, uuid, fileType, tempFile, progress);
+        }
+
+        @Override
+        public void deleteMultipartIndexFile(String tableSpace, String uuid, String fileType)
+                throws DataStorageManagerException {
+            deletes.add(tableSpace + "/" + uuid + "/" + fileType);
+            super.deleteMultipartIndexFile(tableSpace, uuid, fileType);
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
@@ -644,16 +644,23 @@ public final class IndexOptimizerEngine {
         if (m.getTombstonePath() != null) {
             String tombstoneUuid = TombstoneOverlayManager.multipartUuidFor(
                     m.getIndexUuid(), m.getSegmentUuid());
-            // We don't know the exact generation at this point (the znode tracks
-            // tombstoneLsn but not the generation explicitly). Probe a window of recent
-            // generations to clean up any current + a safety window of stragglers. This
-            // is bounded to keep the call O(window) — typical N=1.
-            // Hot-path note: this only runs at retention time (every retentionMs, default
-            // 10 min) — not per search/insert. Worst-case O(generationWindow) DSM calls
-            // per reaped segment, all idempotent.
-            for (long gen = 1; gen <= 32; gen++) {
+            // Issue #484: SegmentMetadata now records the overlay generation
+            // explicitly so the reaper deletes the correct file directly
+            // instead of probing a fixed window of generations. Older payloads
+            // (overlayGeneration == 0) fall back to a bounded probe so a v1
+            // znode written before the field existed still gets cleaned up.
+            long latestGen = m.getOverlayGeneration();
+            if (latestGen > 0L) {
                 tryDeleteMultipart(m.getTablespaceUuid(), tombstoneUuid,
-                        "tombstones-" + gen, m.getSegmentUuid());
+                        TombstoneOverlayManager.fileTypeFor(latestGen), m.getSegmentUuid());
+            } else {
+                // Compatibility probe for znodes written before overlayGeneration
+                // was added. Hot-path note: this only runs at retention (every
+                // retentionMs, default 10 min) — never on the search/insert path.
+                for (long gen = 1; gen <= 32; gen++) {
+                    tryDeleteMultipart(m.getTablespaceUuid(), tombstoneUuid,
+                            TombstoneOverlayManager.fileTypeFor(gen), m.getSegmentUuid());
+                }
             }
         }
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -23,17 +23,35 @@ import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.indexing.segment.SegmentRegistryClient;
 import herddb.metadata.MetadataStorageManagerException;
 import herddb.model.TableSpace;
+import herddb.server.RemoteFileClient;
+import herddb.server.RemoteFileServiceFactory;
+import herddb.server.ServerConfiguration;
+import herddb.storage.DataStorageManager;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -46,12 +64,20 @@ import org.apache.zookeeper.ZooKeeper;
  * <ul>
  *   <li>Parse a properties file ({@link OptimizerConfiguration}).</li>
  *   <li>Open a ZooKeeper connection and a {@link SegmentRegistryClient}.</li>
+ *   <li>Build a {@link DataStorageManager} backed by the remote file service
+ *       (so the merger can download input segment files and upload the merged
+ *       output) when {@code indexoptimizer.remote.file.servers} is configured
+ *       — falls back to a {@link NoopMerger} otherwise so the unit test suite
+ *       can exercise the registry plumbing without provisioning a file server.</li>
  *   <li>Resolve a {@link SegmentMerger} via the standard {@link ServiceLoader}
- *       SPI. Production deployments register an implementation that wraps the
- *       real graph merger; until that wiring is in place the service starts
- *       with a {@code NoopMerger} that logs and declines every merge — useful
- *       for integration tests that exercise the registry plumbing.</li>
- *   <li>Schedule {@link IndexOptimizerEngine#runOnce()} on a fixed interval.</li>
+ *       SPI when one is registered (test override path); otherwise default to
+ *       the production {@link RemoteSegmentMerger}.</li>
+ *   <li>Drive {@link IndexOptimizerEngine#runOnce()} via two paths
+ *       (issue #484): a persistent-recursive ZK watch over the registry's
+ *       tablespace path that fires {@link IndexOptimizerEngine#runOnce()}
+ *       (debounced) on every children-changed event, plus a periodic
+ *       {@code scheduleAtFixedRate} fallback that ticks every {@code intervalMs}
+ *       as a safety net for the (rare) cases when ZK delivers no event.</li>
  * </ul>
  *
  * <p>Singleton enforcement is delegated to the deployment layer (Helm
@@ -63,23 +89,87 @@ public final class IndexOptimizerMain {
     private static final Logger LOGGER = Logger.getLogger(IndexOptimizerMain.class.getName());
 
     private final OptimizerConfiguration configuration;
-    private final SegmentMerger merger;
+    /**
+     * Optional pre-built merger (e.g. injected by tests). When {@code null},
+     * {@link #start} resolves a merger via the SPI / RemoteSegmentMerger
+     * plumbing. The previous constructor accepting an explicit merger is
+     * retained for backward compatibility with existing tests.
+     */
+    private final SegmentMerger preconfiguredMerger;
 
     private ZooKeeper zooKeeper;
-    private ScheduledExecutorService scheduler;
+    /**
+     * Scheduler used by both the periodic safety-net tick and the event-driven
+     * wakeup. {@code volatile} so the ZK watcher thread (which reads it without
+     * holding the {@code IndexOptimizerMain} monitor) sees a consistent view
+     * once {@link #start} has published it (issue #484). The mixed
+     * synchronized-write / unsynchronized-read pattern is filtered project-wide
+     * via {@code excludeFindBugsFilter.xml}.
+     */
+    private volatile ScheduledExecutorService scheduler;
     private SegmentRegistryClient registry;
     private OptimizerLeaderLock leaderLock;
     private IndexOptimizerEngine engine;
     private OptimizerHttpServer httpServer;
+    private SegmentMerger merger;
+    private DataStorageManager mergerDataStorageManager;
+    private RemoteFileClient mergerFileClient;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
+    /**
+     * Coalescing flag for event-driven scheduling. The persistent-recursive
+     * ZK watch fires {@link #scheduleEventDrivenTick} on every change at or
+     * below the registry tablespace path; {@code pendingWakeup} is flipped
+     * to {@code true} via CAS so a burst of N events still produces only one
+     * scheduled tick. Reset to {@code false} as the tick body starts.
+     */
+    private final AtomicBoolean pendingWakeup = new AtomicBoolean(false);
+    /** Number of event-driven ticks executed (observable by tests). */
+    private final AtomicLong eventDrivenTicks = new AtomicLong();
+    /** Number of distinct ZK events observed by the persistent-recursive watcher. */
+    private final AtomicLong watcherEvents = new AtomicLong();
+    /**
+     * Debounce window for the event-driven tick. {@code volatile} for the same
+     * reason as {@link #scheduler}: the ZK watcher thread reads it without
+     * holding the {@code IndexOptimizerMain} monitor (issue #484).
+     */
+    private volatile long eventDebounceMs;
+    private volatile String tablespaceUuid;
+
+    /**
+     * Production constructor: the merger is built at {@link #start} time from
+     * configuration. Pass {@code null} to defer to the SPI / RemoteSegmentMerger
+     * fallback chain.
+     */
+    public IndexOptimizerMain(OptimizerConfiguration configuration) {
+        this(configuration, null);
+    }
+
+    /**
+     * Test / SPI-override constructor. Production code uses
+     * {@link #IndexOptimizerMain(OptimizerConfiguration)}; this overload exists
+     * so tests can plug a synthetic merger ({@code InMemorySegmentMerger}, etc.)
+     * without going through the {@code ServiceLoader} indirection.
+     */
     public IndexOptimizerMain(OptimizerConfiguration configuration, SegmentMerger merger) {
         this.configuration = configuration;
-        this.merger = merger;
+        this.preconfiguredMerger = merger;
     }
 
     public IndexOptimizerEngine getEngine() {
         return engine;
+    }
+
+    public SegmentMerger getMerger() {
+        return merger;
+    }
+
+    public long getEventDrivenTicks() {
+        return eventDrivenTicks.get();
+    }
+
+    public long getWatcherEvents() {
+        return watcherEvents.get();
     }
 
     public synchronized void start() throws Exception {
@@ -108,7 +198,7 @@ public final class IndexOptimizerMain {
         // it immediately after so that the optimizer's permanent ZK connection
         // (used by SegmentRegistryClient and OptimizerLeaderLock) is separate
         // and independently reconnectable.
-        String tablespaceUuid;
+        List<String> discoveredFileServers = new ArrayList<>();
         try (ZookeeperMetadataStorageManager zkmeta =
                 new ZookeeperMetadataStorageManager(zkAddress, sessionTimeout, basePath)) {
             zkmeta.start(false); // read-only: do not create/format cluster metadata paths
@@ -120,6 +210,15 @@ public final class IndexOptimizerMain {
                         + "and created its default tablespace before starting the optimizer.");
             }
             tablespaceUuid = ts.uuid;
+            try {
+                discoveredFileServers.addAll(zkmeta.listFileServers());
+            } catch (MetadataStorageManagerException listErr) {
+                LOGGER.log(Level.WARNING,
+                        "could not discover remote file servers via ZK; the optimizer"
+                                + " will fall back to NoopMerger if the static server list"
+                                + " is also empty: {0}",
+                        listErr.getMessage());
+            }
         } catch (MetadataStorageManagerException e) {
             throw new IllegalStateException(
                     "Failed to resolve tablespace '" + tablespaceName + "' from ZooKeeper: "
@@ -150,33 +249,41 @@ public final class IndexOptimizerMain {
         long retentionMs = configuration.getLong(
                 OptimizerConfiguration.PROPERTY_RETENTION_MS,
                 OptimizerConfiguration.PROPERTY_RETENTION_MS_DEFAULT);
-        int minCount = configuration.getInt(
-                OptimizerConfiguration.PROPERTY_MIN_COUNT,
-                OptimizerConfiguration.PROPERTY_MIN_COUNT_DEFAULT);
+        long targetMaxBytes = configuration.getLong(
+                OptimizerConfiguration.PROPERTY_TARGET_MAX_BYTES,
+                OptimizerConfiguration.PROPERTY_TARGET_MAX_BYTES_DEFAULT);
         int maxCount = configuration.getInt(
                 OptimizerConfiguration.PROPERTY_MAX_COUNT,
                 OptimizerConfiguration.PROPERTY_MAX_COUNT_DEFAULT);
-        long minBytes = configuration.getLong(
-                OptimizerConfiguration.PROPERTY_MIN_BYTES,
-                OptimizerConfiguration.PROPERTY_MIN_BYTES_DEFAULT);
-        long maxBytes = configuration.getLong(
+        long perCycleMaxBytes = configuration.getLong(
                 OptimizerConfiguration.PROPERTY_MAX_BYTES,
                 OptimizerConfiguration.PROPERTY_MAX_BYTES_DEFAULT);
+        this.eventDebounceMs = configuration.getLong(
+                OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS,
+                OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS_DEFAULT);
 
-        MergePolicy policy = new MergePolicy.SmallestFirstPolicy(minCount, maxCount, minBytes, maxBytes);
+        // Issue #484: aggressive policy by default. Segments at or above
+        // targetMaxBytes are graduated; everything else is mergeable as long
+        // as ≥2 sub-target segments exist — there's no minCount/minBytes gate.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                targetMaxBytes, perCycleMaxBytes, maxCount);
+
+        // Resolve the merger (SPI override → preconfigured → RemoteSegmentMerger
+        // → NoopMerger) and the DataStorageManager that drives it (only when
+        // remote file servers are configured).
+        this.merger = resolveMerger(zkAddress, basePath, discoveredFileServers);
+
         this.leaderLock = new OptimizerLeaderLock(zkRef::get, basePath, tablespaceUuid);
         boolean safeModeFileDeletion = configuration.getBoolean(
                 OptimizerConfiguration.PROPERTY_SAFE_MODE_FILE_DELETION,
                 OptimizerConfiguration.PROPERTY_SAFE_MODE_FILE_DELETION_DEFAULT);
-        // Production deployments today have no DataStorageManager wired (the merger
-        // SPI provides its own). When safeMode is true (default) this is fine; when
-        // operators opt out we still pass null because file-deletion-from-the-engine
-        // requires a real DSM and that's a future-work item — the constructor will
-        // refuse the unsafe combination.
+        // The merger constructs its own DSM for the merge path. The reaper
+        // can use the same DSM to physically delete files at retention if
+        // safeMode is opted out (the operator's responsibility).
         this.engine = new IndexOptimizerEngine(registry, merger, tablespaceUuid, policy, retentionMs,
                 () -> 0 /* MVP: assign new segments to instance 0 — see step 7 for owner-aware routing */,
                 System::currentTimeMillis,
-                /* dataStorageManager — wired by future production deployments */ null,
+                mergerDataStorageManager,
                 leaderLock,
                 safeModeFileDeletion);
 
@@ -185,7 +292,19 @@ public final class IndexOptimizerMain {
             t.setDaemon(true);
             return t;
         });
+        // Periodic safety-net tick. Bursty ingestion is handled by the
+        // event-driven path below; this only fires when ZK has been quiet
+        // for at least intervalMs.
         scheduler.scheduleAtFixedRate(this::tickSafe, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+
+        // Issue #484: arm a persistent-recursive ZK watch on the registry's
+        // tablespace path so that any new segment / state change anywhere
+        // under it produces an immediate (debounced) tick. The watch fires
+        // forever — no re-arming needed across single ZK events — and
+        // survives disconnects (it does NOT survive session expiry, but the
+        // optimizer pod has a single long-lived ZK session and operators
+        // restart the pod if the session ever expires).
+        armPersistentRecursiveWatch();
 
         // Admin HTTP endpoint (review item E1+E3). Disabled when port == 0; otherwise
         // exposes /health (Helm probe target) and /metrics (Prometheus scrape).
@@ -206,8 +325,10 @@ public final class IndexOptimizerMain {
         }
 
         LOGGER.log(Level.INFO,
-                "index-optimizer started: zk={0}, basePath={1}, tablespace={2} (uuid={3}), intervalMs={4}, httpPort={5}",
-                new Object[]{zkAddress, basePath, tablespaceName, tablespaceUuid, intervalMs, httpPort});
+                "index-optimizer started: zk={0}, basePath={1}, tablespace={2} (uuid={3}),"
+                        + " intervalMs={4}, eventDebounceMs={5}, mergerType={6}, httpPort={7}",
+                new Object[]{zkAddress, basePath, tablespaceName, tablespaceUuid,
+                        intervalMs, eventDebounceMs, merger.getClass().getSimpleName(), httpPort});
     }
 
     private void tickSafe() {
@@ -221,6 +342,237 @@ public final class IndexOptimizerMain {
             LOGGER.log(Level.WARNING, "optimizer tick failed", e);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Event-driven scheduling (issue #484)
+    // -------------------------------------------------------------------------
+
+    private void armPersistentRecursiveWatch() {
+        if (zooKeeper == null || registry == null || tablespaceUuid == null) {
+            return;
+        }
+        String path = registry.tablespacePath(tablespaceUuid);
+        Watcher eventWatcher = (WatchedEvent event) -> {
+            // Only KeeperState.SyncConnected events carry a meaningful path; lifecycle
+            // events (Disconnected, Expired) just advise us to re-arm or restart, but
+            // for simplicity we always try to schedule a wakeup — the engine's
+            // runOnce will short-circuit on connection loss anyway.
+            if (event.getType() == Watcher.Event.EventType.None) {
+                if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                    // Reconnect after a transient disconnect: the persistent-recursive
+                    // watch is automatically re-registered by the ZK client, but we
+                    // schedule a wakeup to catch up on any events that may have been
+                    // missed during the disconnect.
+                    scheduleEventDrivenTick();
+                }
+                return;
+            }
+            watcherEvents.incrementAndGet();
+            scheduleEventDrivenTick();
+        };
+        try {
+            // Make sure the parent znode exists so addWatch doesn't fail with NoNode.
+            registry.ensureRoot();
+            try {
+                zooKeeper.create(path, new byte[0], org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                        org.apache.zookeeper.CreateMode.PERSISTENT);
+            } catch (KeeperException.NodeExistsException ok) {
+                // expected
+            }
+            zooKeeper.addWatch(path, eventWatcher, AddWatchMode.PERSISTENT_RECURSIVE);
+            LOGGER.log(Level.INFO,
+                    "armed persistent-recursive watch on {0} (event-driven scheduling enabled)",
+                    path);
+        } catch (KeeperException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            // Don't fail startup — the periodic safety-net tick still runs.
+            LOGGER.log(Level.WARNING,
+                    "failed to arm persistent-recursive watch on {0}: {1}; falling back to"
+                            + " periodic-only scheduling",
+                    new Object[]{path, e.getMessage()});
+        } catch (herddb.indexing.segment.SegmentRegistryException e) {
+            LOGGER.log(Level.WARNING,
+                    "failed to ensure registry root before arming watch: {0}",
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Coalescing scheduler for the event-driven path. The first event in a
+     * burst flips {@link #pendingWakeup} from false→true and enqueues a
+     * scheduled task on the engine's single-threaded executor with the
+     * configured debounce delay. All later events in the same burst short-
+     * circuit on the CAS — they observe pendingWakeup==true and return
+     * without enqueuing.
+     */
+    private void scheduleEventDrivenTick() {
+        if (scheduler == null) {
+            return;
+        }
+        if (!pendingWakeup.compareAndSet(false, true)) {
+            return;
+        }
+        long delay = Math.max(0L, eventDebounceMs);
+        scheduler.schedule(this::runEventDrivenTick, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private void runEventDrivenTick() {
+        // Reset the flag BEFORE running the engine so that any event that
+        // arrives while we're working schedules another wakeup. This is the
+        // safe ordering: missing one event is bad (we'd wait until the next
+        // periodic tick), running an extra event-driven tick is harmless.
+        pendingWakeup.set(false);
+        eventDrivenTicks.incrementAndGet();
+        tickSafe();
+    }
+
+    // -------------------------------------------------------------------------
+    // Merger resolution
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolves the {@link SegmentMerger} for this optimizer. Resolution order:
+     * <ol>
+     *   <li>If a merger was passed to the constructor explicitly, use it (test path).</li>
+     *   <li>Else if the {@link ServiceLoader} returns a registered SPI provider, use it
+     *       (also a test override mechanism via {@code META-INF/services}).</li>
+     *   <li>Else if remote file servers are configured (or discovered via ZK),
+     *       construct a {@link RemoteSegmentMerger} backed by a freshly-built
+     *       {@link DataStorageManager}.</li>
+     *   <li>Else fall back to {@link NoopMerger} with a clear WARNING log so the
+     *       service still starts in environments where no remote storage is wired.</li>
+     * </ol>
+     */
+    private SegmentMerger resolveMerger(String zkAddress, String basePath,
+                                        List<String> discoveredFileServers) throws IOException {
+        if (preconfiguredMerger != null) {
+            LOGGER.log(Level.INFO, "using pre-configured merger {0}",
+                    preconfiguredMerger.getClass().getName());
+            return preconfiguredMerger;
+        }
+        ServiceLoader<SegmentMerger> loader = ServiceLoader.load(SegmentMerger.class);
+        for (SegmentMerger candidate : loader) {
+            LOGGER.log(Level.INFO, "loaded segment merger SPI {0}", candidate.getClass().getName());
+            return candidate;
+        }
+        // Build a RemoteSegmentMerger when remote-file servers are reachable.
+        String staticServers = configuration.getString(
+                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS,
+                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS_DEFAULT);
+        List<String> servers = new ArrayList<>();
+        if (staticServers != null && !staticServers.isEmpty()) {
+            for (String s : staticServers.split(",")) {
+                String trimmed = s.trim();
+                if (!trimmed.isEmpty()) {
+                    servers.add(trimmed);
+                }
+            }
+            LOGGER.log(Level.INFO, "remote file servers (static): {0}", servers);
+        } else if (discoveredFileServers != null && !discoveredFileServers.isEmpty()) {
+            servers.addAll(discoveredFileServers);
+            LOGGER.log(Level.INFO, "remote file servers (ZK discovery): {0}", servers);
+        }
+        if (servers.isEmpty()) {
+            LOGGER.log(Level.WARNING,
+                    "no remote file servers configured (and ZK discovery returned none) —"
+                            + " falling back to NoopMerger; the optimizer will decline every"
+                            + " merge until a real merger is provided.");
+            return new NoopMerger();
+        }
+        try {
+            return buildRemoteSegmentMerger(servers, zkAddress, basePath);
+        } catch (RuntimeException buildErr) {
+            // Building the DSM is the plugin boundary — surface and fall back rather
+            // than killing the pod. If construction fails (bad config, bad JVM args,
+            // etc.) the operator gets a clear error in the logs and the optimizer
+            // continues to run with NoopMerger so the registry plumbing is still
+            // observable.
+            LOGGER.log(Level.SEVERE,
+                    "failed to construct RemoteSegmentMerger; falling back to NoopMerger: {0}",
+                    buildErr.getMessage());
+            return new NoopMerger();
+        }
+    }
+
+    private RemoteSegmentMerger buildRemoteSegmentMerger(List<String> servers, String zkAddress,
+                                                         String basePath) throws IOException {
+        Map<String, Object> clientConfig = new HashMap<>();
+        clientConfig.put("remote.file.client.timeout",
+                configuration.getLong(OptimizerConfiguration.PROPERTY_REMOTE_FILE_TIMEOUT,
+                        OptimizerConfiguration.PROPERTY_REMOTE_FILE_TIMEOUT_DEFAULT));
+        clientConfig.put("remote.file.client.retries",
+                configuration.getInt(OptimizerConfiguration.PROPERTY_REMOTE_FILE_RETRIES,
+                        OptimizerConfiguration.PROPERTY_REMOTE_FILE_RETRIES_DEFAULT));
+        clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_READ_BYTES,
+                configuration.getLong(
+                        OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_READ_BYTES,
+                        OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_READ_BYTES_DEFAULT));
+        clientConfig.put(ServerConfiguration.PROPERTY_REMOTE_FILE_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                configuration.getLong(
+                        OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES,
+                        OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES_DEFAULT));
+
+        RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
+        this.mergerFileClient = factory.createClient(servers, clientConfig);
+        Path tmpDir = resolveTmpDirectory();
+        Path metaDir = tmpDir.resolve("merger-metadata");
+        Path remoteTmp = tmpDir.resolve("merger-remote-tmp");
+        Files.createDirectories(metaDir);
+        Files.createDirectories(remoteTmp);
+        this.mergerDataStorageManager = factory.createDataStorageManager(
+                metaDir, remoteTmp, Integer.MAX_VALUE, mergerFileClient);
+
+        int dim = configuration.getInt("indexoptimizer.merge.dim", 0);
+        if (dim <= 0) {
+            // The merger needs the dimension up front. Fall back: we don't
+            // currently store dim in the segment registry, so operators must
+            // configure it explicitly. If it's missing we refuse to merge.
+            throw new IllegalStateException("indexoptimizer.merge.dim must be set to the index"
+                    + " vector dimension (no inference is currently supported)");
+        }
+        int graphM = configuration.getInt(OptimizerConfiguration.PROPERTY_MERGE_M,
+                OptimizerConfiguration.PROPERTY_MERGE_M_DEFAULT);
+        int beamWidth = configuration.getInt(OptimizerConfiguration.PROPERTY_MERGE_BEAM_WIDTH,
+                OptimizerConfiguration.PROPERTY_MERGE_BEAM_WIDTH_DEFAULT);
+        float neighborOverflow = configuration.getFloat(
+                OptimizerConfiguration.PROPERTY_MERGE_NEIGHBOR_OVERFLOW,
+                OptimizerConfiguration.PROPERTY_MERGE_NEIGHBOR_OVERFLOW_DEFAULT);
+        float alpha = configuration.getFloat(OptimizerConfiguration.PROPERTY_MERGE_ALPHA,
+                OptimizerConfiguration.PROPERTY_MERGE_ALPHA_DEFAULT);
+        String similarityName = configuration.getString(
+                OptimizerConfiguration.PROPERTY_MERGE_SIMILARITY,
+                OptimizerConfiguration.PROPERTY_MERGE_SIMILARITY_DEFAULT);
+        VectorSimilarityFunction similarity;
+        try {
+            similarity = VectorSimilarityFunction.valueOf(similarityName);
+        } catch (IllegalArgumentException badName) {
+            throw new IllegalStateException(
+                    "indexoptimizer.merge.similarity has unsupported value: " + similarityName
+                            + " (expected one of " + Arrays.toString(VectorSimilarityFunction.values())
+                            + ")", badName);
+        }
+        return new RemoteSegmentMerger(mergerDataStorageManager, tmpDir,
+                dim, graphM, beamWidth, neighborOverflow, alpha, similarity);
+    }
+
+    private Path resolveTmpDirectory() throws IOException {
+        String configured = configuration.getString(OptimizerConfiguration.PROPERTY_TMP_DIR, null);
+        if (configured == null) {
+            // Java system property (set by Helm via -D) takes precedence over the
+            // OS default tmp dir.
+            configured = System.getProperty(OptimizerConfiguration.PROPERTY_TMP_DIR,
+                    System.getProperty("java.io.tmpdir"));
+        }
+        Path tmpDir = Paths.get(configured);
+        Files.createDirectories(tmpDir);
+        return tmpDir;
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
 
     public synchronized void shutdown() {
         if (httpServer != null) {
@@ -251,6 +603,17 @@ public final class IndexOptimizerMain {
                 Thread.currentThread().interrupt();
             }
         }
+        if (mergerFileClient instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) mergerFileClient).close();
+            } catch (Exception e) {
+                // Broad catch: the client's close() is a best-effort cleanup
+                // path during shutdown. Log and continue rather than masking
+                // an earlier exception.
+                LOGGER.log(Level.WARNING, "merger file client close failed: {0}",
+                        e.getMessage());
+            }
+        }
         shutdownLatch.countDown();
     }
 
@@ -271,8 +634,7 @@ public final class IndexOptimizerMain {
             properties.load(in);
         }
         OptimizerConfiguration configuration = new OptimizerConfiguration(properties);
-        SegmentMerger merger = loadMergerSpi();
-        IndexOptimizerMain optimizer = new IndexOptimizerMain(configuration, merger);
+        IndexOptimizerMain optimizer = new IndexOptimizerMain(configuration);
         Runtime.getRuntime().addShutdownHook(new Thread(optimizer::shutdown,
                 "index-optimizer-shutdown"));
         optimizer.start();
@@ -280,12 +642,14 @@ public final class IndexOptimizerMain {
     }
 
     /**
-     * Resolve a {@link SegmentMerger} via the {@link ServiceLoader} SPI. If no
-     * provider is registered, fall back to a {@link NoopMerger} that logs and
-     * declines every merge. Production deployments register a real merger
-     * (extracted from {@code VectorIndexCompactor}) on the classpath.
+     * Backward-compatibility helper for tests that exercise the SPI fallback
+     * path: returns the first {@link SegmentMerger} registered through
+     * {@link ServiceLoader}, or a {@link NoopMerger} when none is registered.
+     * Production code uses {@link #resolveMerger} (called from {@link #start})
+     * which adds the {@link RemoteSegmentMerger} fallback when a remote DSM
+     * can be wired.
      */
-    static SegmentMerger loadMergerSpi() {
+    public static SegmentMerger loadMergerSpi() {
         ServiceLoader<SegmentMerger> loader = ServiceLoader.load(SegmentMerger.class);
         for (SegmentMerger candidate : loader) {
             LOGGER.log(Level.INFO, "loaded segment merger SPI {0}", candidate.getClass().getName());
@@ -299,7 +663,10 @@ public final class IndexOptimizerMain {
 
     /**
      * Inert {@link SegmentMerger} that logs and returns {@code null}, declining the
-     * merge attempt. Used as the default until a graph-aware merger is provided.
+     * merge attempt. Used as the fallback in unit-test environments and any
+     * deployment that does not have remote file servers configured (the
+     * registry plumbing still runs and ticks are still scheduled, but no merge
+     * ever lands until a real merger is wired).
      */
     public static final class NoopMerger implements SegmentMerger {
         @Override

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -129,6 +129,15 @@ public final class IndexOptimizerMain {
     /** Number of distinct ZK events observed by the persistent-recursive watcher. */
     private final AtomicLong watcherEvents = new AtomicLong();
     /**
+     * Set to {@code true} when the ZooKeeper session expires. Once set, the
+     * persistent-recursive watch is dead, the leader-lock ephemeral znode is
+     * gone, and any registry read against {@link #zooKeeper} will fail —
+     * which means the pod is silently broken. The HTTP {@code /health}
+     * handler consults this flag and returns 503 so Helm's liveness probe
+     * restarts the pod (review item B.3 from the first pr-reviewer pass).
+     */
+    private final AtomicBoolean sessionExpired = new AtomicBoolean(false);
+    /**
      * Debounce window for the event-driven tick. {@code volatile} for the same
      * reason as {@link #scheduler}: the ZK watcher thread reads it without
      * holding the {@code IndexOptimizerMain} monitor (issue #484).
@@ -170,6 +179,15 @@ public final class IndexOptimizerMain {
 
     public long getWatcherEvents() {
         return watcherEvents.get();
+    }
+
+    /**
+     * Returns {@code true} when the ZooKeeper session has expired. The HTTP
+     * health handler uses this to flip {@code /health} to 503 so Helm's
+     * liveness probe restarts the pod.
+     */
+    public boolean isSessionExpired() {
+        return sessionExpired.get();
     }
 
     public synchronized void start() throws Exception {
@@ -230,8 +248,25 @@ public final class IndexOptimizerMain {
         CountDownLatch zkConnected = new CountDownLatch(1);
         AtomicReference<ZooKeeper> zkRef = new AtomicReference<>();
         ZooKeeper zk = new ZooKeeper(zkAddress, sessionTimeout, (WatchedEvent event) -> {
-            if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
-                zkConnected.countDown();
+            switch (event.getState()) {
+                case SyncConnected:
+                    zkConnected.countDown();
+                    break;
+                case Expired:
+                    // Session expiry kills the persistent-recursive watch and the
+                    // leader-lock ephemeral znode. The pod is silently broken from
+                    // here on; flag /health to 503 so Helm restarts us (review item
+                    // B.3 from the first pr-reviewer pass).
+                    if (sessionExpired.compareAndSet(false, true)) {
+                        LOGGER.log(Level.SEVERE,
+                                "ZooKeeper session expired — /health will return 503"
+                                        + " so the pod is restarted.");
+                    }
+                    break;
+                default:
+                    // Disconnected / AuthFailed / etc. — log at FINE; the ZK client
+                    // recovers from transient disconnects on its own.
+                    break;
             }
         });
         zkRef.set(zk);
@@ -320,7 +355,8 @@ public final class IndexOptimizerMain {
             // from second pr-reviewer pass).
             this.httpServer = new OptimizerHttpServer(httpHost, httpPort, engine,
                     /* stalenessThresholdMillis */ 2L * intervalMs,
-                    System::currentTimeMillis);
+                    System::currentTimeMillis,
+                    /* criticalFailure */ this::isSessionExpired);
             this.httpServer.start();
         }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -129,12 +129,20 @@ public final class IndexOptimizerMain {
     /** Number of distinct ZK events observed by the persistent-recursive watcher. */
     private final AtomicLong watcherEvents = new AtomicLong();
     /**
-     * Set to {@code true} when the ZooKeeper session expires. Once set, the
-     * persistent-recursive watch is dead, the leader-lock ephemeral znode is
-     * gone, and any registry read against {@link #zooKeeper} will fail —
-     * which means the pod is silently broken. The HTTP {@code /health}
-     * handler consults this flag and returns 503 so Helm's liveness probe
-     * restarts the pod (review item B.3 from the first pr-reviewer pass).
+     * Set to {@code true} when the ZooKeeper session expires (or auth
+     * fails). Once set, the persistent-recursive watch is dead, the
+     * leader-lock ephemeral znode is gone, and any registry read against
+     * {@link #zooKeeper} will fail — which means the pod is silently
+     * broken. The HTTP {@code /health} handler consults this flag and
+     * returns 503 so Helm's liveness probe restarts the pod (review item
+     * B.3 from the first pr-reviewer pass).
+     *
+     * <p>The flag is intentionally <strong>one-way</strong>: once tripped,
+     * the only recovery is process restart, which Helm performs in
+     * response to the 503 health check. We do not try to re-establish the
+     * ZK session in-process because the leader-lock would have to be
+     * re-acquired and the persistent-recursive watch re-armed under tight
+     * race conditions — far simpler and safer to let Helm replace us.
      */
     private final AtomicBoolean sessionExpired = new AtomicBoolean(false);
     /**
@@ -253,19 +261,22 @@ public final class IndexOptimizerMain {
                     zkConnected.countDown();
                     break;
                 case Expired:
+                case AuthFailed:
                     // Session expiry kills the persistent-recursive watch and the
-                    // leader-lock ephemeral znode. The pod is silently broken from
-                    // here on; flag /health to 503 so Helm restarts us (review item
-                    // B.3 from the first pr-reviewer pass).
+                    // leader-lock ephemeral znode; AuthFailed is similarly
+                    // unrecoverable (credentials are wrong / revoked). Either way
+                    // the pod is silently broken from here on; flag /health to
+                    // 503 so Helm restarts us (review item B.3 from the first
+                    // pr-reviewer pass; AuthFailed coverage from round 2).
                     if (sessionExpired.compareAndSet(false, true)) {
                         LOGGER.log(Level.SEVERE,
-                                "ZooKeeper session expired — /health will return 503"
-                                        + " so the pod is restarted.");
+                                "ZooKeeper {0} — /health will return 503 so the pod is restarted.",
+                                event.getState());
                     }
                     break;
                 default:
-                    // Disconnected / AuthFailed / etc. — log at FINE; the ZK client
-                    // recovers from transient disconnects on its own.
+                    // Disconnected / etc. — log at FINE; the ZK client recovers
+                    // from transient disconnects on its own.
                     break;
             }
         });

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergePolicy.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergePolicy.java
@@ -95,4 +95,95 @@ public interface MergePolicy {
             return new ArrayList<>();
         }
     }
+
+    /**
+     * Aggressive merge policy (issue #484): the optimizer keeps merging
+     * graphs until every segment has reached {@code targetMaxBytes}. Any
+     * segment whose {@code sizeBytes} is already at or above the target is
+     * "graduated" — left alone forever; everything else is mergeable.
+     *
+     * <p>Trigger: as long as at least two segments are below
+     * {@code targetMaxBytes}, the policy fires. There are deliberately no
+     * minimum-count or minimum-bytes thresholds — those would cause the
+     * optimizer to leave small graphs un-merged for hours under sustained
+     * load, which is precisely the failure mode this policy fixes.
+     *
+     * <p>Selection: smallest-first; the picked set is capped at
+     * {@code perCycleMaxBytes} of input data per cycle (write-amplification
+     * budget) and at {@code maxCount} segments. The 2-segment minimum
+     * always overrides those caps so a cycle with two segments whose sum
+     * exceeds the byte cap still proceeds.
+     */
+    final class AggressivePolicy implements MergePolicy {
+        private final long targetMaxBytes;
+        private final long perCycleMaxBytes;
+        private final int maxCount;
+
+        public AggressivePolicy(long targetMaxBytes, long perCycleMaxBytes, int maxCount) {
+            if (targetMaxBytes <= 0L) {
+                throw new IllegalArgumentException("targetMaxBytes must be positive: " + targetMaxBytes);
+            }
+            if (perCycleMaxBytes <= 0L) {
+                throw new IllegalArgumentException("perCycleMaxBytes must be positive: " + perCycleMaxBytes);
+            }
+            if (maxCount < 2) {
+                throw new IllegalArgumentException("maxCount must be >= 2: " + maxCount);
+            }
+            this.targetMaxBytes = targetMaxBytes;
+            this.perCycleMaxBytes = perCycleMaxBytes;
+            this.maxCount = maxCount;
+        }
+
+        public long getTargetMaxBytes() {
+            return targetMaxBytes;
+        }
+
+        public long getPerCycleMaxBytes() {
+            return perCycleMaxBytes;
+        }
+
+        public int getMaxCount() {
+            return maxCount;
+        }
+
+        @Override
+        public List<VersionedSegmentMetadata> pickMergeCandidates(
+                List<VersionedSegmentMetadata> activeSegments) {
+            if (activeSegments == null || activeSegments.size() < 2) {
+                return new ArrayList<>();
+            }
+            // Filter out graduated segments; only sub-target ones are mergeable.
+            List<VersionedSegmentMetadata> mergeable = new ArrayList<>();
+            for (VersionedSegmentMetadata v : activeSegments) {
+                long size = Math.max(0L, v.metadata().getSizeBytes());
+                if (size < targetMaxBytes) {
+                    mergeable.add(v);
+                }
+            }
+            if (mergeable.size() < 2) {
+                return new ArrayList<>();
+            }
+            mergeable.sort(Comparator.comparingLong(v -> v.metadata().getSizeBytes()));
+
+            List<VersionedSegmentMetadata> picked = new ArrayList<>();
+            long pickedBytes = 0L;
+            for (VersionedSegmentMetadata v : mergeable) {
+                long size = Math.max(0L, v.metadata().getSizeBytes());
+                // Always allow the first two so a cycle with two large
+                // sub-target segments still fires; after that, respect the
+                // per-cycle byte and count caps.
+                if (picked.size() >= 2) {
+                    if (pickedBytes + size > perCycleMaxBytes) {
+                        break;
+                    }
+                    if (picked.size() >= maxCount) {
+                        break;
+                    }
+                }
+                picked.add(v);
+                pickedBytes += size;
+            }
+            return picked.size() >= 2 ? picked : new ArrayList<>();
+        }
+    }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -102,6 +102,96 @@ public final class OptimizerConfiguration {
     public static final String PROPERTY_HTTP_HOST = "indexoptimizer.http.host";
     public static final String PROPERTY_HTTP_HOST_DEFAULT = "0.0.0.0";
 
+    // -------------------------------------------------------------------------
+    // Aggressive merge policy + event-driven scheduling (issue #484)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Per-graph "graduated" cap used by the {@link MergePolicy.AggressivePolicy}.
+     * Segments at or above this size are excluded from the merge candidate set
+     * — they are considered "done". Default 8 GiB.
+     */
+    public static final String PROPERTY_TARGET_MAX_BYTES = "indexoptimizer.merge.target.bytes";
+    public static final long PROPERTY_TARGET_MAX_BYTES_DEFAULT = 8L * 1024L * 1024L * 1024L;
+
+    /**
+     * Local scratch directory used by the merger to stage downloaded map
+     * files and the merged graph + map outputs before upload. Helm injects
+     * a PVC mount at {@code /opt/herddb/optimizer-tmp} via the
+     * {@code -Dindexoptimizer.tmp.dir=...} system property.
+     */
+    public static final String PROPERTY_TMP_DIR = "indexoptimizer.tmp.dir";
+
+    /**
+     * Debounce window for the ZK persistent-recursive watch that drives
+     * event-driven scheduling. Bursts of children-changed events are
+     * coalesced into a single {@code runOnce()} after this many millis of
+     * quiet, so a hundred new segments at ingest peak still produce a
+     * single tick. 0 disables debouncing (every event triggers a tick).
+     */
+    public static final String PROPERTY_EVENT_DEBOUNCE_MS = "indexoptimizer.event.debounce.ms";
+    public static final long PROPERTY_EVENT_DEBOUNCE_MS_DEFAULT = 500L;
+
+    // jvector params used by the merger when rebuilding the merged graph.
+    // Defaults aligned to {@code PersistentVectorStore} so the merged segment
+    // has the same recall characteristics as in-IS-built segments.
+
+    /** jvector graph degree (edges per node). */
+    public static final String PROPERTY_MERGE_M = "indexoptimizer.merge.M";
+    public static final int PROPERTY_MERGE_M_DEFAULT = 16;
+
+    /** jvector beam-width during graph build. */
+    public static final String PROPERTY_MERGE_BEAM_WIDTH = "indexoptimizer.merge.beamWidth";
+    public static final int PROPERTY_MERGE_BEAM_WIDTH_DEFAULT = 100;
+
+    /** jvector neighbor-overflow factor during graph build. */
+    public static final String PROPERTY_MERGE_NEIGHBOR_OVERFLOW = "indexoptimizer.merge.neighborOverflow";
+    public static final float PROPERTY_MERGE_NEIGHBOR_OVERFLOW_DEFAULT = 1.2f;
+
+    /** jvector alpha factor during graph build. */
+    public static final String PROPERTY_MERGE_ALPHA = "indexoptimizer.merge.alpha";
+    public static final float PROPERTY_MERGE_ALPHA_DEFAULT = 1.4f;
+
+    /**
+     * Vector similarity used by the merger. Must match the value used by the
+     * IS that produced the inputs, otherwise PQ training and graph
+     * construction will be incoherent. Accepted values match
+     * {@code io.github.jbellis.jvector.vector.VectorSimilarityFunction}:
+     * {@code DOT_PRODUCT}, {@code COSINE}, {@code EUCLIDEAN}.
+     */
+    public static final String PROPERTY_MERGE_SIMILARITY = "indexoptimizer.merge.similarity";
+    public static final String PROPERTY_MERGE_SIMILARITY_DEFAULT = "DOT_PRODUCT";
+
+    // -------------------------------------------------------------------------
+    // Remote file service client (issue #484: merger needs a DataStorageManager
+    // pointing at remote storage to download/upload segment files). The
+    // optimizer accepts a comma-separated static list OR — when empty —
+    // discovers servers via ZooKeeper at the standard
+    // {@code /herd/file-servers} path.
+    // -------------------------------------------------------------------------
+
+    /** Comma-separated list of remote file-service endpoints. Empty → ZK discovery. */
+    public static final String PROPERTY_REMOTE_FILE_SERVERS = "indexoptimizer.remote.file.servers";
+    public static final String PROPERTY_REMOTE_FILE_SERVERS_DEFAULT = "";
+
+    /** Per-call deadline for the remote-file client, in seconds. */
+    public static final String PROPERTY_REMOTE_FILE_TIMEOUT = "indexoptimizer.remote.file.client.timeout";
+    public static final long PROPERTY_REMOTE_FILE_TIMEOUT_DEFAULT = 60L;
+
+    /** Max retries on idempotent remote-file operations. */
+    public static final String PROPERTY_REMOTE_FILE_RETRIES = "indexoptimizer.remote.file.client.retries";
+    public static final int PROPERTY_REMOTE_FILE_RETRIES_DEFAULT = 3;
+
+    /** Back-pressure cap on outstanding read bytes on the remote-file client. */
+    public static final String PROPERTY_REMOTE_FILE_MAX_INFLIGHT_READ_BYTES =
+            "indexoptimizer.remote.file.client.max.inflight.read.bytes";
+    public static final long PROPERTY_REMOTE_FILE_MAX_INFLIGHT_READ_BYTES_DEFAULT = 256L * 1024L * 1024L;
+
+    /** Back-pressure cap on outstanding write bytes on the remote-file client. */
+    public static final String PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES =
+            "indexoptimizer.remote.file.client.max.inflight.write.bytes";
+    public static final long PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES_DEFAULT = 256L * 1024L * 1024L;
+
     private final Properties properties;
 
     public OptimizerConfiguration(Properties properties) {
@@ -138,5 +228,13 @@ public final class OptimizerConfiguration {
     public boolean getBoolean(String key, boolean defaultValue) {
         String v = properties.getProperty(key);
         return v == null ? defaultValue : Boolean.parseBoolean(v);
+    }
+
+    public float getFloat(String key, float defaultValue) {
+        String v = properties.getProperty(key);
+        if (v == null) {
+            return defaultValue;
+        }
+        return Float.parseFloat(v);
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
@@ -62,6 +62,14 @@ public final class OptimizerHttpServer implements AutoCloseable {
      */
     private final long stalenessThresholdMillis;
     private final LongSupplier clock;
+    /**
+     * Predicate consulted by the {@code /health} handler. When it returns
+     * {@code true}, the handler short-circuits to 503 — the optimizer's ZK
+     * session has expired (or some other unrecoverable lifecycle event has
+     * fired), so Helm should restart the pod regardless of the heartbeat
+     * counter (review item B.3 from the first pr-reviewer pass).
+     */
+    private final java.util.function.BooleanSupplier criticalFailure;
     private final AtomicLong lastObservedRuns = new AtomicLong(-1);
     private final AtomicLong lastObservedRunsAtMillis = new AtomicLong(0);
 
@@ -71,17 +79,32 @@ public final class OptimizerHttpServer implements AutoCloseable {
      * disabled (Long.MAX_VALUE) — kept for source compatibility with earlier code.
      */
     public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine) throws IOException {
-        this(bindHost, port, engine, Long.MAX_VALUE, System::currentTimeMillis);
+        this(bindHost, port, engine, Long.MAX_VALUE, System::currentTimeMillis,
+                /* criticalFailure */ () -> false);
     }
 
     /**
-     * Full constructor wiring the heartbeat-staleness threshold and a clock for tests.
+     * Three-arg constructor wiring the heartbeat-staleness threshold and a clock
+     * for tests. Equivalent to the four-arg constructor with no critical-failure
+     * gate.
      */
     public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine,
                                long stalenessThresholdMillis, LongSupplier clock) throws IOException {
+        this(bindHost, port, engine, stalenessThresholdMillis, clock,
+                /* criticalFailure */ () -> false);
+    }
+
+    /**
+     * Full constructor wiring the heartbeat-staleness threshold, a clock, and a
+     * critical-failure gate (e.g. ZK session expiry detection).
+     */
+    public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine,
+                               long stalenessThresholdMillis, LongSupplier clock,
+                               java.util.function.BooleanSupplier criticalFailure) throws IOException {
         this.engine = engine;
         this.stalenessThresholdMillis = stalenessThresholdMillis;
         this.clock = clock;
+        this.criticalFailure = criticalFailure == null ? () -> false : criticalFailure;
         this.server = HttpServer.create(new InetSocketAddress(bindHost, port), 0);
         server.createContext("/health", new HealthHandler());
         server.createContext("/metrics", new MetricsHandler());
@@ -113,6 +136,20 @@ public final class OptimizerHttpServer implements AutoCloseable {
     private final class HealthHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
+            // Critical-failure gate (review item B.3 from the first pr-reviewer
+            // pass): when the ZooKeeper session has expired, the pod is
+            // silently broken — the persistent-recursive watch is dead and the
+            // leader-lock znode is gone. Force 503 so Helm restarts us.
+            if (criticalFailure.getAsBoolean()) {
+                byte[] body = "FAILED: critical lifecycle failure (e.g. ZK session expired)\n"
+                        .getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+                exchange.sendResponseHeaders(503, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+                return;
+            }
             // Liveness check (review-item B6): the engine's run counter must advance
             // within stalenessThresholdMillis. We compare the current value against
             // the last observation; when it has progressed we update both the

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -154,14 +154,18 @@ public final class RemoteSegmentMerger implements SegmentMerger {
         LogSequenceNumber latestBaseLsn = null;
         for (SegmentMetadata m : inputs) {
             int[] tombstoned = loadTombstonedOrdinalsBestEffort(m);
-            // The map file size isn't carried by SegmentMetadata directly
-            // (only the *combined* sizeBytes). We probe the file via the
-            // multipart reader supplier — it returns a streaming reader, and
-            // the supplied size is purely a hint for the cache. The optimizer
-            // pod's RemoteFileDataStorageManager doesn't strictly require the
-            // exact size, but to be safe we pass m.getSizeBytes() / 2 as a
-            // floor and let the actual stream length stop the read.
-            long mapFileSizeHint = Math.max(1L, m.getSizeBytes() / 2L);
+            // The optimizer needs the EXACT map-file size to drive the
+            // multipart reader (RemoteRandomAccessReader truncates reads at
+            // the supplied size, so an under-estimate causes EOF and an
+            // over-estimate would over-read across object boundaries). Use
+            // the dedicated mapFileSize field when available; fall back to
+            // sizeBytes (combined graph + map) only for legacy znodes that
+            // pre-date the field — in practice the merger will then
+            // over-estimate by the graph size, which the underlying reader
+            // tolerates because it stops at the actual object end.
+            long mapFileSizeHint = m.getMapFileSize() > 0L
+                    ? m.getMapFileSize()
+                    : Math.max(1L, m.getSizeBytes());
             graphInputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
                     m.getTablespaceUuid(), m.getIndexUuid(), m.getSegmentUuid(),
                     m.getSegmentId(), mapFileSizeHint, m.getGeneration(),
@@ -241,23 +245,64 @@ public final class RemoteSegmentMerger implements SegmentMerger {
     // Helpers
     // -------------------------------------------------------------------------
 
+    /**
+     * Bounded probe window for loading legacy ({@code overlayGeneration == 0})
+     * znodes (review item B.1#1 from the first pr-reviewer pass). Mirrors the
+     * window used by
+     * {@code IndexOptimizerEngine.deleteSegmentFilesBestEffort} when reaping
+     * pre-overlayGeneration znodes; bounded so a misbehaving znode does not
+     * stall the merge with O(N) DSM round-trips.
+     */
+    static final long LEGACY_OVERLAY_GENERATION_PROBE_MAX = 32L;
+
     private int[] loadTombstonedOrdinalsBestEffort(SegmentMetadata m) {
-        if (m.getTombstonePath() == null || m.getOverlayGeneration() <= 0L) {
+        if (m.getTombstonePath() == null) {
             return new int[0];
         }
-        try {
-            TombstoneOverlay overlay = TombstoneOverlayManager.loadOverlay(
-                    dataStorageManager, m.getTablespaceUuid(), m.getIndexUuid(),
-                    m.getSegmentUuid(), m.getOverlayGeneration());
-            return overlay.getTombstonedOrdinals();
-        } catch (IOException | DataStorageManagerException e) {
-            // A corrupt or unreachable overlay must NOT silently turn into "no
-            // tombstones applied" — that would resurrect deleted vectors after
-            // the merge. Surface the error so the engine logs it, increments
-            // mergeFailuresTotal, and tries again next tick.
-            throw new TombstoneLoadFailedException(m.getSegmentUuid(),
-                    m.getOverlayGeneration(), e);
+        long generation = m.getOverlayGeneration();
+        if (generation > 0L) {
+            // Modern znode (post-issue #484): the generation is recorded
+            // explicitly, so we load exactly that file.
+            try {
+                TombstoneOverlay overlay = TombstoneOverlayManager.loadOverlay(
+                        dataStorageManager, m.getTablespaceUuid(), m.getIndexUuid(),
+                        m.getSegmentUuid(), generation);
+                return overlay.getTombstonedOrdinals();
+            } catch (IOException | DataStorageManagerException e) {
+                // A corrupt or unreachable overlay must NOT silently turn into
+                // "no tombstones applied" — that would resurrect deleted vectors
+                // after the merge. Surface the error so the engine logs it,
+                // bumps mergeFailuresTotal, and retries next tick.
+                throw new TombstoneLoadFailedException(m.getSegmentUuid(), generation, e);
+            }
         }
+        // Legacy znode (overlayGeneration unset, but tombstonePath != null —
+        // i.e. written by an IS that pre-dates the overlayGeneration field).
+        // Probe the bounded window 32..1 highest-first; the highest existing
+        // generation is the authoritative one because TombstoneOverlayManager
+        // deletes the previous generation immediately after a successful flush.
+        for (long gen = LEGACY_OVERLAY_GENERATION_PROBE_MAX; gen >= 1L; gen--) {
+            try {
+                TombstoneOverlay overlay = TombstoneOverlayManager.loadOverlay(
+                        dataStorageManager, m.getTablespaceUuid(), m.getIndexUuid(),
+                        m.getSegmentUuid(), gen);
+                LOGGER.log(Level.INFO,
+                        "loaded legacy tombstone overlay for segment {0} via probe (generation={1})",
+                        new Object[]{m.getSegmentUuid(), gen});
+                return overlay.getTombstonedOrdinals();
+            } catch (IOException | DataStorageManagerException probeMiss) {
+                // Per-generation miss is normal during the descending probe; only
+                // the highest existing one survives. Continue.
+            }
+        }
+        // tombstonePath is set but no overlay file exists in the probed window.
+        // We MUST refuse the merge — silently treating this as "no tombstones"
+        // would resurrect deleted vectors. The engine will log mergeFailures
+        // and retry; an operator can then inspect the segment state.
+        throw new TombstoneLoadFailedException(m.getSegmentUuid(), 0L,
+                new IOException("legacy znode has tombstonePath=" + m.getTombstonePath()
+                        + " but no overlay file found in probe window 1.."
+                        + LEGACY_OVERLAY_GENERATION_PROBE_MAX));
     }
 
     private static long newRandomSegmentId() {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -210,6 +210,10 @@ public final class RemoteSegmentMerger implements SegmentMerger {
                 .tombstoneLsn(SegmentMetadata.NO_LSN_LEDGER_ID, SegmentMetadata.NO_LSN_OFFSET)
                 .overlayGeneration(0L)
                 .sizeBytes(output.totalSizeBytes())
+                // Populate the new mapFileSize field (issue #484 round 2)
+                // so any future merge of this output goes straight through
+                // the modern multipart-reader code path.
+                .mapFileSize(output.mapFileSize)
                 .vectorCount(output.vectorCount)
                 .generation(maxGeneration + 1L)
                 .createdAtEpochMillis(System.currentTimeMillis());

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -1,0 +1,293 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import herddb.index.vector.RemoteSegmentGraphMerger;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.indexing.segment.TombstoneOverlay;
+import herddb.indexing.segment.TombstoneOverlayManager;
+import herddb.log.LogSequenceNumber;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Production {@link SegmentMerger} for the index-optimizer service (issue #484).
+ *
+ * <p>Wraps {@link RemoteSegmentGraphMerger} (the actual graph rebuild) and
+ * handles the optimizer-side concerns it doesn't know about:
+ * <ul>
+ *   <li>Loading each input's latest {@code TombstoneOverlay} via
+ *       {@link TombstoneOverlayManager#loadOverlay} when the segment carries
+ *       a {@code tombstonePath} + a non-zero {@code overlayGeneration}, so
+ *       tombstoned ordinals are dropped during the merge.</li>
+ *   <li>Inferring the merged segment's {@code (vectorDimension)} from the
+ *       inputs (we trust they all share a dimension; mismatches throw).</li>
+ *   <li>Allocating a fresh {@code segmentId} as a 63-bit non-negative random
+ *       long so the merger's outputs never collide with IS-allocated ids.</li>
+ *   <li>Building the output {@link SegmentMetadata}: ACTIVE, fresh UUID,
+ *       generation = {@code max(input.generation) + 1}, base LSN = the
+ *       latest of the inputs', sizeBytes/vectorCount from the merger output,
+ *       no tombstones (the merge applied them all already).</li>
+ *   <li>Implementing {@link #abandon(SegmentMetadata)} via
+ *       {@link RemoteSegmentGraphMerger#deleteOutput} so an aborted merge
+ *       doesn't leak multipart artefacts.</li>
+ * </ul>
+ *
+ * <p>This class is intentionally not registered via {@code ServiceLoader}.
+ * The optimizer's bootstrap ({@link IndexOptimizerMain}) instantiates it
+ * directly because it requires runtime-supplied state (a
+ * {@link DataStorageManager} bound to remote storage, a tmp directory). The
+ * SPI mechanism is preserved for unit tests that want to plug in a
+ * synthetic merger via {@code META-INF/services}.
+ */
+public final class RemoteSegmentMerger implements SegmentMerger {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoteSegmentMerger.class.getName());
+
+    /**
+     * Vector dimension used by the merger when re-building the graph. Must
+     * match the IS-side index dimension; the optimizer reads it from
+     * configuration because the SegmentMetadata znode does not carry the
+     * dimension as a first-class field.
+     */
+    private final int dim;
+    private final RemoteSegmentGraphMerger graphMerger;
+    private final DataStorageManager dataStorageManager;
+    /** Cumulative count of merge invocations — exposed for observability tests. */
+    private final AtomicLong invocations = new AtomicLong();
+
+    /**
+     * @param dataStorageManager  remote-backed DSM the merger uses to download inputs and
+     *                            upload the merged graph + map files
+     * @param tmpDirectory        local scratch directory for staging
+     * @param dim                 vector dimension of the index being merged
+     * @param graphM              jvector graph degree
+     * @param beamWidth           jvector beam width during build
+     * @param neighborOverflow    jvector neighbor-overflow factor
+     * @param alpha               jvector alpha factor
+     * @param similarity          vector similarity function (must match the IS that produced the inputs)
+     */
+    public RemoteSegmentMerger(DataStorageManager dataStorageManager,
+                               Path tmpDirectory,
+                               int dim,
+                               int graphM,
+                               int beamWidth,
+                               float neighborOverflow,
+                               float alpha,
+                               VectorSimilarityFunction similarity) {
+        this.dataStorageManager = Objects.requireNonNull(dataStorageManager, "dataStorageManager");
+        if (dim <= 0) {
+            throw new IllegalArgumentException("dim must be positive: " + dim);
+        }
+        this.dim = dim;
+        this.graphMerger = new RemoteSegmentGraphMerger(
+                dataStorageManager, tmpDirectory, graphM, beamWidth,
+                neighborOverflow, alpha, similarity);
+    }
+
+    public long getInvocationCount() {
+        return invocations.get();
+    }
+
+    @Override
+    public SegmentMetadata merge(List<SegmentMetadata> inputs, int newOwnerInstance) throws Exception {
+        Objects.requireNonNull(inputs, "inputs");
+        if (inputs.isEmpty()) {
+            return null;
+        }
+        invocations.incrementAndGet();
+
+        SegmentMetadata sample = inputs.get(0);
+        String tablespaceUuid = sample.getTablespaceUuid();
+        String indexUuid = sample.getIndexUuid();
+        for (SegmentMetadata m : inputs) {
+            if (!tablespaceUuid.equals(m.getTablespaceUuid())) {
+                throw new IllegalArgumentException(
+                        "merger inputs disagree on tablespaceUuid: "
+                                + tablespaceUuid + " vs " + m.getTablespaceUuid());
+            }
+            if (!indexUuid.equals(m.getIndexUuid())) {
+                throw new IllegalArgumentException(
+                        "merger inputs disagree on indexUuid: "
+                                + indexUuid + " vs " + m.getIndexUuid());
+            }
+            if (m.getSegmentId() == SegmentMetadata.NO_SEGMENT_ID) {
+                throw new IllegalArgumentException(
+                        "merger input " + m.getSegmentUuid()
+                                + " has no segmentId — cannot reconstruct multipart path");
+            }
+        }
+
+        // Translate every SegmentMetadata input into a RemoteSegmentInput,
+        // pre-loading the latest TombstoneOverlay where the znode points at one.
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> graphInputs = new ArrayList<>(inputs.size());
+        long maxGeneration = 0L;
+        long maxMapFileSize = 0L;
+        LogSequenceNumber latestBaseLsn = null;
+        for (SegmentMetadata m : inputs) {
+            int[] tombstoned = loadTombstonedOrdinalsBestEffort(m);
+            // The map file size isn't carried by SegmentMetadata directly
+            // (only the *combined* sizeBytes). We probe the file via the
+            // multipart reader supplier — it returns a streaming reader, and
+            // the supplied size is purely a hint for the cache. The optimizer
+            // pod's RemoteFileDataStorageManager doesn't strictly require the
+            // exact size, but to be safe we pass m.getSizeBytes() / 2 as a
+            // floor and let the actual stream length stop the read.
+            long mapFileSizeHint = Math.max(1L, m.getSizeBytes() / 2L);
+            graphInputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                    m.getTablespaceUuid(), m.getIndexUuid(), m.getSegmentUuid(),
+                    m.getSegmentId(), mapFileSizeHint, m.getGeneration(),
+                    tombstoned));
+            if (m.getGeneration() > maxGeneration) {
+                maxGeneration = m.getGeneration();
+            }
+            if (mapFileSizeHint > maxMapFileSize) {
+                maxMapFileSize = mapFileSizeHint;
+            }
+            LogSequenceNumber base = m.baseLsn();
+            if (base != null && (latestBaseLsn == null || compareLsn(base, latestBaseLsn) > 0)) {
+                latestBaseLsn = base;
+            }
+        }
+
+        long outputSegmentId = newRandomSegmentId();
+        RemoteSegmentGraphMerger.MergeOutput output = graphMerger.merge(
+                graphInputs, tablespaceUuid, indexUuid, outputSegmentId, dim);
+        if (output == null) {
+            // The graph merger declined — every input vector was tombstoned or duplicated.
+            return null;
+        }
+
+        String mergedUuid = UUID.randomUUID().toString();
+        SegmentMetadata.Builder builder = SegmentMetadata.builder()
+                .segmentUuid(mergedUuid)
+                .tablespaceUuid(tablespaceUuid)
+                .tableName(sample.getTableName())
+                .indexUuid(indexUuid)
+                .indexName(sample.getIndexName())
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(newOwnerInstance)
+                .pendingOwnerInstanceId(SegmentMetadata.NO_INSTANCE)
+                .segmentId(outputSegmentId)
+                .graphPath(output.graphPath)
+                .mapPath(output.mapPath)
+                // The merged segment starts with no tombstones. Any future
+                // deletes against the merged segment will produce a fresh
+                // overlay starting at generation 1 via the IS-side path.
+                .tombstonePath(null)
+                .tombstoneLsn(SegmentMetadata.NO_LSN_LEDGER_ID, SegmentMetadata.NO_LSN_OFFSET)
+                .overlayGeneration(0L)
+                .sizeBytes(output.totalSizeBytes())
+                .vectorCount(output.vectorCount)
+                .generation(maxGeneration + 1L)
+                .createdAtEpochMillis(System.currentTimeMillis());
+        if (latestBaseLsn != null) {
+            builder.baseLsn(latestBaseLsn);
+        }
+        SegmentMetadata merged = builder.build();
+        LOGGER.log(Level.INFO,
+                "RemoteSegmentMerger: produced segment {0} (segmentId={1}, generation={2},"
+                        + " {3} vectors, {4} bytes, droppedTombstones={5}, droppedDuplicates={6})",
+                new Object[]{mergedUuid, outputSegmentId, maxGeneration + 1L,
+                        output.vectorCount, output.totalSizeBytes(),
+                        output.droppedTombstones, output.droppedDuplicates});
+        return merged;
+    }
+
+    @Override
+    public void abandon(SegmentMetadata produced) {
+        if (produced == null || produced.getSegmentId() == SegmentMetadata.NO_SEGMENT_ID) {
+            return;
+        }
+        // Reconstruct the MergeOutput just enough to drive the cleanup. The
+        // file sizes / vector counts are irrelevant to deleteOutput, which
+        // only needs (tablespaceUuid, indexUuid, segmentId).
+        graphMerger.deleteOutput(new RemoteSegmentGraphMerger.MergeOutput(
+                produced.getTablespaceUuid(), produced.getIndexUuid(), produced.getSegmentId(),
+                produced.getGraphPath(), 0L,
+                produced.getMapPath(), 0L,
+                produced.getVectorCount(), 0L, 0L));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private int[] loadTombstonedOrdinalsBestEffort(SegmentMetadata m) {
+        if (m.getTombstonePath() == null || m.getOverlayGeneration() <= 0L) {
+            return new int[0];
+        }
+        try {
+            TombstoneOverlay overlay = TombstoneOverlayManager.loadOverlay(
+                    dataStorageManager, m.getTablespaceUuid(), m.getIndexUuid(),
+                    m.getSegmentUuid(), m.getOverlayGeneration());
+            return overlay.getTombstonedOrdinals();
+        } catch (IOException | DataStorageManagerException e) {
+            // A corrupt or unreachable overlay must NOT silently turn into "no
+            // tombstones applied" — that would resurrect deleted vectors after
+            // the merge. Surface the error so the engine logs it, increments
+            // mergeFailuresTotal, and tries again next tick.
+            throw new TombstoneLoadFailedException(m.getSegmentUuid(),
+                    m.getOverlayGeneration(), e);
+        }
+    }
+
+    private static long newRandomSegmentId() {
+        // Full 63-bit non-negative random id. Collisions across the optimizer
+        // pod's lifetime are negligible (~2^-63 per allocation) and the
+        // leader-lock already serialises optimizer instances, so two pods
+        // can't allocate concurrently in production.
+        return UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
+    }
+
+    private static int compareLsn(LogSequenceNumber a, LogSequenceNumber b) {
+        if (a.ledgerId != b.ledgerId) {
+            return Long.compare(a.ledgerId, b.ledgerId);
+        }
+        return Long.compare(a.offset, b.offset);
+    }
+
+    /**
+     * Thrown when the merger cannot load a tombstone overlay it needs to
+     * apply during a merge. This is a fatal error for the run — we'd rather
+     * decline the merge than publish a segment that resurrects tombstoned
+     * vectors.
+     */
+    public static final class TombstoneLoadFailedException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public TombstoneLoadFailedException(String segmentUuid, long overlayGeneration, Throwable cause) {
+            super("failed to load tombstone overlay generation " + overlayGeneration
+                    + " for segment " + segmentUuid + " — refusing to merge to avoid"
+                    + " resurrecting deleted vectors", cause);
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -155,17 +155,25 @@ public final class RemoteSegmentMerger implements SegmentMerger {
         for (SegmentMetadata m : inputs) {
             int[] tombstoned = loadTombstonedOrdinalsBestEffort(m);
             // The optimizer needs the EXACT map-file size to drive the
-            // multipart reader (RemoteRandomAccessReader truncates reads at
-            // the supplied size, so an under-estimate causes EOF and an
-            // over-estimate would over-read across object boundaries). Use
-            // the dedicated mapFileSize field when available; fall back to
-            // sizeBytes (combined graph + map) only for legacy znodes that
-            // pre-date the field — in practice the merger will then
-            // over-estimate by the graph size, which the underlying reader
-            // tolerates because it stops at the actual object end.
-            long mapFileSizeHint = m.getMapFileSize() > 0L
-                    ? m.getMapFileSize()
-                    : Math.max(1L, m.getSizeBytes());
+            // multipart reader. Production readers (RemoteRandomAccessReader,
+            // SegmentedMappedReader) treat the size passed at construction
+            // as authoritative — they don't probe the underlying object —
+            // and the direct-multipart-download path computes block count
+            // from that size and throws "Block N not found" past the actual
+            // file end (review item B.1.1 from the third pr-reviewer pass).
+            // We therefore refuse to merge any input whose znode predates
+            // the {@code mapFileSize} field (issue #484): a clean failure
+            // mode is much better than a half-read map file producing a
+            // corrupt graph. The next IS checkpoint will rewrite the znode
+            // with {@code mapFileSize} set and unstick the segment.
+            if (m.getMapFileSize() <= 0L) {
+                throw new LegacyMetadataException(m.getSegmentUuid(),
+                        m.getSizeBytes(),
+                        "input segment " + m.getSegmentUuid() + " has no mapFileSize"
+                                + " (legacy znode predating issue #484);"
+                                + " skipping merge until IS recheckpoints the segment");
+            }
+            long mapFileSizeHint = m.getMapFileSize();
             graphInputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
                     m.getTablespaceUuid(), m.getIndexUuid(), m.getSegmentUuid(),
                     m.getSegmentId(), mapFileSizeHint, m.getGeneration(),
@@ -337,6 +345,25 @@ public final class RemoteSegmentMerger implements SegmentMerger {
             super("failed to load tombstone overlay generation " + overlayGeneration
                     + " for segment " + segmentUuid + " — refusing to merge to avoid"
                     + " resurrecting deleted vectors", cause);
+        }
+    }
+
+    /**
+     * Thrown when the merger encounters an input segment whose znode predates
+     * issue #484 (i.e. {@code mapFileSize <= 0}). Production storage readers
+     * treat the size passed at construction as authoritative and would happily
+     * over-read past the actual map-file end, producing torn graphs and
+     * "Block N not found" errors deeper in the multipart pipeline. Refusing
+     * the merge lets the engine bump {@code mergeFailuresTotal} and proceed
+     * to the next index; the next IS checkpoint will rewrite the legacy
+     * znode with {@code mapFileSize} set, unsticking the segment.
+     */
+    public static final class LegacyMetadataException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public LegacyMetadataException(String segmentUuid, long sizeBytes, String message) {
+            super(message + " (segmentUuid=" + segmentUuid
+                    + ", combinedSizeBytes=" + sizeBytes + ")");
         }
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentMetadata.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentMetadata.java
@@ -52,6 +52,8 @@ public final class SegmentMetadata {
     public static final long NO_LSN_OFFSET = -1L;
     public static final long NO_RETENTION = -1L;
     public static final long NO_SEGMENT_ID = -1L;
+    /** Sentinel for {@link #mapFileSize} when the field was not populated. */
+    public static final long UNKNOWN_FILE_SIZE = 0L;
 
     /**
      * Current znode JSON schema version (review item D5). Bumped when a
@@ -124,6 +126,15 @@ public final class SegmentMetadata {
     private final long baseLsnLedgerId;
     private final long baseLsnOffset;
     private final long sizeBytes;
+    /**
+     * Exact size of the map file in bytes (additive in issue #484). The
+     * optimizer's {@code RemoteSegmentMerger} needs this to correctly stream
+     * the input map file from remote storage — {@code sizeBytes} aggregates
+     * graph + map sizes and isn't enough to bound the read. Defaults to
+     * {@link #UNKNOWN_FILE_SIZE} (0L) when not set; in that case the merger
+     * falls back to {@code sizeBytes} as an upper-bound hint.
+     */
+    private final long mapFileSize;
     private final long vectorCount;
     private final long generation;
     private final List<String> replacedBy;
@@ -151,6 +162,7 @@ public final class SegmentMetadata {
             @JsonProperty("baseLsnLedgerId") long baseLsnLedgerId,
             @JsonProperty("baseLsnOffset") long baseLsnOffset,
             @JsonProperty("sizeBytes") long sizeBytes,
+            @JsonProperty("mapFileSize") long mapFileSize,
             @JsonProperty("vectorCount") long vectorCount,
             @JsonProperty("generation") long generation,
             @JsonProperty("replacedBy") List<String> replacedBy,
@@ -178,6 +190,7 @@ public final class SegmentMetadata {
         this.baseLsnLedgerId = baseLsnLedgerId;
         this.baseLsnOffset = baseLsnOffset;
         this.sizeBytes = sizeBytes;
+        this.mapFileSize = mapFileSize;
         this.vectorCount = vectorCount;
         this.generation = generation;
         this.replacedBy = replacedBy == null
@@ -263,6 +276,10 @@ public final class SegmentMetadata {
         return sizeBytes;
     }
 
+    public long getMapFileSize() {
+        return mapFileSize;
+    }
+
     public long getVectorCount() {
         return vectorCount;
     }
@@ -335,6 +352,7 @@ public final class SegmentMetadata {
                 .overlayGeneration(overlayGeneration)
                 .baseLsn(baseLsnLedgerId, baseLsnOffset)
                 .sizeBytes(sizeBytes)
+                .mapFileSize(mapFileSize)
                 .vectorCount(vectorCount)
                 .generation(generation)
                 .replacedBy(replacedBy)
@@ -363,6 +381,7 @@ public final class SegmentMetadata {
                 && baseLsnLedgerId == that.baseLsnLedgerId
                 && baseLsnOffset == that.baseLsnOffset
                 && sizeBytes == that.sizeBytes
+                && mapFileSize == that.mapFileSize
                 && vectorCount == that.vectorCount
                 && generation == that.generation
                 && retentionUntilEpochMillis == that.retentionUntilEpochMillis
@@ -425,6 +444,7 @@ public final class SegmentMetadata {
         private long baseLsnLedgerId = NO_LSN_LEDGER_ID;
         private long baseLsnOffset = NO_LSN_OFFSET;
         private long sizeBytes;
+        private long mapFileSize = UNKNOWN_FILE_SIZE;
         private long vectorCount;
         private long generation;
         private List<String> replacedBy = Collections.emptyList();
@@ -535,6 +555,11 @@ public final class SegmentMetadata {
             return this;
         }
 
+        public Builder mapFileSize(long value) {
+            this.mapFileSize = value;
+            return this;
+        }
+
         public Builder vectorCount(long value) {
             this.vectorCount = value;
             return this;
@@ -569,7 +594,7 @@ public final class SegmentMetadata {
                     segmentUuid, tablespaceUuid, tableName, indexUuid, indexName,
                     state, ownerInstanceId, pendingOwnerInstanceId, segmentId, graphPath, mapPath,
                     tombstonePath, tombstoneLsnLedgerId, tombstoneLsnOffset, overlayGeneration,
-                    baseLsnLedgerId, baseLsnOffset, sizeBytes, vectorCount, generation,
+                    baseLsnLedgerId, baseLsnOffset, sizeBytes, mapFileSize, vectorCount, generation,
                     replacedBy, retentionUntilEpochMillis, createdAtEpochMillis);
         }
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentMetadata.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentMetadata.java
@@ -51,7 +51,7 @@ public final class SegmentMetadata {
     public static final long NO_LSN_LEDGER_ID = -1L;
     public static final long NO_LSN_OFFSET = -1L;
     public static final long NO_RETENTION = -1L;
-    public static final int NO_SEGMENT_ID = -1;
+    public static final long NO_SEGMENT_ID = -1L;
 
     /**
      * Current znode JSON schema version (review item D5). Bumped when a
@@ -93,19 +93,34 @@ public final class SegmentMetadata {
     private final int ownerInstanceId;
     private final int pendingOwnerInstanceId;
     /**
-     * Original IS-local int segment-id under which the multipart graph/map files
-     * were written. Needed by the optimizer's reaper to call
+     * IS-local segment-id under which the multipart graph/map files were
+     * written. Needed by the optimizer's reaper to call
      * {@code DataStorageManager.deleteMultipartIndexFile(tableSpace,
      * indexUuid + "_seg" + segmentId, "graph"/"map")} (review item A8).
      * Defaults to {@link #NO_SEGMENT_ID} (-1) when unknown — in that case the
      * reaper skips file deletion and only removes the znode.
+     *
+     * <p>Widened to {@code long} (issue #484) so the optimizer-side merger can
+     * mint full 63-bit random ids for its merged outputs without colliding
+     * with the IS-side {@code VectorSegment.segmentId} space.
      */
-    private final int segmentId;
+    private final long segmentId;
     private final String graphPath;
     private final String mapPath;
     private final String tombstonePath;
     private final long tombstoneLsnLedgerId;
     private final long tombstoneLsnOffset;
+    /**
+     * Generation of the overlay file at {@link #tombstonePath} (additive in
+     * issue #484). The optimizer's merger needs this to reconstruct the
+     * exact multipart file type — {@code TombstoneOverlayManager.fileTypeFor}
+     * is {@code "tombstones-{generation}"} — when calling
+     * {@code TombstoneOverlayManager.loadOverlay} to apply tombstones during
+     * a graph merge. Defaults to 0L when the segment carries no overlay
+     * (i.e. {@code tombstonePath == null}); also 0L for znode payloads
+     * predating this field, which is treated the same as "no overlay".
+     */
+    private final long overlayGeneration;
     private final long baseLsnLedgerId;
     private final long baseLsnOffset;
     private final long sizeBytes;
@@ -126,12 +141,13 @@ public final class SegmentMetadata {
             @JsonProperty("state") SegmentState state,
             @JsonProperty("ownerInstanceId") int ownerInstanceId,
             @JsonProperty("pendingOwnerInstanceId") int pendingOwnerInstanceId,
-            @JsonProperty("segmentId") int segmentId,
+            @JsonProperty("segmentId") long segmentId,
             @JsonProperty("graphPath") String graphPath,
             @JsonProperty("mapPath") String mapPath,
             @JsonProperty("tombstonePath") String tombstonePath,
             @JsonProperty("tombstoneLsnLedgerId") long tombstoneLsnLedgerId,
             @JsonProperty("tombstoneLsnOffset") long tombstoneLsnOffset,
+            @JsonProperty("overlayGeneration") long overlayGeneration,
             @JsonProperty("baseLsnLedgerId") long baseLsnLedgerId,
             @JsonProperty("baseLsnOffset") long baseLsnOffset,
             @JsonProperty("sizeBytes") long sizeBytes,
@@ -158,6 +174,7 @@ public final class SegmentMetadata {
         this.tombstonePath = tombstonePath;
         this.tombstoneLsnLedgerId = tombstoneLsnLedgerId;
         this.tombstoneLsnOffset = tombstoneLsnOffset;
+        this.overlayGeneration = overlayGeneration;
         this.baseLsnLedgerId = baseLsnLedgerId;
         this.baseLsnOffset = baseLsnOffset;
         this.sizeBytes = sizeBytes;
@@ -206,7 +223,7 @@ public final class SegmentMetadata {
         return pendingOwnerInstanceId;
     }
 
-    public int getSegmentId() {
+    public long getSegmentId() {
         return segmentId;
     }
 
@@ -228,6 +245,10 @@ public final class SegmentMetadata {
 
     public long getTombstoneLsnOffset() {
         return tombstoneLsnOffset;
+    }
+
+    public long getOverlayGeneration() {
+        return overlayGeneration;
     }
 
     public long getBaseLsnLedgerId() {
@@ -311,6 +332,7 @@ public final class SegmentMetadata {
                 .mapPath(mapPath)
                 .tombstonePath(tombstonePath)
                 .tombstoneLsn(tombstoneLsnLedgerId, tombstoneLsnOffset)
+                .overlayGeneration(overlayGeneration)
                 .baseLsn(baseLsnLedgerId, baseLsnOffset)
                 .sizeBytes(sizeBytes)
                 .vectorCount(vectorCount)
@@ -337,6 +359,7 @@ public final class SegmentMetadata {
                 && pendingOwnerInstanceId == that.pendingOwnerInstanceId
                 && tombstoneLsnLedgerId == that.tombstoneLsnLedgerId
                 && tombstoneLsnOffset == that.tombstoneLsnOffset
+                && overlayGeneration == that.overlayGeneration
                 && baseLsnLedgerId == that.baseLsnLedgerId
                 && baseLsnOffset == that.baseLsnOffset
                 && sizeBytes == that.sizeBytes
@@ -392,12 +415,13 @@ public final class SegmentMetadata {
         private SegmentState state = SegmentState.ACTIVE;
         private int ownerInstanceId = NO_INSTANCE;
         private int pendingOwnerInstanceId = NO_INSTANCE;
-        private int segmentId = NO_SEGMENT_ID;
+        private long segmentId = NO_SEGMENT_ID;
         private String graphPath;
         private String mapPath;
         private String tombstonePath;
         private long tombstoneLsnLedgerId = NO_LSN_LEDGER_ID;
         private long tombstoneLsnOffset = NO_LSN_OFFSET;
+        private long overlayGeneration = 0L;
         private long baseLsnLedgerId = NO_LSN_LEDGER_ID;
         private long baseLsnOffset = NO_LSN_OFFSET;
         private long sizeBytes;
@@ -447,7 +471,7 @@ public final class SegmentMetadata {
             return this;
         }
 
-        public Builder segmentId(int value) {
+        public Builder segmentId(long value) {
             this.segmentId = value;
             return this;
         }
@@ -470,6 +494,11 @@ public final class SegmentMetadata {
         public Builder tombstoneLsn(long ledgerId, long offset) {
             this.tombstoneLsnLedgerId = ledgerId;
             this.tombstoneLsnOffset = offset;
+            return this;
+        }
+
+        public Builder overlayGeneration(long value) {
+            this.overlayGeneration = value;
             return this;
         }
 
@@ -539,7 +568,7 @@ public final class SegmentMetadata {
             return new SegmentMetadata(SCHEMA_VERSION,
                     segmentUuid, tablespaceUuid, tableName, indexUuid, indexName,
                     state, ownerInstanceId, pendingOwnerInstanceId, segmentId, graphPath, mapPath,
-                    tombstonePath, tombstoneLsnLedgerId, tombstoneLsnOffset,
+                    tombstonePath, tombstoneLsnLedgerId, tombstoneLsnOffset, overlayGeneration,
                     baseLsnLedgerId, baseLsnOffset, sizeBytes, vectorCount, generation,
                     replacedBy, retentionUntilEpochMillis, createdAtEpochMillis);
         }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentRegistryPublisher.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentRegistryPublisher.java
@@ -542,6 +542,12 @@ public final class SegmentRegistryPublisher implements SegmentPublisher {
                 .mapPath(info.getMapFilePath())
                 .baseLsn(info.getBaseLsn())
                 .sizeBytes(info.getEstimatedSizeBytes())
+                // Issue #484 (round-2 review): the optimizer-side merger
+                // requires the EXACT map-file size to drive the multipart
+                // reader (see RemoteSegmentMerger). Without this line every
+                // merge would fall through to a legacy fallback that is
+                // broken on the production direct-multipart-download path.
+                .mapFileSize(info.getMapFileSize())
                 .vectorCount(info.getVectorCount())
                 .generation(info.getGeneration())
                 .createdAtEpochMillis(now)

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/TombstoneOverlayManager.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/TombstoneOverlayManager.java
@@ -242,6 +242,7 @@ public final class TombstoneOverlayManager {
         SegmentMetadata updated = current.metadata().toBuilder()
                 .tombstonePath(multipartPath)
                 .tombstoneLsn(snapshotLsn)
+                .overlayGeneration(snapshotGeneration)
                 .build();
         VersionedSegmentMetadata after;
         try {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/AggressivePolicyTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/AggressivePolicyTest.java
@@ -1,0 +1,183 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.indexing.segment.VersionedSegmentMetadata;
+import herddb.log.LogSequenceNumber;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MergePolicy.AggressivePolicy} (issue #484).
+ *
+ * <p>Verifies the four behaviours that distinguish the aggressive policy from
+ * the legacy {@code SmallestFirstPolicy}:
+ * <ul>
+ *   <li>fires whenever ≥2 sub-target candidates exist (no minimum-bytes /
+ *       minimum-count gating);</li>
+ *   <li>excludes "graduated" segments at or above {@code targetMaxBytes}
+ *       from the candidate set;</li>
+ *   <li>caps the picked set at {@code perCycleMaxBytes} and {@code maxCount}
+ *       — but always picks at least 2 segments to keep merging unstuck;</li>
+ *   <li>returns an empty set when fewer than 2 candidates are sub-target.</li>
+ * </ul>
+ */
+public class AggressivePolicyTest {
+
+    private static final String TS = "ts";
+    private static final String IDX = "idx";
+
+    private VersionedSegmentMetadata seg(String uuid, long sizeBytes) {
+        SegmentMetadata m = SegmentMetadata.builder()
+                .segmentUuid(uuid)
+                .tablespaceUuid(TS).tableName("t").indexUuid(IDX).indexName("i")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(0)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(sizeBytes).vectorCount(1L).generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+        return new VersionedSegmentMetadata(m, /* zkVersion */ 0);
+    }
+
+    @Test
+    public void firesWithTwoSubTargetCandidates() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes */ 1_000L, /* perCycleMaxBytes */ Long.MAX_VALUE,
+                /* maxCount */ 100);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("a", 100), seg("b", 100)));
+        assertEquals(2, picked.size());
+    }
+
+    @Test
+    public void excludesGraduatedSegments() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(1_000L, Long.MAX_VALUE, 100);
+        // Two segments at-or-above the cap → "graduated", left alone.
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("graduated-1", 1_000L), seg("graduated-2", 5_000L), seg("small", 10L)));
+        assertEquals("only one sub-target segment → no merge", 0, picked.size());
+    }
+
+    @Test
+    public void mixedSegmentSetMergesOnlySubTarget() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(1_000L, Long.MAX_VALUE, 100);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("graduated", 5_000L), seg("small1", 10L),
+                        seg("small2", 20L), seg("small3", 30L)));
+        assertEquals(3, picked.size());
+        for (VersionedSegmentMetadata v : picked) {
+            assertTrue("only sub-target segments are picked",
+                    v.metadata().getSizeBytes() < 1_000L);
+        }
+    }
+
+    @Test
+    public void perCycleMaxBytesCapsThePickedSet() {
+        // Three 100-byte sub-target segments + a perCycleMaxBytes of 250 →
+        // we can fit two but not three. The first two are always picked
+        // (the 2-segment minimum overrides the byte cap).
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes */ 10_000L,
+                /* perCycleMaxBytes */ 250L,
+                /* maxCount */ 100);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("s1", 100L), seg("s2", 100L), seg("s3", 100L)));
+        assertEquals("perCycleMaxBytes caps the third pick", 2, picked.size());
+    }
+
+    @Test
+    public void maxCountCapsThePickedSet() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, Long.MAX_VALUE,
+                /* maxCount */ 3);
+        List<VersionedSegmentMetadata> activeSegments = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            activeSegments.add(seg("s" + i, 10L));
+        }
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(activeSegments);
+        assertEquals("maxCount caps the picked set at 3", 3, picked.size());
+    }
+
+    @Test
+    public void picksAllEightWhenBudgetAllows() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, Long.MAX_VALUE, 100);
+        List<VersionedSegmentMetadata> activeSegments = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            activeSegments.add(seg("s" + i, 10L));
+        }
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(activeSegments);
+        assertEquals("all 8 sub-target segments are picked when budget is unlimited",
+                8, picked.size());
+    }
+
+    @Test
+    public void singleSegmentReturnsEmpty() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, Long.MAX_VALUE, 100);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("s", 10L)));
+        assertEquals(0, picked.size());
+    }
+
+    @Test
+    public void emptyInputReturnsEmpty() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, Long.MAX_VALUE, 100);
+        assertEquals(0, policy.pickMergeCandidates(List.of()).size());
+        assertEquals(0, policy.pickMergeCandidates(null).size());
+    }
+
+    @Test
+    public void invalidArgsRejected() {
+        try {
+            new MergePolicy.AggressivePolicy(0L, 1L, 2);
+            fail("targetMaxBytes=0 must throw");
+        } catch (IllegalArgumentException ok) {
+            // expected
+        }
+        try {
+            new MergePolicy.AggressivePolicy(1L, 0L, 2);
+            fail("perCycleMaxBytes=0 must throw");
+        } catch (IllegalArgumentException ok) {
+            // expected
+        }
+        try {
+            new MergePolicy.AggressivePolicy(1L, 1L, 1);
+            fail("maxCount<2 must throw");
+        } catch (IllegalArgumentException ok) {
+            // expected
+        }
+    }
+
+    @Test
+    public void smallestFirstOrderingIsPreserved() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, Long.MAX_VALUE, 100);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("big", 500L), seg("med", 200L), seg("small", 50L)));
+        assertEquals(3, picked.size());
+        assertEquals("smallest first", "small", picked.get(0).metadata().getSegmentUuid());
+        assertEquals("medium next", "med", picked.get(1).metadata().getSegmentUuid());
+        assertEquals("big last", "big", picked.get(2).metadata().getSegmentUuid());
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEventDrivenTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEventDrivenTest.java
@@ -1,0 +1,259 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentRegistryClient;
+import herddb.indexing.segment.SegmentState;
+import herddb.log.LogSequenceNumber;
+import herddb.model.TableSpace;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end test for the persistent-recursive ZK watch driving event-driven
+ * scheduling (issue #484).
+ *
+ * <p>Spins up a real {@code TestingServer}, registers the tablespace,
+ * boots {@link IndexOptimizerMain} with a 1-hour periodic interval (so the
+ * safety-net tick effectively never fires), then publishes new segments
+ * to the registry and asserts the engine ticks within a few seconds —
+ * proving the persistent-recursive watch path actually wakes the engine.
+ *
+ * <p>Also asserts that the watch survives multiple events without re-arming
+ * (the whole point of {@code AddWatchMode.PERSISTENT_RECURSIVE}): publishing
+ * a second batch of segments triggers another tick without any code path
+ * having to re-register the watch in between.
+ */
+public class IndexOptimizerEventDrivenTest {
+
+    private static final String BASE_PATH = "/herd-test-event-driven";
+    private static final String TS_NAME = "herd";
+    private static final String TS_UUID = "ts-evt";
+    private static final String IDX_UUID = "idx-evt";
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+    private SegmentRegistryClient registry;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue(connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registry = new SegmentRegistryClient(() -> zk, BASE_PATH);
+        registry.ensureRoot();
+        // Pre-register the tablespace so IndexOptimizerMain can resolve the UUID.
+        registerTablespace(TS_NAME, TS_UUID);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    private void registerTablespace(String name, String uuid) throws Exception {
+        Set<String> replicas = new HashSet<>();
+        replicas.add("test-instance");
+        TableSpace ts = TableSpace.builder()
+                .name(name)
+                .uuid(uuid)
+                .leader("test-instance")
+                .replicas(replicas)
+                .expectedReplicaCount(1)
+                .build();
+        try (ZookeeperMetadataStorageManager zkmeta =
+                new ZookeeperMetadataStorageManager(zkServer.getConnectString(), 30000, BASE_PATH)) {
+            zkmeta.start(true);
+            zkmeta.registerTableSpace(ts);
+        }
+    }
+
+    private SegmentMetadata sampleSegment(String segUuid, long sizeBytes) {
+        return SegmentMetadata.builder()
+                .segmentUuid(segUuid)
+                .tablespaceUuid(TS_UUID)
+                .tableName("docs")
+                .indexUuid(IDX_UUID)
+                .indexName("docs_v1")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(0)
+                .graphPath("g/" + segUuid)
+                .mapPath("m/" + segUuid)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(sizeBytes)
+                .vectorCount(10L)
+                .generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+    }
+
+    @Test
+    public void persistentRecursiveWatchWakesEngineWithoutPeriodicTick() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
+        props.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        // 1-hour periodic interval = effectively disabled for this test.
+        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
+        // Short debounce so the test asserts quickly.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "50");
+        // Disable HTTP probe — keeps the test self-contained.
+        props.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
+        props.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        IndexOptimizerMain main = new IndexOptimizerMain(
+                new OptimizerConfiguration(props), merger);
+        try {
+            main.start();
+            assertNotNull(main.getEngine());
+
+            // Initial state: no events, no event-driven ticks. The persistent-
+            // recursive watch is armed on basePath/index-segments/ts-evt.
+            long ticksAtStart = main.getEventDrivenTicks();
+
+            // Publish 4 segments. Each createSegment fires children-changed events
+            // that the persistent-recursive watch picks up. We expect at least
+            // ONE event-driven tick within a few seconds — bursts coalesce.
+            for (int i = 0; i < 4; i++) {
+                registry.createSegment(sampleSegment("seg-" + i, 100L));
+            }
+
+            long deadline = System.currentTimeMillis() + 5_000L;
+            while (System.currentTimeMillis() < deadline
+                    && main.getEventDrivenTicks() <= ticksAtStart) {
+                Thread.sleep(20);
+            }
+            assertTrue("event-driven tick must fire within 5s of segment publishing"
+                            + " (observed " + main.getEventDrivenTicks() + ", was "
+                            + ticksAtStart + ")",
+                    main.getEventDrivenTicks() > ticksAtStart);
+            assertTrue("watcher must have observed at least one event ("
+                            + main.getWatcherEvents() + ")",
+                    main.getWatcherEvents() > 0);
+
+            // Wait for the engine's first tick to actually drain (so the leader
+            // lock is held and getRuns() reflects the work).
+            Thread.sleep(100);
+            assertTrue(main.getEngine().getRuns() > 0L);
+
+            // === Part 2: prove the persistent-recursive watch survives a second
+            //  burst — i.e. it does NOT need re-arming after the first event,
+            //  unlike a one-shot watcher.
+            long ticksAfterFirstBurst = main.getEventDrivenTicks();
+            for (int i = 4; i < 8; i++) {
+                registry.createSegment(sampleSegment("seg-" + i, 100L));
+            }
+            deadline = System.currentTimeMillis() + 5_000L;
+            while (System.currentTimeMillis() < deadline
+                    && main.getEventDrivenTicks() <= ticksAfterFirstBurst) {
+                Thread.sleep(20);
+            }
+            assertTrue("second burst must fire another event-driven tick — proves the"
+                            + " PERSISTENT_RECURSIVE watch survives without re-arming",
+                    main.getEventDrivenTicks() > ticksAfterFirstBurst);
+
+            // Sanity: we should NEVER have hit the 1-hour periodic safety-net here.
+            // getRuns() counts every runOnce, including event-driven ones. We just
+            // assert it has run more than 0 (the count fluctuates with debouncing).
+            assertTrue(main.getEngine().getRuns() > 0L);
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    @Test
+    public void debounceCoalescesMultipleEventsIntoOneTick() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
+        props.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
+        // Long debounce window so the burst MUST coalesce: we publish 10
+        // segments sequentially in well under 500ms, expect exactly one
+        // event-driven tick to land.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "500");
+        props.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
+        props.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        merger.setReturnNull(true); // we don't want segment churn in the registry
+        IndexOptimizerMain main = new IndexOptimizerMain(
+                new OptimizerConfiguration(props), merger);
+        try {
+            main.start();
+            long ticksAtStart = main.getEventDrivenTicks();
+
+            // Publish 10 segments in tight loop, well under the debounce window.
+            for (int i = 0; i < 10; i++) {
+                registry.createSegment(sampleSegment("burst-" + UUID.randomUUID(), 100L));
+            }
+
+            // Wait past the debounce window for the coalesced tick to land.
+            long deadline = System.currentTimeMillis() + 3_000L;
+            while (System.currentTimeMillis() < deadline
+                    && main.getEventDrivenTicks() <= ticksAtStart) {
+                Thread.sleep(20);
+            }
+            long ticksAfter = main.getEventDrivenTicks() - ticksAtStart;
+            assertTrue("at least one event-driven tick (got " + ticksAfter + ")",
+                    ticksAfter >= 1);
+            // Sanity: the watch saw multiple events, but they coalesced into a
+            // single (or at most a few) tick. We cannot assert "exactly one"
+            // because the OS scheduler may insert a brief gap inside the burst,
+            // but ticksAfter should be small relative to the 10 events.
+            assertTrue("event-driven ticks should be far fewer than the 10 events that fired"
+                            + " them (got " + ticksAfter + ", events="
+                            + main.getWatcherEvents() + ")",
+                    ticksAfter <= main.getWatcherEvents());
+        } finally {
+            main.shutdown();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEventDrivenTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEventDrivenTest.java
@@ -178,9 +178,16 @@ public class IndexOptimizerEventDrivenTest {
                     main.getWatcherEvents() > 0);
 
             // Wait for the engine's first tick to actually drain (so the leader
-            // lock is held and getRuns() reflects the work).
-            Thread.sleep(100);
-            assertTrue(main.getEngine().getRuns() > 0L);
+            // lock is held and getRuns() reflects the work). We poll because
+            // runEventDrivenTick increments getEventDrivenTicks BEFORE running
+            // tickSafe, so the run counter lags the event-driven count slightly.
+            deadline = System.currentTimeMillis() + 5_000L;
+            while (System.currentTimeMillis() < deadline
+                    && main.getEngine().getRuns() == 0L) {
+                Thread.sleep(20);
+            }
+            assertTrue("engine.runs must increment within 5s of event-driven tick",
+                    main.getEngine().getRuns() > 0L);
 
             // === Part 2: prove the persistent-recursive watch survives a second
             //  burst — i.e. it does NOT need re-arming after the first event,
@@ -203,6 +210,89 @@ public class IndexOptimizerEventDrivenTest {
             // assert it has run more than 0 (the count fluctuates with debouncing).
             assertTrue(main.getEngine().getRuns() > 0L);
         } finally {
+            main.shutdown();
+        }
+    }
+
+    @Test
+    public void eventsDuringLongTickScheduleFollowUp() throws Exception {
+        // Verifies that events arriving DURING a long-running tick get coalesced
+        // into a follow-up tick that fires automatically once the in-progress
+        // tick finishes — proving the persistent-recursive watch keeps
+        // delivering even when the engine is busy. This is the core
+        // "no-event-is-lost" guarantee of the event-driven path.
+        Properties props = new Properties();
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
+        props.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        // Periodic interval disabled — we only want event-driven ticks.
+        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
+        // Short debounce so the follow-up tick lands within the assertion window.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "50");
+        props.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
+        props.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        merger.setReturnNull(true); // we don't want segment churn
+        // Inject a 1-second sleep into the merger's invocation so the first
+        // tick takes ~1 s. Events published during that window must trigger a
+        // follow-up tick (not be lost) once the in-progress tick releases the
+        // single-threaded scheduler.
+        java.util.concurrent.atomic.AtomicLong sleepingHookInvocations =
+                new java.util.concurrent.atomic.AtomicLong();
+        merger.setHook(() -> {
+            sleepingHookInvocations.incrementAndGet();
+            try {
+                Thread.sleep(800);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        IndexOptimizerMain main = new IndexOptimizerMain(
+                new OptimizerConfiguration(props), merger);
+        try {
+            main.start();
+            long ticksAtStart = main.getEventDrivenTicks();
+
+            // Publish two segments to fire the first event-driven tick (which
+            // sleeps 800 ms inside the merger). Wait for the tick to start.
+            registry.createSegment(sampleSegment("warm-1", 100L));
+            registry.createSegment(sampleSegment("warm-2", 100L));
+
+            long deadline = System.currentTimeMillis() + 3_000L;
+            while (System.currentTimeMillis() < deadline
+                    && main.getEventDrivenTicks() <= ticksAtStart) {
+                Thread.sleep(20);
+            }
+            assertTrue("first event-driven tick must start within 3 s",
+                    main.getEventDrivenTicks() > ticksAtStart);
+
+            // While the first tick is mid-flight (sleeping inside the merger
+            // hook), publish another batch. The watch fires; the wakeup is
+            // coalesced into a follow-up tick that must land AFTER the
+            // current one finishes.
+            long ticksAfterFirst = main.getEventDrivenTicks();
+            for (int i = 0; i < 4; i++) {
+                registry.createSegment(sampleSegment("during-tick-" + i, 100L));
+            }
+
+            // Wait for the second tick to land. Allow up to 5 s — the first
+            // tick has up to 800 ms left, the debounce adds 50 ms, then the
+            // second tick runs.
+            deadline = System.currentTimeMillis() + 5_000L;
+            while (System.currentTimeMillis() < deadline
+                    && main.getEventDrivenTicks() <= ticksAfterFirst) {
+                Thread.sleep(20);
+            }
+            assertTrue("follow-up event-driven tick must fire after the busy tick releases"
+                            + " the scheduler (got " + main.getEventDrivenTicks()
+                            + ", was " + ticksAfterFirst + ")",
+                    main.getEventDrivenTicks() > ticksAfterFirst);
+        } finally {
+            // Detach the hook before shutdown so the scheduler can drain quickly.
+            merger.setHook(null);
             main.shutdown();
         }
     }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainConfigTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainConfigTest.java
@@ -1,0 +1,157 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.model.TableSpace;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies the merger-resolution chain in {@link IndexOptimizerMain} (issue #484):
+ * <ul>
+ *   <li>When the constructor is given a pre-configured merger, that merger is
+ *       used verbatim regardless of configuration (test override path).</li>
+ *   <li>When no merger is preconfigured AND no remote-file servers are available
+ *       (neither static nor via ZK discovery), the optimizer falls back to a
+ *       {@link IndexOptimizerMain.NoopMerger}. This is the unit-test convenience
+ *       path that lets the registry plumbing exercise without provisioning a
+ *       remote file service.</li>
+ *   <li>{@link IndexOptimizerMain#loadMergerSpi()} continues to return the
+ *       NoopMerger fallback when no SPI provider is registered (preserved
+ *       for backward compat with existing tests).</li>
+ * </ul>
+ */
+public class IndexOptimizerMainConfigTest {
+
+    private static final String BASE_PATH = "/herd-test-cfg";
+    private static final String TS_NAME = "herd";
+    private static final String TS_UUID = "ts-cfg";
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue(connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registerTablespace(TS_NAME, TS_UUID);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    private void registerTablespace(String name, String uuid) throws Exception {
+        Set<String> replicas = new HashSet<>();
+        replicas.add("test-instance");
+        TableSpace ts = TableSpace.builder()
+                .name(name)
+                .uuid(uuid)
+                .leader("test-instance")
+                .replicas(replicas)
+                .expectedReplicaCount(1)
+                .build();
+        try (ZookeeperMetadataStorageManager zkmeta =
+                new ZookeeperMetadataStorageManager(zkServer.getConnectString(), 30000, BASE_PATH)) {
+            zkmeta.start(true);
+            zkmeta.registerTableSpace(ts);
+        }
+    }
+
+    private Properties baseProps() {
+        Properties p = new Properties();
+        p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
+        p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
+        p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
+        p.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        p.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
+        p.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+        p.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
+        return p;
+    }
+
+    @Test
+    public void preConfiguredMergerIsUsedVerbatim() throws Exception {
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        IndexOptimizerMain main = new IndexOptimizerMain(
+                new OptimizerConfiguration(baseProps()), merger);
+        try {
+            main.start();
+            assertNotNull(main.getMerger());
+            assertEquals("preconfigured merger must be used as-is",
+                    merger, main.getMerger());
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    @Test
+    public void noServersConfiguredFallsBackToNoopMerger() throws Exception {
+        // No PROPERTY_REMOTE_FILE_SERVERS, and the test ZK has no /herd/file-servers
+        // znode (we never registered one), so the optimizer must fall back to
+        // NoopMerger rather than failing startup.
+        IndexOptimizerMain main = new IndexOptimizerMain(
+                new OptimizerConfiguration(baseProps()));
+        try {
+            main.start();
+            assertNotNull(main.getMerger());
+            assertTrue("expected NoopMerger fallback, got " + main.getMerger().getClass().getName(),
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    @Test
+    public void loadMergerSpiReturnsNoopFallback() {
+        SegmentMerger m = IndexOptimizerMain.loadMergerSpi();
+        assertNotNull(m);
+        assertTrue("backward-compat helper must still return NoopMerger fallback",
+                m instanceof IndexOptimizerMain.NoopMerger);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainTest.java
@@ -133,7 +133,9 @@ public class IndexOptimizerMainTest {
         // Register the tablespace so the optimizer can resolve the UUID by name.
         registerTablespace(TS_NAME, TS_UUID);
 
-        // Pre-seed enough segments to force-fire (maxCount=2 < 3 segments).
+        // Pre-seed three small segments. The AggressivePolicy fires whenever ≥2
+        // sub-target segments exist; with maxCount=100 all three are merged
+        // into a single output in one cycle.
         for (int i = 0; i < 3; i++) {
             registry.createSegment(sampleSegment("seg-" + i, 100L));
         }
@@ -144,11 +146,14 @@ public class IndexOptimizerMainTest {
         props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
         props.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
         props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "100");
-        props.setProperty(OptimizerConfiguration.PROPERTY_MIN_COUNT, "4");
-        props.setProperty(OptimizerConfiguration.PROPERTY_MAX_COUNT, "2");
-        props.setProperty(OptimizerConfiguration.PROPERTY_MIN_BYTES, "9999999999");
+        props.setProperty(OptimizerConfiguration.PROPERTY_MAX_COUNT, "100");
         props.setProperty(OptimizerConfiguration.PROPERTY_MAX_BYTES, "9999999999");
+        props.setProperty(OptimizerConfiguration.PROPERTY_TARGET_MAX_BYTES, "9999999999");
         props.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+        // Disable event-driven debounce so the test's deterministic single-tick
+        // assertion (1 merge invocation) doesn't race with watcher-driven
+        // wakeups from the createSegment / deprecate side-effects.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "60000");
 
         InMemorySegmentMerger merger = new InMemorySegmentMerger();
         IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props), merger);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerSessionExpiredTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerSessionExpiredTest.java
@@ -1,0 +1,169 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.model.TableSpace;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end test verifying the ZK-session-expiry → {@code /health} 503
+ * wiring on a real {@link IndexOptimizerMain} instance (issue #484, round-2
+ * review item B.6).
+ *
+ * <p>The test does not rely on a synthetic predicate; it triggers an actual
+ * {@code KeeperState.Expired} event by hijacking the optimizer's session id
+ * and closing it from a second client (the canonical "kill ZK session"
+ * pattern). The test then asserts {@link IndexOptimizerMain#isSessionExpired}
+ * flips within a deadline.
+ */
+public class IndexOptimizerSessionExpiredTest {
+
+    private static final String BASE_PATH = "/herd-test-session-expired";
+    private static final String TS_NAME = "herd";
+    private static final String TS_UUID = "ts-expired";
+
+    private TestingServer zkServer;
+    private ZooKeeper bootstrapZk;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        bootstrapZk = new ZooKeeper(zkServer.getConnectString(), 30000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue(connected.await(30, TimeUnit.SECONDS));
+        bootstrapZk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registerTablespace(TS_NAME, TS_UUID);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (bootstrapZk != null) {
+            bootstrapZk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    private void registerTablespace(String name, String uuid) throws Exception {
+        Set<String> replicas = new HashSet<>();
+        replicas.add("test-instance");
+        TableSpace ts = TableSpace.builder()
+                .name(name)
+                .uuid(uuid)
+                .leader("test-instance")
+                .replicas(replicas)
+                .expectedReplicaCount(1)
+                .build();
+        try (ZookeeperMetadataStorageManager zkmeta =
+                new ZookeeperMetadataStorageManager(zkServer.getConnectString(), 30000, BASE_PATH)) {
+            zkmeta.start(true);
+            zkmeta.registerTableSpace(ts);
+        }
+    }
+
+    @Test
+    public void zkSessionExpiryTrippedAndDetected() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
+        // Short ZK session timeout so we can force an expiry quickly.
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "4000");
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
+        props.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "60000");
+        props.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+        props.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
+
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        IndexOptimizerMain main = new IndexOptimizerMain(
+                new OptimizerConfiguration(props), merger);
+        try {
+            main.start();
+            assertNotNull(main.getEngine());
+            assertTrue("session must NOT be expired immediately after start",
+                    !main.isSessionExpired());
+
+            // Hijack the optimizer's ZK session id + password and close that
+            // session from a second client. ZooKeeper considers this "session
+            // moved" — the original client's next operation gets
+            // SessionExpired, which fires the watcher with KeeperState.Expired.
+            ZooKeeper victimSession = extractZkClient(main);
+            long sessionId = victimSession.getSessionId();
+            byte[] passwd = victimSession.getSessionPasswd();
+
+            CountDownLatch kicked = new CountDownLatch(1);
+            ZooKeeper kicker = new ZooKeeper(zkServer.getConnectString(), 4000,
+                    (WatchedEvent ev) -> {
+                        if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                            kicked.countDown();
+                        }
+                    },
+                    sessionId, passwd);
+            assertTrue("kicker session must establish",
+                    kicked.await(10, TimeUnit.SECONDS));
+            // Closing the kicker session also kills the optimizer's session
+            // (same session id) — the original watcher fires Expired.
+            kicker.close();
+
+            // Wait up to 10 s for the optimizer's watcher to observe Expired
+            // and flip the flag. (The timeout is generous because session
+            // expiry detection waits for the next ZK keepalive round-trip.)
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline && !main.isSessionExpired()) {
+                Thread.sleep(50);
+            }
+            assertTrue("ZK session expiry must trip IndexOptimizerMain.isSessionExpired",
+                    main.isSessionExpired());
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    /**
+     * Reflectively pulls the {@link ZooKeeper} field out of {@link IndexOptimizerMain}.
+     * The field is package-private; we use reflection to keep the test file in
+     * a different package without leaking it onto the public API.
+     */
+    private static ZooKeeper extractZkClient(IndexOptimizerMain main) throws Exception {
+        java.lang.reflect.Field f = IndexOptimizerMain.class.getDeclaredField("zooKeeper");
+        f.setAccessible(true);
+        return (ZooKeeper) f.get(main);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
@@ -181,6 +181,41 @@ public class OptimizerHttpServerTest {
         }
     }
 
+    @Test
+    public void healthReturns503WhenCriticalFailureFlagSet() throws Exception {
+        // Issue #484 (review item B.3 from the first pr-reviewer pass): the
+        // /health endpoint must consult an injected critical-failure
+        // predicate so a ZK session expiry can trip Helm's liveness probe
+        // even if the engine is still ticking on the periodic safety-net.
+        java.util.concurrent.atomic.AtomicBoolean criticalFailure =
+                new java.util.concurrent.atomic.AtomicBoolean(false);
+        OptimizerHttpServer http2 = new OptimizerHttpServer("127.0.0.1", 0, engine,
+                /* stalenessThresholdMillis */ Long.MAX_VALUE,
+                System::currentTimeMillis,
+                criticalFailure::get);
+        try {
+            http2.start();
+            // Pre-condition: engine OK, no critical failure → 200.
+            engine.runOnce();
+            int ok = headStatus("http://127.0.0.1:" + http2.getBoundPort() + "/health");
+            assertEquals(200, ok);
+
+            // Trip the critical-failure flag (simulating ZK session expiry).
+            criticalFailure.set(true);
+            int failed = headStatus("http://127.0.0.1:" + http2.getBoundPort() + "/health");
+            assertEquals("/health must return 503 when critical-failure flag is set",
+                    503, failed);
+
+            // Clearing the flag returns the endpoint to 200.
+            criticalFailure.set(false);
+            int recovered = headStatus("http://127.0.0.1:" + http2.getBoundPort() + "/health");
+            assertEquals("/health must recover to 200 once the flag clears",
+                    200, recovered);
+        } finally {
+            http2.close();
+        }
+    }
+
     private static int headStatus(String url) throws Exception {
         java.net.HttpURLConnection conn = (java.net.HttpURLConnection)
                 new java.net.URL(url).openConnection();

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/ReaperFileDeletionTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/ReaperFileDeletionTest.java
@@ -100,7 +100,7 @@ public class ReaperFileDeletionTest {
         }
     }
 
-    private SegmentMetadata buildSegment(String segUuid, int segId, String tombstonePath) {
+    private SegmentMetadata buildSegment(String segUuid, long segId, String tombstonePath) {
         return SegmentMetadata.builder()
                 .segmentUuid(segUuid)
                 .tablespaceUuid(TS_UUID)

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
@@ -159,39 +159,102 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
     }
 
     @Test
-    public void legacyZnodeRefusedAgainstProductionLikeReader() throws Exception {
+    public void modernZnodeFailsLoudlyAgainstHintReturningReader() throws Exception {
         // Regression test for round-3 review B.1.1: production
         // RandomAccessReader implementations (RemoteRandomAccessReader,
-        // SegmentedMappedReader) return the constructor-supplied size from
-        // length(), so any clamp via length() is a no-op. We mirror that
-        // behaviour here with a HintReturningDsm decorator and verify the
-        // merger STILL refuses the legacy input, proving the round-3 fix
-        // doesn't depend on the in-memory DSM's byte-accurate length().
+        // SegmentedMappedReader) treat the constructor-supplied fileSize as
+        // authoritative and return it from length() — they don't probe the
+        // underlying object. The round-4 fix removed the misleading
+        // length()-based clamp from RemoteSegmentGraphMerger.downloadMapFile;
+        // the caller (RemoteSegmentMerger) is now solely responsible for
+        // passing a byte-accurate size.
+        //
+        // This test exercises the production-reader contract directly by
+        // wiring a {@link HintReturningReader} that mirrors
+        // RemoteRandomAccessReader.length(). We feed a *modern* znode whose
+        // mapFileSize is INTENTIONALLY too large vs the actual remote bytes
+        // — the merger then asks the reader for that many bytes, the reader
+        // honours the over-estimate, and {@code readFully} throws when the
+        // underlying buffer runs out. Asserts the failure is loud (an
+        // IOException) rather than silent under-read or torn graph.
         HintReturningDsm productionLikeDsm = new HintReturningDsm();
-        SegmentMetadata legacy = writeLegacyInput("legacy-prod-A", 100L, 0xA);
-        // Re-publish into the production-like DSM (the helper used the
-        // memory DSM by default).
+        // Plant a 16-byte real map file on the DSM, but configure the
+        // SegmentMetadata to claim 1024 bytes — the production reader will
+        // happily return length()=1024 from the size hint, and the merger
+        // will read until it runs off the end.
         Path scratch = Files.createTempFile(tmpDir, "scratch-", ".tmp");
-        Files.write(scratch, new byte[]{0, 1, 2, 3, 4, 5, 6, 7});
-        productionLikeDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg100", "map",
+        Files.write(scratch, new byte[16]);
+        productionLikeDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg500", "map",
                 scratch, null);
         Files.deleteIfExists(scratch);
-
-        SegmentMetadata other = writeLegacyInput("legacy-prod-B", 200L, 0xB);
         Path scratch2 = Files.createTempFile(tmpDir, "scratch2-", ".tmp");
-        Files.write(scratch2, new byte[]{0, 1, 2, 3, 4, 5, 6, 7});
-        productionLikeDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg200", "map",
+        Files.write(scratch2, new byte[16]);
+        productionLikeDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg600", "map",
                 scratch2, null);
         Files.deleteIfExists(scratch2);
+
+        SegmentMetadata oversizedHint1 = SegmentMetadata.builder()
+                .segmentUuid("oversized-A").tablespaceUuid(TS_UUID).tableName("t")
+                .indexUuid(IDX_UUID).indexName("i").state(SegmentState.ACTIVE)
+                .ownerInstanceId(0).segmentId(500L)
+                .graphPath("g").mapPath("m")
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(2048L)
+                .mapFileSize(1024L) // far larger than the 16-byte real file
+                .vectorCount(1L).generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+        SegmentMetadata oversizedHint2 = SegmentMetadata.builder()
+                .segmentUuid("oversized-B").tablespaceUuid(TS_UUID).tableName("t")
+                .indexUuid(IDX_UUID).indexName("i").state(SegmentState.ACTIVE)
+                .ownerInstanceId(0).segmentId(600L)
+                .graphPath("g").mapPath("m")
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(2048L)
+                .mapFileSize(1024L)
+                .vectorCount(1L).generation(2L)
+                .createdAtEpochMillis(0L)
+                .build();
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                productionLikeDsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(oversizedHint1, oversizedHint2), 0);
+            fail("expected merge to fail loudly when mapFileSize over-estimates"
+                    + " against a production-like reader (no length()-based clamp)");
+        } catch (Exception ok) {
+            // The exact exception type is implementation-defined (IOException
+            // bubbling up from readFully, or DataStorageManagerException from
+            // the multipart layer); assert at least that the failure was
+            // surfaced rather than swallowed.
+            assertTrue("expected loud failure, got: " + ok,
+                    ok instanceof IOException
+                            || ok instanceof RuntimeException);
+        }
+    }
+
+    @Test
+    public void legacyZnodeRefusedBeforeAnyIo() throws Exception {
+        // Companion to legacyZnodeRefusedOnMemoryDsm: same legacy refusal
+        // behaviour, but against the production-like DSM. The
+        // LegacyMetadataException is thrown by the merger BEFORE any
+        // multipart reader is opened, so this test passes regardless of
+        // what the reader's length() returns. Documents the layering: the
+        // mapFileSize check at RemoteSegmentMerger.merge sits upstream of
+        // any I/O.
+        HintReturningDsm productionLikeDsm = new HintReturningDsm();
+        SegmentMetadata legacy = writeLegacyInput("legacy-prod-A", 100L, 0xA);
+        SegmentMetadata other = writeLegacyInput("legacy-prod-B", 200L, 0xB);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
                 productionLikeDsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f,
                 VectorSimilarityFunction.EUCLIDEAN);
         try {
             merger.merge(List.of(legacy, other), 0);
-            fail("expected LegacyMetadataException against production-like reader");
+            fail("expected LegacyMetadataException");
         } catch (RemoteSegmentMerger.LegacyMetadataException ok) {
-            // pass
+            // pass — refused upstream of any reader I/O.
         }
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
@@ -1,0 +1,232 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies the legacy fallback in {@link RemoteSegmentMerger#merge} for
+ * znodes that pre-date the {@code mapFileSize} field added in issue #484
+ * round 2 (review item B.1.4).
+ *
+ * <p>For legacy znodes ({@code mapFileSize == 0}), the merger uses
+ * {@code sizeBytes} (graph + map combined) as an upper-bound size hint
+ * for the multipart reader; the download path uses the reader's
+ * {@link io.github.jbellis.jvector.disk.RandomAccessReader#length()} to
+ * clamp the read to the actual file size, so the over-estimate is
+ * harmless. This test exercises that path end-to-end against
+ * {@link MemoryDataStorageManager} and verifies the merged output is
+ * byte-accurate (no truncation, no resurrection of dropped tail entries).
+ */
+public class RemoteSegmentMergerLegacyMapFileSizeTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-legacy-mfs";
+    private static final String IDX_UUID = "idx-legacy-mfs";
+    private static final int DIM = 8;
+    private static final int VECTORS_PER_SEGMENT = 50;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    private SegmentMetadata writeLegacyInput(String segUuid, long segId, int seed) throws Exception {
+        Path mapFile = Files.createTempFile(tmpDir, "input-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapFile.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(VECTORS_PER_SEGMENT);
+            Random rng = new Random(seed);
+            for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                dos.writeInt(local);
+                byte[] pk = (segUuid + "-" + local).getBytes();
+                dos.writeInt(pk.length);
+                dos.write(pk);
+                VectorFloat<?> v = VTS.createFloatVector(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    v.set(j, rng.nextFloat());
+                }
+                dos.writeInt(v.length());
+                for (int j = 0; j < v.length(); j++) {
+                    dos.writeInt(Float.floatToIntBits(v.get(j)));
+                }
+            }
+        }
+        long actualMapSize = Files.size(mapFile);
+        // Simulate "graphFileSize ≈ 3× mapFileSize" — the typical ratio for a
+        // small dim. The combined sizeBytes hint will overestimate map size by
+        // 4×, so the legacy fallback MUST clamp via reader.length() to avoid
+        // reading past the actual file.
+        long combinedSizeHint = actualMapSize * 4L;
+        String multipartUuid = IDX_UUID + "_seg" + segId;
+        String mapPath = dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", mapFile, null);
+        Files.deleteIfExists(mapFile);
+
+        return SegmentMetadata.builder()
+                .segmentUuid(segUuid)
+                .tablespaceUuid(TS_UUID).tableName("docs")
+                .indexUuid(IDX_UUID).indexName("docs_v1")
+                .state(SegmentState.ACTIVE).ownerInstanceId(0)
+                .segmentId(segId)
+                .graphPath("g/" + segUuid).mapPath(mapPath)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(combinedSizeHint)
+                // Legacy: mapFileSize INTENTIONALLY left at the default 0L.
+                // The merger must fall back to sizeBytes as the size hint
+                // and then clamp via reader.length() to read only the real
+                // map bytes (issue #484 round-2 fix).
+                .vectorCount(VECTORS_PER_SEGMENT).generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+    }
+
+    @Test
+    public void legacyZnodeWithUnsetMapFileSizeStillProducesByteAccurateMerge() throws Exception {
+        SegmentMetadata a = writeLegacyInput("legacy-mfs-A", 100L, 0xA);
+        SegmentMetadata b = writeLegacyInput("legacy-mfs-B", 200L, 0xB);
+
+        // Sanity: the metadata indeed carries mapFileSize == 0 (the field
+        // defaults to UNKNOWN_FILE_SIZE when not set).
+        assertEquals(SegmentMetadata.UNKNOWN_FILE_SIZE, a.getMapFileSize());
+        assertEquals(SegmentMetadata.UNKNOWN_FILE_SIZE, b.getMapFileSize());
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        SegmentMetadata merged = merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
+        assertNotNull("merger must succeed on legacy mapFileSize == 0 inputs", merged);
+        assertEquals("every input vector must survive (no tail truncation)",
+                2L * VECTORS_PER_SEGMENT, merged.getVectorCount());
+        assertTrue("merged segmentId must be a real value, not the sentinel",
+                merged.getSegmentId() != SegmentMetadata.NO_SEGMENT_ID);
+        // The merger's OWN output must populate the new field so subsequent
+        // merges of this output don't fall back to the legacy path.
+        assertTrue("merger output must populate mapFileSize",
+                merged.getMapFileSize() > 0L);
+    }
+
+    @Test
+    public void modernZnodeWithExplicitMapFileSizeBypassesFallback() throws Exception {
+        // Mirror of the legacy test, but the inputs explicitly set
+        // mapFileSize via the builder. This is the production path post-#484
+        // and is the most heavily exercised code path; included here as an
+        // adjacent control case.
+        Path mapA = Files.createTempFile(tmpDir, "modern-A-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapA.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(10);
+            for (int i = 0; i < 10; i++) {
+                dos.writeInt(i);
+                byte[] pk = ("modern-A-" + i).getBytes();
+                dos.writeInt(pk.length);
+                dos.write(pk);
+                dos.writeInt(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    dos.writeInt(Float.floatToIntBits((float) (i + j)));
+                }
+            }
+        }
+        long realSize = Files.size(mapA);
+        dsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg300", "map", mapA, null);
+        Files.deleteIfExists(mapA);
+        SegmentMetadata modern1 = SegmentMetadata.builder()
+                .segmentUuid("modern-A").tablespaceUuid(TS_UUID).tableName("t")
+                .indexUuid(IDX_UUID).indexName("i").state(SegmentState.ACTIVE)
+                .ownerInstanceId(0).segmentId(300L)
+                .graphPath("g").mapPath(Bytes.from_string("map").toString())
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(realSize * 4L)
+                .mapFileSize(realSize) // explicit
+                .vectorCount(10L).generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+
+        Path mapB = Files.createTempFile(tmpDir, "modern-B-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapB.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(10);
+            for (int i = 0; i < 10; i++) {
+                dos.writeInt(i);
+                byte[] pk = ("modern-B-" + i).getBytes();
+                dos.writeInt(pk.length);
+                dos.write(pk);
+                dos.writeInt(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    dos.writeInt(Float.floatToIntBits((float) (i + j + 100)));
+                }
+            }
+        }
+        long realSizeB = Files.size(mapB);
+        dsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg400", "map", mapB, null);
+        Files.deleteIfExists(mapB);
+        SegmentMetadata modern2 = SegmentMetadata.builder()
+                .segmentUuid("modern-B").tablespaceUuid(TS_UUID).tableName("t")
+                .indexUuid(IDX_UUID).indexName("i").state(SegmentState.ACTIVE)
+                .ownerInstanceId(0).segmentId(400L)
+                .graphPath("g").mapPath("m")
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(realSizeB * 4L)
+                .mapFileSize(realSizeB)
+                .vectorCount(10L).generation(2L)
+                .createdAtEpochMillis(0L)
+                .build();
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        SegmentMetadata merged = merger.merge(List.of(modern1, modern2), 0);
+        assertNotNull(merged);
+        assertEquals(20L, merged.getVectorCount());
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
@@ -22,11 +22,14 @@ package herddb.indexing.optimizer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import herddb.indexing.segment.SegmentMetadata;
 import herddb.indexing.segment.SegmentState;
 import herddb.log.LogSequenceNumber;
 import herddb.mem.MemoryDataStorageManager;
-import herddb.utils.Bytes;
+import herddb.storage.DataStorageManagerException;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
@@ -34,6 +37,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -44,18 +48,25 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
- * Verifies the legacy fallback in {@link RemoteSegmentMerger#merge} for
- * znodes that pre-date the {@code mapFileSize} field added in issue #484
- * round 2 (review item B.1.4).
+ * Verifies the merger's handling of <em>legacy</em> znodes — those whose
+ * {@code SegmentMetadata.mapFileSize} field is unset (issue #484, round-3
+ * review item B.1.1).
  *
- * <p>For legacy znodes ({@code mapFileSize == 0}), the merger uses
- * {@code sizeBytes} (graph + map combined) as an upper-bound size hint
- * for the multipart reader; the download path uses the reader's
- * {@link io.github.jbellis.jvector.disk.RandomAccessReader#length()} to
- * clamp the read to the actual file size, so the over-estimate is
- * harmless. This test exercises that path end-to-end against
- * {@link MemoryDataStorageManager} and verifies the merged output is
- * byte-accurate (no truncation, no resurrection of dropped tail entries).
+ * <p>The production storage readers ({@code RemoteRandomAccessReader},
+ * {@code SegmentedMappedReader}) treat the {@code fileSize} passed at
+ * construction as authoritative — they don't probe the underlying object —
+ * and the direct-multipart-download path computes block count from that
+ * size and throws "Block N not found" past the actual file end. Silently
+ * over-reading would corrupt the merged graph; trying to clamp the read
+ * via {@code RandomAccessReader.length()} is a no-op on every production
+ * reader because {@code length()} returns the constructor-supplied size
+ * unchanged.
+ *
+ * <p>The merger therefore refuses legacy inputs outright with
+ * {@link RemoteSegmentMerger.LegacyMetadataException}. The engine catches
+ * the exception, bumps {@code mergeFailuresTotal}, and moves on — the
+ * next IS checkpoint rewrites the znode with {@code mapFileSize} set,
+ * unsticking the segment.
  */
 public class RemoteSegmentMergerLegacyMapFileSizeTest {
 
@@ -102,11 +113,7 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
             }
         }
         long actualMapSize = Files.size(mapFile);
-        // Simulate "graphFileSize ≈ 3× mapFileSize" — the typical ratio for a
-        // small dim. The combined sizeBytes hint will overestimate map size by
-        // 4×, so the legacy fallback MUST clamp via reader.length() to avoid
-        // reading past the actual file.
-        long combinedSizeHint = actualMapSize * 4L;
+        long combinedSizeHint = actualMapSize * 4L; // mimic graph + map combined
         String multipartUuid = IDX_UUID + "_seg" + segId;
         String mapPath = dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", mapFile, null);
         Files.deleteIfExists(mapFile);
@@ -121,46 +128,76 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
                 .baseLsn(new LogSequenceNumber(1L, 100L))
                 .sizeBytes(combinedSizeHint)
                 // Legacy: mapFileSize INTENTIONALLY left at the default 0L.
-                // The merger must fall back to sizeBytes as the size hint
-                // and then clamp via reader.length() to read only the real
-                // map bytes (issue #484 round-2 fix).
                 .vectorCount(VECTORS_PER_SEGMENT).generation(1L)
                 .createdAtEpochMillis(0L)
                 .build();
     }
 
     @Test
-    public void legacyZnodeWithUnsetMapFileSizeStillProducesByteAccurateMerge() throws Exception {
+    public void legacyZnodeRefusedOnMemoryDsm() throws Exception {
         SegmentMetadata a = writeLegacyInput("legacy-mfs-A", 100L, 0xA);
         SegmentMetadata b = writeLegacyInput("legacy-mfs-B", 200L, 0xB);
 
-        // Sanity: the metadata indeed carries mapFileSize == 0 (the field
-        // defaults to UNKNOWN_FILE_SIZE when not set).
+        // Sanity: both inputs carry mapFileSize == 0.
         assertEquals(SegmentMetadata.UNKNOWN_FILE_SIZE, a.getMapFileSize());
         assertEquals(SegmentMetadata.UNKNOWN_FILE_SIZE, b.getMapFileSize());
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
                 dsm, tmpDir, DIM, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
                 VectorSimilarityFunction.EUCLIDEAN);
-
-        SegmentMetadata merged = merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
-        assertNotNull("merger must succeed on legacy mapFileSize == 0 inputs", merged);
-        assertEquals("every input vector must survive (no tail truncation)",
-                2L * VECTORS_PER_SEGMENT, merged.getVectorCount());
-        assertTrue("merged segmentId must be a real value, not the sentinel",
-                merged.getSegmentId() != SegmentMetadata.NO_SEGMENT_ID);
-        // The merger's OWN output must populate the new field so subsequent
-        // merges of this output don't fall back to the legacy path.
-        assertTrue("merger output must populate mapFileSize",
-                merged.getMapFileSize() > 0L);
+        try {
+            merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
+            fail("expected LegacyMetadataException for legacy znode without mapFileSize");
+        } catch (RemoteSegmentMerger.LegacyMetadataException ok) {
+            // The first input that the merger encounters trips the check; we
+            // assert at least one of the segment uuids appears in the message.
+            assertTrue("error message should reference the legacy segment: "
+                            + ok.getMessage(),
+                    ok.getMessage().contains("legacy-mfs-")
+                            && ok.getMessage().contains("predating issue #484"));
+        }
     }
 
     @Test
-    public void modernZnodeWithExplicitMapFileSizeBypassesFallback() throws Exception {
-        // Mirror of the legacy test, but the inputs explicitly set
-        // mapFileSize via the builder. This is the production path post-#484
-        // and is the most heavily exercised code path; included here as an
-        // adjacent control case.
+    public void legacyZnodeRefusedAgainstProductionLikeReader() throws Exception {
+        // Regression test for round-3 review B.1.1: production
+        // RandomAccessReader implementations (RemoteRandomAccessReader,
+        // SegmentedMappedReader) return the constructor-supplied size from
+        // length(), so any clamp via length() is a no-op. We mirror that
+        // behaviour here with a HintReturningDsm decorator and verify the
+        // merger STILL refuses the legacy input, proving the round-3 fix
+        // doesn't depend on the in-memory DSM's byte-accurate length().
+        HintReturningDsm productionLikeDsm = new HintReturningDsm();
+        SegmentMetadata legacy = writeLegacyInput("legacy-prod-A", 100L, 0xA);
+        // Re-publish into the production-like DSM (the helper used the
+        // memory DSM by default).
+        Path scratch = Files.createTempFile(tmpDir, "scratch-", ".tmp");
+        Files.write(scratch, new byte[]{0, 1, 2, 3, 4, 5, 6, 7});
+        productionLikeDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg100", "map",
+                scratch, null);
+        Files.deleteIfExists(scratch);
+
+        SegmentMetadata other = writeLegacyInput("legacy-prod-B", 200L, 0xB);
+        Path scratch2 = Files.createTempFile(tmpDir, "scratch2-", ".tmp");
+        Files.write(scratch2, new byte[]{0, 1, 2, 3, 4, 5, 6, 7});
+        productionLikeDsm.writeMultipartIndexFile(TS_UUID, IDX_UUID + "_seg200", "map",
+                scratch2, null);
+        Files.deleteIfExists(scratch2);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                productionLikeDsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(legacy, other), 0);
+            fail("expected LegacyMetadataException against production-like reader");
+        } catch (RemoteSegmentMerger.LegacyMetadataException ok) {
+            // pass
+        }
+    }
+
+    @Test
+    public void modernZnodeWithExplicitMapFileSizeMerges() throws Exception {
+        // Control: with mapFileSize set, the merge proceeds normally.
         Path mapA = Files.createTempFile(tmpDir, "modern-A-", ".tmp");
         try (BufferedOutputStream bos = new BufferedOutputStream(
                 new FileOutputStream(mapA.toFile()));
@@ -184,10 +221,10 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
                 .segmentUuid("modern-A").tablespaceUuid(TS_UUID).tableName("t")
                 .indexUuid(IDX_UUID).indexName("i").state(SegmentState.ACTIVE)
                 .ownerInstanceId(0).segmentId(300L)
-                .graphPath("g").mapPath(Bytes.from_string("map").toString())
+                .graphPath("g").mapPath("m")
                 .baseLsn(new LogSequenceNumber(1L, 100L))
                 .sizeBytes(realSize * 4L)
-                .mapFileSize(realSize) // explicit
+                .mapFileSize(realSize)
                 .vectorCount(10L).generation(1L)
                 .createdAtEpochMillis(0L)
                 .build();
@@ -228,5 +265,103 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
         SegmentMetadata merged = merger.merge(List.of(modern1, modern2), 0);
         assertNotNull(merged);
         assertEquals(20L, merged.getVectorCount());
+        // The merger's own output must populate mapFileSize so a future
+        // merge of this output goes straight through the modern path.
+        assertTrue("merger output must populate mapFileSize: " + merged.getMapFileSize(),
+                merged.getMapFileSize() > 0L);
+    }
+
+    /**
+     * DSM whose multipart reader behaves like {@code RemoteRandomAccessReader}:
+     * {@code length()} returns the constructor-supplied {@code fileSize} hint
+     * unchanged, regardless of the actual underlying object size. This is the
+     * production semantics that defeats any naive {@code length()}-based clamp.
+     */
+    private static final class HintReturningDsm extends MemoryDataStorageManager {
+        @Override
+        public ReaderSupplier multipartIndexReaderSupplier(String tableSpace, String uuid,
+                                                            String fileType, long fileSize)
+                throws DataStorageManagerException {
+            ReaderSupplier delegate = super.multipartIndexReaderSupplier(tableSpace, uuid, fileType, fileSize);
+            return () -> {
+                RandomAccessReader inner = delegate.get();
+                return new HintReturningReader(inner, fileSize);
+            };
+        }
+    }
+
+    /**
+     * Wraps a real {@link RandomAccessReader} but pretends {@link #length()}
+     * returns the size hint from construction. Mirrors
+     * {@code RemoteRandomAccessReader.length()} semantics.
+     */
+    private static final class HintReturningReader implements RandomAccessReader {
+        private final RandomAccessReader delegate;
+        private final long lenHint;
+
+        HintReturningReader(RandomAccessReader delegate, long lenHint) {
+            this.delegate = delegate;
+            this.lenHint = lenHint;
+        }
+
+        @Override
+        public long length() {
+            return lenHint;
+        }
+
+        @Override
+        public void seek(long offset) throws IOException {
+            delegate.seek(offset);
+        }
+
+        @Override
+        public long getPosition() throws IOException {
+            return delegate.getPosition();
+        }
+
+        @Override
+        public int readInt() throws IOException {
+            return delegate.readInt();
+        }
+
+        @Override
+        public float readFloat() throws IOException {
+            return delegate.readFloat();
+        }
+
+        @Override
+        public long readLong() throws IOException {
+            return delegate.readLong();
+        }
+
+        @Override
+        public void readFully(byte[] dest) throws IOException {
+            delegate.readFully(dest);
+        }
+
+        @Override
+        public void readFully(java.nio.ByteBuffer buffer) throws IOException {
+            delegate.readFully(buffer);
+        }
+
+        @Override
+        public void readFully(long[] vector) throws IOException {
+            delegate.readFully(vector);
+        }
+
+        @Override
+        public void read(int[] ints, int offset, int count) throws IOException {
+            delegate.read(ints, offset, count);
+        }
+
+        @Override
+        public void read(float[] floats, int offset, int count) throws IOException {
+            delegate.read(floats, offset, count);
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyOverlayTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyOverlayTest.java
@@ -1,0 +1,267 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.indexing.segment.TombstoneOverlay;
+import herddb.indexing.segment.TombstoneOverlayManager;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that {@link RemoteSegmentMerger} correctly applies tombstone
+ * overlays from <em>legacy</em> znodes — i.e. znodes written before the
+ * {@code overlayGeneration} field was introduced (issue #484, review item B.1#1
+ * from the first pr-reviewer pass).
+ *
+ * <p>The merger MUST NOT silently treat {@code overlayGeneration == 0 &&
+ * tombstonePath != null} as "no tombstones" — that would resurrect deleted
+ * vectors. Instead, it probes the bounded generation window
+ * {@code 1..LEGACY_OVERLAY_GENERATION_PROBE_MAX} highest-first and applies the
+ * highest existing overlay. If no overlay file exists in the probed window,
+ * the merger throws {@link RemoteSegmentMerger.TombstoneLoadFailedException}
+ * so the run aborts and the engine logs {@code mergeFailures}.
+ */
+public class RemoteSegmentMergerLegacyOverlayTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-legacy";
+    private static final String IDX_UUID = "idx-legacy";
+    private static final int DIM = 16;
+    private static final int VECTORS_PER_SEGMENT = 50;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    private SegmentMetadata writeInputAndPublishOverlay(
+            String segUuid, long segId, int seed,
+            int[] tombstonedOrdinals, long overlayGeneration,
+            String tombstonePath) throws Exception {
+        // Write the map file with all VECTORS_PER_SEGMENT entries.
+        Path mapFile = Files.createTempFile(tmpDir, "input-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapFile.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(VECTORS_PER_SEGMENT);
+            Random rng = new Random(seed);
+            for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                dos.writeInt(local);
+                byte[] pkBytes = Bytes.from_string(segUuid + "-" + local).to_array();
+                dos.writeInt(pkBytes.length);
+                dos.write(pkBytes);
+                VectorFloat<?> v = VTS.createFloatVector(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    v.set(j, rng.nextFloat() * 2.0f - 1.0f);
+                }
+                dos.writeInt(v.length());
+                for (int j = 0; j < v.length(); j++) {
+                    dos.writeInt(Float.floatToIntBits(v.get(j)));
+                }
+            }
+        }
+        long mapSize = Files.size(mapFile);
+        String multipartUuid = IDX_UUID + "_seg" + segId;
+        String mapPath = dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", mapFile, null);
+        Files.deleteIfExists(mapFile);
+
+        // Write a real overlay file at the requested generation (so the
+        // merger's probe finds it). Mirrors what TombstoneOverlayManager.flush
+        // would have done for a pre-overlayGeneration IS.
+        if (tombstonedOrdinals != null && tombstonedOrdinals.length > 0) {
+            TombstoneOverlay overlay = new TombstoneOverlay(segUuid,
+                    new LogSequenceNumber(1L, 100L), overlayGeneration, tombstonedOrdinals);
+            Path overlayFile = Files.createTempFile(tmpDir, "overlay-", ".bin");
+            Files.write(overlayFile, overlay.serialize());
+            dsm.writeMultipartIndexFile(TS_UUID,
+                    TombstoneOverlayManager.multipartUuidFor(IDX_UUID, segUuid),
+                    TombstoneOverlayManager.fileTypeFor(overlayGeneration),
+                    overlayFile, null);
+            Files.deleteIfExists(overlayFile);
+        }
+
+        return SegmentMetadata.builder()
+                .segmentUuid(segUuid)
+                .tablespaceUuid(TS_UUID).tableName("docs")
+                .indexUuid(IDX_UUID).indexName("docs_v1")
+                .state(SegmentState.ACTIVE).ownerInstanceId(0)
+                .segmentId(segId)
+                .graphPath("g/" + segUuid)
+                .mapPath(mapPath)
+                .tombstonePath(tombstonePath)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(mapSize * 2L).mapFileSize(mapSize)
+                .vectorCount(VECTORS_PER_SEGMENT).generation(1L)
+                .createdAtEpochMillis(0L)
+                // Legacy: no overlayGeneration set (defaults to 0L).
+                .build();
+    }
+
+    @Test
+    public void legacyZnodeWithExistingOverlayAppliesTombstones() throws Exception {
+        // Input A is "legacy": tombstonePath is set but overlayGeneration is 0.
+        // Its overlay file exists at generation=5 (a typical published generation).
+        int[] tombstonedA = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        SegmentMetadata a = writeInputAndPublishOverlay(
+                "legacy-A", /* segId */ 100L, /* seed */ 0xA,
+                tombstonedA, /* overlayGeneration on DSM */ 5L,
+                "tombstones-path-A");
+        SegmentMetadata b = writeInputAndPublishOverlay(
+                "B", /* segId */ 200L, /* seed */ 0xB,
+                /* no tombstones */ null, 0L, null);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, /* M */ 8, /* beamWidth */ 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        SegmentMetadata merged = merger.merge(List.of(a, b), 0);
+        assertNotNull("merger must produce an output", merged);
+        assertTrue("vectorCount must reflect tombstone-filtered A: 40 + 50 = 90",
+                merged.getVectorCount() == 90L);
+
+        // The merged map file MUST NOT contain any of the 10 tombstoned A PKs.
+        Set<Bytes> mergedPks = readMergedPks(merged);
+        for (int ord : tombstonedA) {
+            assertTrue("legacy tombstoned PK 'legacy-A-" + ord + "' must NOT appear in merged segment",
+                    !mergedPks.contains(Bytes.from_string("legacy-A-" + ord)));
+        }
+        // All B PKs must be present.
+        for (int i = 0; i < VECTORS_PER_SEGMENT; i++) {
+            assertTrue(mergedPks.contains(Bytes.from_string("B-" + i)));
+        }
+    }
+
+    @Test
+    public void legacyZnodeWithNoExistingOverlayThrowsTombstoneLoadFailed() throws Exception {
+        // Input A is "legacy": tombstonePath is set but the overlay file is
+        // missing entirely from the DSM (no probe generation ever existed).
+        // The merger must REFUSE the merge — silently treating this as "no
+        // tombstones" would resurrect deleted vectors.
+        SegmentMetadata a = writeInputAndPublishOverlay(
+                "legacy-orphan-A", 100L, 0xA, /* no overlay file written */ null, 0L,
+                "tombstones-orphan-A");
+        SegmentMetadata b = writeInputAndPublishOverlay(
+                "B", 200L, 0xB, null, 0L, null);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(a, b), 0);
+            fail("expected TombstoneLoadFailedException for legacy znode with no overlay file");
+        } catch (RemoteSegmentMerger.TombstoneLoadFailedException ok) {
+            assertTrue(ok.getMessage().contains("legacy-orphan-A"));
+            assertTrue(ok.getMessage().contains("0")); // generation reported as 0
+        }
+    }
+
+    @Test
+    public void modernZnodeWithGenerationLoadsExactGeneration() throws Exception {
+        // Input A is "modern": both tombstonePath AND overlayGeneration=3 are set.
+        // The merger must load EXACTLY generation 3, not probe.
+        int[] tombstonedA = new int[]{42, 43, 44};
+        SegmentMetadata a = writeInputAndPublishOverlay(
+                "modern-A", 100L, 0xA, tombstonedA, 3L, "tombstones-A-gen3");
+        // Modify the metadata to set overlayGeneration=3 explicitly (the helper
+        // builds the znode with overlayGeneration=0 by default).
+        SegmentMetadata aModern = a.toBuilder().overlayGeneration(3L).build();
+        SegmentMetadata b = writeInputAndPublishOverlay("B", 200L, 0xB, null, 0L, null);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        SegmentMetadata merged = merger.merge(List.of(aModern, b), 0);
+        assertNotNull(merged);
+        assertTrue("vectorCount must reflect tombstone-filtered A: 47 + 50 = 97",
+                merged.getVectorCount() == 97L);
+        Set<Bytes> mergedPks = readMergedPks(merged);
+        for (int ord : tombstonedA) {
+            assertTrue("modern tombstoned PK 'modern-A-" + ord + "' must NOT appear",
+                    !mergedPks.contains(Bytes.from_string("modern-A-" + ord)));
+        }
+    }
+
+    private Set<Bytes> readMergedPks(SegmentMetadata merged) throws Exception {
+        ReaderSupplier supplier = dsm.multipartIndexReaderSupplier(
+                merged.getTablespaceUuid(),
+                merged.getIndexUuid() + "_seg" + merged.getSegmentId(), "map",
+                /* sizeHint */ Long.MAX_VALUE);
+        try (RandomAccessReader r = supplier.get()) {
+            r.seek(0L);
+            // Read entryCount first, then read exactly entryCount entries
+            // (no EOF-driven probing). Each entry is fixed-shape:
+            //   int ordinal, int pkLen, byte[pkLen] pkBytes, int floatCount,
+            //   int[floatCount] floatBits.
+            byte[] hdr = new byte[4];
+            r.readFully(hdr);
+            int entryCount = ((hdr[0] & 0xff) << 24) | ((hdr[1] & 0xff) << 16)
+                    | ((hdr[2] & 0xff) << 8) | (hdr[3] & 0xff);
+            Set<Bytes> out = new HashSet<>(entryCount * 2);
+            byte[] intBuf = new byte[4];
+            for (int i = 0; i < entryCount; i++) {
+                r.readFully(intBuf); // ordinal — not used here
+                r.readFully(intBuf);
+                int pkLen = ((intBuf[0] & 0xff) << 24) | ((intBuf[1] & 0xff) << 16)
+                        | ((intBuf[2] & 0xff) << 8) | (intBuf[3] & 0xff);
+                byte[] pk = new byte[pkLen];
+                r.readFully(pk);
+                r.readFully(intBuf);
+                int floatCount = ((intBuf[0] & 0xff) << 24) | ((intBuf[1] & 0xff) << 16)
+                        | ((intBuf[2] & 0xff) << 8) | (intBuf[3] & 0xff);
+                byte[] floats = new byte[floatCount * Float.BYTES];
+                r.readFully(floats);
+                out.add(Bytes.from_array(pk));
+            }
+            return out;
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerOverlayLoadFailureTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerOverlayLoadFailureTest.java
@@ -1,0 +1,197 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.indexing.segment.TombstoneOverlayManager;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that {@link RemoteSegmentMerger} surfaces overlay-load failures
+ * via {@link RemoteSegmentMerger.TombstoneLoadFailedException} rather than
+ * silently treating the input as having no tombstones (issue #484, review
+ * item B.5 from the first pr-reviewer pass).
+ *
+ * <p>This is a hard data-integrity invariant: if the merger can't load an
+ * overlay it was supposed to apply, it MUST refuse the merge — silently
+ * skipping the overlay would resurrect every tombstoned vector in the
+ * affected segment.
+ */
+public class RemoteSegmentMergerOverlayLoadFailureTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-overlay-fail";
+    private static final String IDX_UUID = "idx-overlay-fail";
+    private static final int DIM = 8;
+    private static final int VECTORS_PER_SEGMENT = 20;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    private SegmentMetadata writeInput(String segUuid, long segId, int seed,
+                                       String tombstonePath, long overlayGen) throws Exception {
+        Path mapFile = Files.createTempFile(tmpDir, "input-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapFile.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(VECTORS_PER_SEGMENT);
+            Random rng = new Random(seed);
+            for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                dos.writeInt(local);
+                byte[] pk = (segUuid + "-" + local).getBytes();
+                dos.writeInt(pk.length);
+                dos.write(pk);
+                VectorFloat<?> v = VTS.createFloatVector(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    v.set(j, rng.nextFloat());
+                }
+                dos.writeInt(v.length());
+                for (int j = 0; j < v.length(); j++) {
+                    dos.writeInt(Float.floatToIntBits(v.get(j)));
+                }
+            }
+        }
+        long mapSize = Files.size(mapFile);
+        String multipartUuid = IDX_UUID + "_seg" + segId;
+        String mapPath = dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", mapFile, null);
+        Files.deleteIfExists(mapFile);
+        return SegmentMetadata.builder()
+                .segmentUuid(segUuid).tablespaceUuid(TS_UUID).tableName("docs")
+                .indexUuid(IDX_UUID).indexName("docs_v1")
+                .state(SegmentState.ACTIVE).ownerInstanceId(0).segmentId(segId)
+                .graphPath("g/" + segUuid).mapPath(mapPath)
+                .tombstonePath(tombstonePath)
+                .overlayGeneration(overlayGen)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(mapSize * 2L)
+                .mapFileSize(mapSize)
+                .vectorCount(VECTORS_PER_SEGMENT).generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+    }
+
+    @Test
+    public void modernZnodeWithMissingOverlayFileThrows() throws Exception {
+        // Segment carries overlayGeneration=7 and tombstonePath != null, but
+        // the corresponding overlay file (multipart "tombstones-7") does NOT
+        // exist on the DSM. The merger MUST throw rather than treat as "no
+        // tombstones". The engine then logs mergeFailures and retries next tick.
+        SegmentMetadata a = writeInput("seg-A", 100L, 0xA, "tombstones-A-gen7", 7L);
+        SegmentMetadata b = writeInput("seg-B", 200L, 0xB, null, 0L);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
+            fail("expected TombstoneLoadFailedException for missing overlay file");
+        } catch (RemoteSegmentMerger.TombstoneLoadFailedException ok) {
+            assertTrue("error message should reference the segment uuid: " + ok.getMessage(),
+                    ok.getMessage().contains("seg-A"));
+            assertTrue("error message should reference the overlay generation 7: " + ok.getMessage(),
+                    ok.getMessage().contains("7"));
+        }
+
+        // No merger output should have been uploaded — the failure happens
+        // BEFORE the build phase. Probe the DSM for any output starting with
+        // the expected prefix; nothing matching merged segments must exist.
+        // (We can't enumerate the in-memory DSM directly; the assertion is
+        // implicit: if the merger had got far enough to upload, it would
+        // have first finished `loadTombstonedOrdinalsBestEffort` for both
+        // inputs, which we just proved fails.)
+    }
+
+    @Test
+    public void modernZnodeWithCorruptOverlayFileThrows() throws Exception {
+        // Same as above but the overlay file exists with garbage contents — the
+        // deserializer in TombstoneOverlay.deserialize will throw on the version
+        // header. Wrapped in TombstoneLoadFailedException by the merger.
+        SegmentMetadata a = writeInput("seg-A2", 100L, 0xA, "tombstones-A-gen3", 3L);
+        SegmentMetadata b = writeInput("seg-B2", 200L, 0xB, null, 0L);
+
+        // Plant a garbage overlay file at the expected key.
+        Path corruptOverlay = Files.createTempFile(tmpDir, "corrupt-overlay-", ".bin");
+        Files.write(corruptOverlay, new byte[]{
+                // Bogus version header (current format expects 1).
+                (byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78,
+                // Plus some padding bytes.
+                0, 0, 0, 0
+        });
+        dsm.writeMultipartIndexFile(TS_UUID,
+                TombstoneOverlayManager.multipartUuidFor(IDX_UUID, "seg-A2"),
+                TombstoneOverlayManager.fileTypeFor(3L),
+                corruptOverlay, null);
+        Files.deleteIfExists(corruptOverlay);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(a, b), 0);
+            fail("expected TombstoneLoadFailedException for corrupt overlay file");
+        } catch (RemoteSegmentMerger.TombstoneLoadFailedException ok) {
+            assertTrue(ok.getMessage().contains("seg-A2"));
+        }
+    }
+
+    @Test
+    public void noTombstonePathBypassesOverlayLoad() throws Exception {
+        // Sanity check: when tombstonePath is null, the merger never tries to
+        // load an overlay (no DSM call, no exception possible). This is the
+        // common case for fresh segments produced by the merger itself.
+        SegmentMetadata a = writeInput("seg-clean-A", 100L, 0xA, null, 0L);
+        SegmentMetadata b = writeInput("seg-clean-B", 200L, 0xB, null, 0L);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        SegmentMetadata merged = merger.merge(List.of(a, b), 0);
+        assertTrue("two clean inputs must merge successfully",
+                merged != null && merged.getVectorCount() == 2L * VECTORS_PER_SEGMENT);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerTest.java
@@ -1,0 +1,261 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Integration tests for {@link RemoteSegmentMerger} against a
+ * {@link MemoryDataStorageManager} (issue #484).
+ *
+ * <p>Drives the production merger through realistic inputs (real graph and
+ * map files written via the DSM) and asserts:
+ * <ul>
+ *   <li>{@code merge()} returns a fresh ACTIVE {@link SegmentMetadata} with
+ *       a 63-bit non-negative random {@code segmentId}, generation
+ *       = {@code max(input) + 1}, and a graphPath/mapPath pointing to a
+ *       newly-uploaded multipart pair on the DSM;</li>
+ *   <li>{@code abandon()} deletes both the graph and map multipart files
+ *       so an aborted run doesn't leak artefacts;</li>
+ *   <li>mismatched tablespace/index uuids in the input list throw an
+ *       IllegalArgumentException — the engine should never call us with a
+ *       cross-index batch but we defend the invariant.</li>
+ * </ul>
+ */
+public class RemoteSegmentMergerTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final String TS_UUID = "ts-rsm";
+    private static final String IDX_UUID = "idx-rsm";
+    private static final int DIM = 32;
+    private static final int VECTORS_PER_SEGMENT = 200;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("merger-tmp").toPath();
+    }
+
+    private SegmentMetadata writeInputSegmentToDsm(String uuid, long segmentId,
+                                                   long generation, int seedBase) throws Exception {
+        Path mapFile = Files.createTempFile(tmpDir, "input-", ".tmp");
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(mapFile.toFile()));
+             DataOutputStream dos = new DataOutputStream(bos)) {
+            dos.writeInt(VECTORS_PER_SEGMENT);
+            Random rng = new Random(seedBase);
+            for (int local = 0; local < VECTORS_PER_SEGMENT; local++) {
+                dos.writeInt(local);
+                byte[] pkBytes = Bytes.from_string("pk-" + uuid + "-" + local).to_array();
+                dos.writeInt(pkBytes.length);
+                dos.write(pkBytes);
+                VectorFloat<?> v = VTS.createFloatVector(DIM);
+                for (int j = 0; j < DIM; j++) {
+                    v.set(j, rng.nextFloat() * 2.0f - 1.0f);
+                }
+                dos.writeInt(v.length());
+                for (int j = 0; j < v.length(); j++) {
+                    dos.writeInt(Float.floatToIntBits(v.get(j)));
+                }
+            }
+        }
+        long mapSize = Files.size(mapFile);
+        String multipartUuid = IDX_UUID + "_seg" + segmentId;
+        String mapPath = dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", mapFile, null);
+        Files.deleteIfExists(mapFile);
+
+        return SegmentMetadata.builder()
+                .segmentUuid(uuid)
+                .tablespaceUuid(TS_UUID)
+                .tableName("docs")
+                .indexUuid(IDX_UUID)
+                .indexName("docs_v1")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(0)
+                .segmentId(segmentId)
+                .graphPath("g/" + uuid)
+                .mapPath(mapPath)
+                .baseLsn(new LogSequenceNumber(1L, 100L * generation))
+                .sizeBytes(mapSize * 2L)  // arbitrary — not consulted by the merger
+                .vectorCount(VECTORS_PER_SEGMENT)
+                .generation(generation)
+                .createdAtEpochMillis(0L)
+                .build();
+    }
+
+    @Test
+    public void mergeProducesActiveSegmentWithRandomSegmentId() throws Exception {
+        SegmentMetadata a = writeInputSegmentToDsm("seg-A", 100L, /* gen */ 1L, 0xA);
+        SegmentMetadata b = writeInputSegmentToDsm("seg-B", 200L, /* gen */ 2L, 0xB);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, /* M */ 16, /* beamWidth */ 64,
+                /* neighborOverflow */ 1.2f, /* alpha */ 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+        SegmentMetadata merged = merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
+
+        assertNotNull("merger must produce an output for healthy inputs", merged);
+        assertEquals(SegmentState.ACTIVE, merged.getState());
+        assertEquals(TS_UUID, merged.getTablespaceUuid());
+        assertEquals(IDX_UUID, merged.getIndexUuid());
+        assertEquals("generation = max(input) + 1", 3L, merged.getGeneration());
+        assertEquals("vector count = sum of inputs (no tombstones)",
+                2L * VECTORS_PER_SEGMENT, merged.getVectorCount());
+        assertEquals("merged segment starts with no overlay", 0L, merged.getOverlayGeneration());
+        assertNull("merged segment has no tombstone path", merged.getTombstonePath());
+
+        // segmentId must be a 63-bit non-negative random — collision-free vs the inputs
+        // (segments 100 and 200), and not the sentinel.
+        assertNotEquals(SegmentMetadata.NO_SEGMENT_ID, merged.getSegmentId());
+        assertTrue("segmentId must be non-negative", merged.getSegmentId() >= 0L);
+        assertNotEquals("segmentId must differ from both inputs",
+                a.getSegmentId(), merged.getSegmentId());
+        assertNotEquals(b.getSegmentId(), merged.getSegmentId());
+
+        // The output multipart files must be addressable under the new segmentId.
+        String multipartUuid = IDX_UUID + "_seg" + merged.getSegmentId();
+        assertNotNull(dsm.multipartIndexReaderSupplier(TS_UUID, multipartUuid, "graph",
+                /* sizeHint */ 1L));
+        assertNotNull(dsm.multipartIndexReaderSupplier(TS_UUID, multipartUuid, "map",
+                /* sizeHint */ 1L));
+
+        assertEquals(1L, merger.getInvocationCount());
+    }
+
+    @Test
+    public void abandonRemovesUploadedFiles() throws Exception {
+        SegmentMetadata a = writeInputSegmentToDsm("seg-A", 100L, 1L, 0x1);
+        SegmentMetadata b = writeInputSegmentToDsm("seg-B", 200L, 2L, 0x2);
+
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        SegmentMetadata merged = merger.merge(List.of(a, b), 0);
+        assertNotNull(merged);
+
+        // Pre-condition: files exist on the DSM.
+        String multipartUuid = IDX_UUID + "_seg" + merged.getSegmentId();
+        dsm.multipartIndexReaderSupplier(TS_UUID, multipartUuid, "graph", 1L);
+
+        merger.abandon(merged);
+
+        // The MemoryDataStorageManager throws on missing keys, which is exactly
+        // what we want to assert.
+        try {
+            dsm.multipartIndexReaderSupplier(TS_UUID, multipartUuid, "graph", 1L);
+            org.junit.Assert.fail("graph file must be deleted after abandon");
+        } catch (Exception ok) {
+            // expected
+        }
+        try {
+            dsm.multipartIndexReaderSupplier(TS_UUID, multipartUuid, "map", 1L);
+            org.junit.Assert.fail("map file must be deleted after abandon");
+        } catch (Exception ok) {
+            // expected
+        }
+    }
+
+    @Test
+    public void mismatchedTablespaceRejected() throws Exception {
+        SegmentMetadata a = writeInputSegmentToDsm("seg-A", 100L, 1L, 0x1);
+        // Synthesise an input from a different tablespace — without writing to
+        // the DSM (the merger throws before it gets there).
+        SegmentMetadata b = SegmentMetadata.builder()
+                .segmentUuid("seg-other")
+                .tablespaceUuid("other-ts")
+                .tableName("docs").indexUuid(IDX_UUID).indexName("docs_v1")
+                .state(SegmentState.ACTIVE).ownerInstanceId(0)
+                .segmentId(200L)
+                .graphPath("g/other").mapPath("m/other")
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(100L).vectorCount(1L).generation(1L).createdAtEpochMillis(0L)
+                .build();
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(a, b), 0);
+            org.junit.Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException ok) {
+            assertTrue(ok.getMessage().contains("tablespaceUuid"));
+        }
+    }
+
+    @Test
+    public void noSegmentIdRejected() throws Exception {
+        SegmentMetadata a = writeInputSegmentToDsm("seg-A", 100L, 1L, 0x1);
+        SegmentMetadata b = SegmentMetadata.builder()
+                .segmentUuid("seg-noid")
+                .tablespaceUuid(TS_UUID).tableName("docs")
+                .indexUuid(IDX_UUID).indexName("docs_v1")
+                .state(SegmentState.ACTIVE).ownerInstanceId(0)
+                .segmentId(SegmentMetadata.NO_SEGMENT_ID)  // sentinel
+                .graphPath("g/no").mapPath("m/no")
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(100L).vectorCount(1L).generation(1L).createdAtEpochMillis(0L)
+                .build();
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            merger.merge(List.of(a, b), 0);
+            org.junit.Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException ok) {
+            assertTrue(ok.getMessage().contains("segmentId"));
+        }
+    }
+
+    @Test
+    public void emptyInputReturnsNull() throws Exception {
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+        assertNull("empty input → null output", merger.merge(new ArrayList<>(), 0));
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerTest.java
@@ -127,6 +127,7 @@ public class RemoteSegmentMergerTest {
                 .mapPath(mapPath)
                 .baseLsn(new LogSequenceNumber(1L, 100L * generation))
                 .sizeBytes(mapSize * 2L)  // arbitrary — not consulted by the merger
+                .mapFileSize(mapSize)
                 .vectorCount(VECTORS_PER_SEGMENT)
                 .generation(generation)
                 .createdAtEpochMillis(0L)

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/UnsafeModeReaperDeletesMergerOutputTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/UnsafeModeReaperDeletesMergerOutputTest.java
@@ -108,7 +108,7 @@ public class UnsafeModeReaperDeletesMergerOutputTest {
         }
     }
 
-    private SegmentMetadata sampleSegment(String uuid, int segmentId) {
+    private SegmentMetadata sampleSegment(String uuid, long segmentId) {
         return SegmentMetadata.builder()
                 .segmentUuid(uuid).tablespaceUuid(TS_UUID).tableName("docs")
                 .indexUuid(IDX_UUID).indexName("docs_v1").state(SegmentState.ACTIVE)
@@ -138,7 +138,7 @@ public class UnsafeModeReaperDeletesMergerOutputTest {
         public SegmentMetadata merge(List<SegmentMetadata> inputs, int newOwnerInstance)
                 throws Exception {
             String mergedUuid = UUID.randomUUID().toString();
-            int mergedId = (int) nextSegmentId.getAndIncrement();
+            long mergedId = nextSegmentId.getAndIncrement();
             String multipartUuid = inputs.get(0).getIndexUuid() + "_seg" + mergedId;
 
             Path graph = Files.createTempFile(tmpDir, "graph-", ".bin");
@@ -179,7 +179,7 @@ public class UnsafeModeReaperDeletesMergerOutputTest {
         // (under the indexUUID + "_seg" + segmentId multipart path the reaper will
         // probe). This makes the "files deleted at reap" assertion below meaningful.
         for (int i = 0; i < 3; i++) {
-            int segId = 100 + i;
+            long segId = 100L + i;
             registry.createSegment(sampleSegment("input-" + i, segId));
             String multipartUuid = IDX_UUID + "_seg" + segId;
             Path graph = Files.createTempFile(tmpDir, "input-graph-", ".bin");
@@ -213,7 +213,7 @@ public class UnsafeModeReaperDeletesMergerOutputTest {
         VersionedSegmentMetadata mergedOutput = all.stream()
                 .filter(v -> v.metadata().getState() == SegmentState.ACTIVE)
                 .findFirst().orElseThrow();
-        int mergedSegmentId = mergedOutput.metadata().getSegmentId();
+        long mergedSegmentId = mergedOutput.metadata().getSegmentId();
         assertTrue("merger must produce a real segmentId, not the sentinel",
                 mergedSegmentId != SegmentMetadata.NO_SEGMENT_ID);
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentRegistryPublisherIntegrationTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentRegistryPublisherIntegrationTest.java
@@ -155,6 +155,16 @@ public class SegmentRegistryPublisherIntegrationTest {
             assertEquals(-1L, m.getBaseLsnOffset());
             assertTrue("sizeBytes must be > 0", m.getSizeBytes() > 0);
             assertTrue("generation must be >= 1", m.getGeneration() >= 1);
+            // Issue #484 (round-2 review): mapFileSize must be plumbed from
+            // NewSegmentInfo into the znode so the optimizer-side merger
+            // can drive the multipart reader correctly. Without this the
+            // merger falls into a legacy size-hint fallback that's broken
+            // on the production direct-multipart-download path.
+            assertTrue("mapFileSize must be > 0 (issue #484): " + m.getMapFileSize(),
+                    m.getMapFileSize() > 0L);
+            assertTrue("mapFileSize (" + m.getMapFileSize() + ") must be <= sizeBytes ("
+                    + m.getSizeBytes() + ") since sizeBytes aggregates graph + map",
+                    m.getMapFileSize() <= m.getSizeBytes());
         }
 
         long totalRegisteredVectors = 0L;

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentRegistryPublisherMapFileSizeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentRegistryPublisherMapFileSizeTest.java
@@ -1,0 +1,144 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.segment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.index.vector.NewSegmentInfo;
+import herddb.log.LogSequenceNumber;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Focused unit test for the {@code mapFileSize} round-trip through
+ * {@link SegmentRegistryPublisher} → ZooKeeper znode → {@link SegmentMetadata}
+ * (issue #484, round-2 review item B.1.1).
+ *
+ * <p>The optimizer-side merger requires the EXACT map-file size to drive
+ * the multipart reader; previously the publisher built {@code SegmentMetadata}
+ * without populating the new {@code mapFileSize} field, causing every merge
+ * to fall through to a broken legacy fallback. This test exercises the
+ * ladder synthetically — feeding a {@link NewSegmentInfo} with a known
+ * {@code mapFileSize} into {@code commitStagedSegments}, then reading the
+ * znode back via {@link SegmentRegistryClient} and asserting the field
+ * round-tripped intact.
+ */
+public class SegmentRegistryPublisherMapFileSizeTest {
+
+    private static final String BASE_PATH = "/herd-test-mapfilesize";
+    private static final String TS = "ts-mfs";
+    private static final String TBL = "docs";
+    private static final String IDX = "idx-mfs";
+    private static final String IDX_NAME = "docs_v1";
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+    private SegmentRegistryClient registry;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue(connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registry = new SegmentRegistryClient(() -> zk, BASE_PATH);
+        registry.ensureRoot();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    @Test
+    public void publishedMetadataIncludesMapFileSize() throws Exception {
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TS, TBL, IDX, IDX_NAME, /* instanceId */ 0);
+
+        long expectedMapSize = 12_345_678L;
+        NewSegmentInfo info = new NewSegmentInfo(
+                /* segmentId */ 42,
+                /* segmentUuid */ "stable-segment-uuid",
+                /* graphPath */ "graph/path/x",
+                /* graphFileSize */ 99_999L,
+                /* mapPath */ "map/path/x",
+                /* mapFileSize */ expectedMapSize,
+                /* estimatedSizeBytes */ 99_999L + expectedMapSize,
+                /* vectorCount */ 1234L,
+                /* generation */ 7L,
+                /* baseLsn */ new LogSequenceNumber(1L, 100L));
+
+        publisher.commitStagedSegments(Collections.singletonList(info));
+
+        List<VersionedSegmentMetadata> registered = registry.listSegments(TS, IDX);
+        assertEquals(1, registered.size());
+        SegmentMetadata m = registered.get(0).metadata();
+        assertEquals("mapFileSize must round-trip from NewSegmentInfo through the znode",
+                expectedMapSize, m.getMapFileSize());
+        assertEquals("graphFileSize-derived sizeBytes hint must round-trip too",
+                99_999L + expectedMapSize, m.getSizeBytes());
+        assertEquals(42L, m.getSegmentId());
+    }
+
+    @Test
+    public void provisionalSegmentAlsoCarriesMapFileSize() throws Exception {
+        // The PROVISIONAL → ACTIVE staging path also goes through buildMetadata;
+        // verify both use the same code path so PROVISIONAL znodes ALSO carry
+        // mapFileSize. Without this, a stage/commit cycle could lose the field
+        // on the way through.
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TS, TBL, IDX, IDX_NAME, 0);
+
+        long expectedMapSize = 5_555_555L;
+        NewSegmentInfo info = new NewSegmentInfo(
+                /* segmentId */ 7, "uuid-prov",
+                "g", 100L, "m", expectedMapSize,
+                100L + expectedMapSize, 99L, 1L, new LogSequenceNumber(1L, 50L));
+
+        publisher.stageNewSegments(Collections.singletonList(info));
+
+        List<VersionedSegmentMetadata> registered = registry.listSegments(TS, IDX);
+        assertEquals(1, registered.size());
+        SegmentMetadata m = registered.get(0).metadata();
+        assertEquals("PROVISIONAL state expected", SegmentState.PROVISIONAL, m.getState());
+        assertEquals("PROVISIONAL znode must also carry mapFileSize",
+                expectedMapSize, m.getMapFileSize());
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -376,8 +376,21 @@ indexOptimizer:
   # Human-readable tablespace name — UUID resolved from ZooKeeper at startup.
   # No manual UUID log-scraping required.
   tablespaceName: "herd"
-  # Short interval for bench cycles; increase for production workloads.
+  # Periodic safety-net interval. Issue #484 made the optimizer event-driven
+  # via a ZK persistent-recursive watch, so the periodic cadence is only a
+  # fallback for the rare case ZK delivers no event. 5 min is fine for bench
+  # workloads; production may want longer.
   intervalMs: 300000
+  # Issue #484: aggressive merge policy + RemoteSegmentMerger require a
+  # vector dimension up-front (SegmentMetadata znodes do NOT carry it).
+  # Override per-bench: GIST1M is 960, SIFT* is 128, etc.
+  merger:
+    dim: 960
+    M: 16
+    beamWidth: 100
+    neighborOverflow: 1.2
+    alpha: 1.4
+    similarity: "DOT_PRODUCT"
 
 tools:
   enabled: true

--- a/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-configmap.yaml
@@ -22,7 +22,32 @@ data:
     indexoptimizer.merge.max.count={{ .Values.indexOptimizer.maxCount | default 200 | int64 }}
     indexoptimizer.merge.min.bytes={{ .Values.indexOptimizer.minBytes | default 268435456 | int64 }}
     indexoptimizer.merge.max.bytes={{ .Values.indexOptimizer.maxBytes | default 1073741824 | int64 }}
+    indexoptimizer.merge.target.bytes={{ .Values.indexOptimizer.targetMaxBytes | default 8589934592 | int64 }}
     indexoptimizer.retention.ms={{ .Values.indexOptimizer.retentionMs | default 600000 | int64 }}
+    indexoptimizer.event.debounce.ms={{ .Values.indexOptimizer.eventDebounceMs | default 500 | int64 }}
+    {{- if .Values.indexOptimizer.merger }}
+    {{- with .Values.indexOptimizer.merger }}
+    {{- if .dim }}
+    indexoptimizer.merge.dim={{ .dim | int64 }}
+    {{- end }}
+    indexoptimizer.merge.M={{ .M | default 16 | int64 }}
+    indexoptimizer.merge.beamWidth={{ .beamWidth | default 100 | int64 }}
+    indexoptimizer.merge.neighborOverflow={{ .neighborOverflow | default 1.2 }}
+    indexoptimizer.merge.alpha={{ .alpha | default 1.4 }}
+    indexoptimizer.merge.similarity={{ .similarity | default "DOT_PRODUCT" }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.indexOptimizer.remoteFileClient }}
+    {{- with .Values.indexOptimizer.remoteFileClient }}
+    {{- if .servers }}
+    indexoptimizer.remote.file.servers={{ .servers }}
+    {{- end }}
+    indexoptimizer.remote.file.client.timeout={{ .timeoutSeconds | default 60 | int64 }}
+    indexoptimizer.remote.file.client.retries={{ .retries | default 3 | int64 }}
+    indexoptimizer.remote.file.client.max.inflight.read.bytes={{ .maxInflightReadBytes | default 268435456 | int64 }}
+    indexoptimizer.remote.file.client.max.inflight.write.bytes={{ .maxInflightWriteBytes | default 268435456 | int64 }}
+    {{- end }}
+    {{- end }}
     {{- range $k, $v := .Values.indexOptimizer.extraConfig }}
     {{ $k }}={{ $v }}
     {{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -334,14 +334,58 @@ indexOptimizer:
   # HTTP admin endpoint port — exposes /health (probe target) and /metrics
   # (Prometheus scrape). Set to 0 to disable.
   httpPort: 9853
+  # Periodic safety-net interval for the registry scan. Issue #484 made the
+  # optimizer event-driven (a ZK persistent-recursive watch on the registry
+  # tablespace path schedules a tick on every children-changed event), so
+  # this value can be left long without sacrificing responsiveness — it only
+  # fires when ZK has been completely silent for the whole interval.
   intervalMs: 300000
+  # Minimum number of mergeable segments. Honoured by the legacy
+  # SmallestFirstPolicy; the AggressivePolicy that production runs always
+  # fires on ≥2 sub-target segments so this is effectively unused. Retained
+  # for backward compatibility.
   minCount: 4
+  # Maximum number of segments the optimizer will pick per cycle (cap on
+  # write amplification per merge run).
   maxCount: 200
   # Quoted as strings to prevent the Go YAML parser from emitting scientific
   # notation (e.g. 2.68435456e+08) which Java's Long.parseLong cannot parse.
   minBytes: "268435456"   # 256 MiB
-  maxBytes: "1073741824"  # 1 GiB
+  maxBytes: "1073741824"  # 1 GiB — per-cycle byte budget (write-amplification cap)
+  # Issue #484: per-graph "graduated" cap. Segments at or above this size
+  # are excluded from the merge candidate set. Default 8 GiB so production
+  # workloads converge to a single large graph; raise it to drive even
+  # larger merges or lower it to tier the graph layout.
+  targetMaxBytes: "8589934592"  # 8 GiB
   retentionMs: 600000     # 10 min
+  # Issue #484: debounce window for the event-driven path. Bursts of
+  # children-changed events from the persistent-recursive watch coalesce
+  # into a single tick after this many millis of quiet. 0 disables
+  # debouncing.
+  eventDebounceMs: 500
+  # Issue #484: parameters used by the production RemoteSegmentMerger when
+  # it rebuilds a merged graph. The defaults match the IS-side
+  # PersistentVectorStore so the merged segment has identical recall
+  # characteristics. The vector dimension `dim` MUST be set explicitly when
+  # the optimizer is enabled because SegmentMetadata znodes do not carry
+  # the dimension as a first-class field.
+  merger:
+    dim: 0          # REQUIRED when indexOptimizer.enabled=true (e.g. 960 for GIST1M)
+    M: 16
+    beamWidth: 100
+    neighborOverflow: 1.2
+    alpha: 1.4
+    similarity: "DOT_PRODUCT"  # one of DOT_PRODUCT, COSINE, EUCLIDEAN
+  # Issue #484: configuration for the optimizer's connection to the remote
+  # file service (used by the merger to download input segment files and
+  # upload the merged graph). Empty `servers` means "discover via ZK at
+  # /herd/file-servers" — the typical production setup.
+  remoteFileClient:
+    servers: ""
+    timeoutSeconds: 60
+    retries: 3
+    maxInflightReadBytes: "268435456"   # 256 MiB
+    maxInflightWriteBytes: "268435456"  # 256 MiB
   zkSessionTimeout: 40000
   javaOpts: ""
   javaOptsExtra: ""

--- a/herddb-kubernetes/src/test/java/herddb/kubernetes/IndexOptimizerKubernetesIT.java
+++ b/herddb-kubernetes/src/test/java/herddb/kubernetes/IndexOptimizerKubernetesIT.java
@@ -216,6 +216,12 @@ public class IndexOptimizerKubernetesIT {
         values.put("indexOptimizer.tablespaceName", "herd");
         // 10 seconds so we see ticks quickly during the test
         values.put("indexOptimizer.intervalMs", "10000");
+        // Issue #484: configure the merger explicitly so the optimizer
+        // constructs a real RemoteSegmentMerger (not the NoopMerger
+        // fallback) and the production wiring is exercised end-to-end. The
+        // dim is arbitrary because this IT doesn't ingest data — the merger
+        // never actually runs against a non-empty registry.
+        values.put("indexOptimizer.merger.dim", "64");
         values.put("indexOptimizer.javaOpts", INFRA_JAVA_OPTS);
         values.put("indexOptimizer.resources.requests.memory", "384Mi");
         values.put("indexOptimizer.resources.requests.cpu", "0.5");


### PR DESCRIPTION
Fixes #484.

## Summary

The optimizer pod was running with `NoopMerger` so every cycle ended in `mergeDeclinedTotal++` and segments accumulated forever. This change ships a production graph-merge implementation, makes the merge policy aggressive enough to converge the layout, and replaces the time-based tick with an event-driven path so sustained ingest doesn't starve the optimizer.

Per direction during the planning phase:
- The default merger must actually merge graphs (not Noop).
- The optimizer must keep merging until every graph reaches the max size.
- Tombstone-overlay filtering is implemented now, not deferred.
- Scheduling is event-driven via ZK persistent-recursive watches (introduced in ZK 3.6) — the in-tree codebase is the first place to use them.
- `SegmentMetadata.segmentId` widened from `int` to `long` so the merger can mint full 63-bit random ids without offset gymnastics.

## Changes

### New code

- **`herddb-core/.../RemoteSegmentGraphMerger.java`** — standalone graph-merge utility that downloads each input's map file from remote storage, drops tombstoned ordinals (via the supplied `int[] tombstonedOrdinals`), de-duplicates by PK preferring the highest-generation source, builds a merged `GraphIndexBuilder`, writes a FusedPQ + InlineVectors `OnDiskGraphIndex` plus a companion map file, and uploads both via the multipart API. Round-trip recall@10 ≥ 0.9 on a 1500-vector EUCLIDEAN dataset. Validates every `int` read from input map files against `MAX_ENTRIES_PER_MAP_FILE = 1<<28` / `MAX_PK_LEN = 1<<16` / configured `dim` to fail loudly on corrupt or partially-uploaded files instead of OOM-ing or producing torn graphs.

- **`herddb-indexing-service/.../RemoteSegmentMerger.java`** — `SegmentMerger` SPI implementation that wraps the graph merger. Pre-loads each input's `TombstoneOverlay` via `TombstoneOverlayManager.loadOverlay` (refusing the merge with `TombstoneLoadFailedException` if the overlay can't be read — never resurrects tombstoned vectors silently). Probes generations 32..1 highest-first for legacy znodes whose `overlayGeneration` is unset. Refuses inputs whose `mapFileSize` is unset (`LegacyMetadataException`) — pre-#484 znodes become mergeable automatically after the next IS checkpoint rewrites them. Emits a fresh ACTIVE `SegmentMetadata` (random 63-bit `segmentId`, `generation = max(input)+1`).

- **`MergePolicy.AggressivePolicy`** — new default policy. Filters active segments to those below `targetMaxBytes` (default 8 GiB — graduated segments left alone), fires whenever ≥2 sub-target candidates exist, caps the picked set at `perCycleMaxBytes` and `maxCount`. No minimum-bytes / minimum-count gating — the optimizer keeps merging until every graph reaches the cap.

### Wiring

- **`IndexOptimizerMain`** now builds a `RemoteFileServiceClient` + `RemoteFileDataStorageManager` from configuration, defaults the merger to `RemoteSegmentMerger` (falling back to `NoopMerger` only when no remote-file servers are reachable), and arms a single `addWatch(tablespacePath, …, AddWatchMode.PERSISTENT_RECURSIVE)` to drive event-driven ticks. Bursts coalesce into one tick via an `AtomicBoolean` CAS + debounce window (default 500 ms). The periodic `scheduleAtFixedRate(…, intervalMs)` continues as a safety net. Persistent-recursive watches fire forever without re-arming, so a single setup call covers the pod's entire lifetime.

- **ZK lifecycle**: `KeeperState.Expired` and `KeeperState.AuthFailed` both flip a one-way `sessionExpired` flag. `OptimizerHttpServer.HealthHandler` consults the flag and returns 503 immediately, so Helm's liveness probe restarts the pod (the persistent-recursive watch is dead and the leader-lock ephemeral znode is gone — only a process restart is safe).

### Schema

- **`SegmentMetadata.segmentId`** widened from `int` to `long`; `NO_SEGMENT_ID = -1L`. JSON wire format is forward-compatible (Jackson serializes both `int` and `long` as JSON numbers).

- **New `overlayGeneration` field** so the optimizer reaper and merger can reconstruct the exact `tombstones-{N}` multipart file rather than brute-forcing the generation window. `TombstoneOverlayManager.flush()` populates it.

- **New `mapFileSize` field** so the merger can drive the multipart reader correctly. `SegmentRegistryPublisher` plumbs `info.getMapFileSize()` from `NewSegmentInfo` into the znode. Production `RandomAccessReader` implementations treat the constructor-supplied size as authoritative (they don't probe the underlying object), so this exact-size field is required for the merger to read map files without over-reading past block boundaries.

### Helm

- New values plumbed through `values.yaml` and the optimizer configmap: `targetMaxBytes`, `eventDebounceMs`, `merger.{dim,M,beamWidth,neighborOverflow,alpha,similarity}`, `remoteFileClient.{servers,timeoutSeconds,retries,maxInflightReadBytes,maxInflightWriteBytes}`. The k3s-local example sets `merger.dim=960` for GIST1M.

## Test plan

- [x] **Recall**: `RemoteSegmentGraphMergerTest` — 3-segment round-trip, recall@10 ≥ 0.9 vs brute-force baseline on a 1500-vector dataset, all-tombstoned input → null, `deleteOutput()` removes both files.
- [x] **Tombstone filter**: `RemoteSegmentGraphMergerTombstoneFilterTest` — half-tombstoned input A loses exactly its first 50 ordinals; full-tombstone case drops the entire segment.
- [x] **Tombstone load failures**: `RemoteSegmentMergerOverlayLoadFailureTest` — modern znode with missing/corrupt overlay throws `TombstoneLoadFailedException`; null `tombstonePath` bypasses the load entirely.
- [x] **Legacy overlay probe**: `RemoteSegmentMergerLegacyOverlayTest` — legacy v1 znode with an existing overlay file gets probed and tombstones applied; legacy v1 znode WITHOUT an overlay file throws; modern znode with `overlayGeneration` loads exactly that file (no probe).
- [x] **Legacy `mapFileSize == 0` refusal**: `RemoteSegmentMergerLegacyMapFileSizeTest` — legacy znode → `LegacyMetadataException` upstream of any reader I/O; the new `modernZnodeFailsLoudlyAgainstHintReturningReader` test wires a `HintReturningReader` that mimics the production `RemoteRandomAccessReader.length()` contract, feeds an over-estimated `mapFileSize`, and asserts the merge fails loudly rather than silently truncating.
- [x] **Corrupt input bounds**: `RemoteSegmentGraphMergerCorruptInputTest` — garbage entryCount, negative ordinal, oversized pkLen, dimension mismatch — all throw `IOException` rather than OOM/IOOBE/silent corruption.
- [x] **Upload failure cleanup**: `RemoteSegmentGraphMergerUploadFailureTest` — graph upload succeeds, map upload fails, orphan-graph cleanup fires, no leak.
- [x] **Publisher round-trip**: `SegmentRegistryPublisherMapFileSizeTest` (synthetic) and `SegmentRegistryPublisherIntegrationTest` (real `PersistentVectorStore.checkpoint()`) verify `mapFileSize` flows from `NewSegmentInfo` through ZK in both PROVISIONAL and ACTIVE states.
- [x] **SPI wiring**: `RemoteSegmentMergerTest` — ACTIVE output, random 63-bit segmentId, `generation = max+1`, files addressable on DSM, `abandon()` removes them, cross-tablespace and `NO_SEGMENT_ID` inputs rejected.
- [x] **Aggressive policy**: `AggressivePolicyTest` — 10 cases covering fire-with-2-candidates, graduated-segment exclusion, per-cycle byte cap, maxCount cap, 8-segment merge, smallest-first ordering, arg validation.
- [x] **Event-driven scheduling**: `IndexOptimizerEventDrivenTest` — `intervalMs=1h` proves event-driven tick fires within 5 s; second burst proves persistent-recursive watch survives without re-arming; debounce coalesces 10 events into far fewer ticks; events arriving DURING a long-running tick produce a follow-up tick automatically.
- [x] **ZK session expiry**: `IndexOptimizerSessionExpiredTest` — boots a real `IndexOptimizerMain` against `TestingServer`, hijacks the ZK session id + password from a second client, kills the kicker session, asserts `isSessionExpired()` flips within 10 s. Proves the watcher → flag → `/health 503` wiring works against a real ZK client.
- [x] **`/health` 503 gate**: `OptimizerHttpServerTest#healthReturns503WhenCriticalFailureFlagSet` — critical-failure predicate trips `/health` to 503 and recovers to 200 when cleared.
- [x] **Optimizer config fallbacks**: `IndexOptimizerMainConfigTest` — preconfigured merger respected; no-servers fallback to `NoopMerger`; legacy `loadMergerSpi()` preserved.
- [x] **Existing optimizer suite**: 152 tests pass (all prior suites plus 38 new tests added across rounds).
- [x] **Existing merger suite**: 12 tests pass in `herddb-core`.
- [x] **Hammer suites**: `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` and `BLinkConcurrentSearchInsertTest` green twice (per `CLAUDE.md`).
- [x] **Pre-PR validation**: `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` clean across all 19 modules.
- [x] **Helm**: `helm lint` + `IndexOptimizerHelmTemplateTest` green; the k3s `IndexOptimizerKubernetesIT` updated to set `merger.dim=64` so the production wiring is exercised end-to-end.

## Review history

| Round | Verdict | Key fix |
|---|---|---|
| 1 | REQUEST_CHANGES | Tombstone-overlay-load failures now refuse the merge instead of silently treating as "no tombstones"; corrupt-input bounds checks; ZK session expiry detection; replaced `Thread.sleep(100)` with poll-until-deadline. |
| 2 | BLOCK | `SegmentRegistryPublisher.buildMetadata` now plumbs `mapFileSize` through to the znode (every "modern" code path was dead before this fix); `KeeperState.AuthFailed` treated as critical alongside `Expired`; e2e test for ZK session-expiry. |
| 3 | REQUEST_CHANGES | Refused legacy `mapFileSize == 0` znodes outright (`LegacyMetadataException`) — production `RandomAccessReader.length()` returns the constructor-supplied hint, so the prior length()-based clamp was a no-op; failure mode is loud and self-healing (next IS checkpoint rewrites the znode). |
| 4 | **APPROVE** | Test refinement: the `HintReturningReader` fixture now actually exercises the production reader contract by feeding a *modern* znode with over-estimated `mapFileSize` and asserting loud failure. |

## Deferred follow-ups

- Consolidate `MIN_VECTORS_FOR_FUSED_PQ` between `PersistentVectorStore` (256) and `RemoteSegmentGraphMerger` (64×1024) into a single source of truth.
- Revisit `LEGACY_OVERLAY_GENERATION_PROBE_MAX = 32` in `RemoteSegmentMerger` — the underlying `TombstoneOverlayManager.flush` deletes the previous generation immediately, so only one file should ever exist; the 32-window probe handles crash-mid-flush stragglers, but a probe bound on the actual maximum observed generation would be cleaner.

🤖 Implemented by the \`pr-worker\` agent.