### PR TITLE
issue #497: eliminate per-key heap allocation in BLink writePage

### DIFF
--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -943,7 +943,8 @@ public class FileDataStorageManager extends DataStorageManager {
         // write the whole range to the OutputStream in a single call. The ByteBuf
         // auto-expands as the DataWriter appends data, and returns to the pool on
         // release, giving similar recycling behaviour to RecyclableByteArrayOutputStream.
-        ByteBuf buf = PooledByteBufAllocator.DEFAULT.heapBuffer(4096);
+        // Pre-size using the writer's estimate (+16 for outer version/flags VLongs and hash).
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.heapBuffer(writer.sizeEstimate() + 16);
         try {
             herddb.utils.ByteBufUtils.writeVLong(buf, 1); // outer version
             herddb.utils.ByteBufUtils.writeVLong(buf, 0); // outer flags for future implementations

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -40,6 +40,7 @@ import herddb.storage.IndexStatus;
 import herddb.storage.TableStatus;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.ByteBufCursor;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.CleanDirectoryFileVisitor;
 import herddb.utils.DeleteFileVisitor;
@@ -56,6 +57,8 @@ import herddb.utils.SystemInstrumentation;
 import herddb.utils.SystemProperties;
 import herddb.utils.VisibleByteArrayOutputStream;
 import herddb.utils.XXHash64Utils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.Recycler;
 import java.io.BufferedInputStream;
 import java.io.IOError;
@@ -936,20 +939,27 @@ public class FileDataStorageManager extends DataStorageManager {
     }
 
     private long writeIndexPage(DataWriter writer, ManagedFile file, OutputStream stream) throws IOException {
-        try (RecyclableByteArrayOutputStream oo = getWriteBuffer();
-             ExtendedDataOutputStream dataOutput = new ExtendedDataOutputStream(oo)) {
-            dataOutput.writeVLong(1); // version
-            dataOutput.writeVLong(0); // flags for future implementations
-            writer.write(dataOutput);
-            dataOutput.flush();
-            long hash = hashWritesEnabled ? XXHash64Utils.hash(oo.getBuffer(), 0, oo.size()) : NO_HASH_PRESENT;
-            dataOutput.writeLong(hash);
-            dataOutput.flush();
-            stream.write(oo.getBuffer(), 0, oo.size());
+        // Use a pooled heap ByteBuf so we can access buf.array() for hashing and
+        // write the whole range to the OutputStream in a single call. The ByteBuf
+        // auto-expands as the DataWriter appends data, and returns to the pool on
+        // release, giving similar recycling behaviour to RecyclableByteArrayOutputStream.
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.heapBuffer(4096);
+        try {
+            herddb.utils.ByteBufUtils.writeVLong(buf, 1); // outer version
+            herddb.utils.ByteBufUtils.writeVLong(buf, 0); // outer flags for future implementations
+            writer.write(new ByteBufDataOutput(buf));
+            int payloadLen = buf.writerIndex();
+            long hash = hashWritesEnabled
+                    ? XXHash64Utils.hash(buf.array(), buf.arrayOffset(), payloadLen)
+                    : NO_HASH_PRESENT;
+            buf.writeLong(hash);
+            stream.write(buf.array(), buf.arrayOffset(), buf.writerIndex());
             if (file != null) { // O_DIRECT does not need fsync
                 file.sync();
             }
-            return oo.size();
+            return buf.writerIndex();
+        } finally {
+            buf.release();
         }
     }
 

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -36,6 +36,7 @@ import herddb.sql.SQLRecordKeyFunction;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.Holder;
@@ -240,7 +241,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         long pageId = newPageId.getAndIncrement();
         Holder<Long> count = new Holder<>();
 
-        dataStorageManager.writeIndexPage(tableSpaceUUID, index.uuid, pageId, (out) -> {
+        dataStorageManager.writeIndexPage(tableSpaceUUID, index.uuid, pageId, (ByteBufDataOutput out) -> {
 
             long entries = 0;
             out.writeVLong(1); // version

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -37,9 +37,11 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteBufDataOutput;
+import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.Holder;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -241,25 +243,42 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         long pageId = newPageId.getAndIncrement();
         Holder<Long> count = new Holder<>();
 
-        dataStorageManager.writeIndexPage(tableSpaceUUID, index.uuid, pageId, (ByteBufDataOutput out) -> {
-
-            long entries = 0;
-            out.writeVLong(1); // version
-            out.writeVLong(0); // flags for future implementations
-            out.writeVInt(data.size());
-            for (Map.Entry<Bytes, List<Bytes>> entry : data.entrySet()) {
-                out.writeArray(entry.getKey());
-                List<Bytes> entrydata = entry.getValue();
-                out.writeVInt(entrydata.size());
-                for (Bytes v : entrydata) {
-                    out.writeArray(v);
-                    ++entries;
-                }
-            }
-
-            count.value = entries;
-
-        });
+        dataStorageManager.writeIndexPage(tableSpaceUUID, index.uuid, pageId,
+                new DataStorageManager.DataWriter() {
+                    @Override
+                    public void write(ByteBufDataOutput out) throws IOException {
+                        long entries = 0;
+                        out.writeVLong(1); // version
+                        out.writeVLong(0); // flags for future implementations
+                        out.writeVInt(data.size());
+                        for (Map.Entry<Bytes, List<Bytes>> entry : data.entrySet()) {
+                            out.writeArray(entry.getKey());
+                            List<Bytes> entrydata = entry.getValue();
+                            out.writeVInt(entrydata.size());
+                            for (Bytes v : entrydata) {
+                                out.writeArray(v);
+                                ++entries;
+                            }
+                        }
+                        count.value = entries;
+                    }
+                    @Override
+                    public int sizeEstimate() {
+                        // vlong(1) + vlong(0) + vint(data.size())
+                        int est = 1 + 1 + ByteBufUtils.varIntLen(data.size());
+                        for (Map.Entry<Bytes, List<Bytes>> entry : data.entrySet()) {
+                            int klen = entry.getKey().getLength();
+                            est += ByteBufUtils.varIntLen(klen) + klen;
+                            List<Bytes> vals = entry.getValue();
+                            est += ByteBufUtils.varIntLen(vals.size());
+                            for (Bytes v : vals) {
+                                int vlen = v.getLength();
+                                est += ByteBufUtils.varIntLen(vlen) + vlen;
+                            }
+                        }
+                        return est;
+                    }
+                });
 
         IndexStatus indexStatus = new IndexStatus(index.name, sequenceNumber, newPageId.get(), Collections.singleton(pageId), null);
         result.addAll(dataStorageManager.indexCheckpoint(tableSpaceUUID, index.uuid, indexStatus, pin));

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -45,7 +45,6 @@ import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.ByteBufDataOutput;
-import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.HerdDBByteBufAllocators;
@@ -1044,32 +1043,6 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             createPage(pageId, data, LEAF_NODE_PAGE);
         }
 
-        /**
-         * Estimates the serialised size of a BLink node page (INNER or LEAF).
-         * Used to pre-size the backing {@code ByteBuf} via
-         * {@code DataWriter.sizeEstimate()} so the first write rarely triggers
-         * a buffer expansion on large pages.
-         */
-        private static int nodePageSizeEstimate(Map<Bytes, Long> data) {
-            // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
-            int estimate = 3;
-            for (Map.Entry<Bytes, Long> e : data.entrySet()) {
-                Bytes k = e.getKey();
-                if (k == Bytes.POSITIVE_INFINITY) {
-                    // byte(INF_BLOCK) + vlong(pageId) — worst case 9 bytes
-                    estimate += 1 + 9;
-                } else {
-                    int keyLen = k.getLength();
-                    // byte(KEY_VALUE_BLOCK) + vint(keyLen) + keyLen + vlong(pageId)
-                    estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
-                            + ByteBufUtils.varLongLen(e.getValue());
-                }
-            }
-            // byte(END_BLOCK)
-            estimate += 1;
-            return estimate;
-        }
-
         private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             /* Write/overwrite switch */
             if (pageId == NEW_PAGE) {
@@ -1109,7 +1082,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                 }
                 @Override
                 public int sizeEstimate() {
-                    return nodePageSizeEstimate(data);
+                    return IncrementalBLinkPageCodec.nodePageSizeEstimate(data);
                 }
             };
 

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -45,6 +45,7 @@ import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.ByteBufDataOutput;
+import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.HerdDBByteBufAllocators;
@@ -1043,42 +1044,73 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             createPage(pageId, data, LEAF_NODE_PAGE);
         }
 
+        /**
+         * Estimates the serialised size of a BLink node page (INNER or LEAF).
+         * Used to pre-size the backing {@code ByteBuf} via
+         * {@code DataWriter.sizeEstimate()} so the first write rarely triggers
+         * a buffer expansion on large pages.
+         */
+        private static int nodePageSizeEstimate(Map<Bytes, Long> data) {
+            // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
+            int estimate = 3;
+            for (Map.Entry<Bytes, Long> e : data.entrySet()) {
+                Bytes k = e.getKey();
+                if (k == Bytes.POSITIVE_INFINITY) {
+                    // byte(INF_BLOCK) + vlong(pageId) — worst case 9 bytes
+                    estimate += 1 + 9;
+                } else {
+                    int keyLen = k.getLength();
+                    // byte(KEY_VALUE_BLOCK) + vint(keyLen) + keyLen + vlong(pageId)
+                    estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
+                            + ByteBufUtils.varLongLen(e.getValue());
+                }
+            }
+            // byte(END_BLOCK)
+            estimate += 1;
+            return estimate;
+        }
+
         private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             /* Write/overwrite switch */
             if (pageId == NEW_PAGE) {
                 pageId = newPageId.getAndIncrement();
             }
 
-            DataStorageManager.DataWriter writer = (ByteBufDataOutput out) -> {
+            DataStorageManager.DataWriter writer = new DataStorageManager.DataWriter() {
+                @Override
+                public void write(ByteBufDataOutput out) throws IOException {
+                    /* Data version */
+                    out.writeVLong(1);
 
-                /* Data version */
-                out.writeVLong(1);
+                    /* flags for future implementations, actually unused */
+                    out.writeVLong(0);
 
-                /* flags for future implementations, actually unused */
-                out.writeVLong(0);
+                    out.writeByte(type);
 
-                out.writeByte(type);
-
-                data.forEach((x, y) -> {
-                    try {
-                        if (x == Bytes.POSITIVE_INFINITY) {
-                            // Handle special case for +inf key
-                            out.writeByte(NODE_PAGE_INF_BLOCK);
-                            out.writeVLong(y);
-                        } else {
-                            out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
-                            // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
-                            // zero-copy for off-heap IndexKeySlab keys (issue #497).
-                            out.writeArray(x);
-                            out.writeVLong(y);
+                    data.forEach((x, y) -> {
+                        try {
+                            if (x == Bytes.POSITIVE_INFINITY) {
+                                // Handle special case for +inf key
+                                out.writeByte(NODE_PAGE_INF_BLOCK);
+                                out.writeVLong(y);
+                            } else {
+                                out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
+                                // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
+                                // zero-copy for off-heap IndexKeySlab keys (issue #497).
+                                out.writeArray(x);
+                                out.writeVLong(y);
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException("Unexpected IOException during node page write preparation", e);
                         }
-                    } catch (IOException e) {
-                        throw new UncheckedIOException("Unexpected IOException during node page write preparation", e);
-                    }
-                });
+                    });
 
-                out.writeByte(NODE_PAGE_END_BLOCK);
-
+                    out.writeByte(NODE_PAGE_END_BLOCK);
+                }
+                @Override
+                public int sizeEstimate() {
+                    return nodePageSizeEstimate(data);
+                }
             };
 
             /*

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -44,6 +44,7 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteArrayCursor;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.HerdDBByteBufAllocators;
@@ -750,7 +751,11 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                     edos.writeBoolean(hasInf);
 
                     if (!hasInf) {
-                        edos.writeArray(node.rightsep.to_array());
+                        // writeArray(Bytes) on ExtendedDataOutputStream now uses
+                        // Bytes.writeTo(OutputStream) — avoids an extra heap copy
+                        // for off-heap rightsep keys stored in an IndexKeySlab
+                        // (issue #497).
+                        edos.writeArray(node.rightsep);
                     }
                 }
 
@@ -1044,7 +1049,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                 pageId = newPageId.getAndIncrement();
             }
 
-            DataStorageManager.DataWriter writer = out -> {
+            DataStorageManager.DataWriter writer = (ByteBufDataOutput out) -> {
 
                 /* Data version */
                 out.writeVLong(1);
@@ -1062,7 +1067,9 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                             out.writeVLong(y);
                         } else {
                             out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
-                            out.writeArray(x.to_array());
+                            // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
+                            // zero-copy for off-heap IndexKeySlab keys (issue #497).
+                            out.writeArray(x);
                             out.writeVLong(y);
                         }
                     } catch (IOException e) {

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -42,6 +42,7 @@ import herddb.sql.SQLRecordKeyFunction;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.HerdDBByteBufAllocators;
 import herddb.utils.IndexKeySlab;
@@ -991,7 +992,7 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
 
         private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             long pid = (pageId == NEW_PAGE) ? allocatePageId() : pageId;
-            DataStorageManager.DataWriter writer = out -> {
+            DataStorageManager.DataWriter writer = (ByteBufDataOutput out) -> {
                 out.writeVLong(1);
                 out.writeVLong(0);
                 out.writeByte(type);
@@ -1002,7 +1003,9 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
                             out.writeVLong(y);
                         } else {
                             out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
-                            out.writeArray(x.to_array());
+                            // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
+                            // zero-copy for off-heap IndexKeySlab keys (issue #497).
+                            out.writeArray(x);
                             out.writeVLong(y);
                         }
                     } catch (IOException e) {

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -43,7 +43,6 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteBufDataOutput;
-import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.HerdDBByteBufAllocators;
 import herddb.utils.IndexKeySlab;
@@ -1010,32 +1009,6 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             createPage(pageId, data, LEAF_NODE_PAGE);
         }
 
-        /**
-         * Estimates the serialised size of a BLink node page (INNER or LEAF).
-         * Used to pre-size the backing {@code ByteBuf} via
-         * {@code DataWriter.sizeEstimate()} so the first write rarely triggers
-         * a buffer expansion on large pages.
-         */
-        private static int nodePageSizeEstimate(Map<Bytes, Long> data) {
-            // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
-            int estimate = 3;
-            for (Map.Entry<Bytes, Long> e : data.entrySet()) {
-                Bytes k = e.getKey();
-                if (k == Bytes.POSITIVE_INFINITY) {
-                    // byte(INF_BLOCK) + vlong(pageId) — worst case 9 bytes
-                    estimate += 1 + 9;
-                } else {
-                    int keyLen = k.getLength();
-                    // byte(KEY_VALUE_BLOCK) + vint(keyLen) + keyLen + vlong(pageId)
-                    estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
-                            + ByteBufUtils.varLongLen(e.getValue());
-                }
-            }
-            // byte(END_BLOCK)
-            estimate += 1;
-            return estimate;
-        }
-
         private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             long pid = (pageId == NEW_PAGE) ? allocatePageId() : pageId;
             DataStorageManager.DataWriter writer = new DataStorageManager.DataWriter() {
@@ -1065,7 +1038,7 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
                 }
                 @Override
                 public int sizeEstimate() {
-                    return nodePageSizeEstimate(data);
+                    return IncrementalBLinkPageCodec.nodePageSizeEstimate(data);
                 }
             };
 

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkKeyToPageIndex.java
@@ -43,6 +43,7 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteBufDataOutput;
+import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.HerdDBByteBufAllocators;
 import herddb.utils.IndexKeySlab;
@@ -821,9 +822,19 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             List<BLinkNodeMetadata<Bytes>> slice = nodes.subList(from, to);
             long pageId = allocatePageId();
             final int chunkIndex = i;
-            dataStorageManager.writeIndexPage(tableSpace, indexName, pageId, out -> {
-                IncrementalBLinkPageCodec.writeSnapshotChunk(out, epoch, chunkIndex, totalChunks, slice);
-            });
+            dataStorageManager.writeIndexPage(tableSpace, indexName, pageId,
+                    new DataStorageManager.DataWriter() {
+                        @Override
+                        public void write(ByteBufDataOutput out) throws IOException {
+                            IncrementalBLinkPageCodec.writeSnapshotChunk(
+                                    out, epoch, chunkIndex, totalChunks, slice);
+                        }
+                        @Override
+                        public int sizeEstimate() {
+                            return IncrementalBLinkPageCodec.snapshotChunkSizeEstimate(
+                                    epoch, chunkIndex, totalChunks, slice);
+                        }
+                    });
             refs.add(new IncrementalBLinkManifest.SnapshotChunkRef(pageId, i, totalChunks));
         }
         return refs;
@@ -835,9 +846,18 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             throws DataStorageManagerException {
         long[] removedArr = toArray(removedIds);
         long[] deadArr = toArray(deadStoreIds);
-        dataStorageManager.writeIndexPage(tableSpace, indexName, pageId, out -> {
-            IncrementalBLinkPageCodec.writeDelta(out, epoch, upserted, removedArr, deadArr);
-        });
+        dataStorageManager.writeIndexPage(tableSpace, indexName, pageId,
+                new DataStorageManager.DataWriter() {
+                    @Override
+                    public void write(ByteBufDataOutput out) throws IOException {
+                        IncrementalBLinkPageCodec.writeDelta(out, epoch, upserted, removedArr, deadArr);
+                    }
+                    @Override
+                    public int sizeEstimate() {
+                        return IncrementalBLinkPageCodec.deltaSizeEstimate(
+                                epoch, upserted, removedArr, deadArr);
+                    }
+                });
     }
 
     private static long[] toArray(List<Long> list) {
@@ -990,30 +1010,63 @@ public class IncrementalBLinkKeyToPageIndex implements KeyToPageIndex {
             createPage(pageId, data, LEAF_NODE_PAGE);
         }
 
+        /**
+         * Estimates the serialised size of a BLink node page (INNER or LEAF).
+         * Used to pre-size the backing {@code ByteBuf} via
+         * {@code DataWriter.sizeEstimate()} so the first write rarely triggers
+         * a buffer expansion on large pages.
+         */
+        private static int nodePageSizeEstimate(Map<Bytes, Long> data) {
+            // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
+            int estimate = 3;
+            for (Map.Entry<Bytes, Long> e : data.entrySet()) {
+                Bytes k = e.getKey();
+                if (k == Bytes.POSITIVE_INFINITY) {
+                    // byte(INF_BLOCK) + vlong(pageId) — worst case 9 bytes
+                    estimate += 1 + 9;
+                } else {
+                    int keyLen = k.getLength();
+                    // byte(KEY_VALUE_BLOCK) + vint(keyLen) + keyLen + vlong(pageId)
+                    estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
+                            + ByteBufUtils.varLongLen(e.getValue());
+                }
+            }
+            // byte(END_BLOCK)
+            estimate += 1;
+            return estimate;
+        }
+
         private long createPage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             long pid = (pageId == NEW_PAGE) ? allocatePageId() : pageId;
-            DataStorageManager.DataWriter writer = (ByteBufDataOutput out) -> {
-                out.writeVLong(1);
-                out.writeVLong(0);
-                out.writeByte(type);
-                data.forEach((x, y) -> {
-                    try {
-                        if (x == Bytes.POSITIVE_INFINITY) {
-                            out.writeByte(NODE_PAGE_INF_BLOCK);
-                            out.writeVLong(y);
-                        } else {
-                            out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
-                            // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
-                            // zero-copy for off-heap IndexKeySlab keys (issue #497).
-                            out.writeArray(x);
-                            out.writeVLong(y);
+            DataStorageManager.DataWriter writer = new DataStorageManager.DataWriter() {
+                @Override
+                public void write(ByteBufDataOutput out) throws IOException {
+                    out.writeVLong(1);
+                    out.writeVLong(0);
+                    out.writeByte(type);
+                    data.forEach((x, y) -> {
+                        try {
+                            if (x == Bytes.POSITIVE_INFINITY) {
+                                out.writeByte(NODE_PAGE_INF_BLOCK);
+                                out.writeVLong(y);
+                            } else {
+                                out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
+                                // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
+                                // zero-copy for off-heap IndexKeySlab keys (issue #497).
+                                out.writeArray(x);
+                                out.writeVLong(y);
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(
+                                    "Unexpected IOException during node page write preparation", e);
                         }
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(
-                                "Unexpected IOException during node page write preparation", e);
-                    }
-                });
-                out.writeByte(NODE_PAGE_END_BLOCK);
+                    });
+                    out.writeByte(NODE_PAGE_END_BLOCK);
+                }
+                @Override
+                public int sizeEstimate() {
+                    return nodePageSizeEstimate(data);
+                }
             };
 
             /*

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
@@ -22,8 +22,8 @@ package herddb.index.blink;
 
 import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
 import herddb.utils.ByteBufCursor;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
-import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.HerdDBByteBufAllocators;
 import herddb.utils.IndexKeySlab;
 import java.io.IOException;
@@ -80,7 +80,7 @@ final class IncrementalBLinkPageCodec {
     // ---------------- snapshot chunk ----------------
 
     static void writeSnapshotChunk(
-            ExtendedDataOutputStream out,
+            ByteBufDataOutput out,
             long epoch, int chunkIndex, int totalChunks,
             List<BLinkNodeMetadata<Bytes>> nodes
     ) throws IOException {
@@ -132,7 +132,7 @@ final class IncrementalBLinkPageCodec {
     // ---------------- delta ----------------
 
     static void writeDelta(
-            ExtendedDataOutputStream out,
+            ByteBufDataOutput out,
             long epoch,
             List<BLinkNodeMetadata<Bytes>> upserted,
             long[] removedNodeIds,
@@ -205,7 +205,7 @@ final class IncrementalBLinkPageCodec {
 
     // ---------------- shared node-metadata codec ----------------
 
-    private static void writeNodeMetadata(ExtendedDataOutputStream out, BLinkNodeMetadata<Bytes> node)
+    private static void writeNodeMetadata(ByteBufDataOutput out, BLinkNodeMetadata<Bytes> node)
             throws IOException {
         out.writeBoolean(node.leaf);
         out.writeVLong(node.id);
@@ -218,7 +218,9 @@ final class IncrementalBLinkPageCodec {
             out.writeByte(RIGHTSEP_INF);
         } else {
             out.writeByte(RIGHTSEP_BYTES);
-            out.writeArray(node.rightsep.to_array());
+            // writeArray(Bytes) uses Bytes.writeTo(ByteBuf) — zero-copy for
+            // off-heap-backed rightsep keys (issue #497).
+            out.writeArray(node.rightsep);
         }
     }
 
@@ -281,9 +283,9 @@ final class IncrementalBLinkPageCodec {
                 byte[] rs = in.readArray();
                 if (rs == null) {
                     // The writer never emits a null rightsep array (it always
-                    // calls writeArray on a non-null Bytes.to_array()), so a
-                    // null here means the on-disk page is corrupted. Fail
-                    // fast with an actionable message.
+                    // calls writeArray on a non-null Bytes), so a null here
+                    // means the on-disk page is corrupted. Fail fast with an
+                    // actionable message.
                     throw new IOException("corrupted node metadata: null rightsep at index " + i);
                 }
                 rightsepBytes[i] = rs;

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
@@ -51,7 +51,7 @@ import java.util.Map;
  * three-field header with distinct {@code kind} values so the two formats can
  * coexist in the same index directory without ambiguity.</p>
  */
-final class IncrementalBLinkPageCodec {
+public final class IncrementalBLinkPageCodec {
 
     static final long PAGE_VERSION = 1L;
 
@@ -164,6 +164,40 @@ final class IncrementalBLinkPageCodec {
     // -------- size estimators (used by callers to pre-size the ByteBuf) --------
 
     /**
+     * Estimates the serialised size of a BLink node page (INNER or LEAF) for
+     * the given {@code data} map.
+     *
+     * <p>All three BLink page writers — {@code BLinkKeyToPageIndex},
+     * {@code IncrementalBLinkKeyToPageIndex}, and {@code PersistentVectorStore}
+     * — share the same wire format and delegate to this method for their
+     * {@code DataWriter.sizeEstimate()} overrides.
+     *
+     * <p>The estimate is exact for key lengths and page-ID VLong widths; it
+     * uses a conservative 9-byte maximum for the {@code POSITIVE_INFINITY}
+     * entry's VLong (the actual page-id VLong could be 1–9 bytes, but +inf
+     * entries are rare).
+     */
+    public static int nodePageSizeEstimate(Map<Bytes, Long> data) {
+        // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
+        int estimate = 3;
+        for (Map.Entry<Bytes, Long> e : data.entrySet()) {
+            Bytes k = e.getKey();
+            if (k == Bytes.POSITIVE_INFINITY) {
+                // byte(INF_BLOCK) + vlong(pageId) — worst case 9 bytes
+                estimate += 1 + 9;
+            } else {
+                int keyLen = k.getLength();
+                // byte(KEY_VALUE_BLOCK) + vint(keyLen) + keyLen + vlong(pageId)
+                estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
+                        + ByteBufUtils.varLongLen(e.getValue());
+            }
+        }
+        // byte(END_BLOCK)
+        estimate += 1;
+        return estimate;
+    }
+
+    /**
      * Estimates the serialised byte size of a snapshot-chunk page for the
      * given {@code nodes} list. Used by the caller to pre-size the backing
      * {@code ByteBuf} via {@code DataWriter.sizeEstimate()}.
@@ -216,8 +250,13 @@ final class IncrementalBLinkPageCodec {
      * {@code keys}, {@code bytes}, rightsep key bytes) and a conservative
      * 9-byte worst-case for the zig-zag-encoded {@code outlink} and
      * {@code rightlink} fields.
+     *
+     * <p>Handles all values that {@link #writeNodeMetadata} accepts:
+     * {@code null} rightsep encodes as a vint(-1) null marker (5 bytes);
+     * {@link Bytes#POSITIVE_INFINITY} encodes as a single-byte sentinel;
+     * any other {@code Bytes} encodes as vint(len) + len bytes.
      */
-    private static int nodeMetadataSizeEstimate(BLinkNodeMetadata<Bytes> node) {
+    static int nodeMetadataSizeEstimate(BLinkNodeMetadata<Bytes> node) {
         // boolean(1) + vlong(id) + vlong(storeId) + vint(keys) + vlong(bytes)
         //   + zlong(outlink)[worst 9] + zlong(rightlink)[worst 9] + byte(rightsep_type)
         int estimate = 1
@@ -228,7 +267,10 @@ final class IncrementalBLinkPageCodec {
                 + 9  // zlong(outlink): zig-zag may produce a large unsigned value
                 + 9  // zlong(rightlink): same
                 + 1; // rightsep type byte
-        if (node.rightsep != Bytes.POSITIVE_INFINITY) {
+        if (node.rightsep == null) {
+            // writeNodeMetadata emits writeArray(null) → writeNullArray() → vint(-1) = 5 bytes
+            estimate += 5;
+        } else if (node.rightsep != Bytes.POSITIVE_INFINITY) {
             int keyLen = node.rightsep.getLength();
             estimate += ByteBufUtils.varIntLen(keyLen) + keyLen;
         }

--- a/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
+++ b/herddb-core/src/main/java/herddb/index/blink/IncrementalBLinkPageCodec.java
@@ -23,6 +23,7 @@ package herddb.index.blink;
 import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
 import herddb.utils.ByteBufCursor;
 import herddb.utils.ByteBufDataOutput;
+import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.HerdDBByteBufAllocators;
 import herddb.utils.IndexKeySlab;
@@ -158,6 +159,80 @@ final class IncrementalBLinkPageCodec {
         for (long id : deadStoreIds) {
             out.writeVLong(id);
         }
+    }
+
+    // -------- size estimators (used by callers to pre-size the ByteBuf) --------
+
+    /**
+     * Estimates the serialised byte size of a snapshot-chunk page for the
+     * given {@code nodes} list. Used by the caller to pre-size the backing
+     * {@code ByteBuf} via {@code DataWriter.sizeEstimate()}.
+     */
+    static int snapshotChunkSizeEstimate(
+            long epoch, int chunkIndex, int totalChunks,
+            List<BLinkNodeMetadata<Bytes>> nodes) {
+        // PAGE_VERSION(vlong) + PAGE_FLAGS(vlong) + PAGE_KIND(byte)
+        //   + epoch(vlong) + chunkIndex(vint) + totalChunks(vint) + count(vint)
+        int estimate = 1 + 1 + 1
+                + ByteBufUtils.varLongLen(epoch)
+                + ByteBufUtils.varIntLen(chunkIndex)
+                + ByteBufUtils.varIntLen(totalChunks)
+                + ByteBufUtils.varIntLen(nodes.size());
+        for (BLinkNodeMetadata<Bytes> node : nodes) {
+            estimate += nodeMetadataSizeEstimate(node);
+        }
+        return estimate;
+    }
+
+    /**
+     * Estimates the serialised byte size of a delta page.
+     */
+    static int deltaSizeEstimate(
+            long epoch,
+            List<BLinkNodeMetadata<Bytes>> upserted,
+            long[] removedNodeIds,
+            long[] deadStoreIds) {
+        // PAGE_VERSION + PAGE_FLAGS + PAGE_KIND + epoch + 3 vint counts
+        int estimate = 1 + 1 + 1
+                + ByteBufUtils.varLongLen(epoch)
+                + ByteBufUtils.varIntLen(upserted.size())
+                + ByteBufUtils.varIntLen(removedNodeIds.length)
+                + ByteBufUtils.varIntLen(deadStoreIds.length);
+        for (BLinkNodeMetadata<Bytes> node : upserted) {
+            estimate += nodeMetadataSizeEstimate(node);
+        }
+        for (long id : removedNodeIds) {
+            estimate += ByteBufUtils.varLongLen(id);
+        }
+        for (long id : deadStoreIds) {
+            estimate += ByteBufUtils.varLongLen(id);
+        }
+        return estimate;
+    }
+
+    /**
+     * Estimates the serialised size of one {@link BLinkNodeMetadata} record.
+     * Uses exact lengths for known fields ({@code id}, {@code storeId},
+     * {@code keys}, {@code bytes}, rightsep key bytes) and a conservative
+     * 9-byte worst-case for the zig-zag-encoded {@code outlink} and
+     * {@code rightlink} fields.
+     */
+    private static int nodeMetadataSizeEstimate(BLinkNodeMetadata<Bytes> node) {
+        // boolean(1) + vlong(id) + vlong(storeId) + vint(keys) + vlong(bytes)
+        //   + zlong(outlink)[worst 9] + zlong(rightlink)[worst 9] + byte(rightsep_type)
+        int estimate = 1
+                + ByteBufUtils.varLongLen(node.id)
+                + ByteBufUtils.varLongLen(node.storeId)
+                + ByteBufUtils.varIntLen(node.keys)
+                + ByteBufUtils.varLongLen(node.bytes)
+                + 9  // zlong(outlink): zig-zag may produce a large unsigned value
+                + 9  // zlong(rightlink): same
+                + 1; // rightsep type byte
+        if (node.rightsep != Bytes.POSITIVE_INFINITY) {
+            int keyLen = node.rightsep.getLength();
+            estimate += ByteBufUtils.varIntLen(keyLen) + keyLen;
+        }
+        return estimate;
     }
 
     static DeltaContents readDelta(ByteBufCursor in) throws IOException {

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -45,13 +45,14 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteBufCursor;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
-import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.HerdDBByteBufAllocators;
 import herddb.utils.IndexKeySlab;
 import herddb.utils.SystemProperties;
-import java.io.ByteArrayOutputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -134,17 +135,18 @@ public class BRINIndexManager extends AbstractIndexManager {
         }
 
         byte[] serialize() throws IOException {
-            try (ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-                 ExtendedDataOutputStream eout = new ExtendedDataOutputStream(out)) {
-                serialize(eout);
-
-                eout.flush();
-
-                return out.toByteArray();
+            ByteBuf buf = Unpooled.buffer(1024);
+            try {
+                serialize(new ByteBufDataOutput(buf));
+                byte[] result = new byte[buf.writerIndex()];
+                buf.getBytes(0, result);
+                return result;
+            } finally {
+                buf.release();
             }
         }
 
-        void serialize(ExtendedDataOutputStream out) throws IOException {
+        void serialize(ByteBufDataOutput out) throws IOException {
             out.writeVLong(3); // version
             out.writeVLong(0); // flags for future implementations
 
@@ -586,7 +588,8 @@ public class BRINIndexManager extends AbstractIndexManager {
                 contents.pageData = values;
 
                 long pageId = newPageId.getAndIncrement();
-                dataStorageManager.writeIndexPage(tableSpaceUUID, index.uuid, pageId, (out) -> contents.serialize(out));
+                dataStorageManager.writeIndexPage(tableSpaceUUID, index.uuid, pageId,
+                        (ByteBufDataOutput out) -> contents.serialize(out));
 
                 return pageId;
             } catch (DataStorageManagerException err) {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -29,6 +29,7 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteBufDataOutput;
+import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.VectorSearchRequestContext;
 import herddb.utils.VisibleByteArrayOutputStream;
@@ -6318,32 +6319,61 @@ public class PersistentVectorStore extends AbstractVectorStore {
             writePage(pageId, data, BLINK_LEAF_NODE_PAGE);
         }
 
+        /**
+         * Estimates the serialised size of a BLink node page for pre-sizing
+         * the backing {@code ByteBuf}.
+         */
+        private static int nodePageSizeEstimate(Map<Bytes, Long> data) {
+            // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
+            int estimate = 3;
+            for (Map.Entry<Bytes, Long> e : data.entrySet()) {
+                Bytes k = e.getKey();
+                if (k == Bytes.POSITIVE_INFINITY) {
+                    estimate += 1 + 9; // byte(INF_BLOCK) + vlong(pageId) worst case
+                } else {
+                    int keyLen = k.getLength();
+                    estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
+                            + ByteBufUtils.varLongLen(e.getValue());
+                }
+            }
+            estimate += 1; // byte(END_BLOCK)
+            return estimate;
+        }
+
         private long writePage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             if (pageId == NEW_PAGE) {
                 pageId = newPageId.getAndIncrement();
             }
-            dataStorageManager.writeIndexPage(tableSpaceUUID, storeName, pageId, (ByteBufDataOutput out) -> {
-                out.writeVLong(1);
-                out.writeVLong(0);
-                out.writeByte(type);
-                data.forEach((x, y) -> {
-                    try {
-                        if (x == Bytes.POSITIVE_INFINITY) {
-                            out.writeByte(NODE_PAGE_INF_BLOCK);
-                            out.writeVLong(y);
-                        } else {
-                            out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
-                            // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
-                            // zero-copy for off-heap IndexKeySlab keys (issue #497).
-                            out.writeArray(x);
-                            out.writeVLong(y);
+            dataStorageManager.writeIndexPage(tableSpaceUUID, storeName, pageId,
+                    new DataStorageManager.DataWriter() {
+                        @Override
+                        public void write(ByteBufDataOutput out) throws IOException {
+                            out.writeVLong(1);
+                            out.writeVLong(0);
+                            out.writeByte(type);
+                            data.forEach((x, y) -> {
+                                try {
+                                    if (x == Bytes.POSITIVE_INFINITY) {
+                                        out.writeByte(NODE_PAGE_INF_BLOCK);
+                                        out.writeVLong(y);
+                                    } else {
+                                        out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
+                                        // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
+                                        // zero-copy for off-heap IndexKeySlab keys (issue #497).
+                                        out.writeArray(x);
+                                        out.writeVLong(y);
+                                    }
+                                } catch (IOException e) {
+                                    throw new java.io.UncheckedIOException(e);
+                                }
+                            });
+                            out.writeByte(NODE_PAGE_END_BLOCK);
                         }
-                    } catch (IOException e) {
-                        throw new java.io.UncheckedIOException(e);
-                    }
-                });
-                out.writeByte(NODE_PAGE_END_BLOCK);
-            });
+                        @Override
+                        public int sizeEstimate() {
+                            return nodePageSizeEstimate(data);
+                        }
+                    });
             return pageId;
         }
     }

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -28,6 +28,7 @@ import herddb.log.LogSequenceNumber;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.VectorSearchRequestContext;
 import herddb.utils.VisibleByteArrayOutputStream;
@@ -6321,7 +6322,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             if (pageId == NEW_PAGE) {
                 pageId = newPageId.getAndIncrement();
             }
-            dataStorageManager.writeIndexPage(tableSpaceUUID, storeName, pageId, out -> {
+            dataStorageManager.writeIndexPage(tableSpaceUUID, storeName, pageId, (ByteBufDataOutput out) -> {
                 out.writeVLong(1);
                 out.writeVLong(0);
                 out.writeByte(type);
@@ -6332,7 +6333,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             out.writeVLong(y);
                         } else {
                             out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
-                            out.writeArray(x.to_array());
+                            // writeArray(Bytes) calls Bytes.writeTo(ByteBuf):
+                            // zero-copy for off-heap IndexKeySlab keys (issue #497).
+                            out.writeArray(x);
                             out.writeVLong(y);
                         }
                     } catch (IOException e) {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -24,12 +24,12 @@ import herddb.core.MemoryManager;
 import herddb.index.blink.BLink;
 import herddb.index.blink.BLinkIndexDataStorage;
 import herddb.index.blink.BytesLongSizeEvaluator;
+import herddb.index.blink.IncrementalBLinkPageCodec;
 import herddb.log.LogSequenceNumber;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteBufDataOutput;
-import herddb.utils.ByteBufUtils;
 import herddb.utils.Bytes;
 import herddb.utils.VectorSearchRequestContext;
 import herddb.utils.VisibleByteArrayOutputStream;
@@ -6319,27 +6319,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             writePage(pageId, data, BLINK_LEAF_NODE_PAGE);
         }
 
-        /**
-         * Estimates the serialised size of a BLink node page for pre-sizing
-         * the backing {@code ByteBuf}.
-         */
-        private static int nodePageSizeEstimate(Map<Bytes, Long> data) {
-            // vlong(1) + vlong(0) + byte(type) = 1 + 1 + 1 = 3
-            int estimate = 3;
-            for (Map.Entry<Bytes, Long> e : data.entrySet()) {
-                Bytes k = e.getKey();
-                if (k == Bytes.POSITIVE_INFINITY) {
-                    estimate += 1 + 9; // byte(INF_BLOCK) + vlong(pageId) worst case
-                } else {
-                    int keyLen = k.getLength();
-                    estimate += 1 + ByteBufUtils.varIntLen(keyLen) + keyLen
-                            + ByteBufUtils.varLongLen(e.getValue());
-                }
-            }
-            estimate += 1; // byte(END_BLOCK)
-            return estimate;
-        }
-
         private long writePage(long pageId, Map<Bytes, Long> data, byte type) throws IOException {
             if (pageId == NEW_PAGE) {
                 pageId = newPageId.getAndIncrement();
@@ -6371,7 +6350,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         }
                         @Override
                         public int sizeEstimate() {
-                            return nodePageSizeEstimate(data);
+                            return IncrementalBLinkPageCodec.nodePageSizeEstimate(data);
                         }
                     });
             return pageId;

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -37,11 +37,14 @@ import herddb.storage.FullTableScanConsumer;
 import herddb.storage.IndexStatus;
 import herddb.storage.TableStatus;
 import herddb.utils.ByteBufCursor;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -289,20 +292,17 @@ public class MemoryDataStorageManager extends DataStorageManager {
             long pageId, DataWriter writer
     ) throws DataStorageManagerException {
 
-        Bytes page_wrapper;
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-             ExtendedDataOutputStream eout = new ExtendedDataOutputStream(out)) {
-
-            writer.write(eout);
-
-            eout.flush();
-
-            page_wrapper = Bytes.from_array(out.toByteArray());
+        ByteBuf buf = Unpooled.buffer(1024);
+        try {
+            writer.write(new ByteBufDataOutput(buf));
+            byte[] data = new byte[buf.writerIndex()];
+            buf.getBytes(0, data);
+            indexpages.put(tableSpace + "." + indexName + "_" + pageId, Bytes.from_array(data));
         } catch (IOException ex) {
             throw new DataStorageManagerException(ex);
+        } finally {
+            buf.release();
         }
-
-        indexpages.put(tableSpace + "." + indexName + "_" + pageId, page_wrapper);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -292,7 +292,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
             long pageId, DataWriter writer
     ) throws DataStorageManagerException {
 
-        ByteBuf buf = Unpooled.buffer(1024);
+        ByteBuf buf = Unpooled.buffer(writer.sizeEstimate());
         try {
             writer.write(new ByteBufDataOutput(buf));
             byte[] data = new byte[buf.writerIndex()];

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -148,6 +148,7 @@ public abstract class DataStorageManager implements AutoCloseable {
                 "Lazy page loading not supported by " + getClass().getName());
     }
 
+    @FunctionalInterface
     public interface DataWriter {
 
         /**

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -148,7 +148,6 @@ public abstract class DataStorageManager implements AutoCloseable {
                 "Lazy page loading not supported by " + getClass().getName());
     }
 
-    @FunctionalInterface
     public interface DataWriter {
 
         /**
@@ -163,6 +162,22 @@ public abstract class DataStorageManager implements AutoCloseable {
          * performs a zero-copy direct-to-direct copy (issue #497).
          */
         void write(ByteBufDataOutput out) throws IOException;
+
+        /**
+         * Returns a best-effort estimate of the payload size in bytes written
+         * by {@link #write}. Used by {@code DataStorageManager} implementations
+         * to pre-size the backing {@code ByteBuf} so the first write rarely
+         * triggers an expansion. The estimate does <em>not</em> need to include
+         * the outer framing bytes added by the DSM (outer version / flags /
+         * hash footer), as the DSM adds a constant-size margin itself.
+         *
+         * <p>The default (4 KiB) is suitable when the payload size is not
+         * known in advance. Override to provide a tighter estimate and avoid
+         * buffer-copy expansions on large pages.
+         */
+        default int sizeEstimate() {
+            return 4096;
+        }
     }
 
     public abstract void writeIndexPage(String tableSpace, String uuid, long pageId, DataWriter writer);

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -30,7 +30,7 @@ import herddb.model.Record;
 import herddb.model.Table;
 import herddb.model.Transaction;
 import herddb.utils.ByteBufCursor;
-import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.ByteBufDataOutput;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -151,7 +151,18 @@ public abstract class DataStorageManager implements AutoCloseable {
     @FunctionalInterface
     public interface DataWriter {
 
-        void write(ExtendedDataOutputStream out) throws IOException;
+        /**
+         * Serialises one index page into {@code out}. Implementations write
+         * their payload directly into the supplied {@link ByteBufDataOutput};
+         * the surrounding framing (outer version / flags / hash footer) is
+         * added by the {@code DataStorageManager} implementation.
+         *
+         * <p>For off-heap-backed {@link herddb.utils.Bytes} keys use
+         * {@link ByteBufDataOutput#writeArray(herddb.utils.Bytes)} — it calls
+         * {@link herddb.utils.Bytes#writeTo(io.netty.buffer.ByteBuf)} which
+         * performs a zero-copy direct-to-direct copy (issue #497).
+         */
+        void write(ByteBufDataOutput out) throws IOException;
     }
 
     public abstract void writeIndexPage(String tableSpace, String uuid, long pageId, DataWriter writer);

--- a/herddb-core/src/test/java/herddb/index/blink/SizeEstimateTest.java
+++ b/herddb-core/src/test/java/herddb/index/blink/SizeEstimateTest.java
@@ -1,0 +1,353 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+*/
+
+package herddb.index.blink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
+import herddb.utils.ByteBufDataOutput;
+import herddb.utils.Bytes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Verifies that the {@link IncrementalBLinkPageCodec} size-estimate methods
+ * never under-count the actual bytes written by the corresponding write method.
+ *
+ * <p>For purely VInt/VLong-encoded payloads (no zig-zag fields), the estimate
+ * must be exact. For payloads that include zig-zag-encoded fields (outlink /
+ * rightlink in node metadata), the estimate is conservative
+ * ({@code estimate >= actual}).
+ */
+public class SizeEstimateTest {
+
+    // -------------------------------------------------------------------------
+    // Constants mirrored from BLinkKeyToPageIndex (package-private there)
+    // -------------------------------------------------------------------------
+
+    private static final byte INNER_NODE_PAGE = 1;
+    private static final byte NODE_PAGE_END_BLOCK = 0;
+    private static final byte NODE_PAGE_KEY_VALUE_BLOCK = 1;
+    private static final byte NODE_PAGE_INF_BLOCK = 2;
+
+    // -------------------------------------------------------------------------
+    // nodePageSizeEstimate — no POSITIVE_INFINITY key: must be exact
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void nodePageSizeEstimate_noInfKey_isExact() throws IOException {
+        Map<Bytes, Long> data = new LinkedHashMap<>();
+        // 1-byte VLong page id (< 128), 1-byte key length
+        data.put(Bytes.from_string("a"), 1L);
+        // 2-byte key length (len=200 → varIntLen=2), large page id
+        data.put(Bytes.from_array(new byte[200]), 0x3FFFL);
+        // 4-byte VLong page id, short key
+        data.put(Bytes.from_string("longerkey"), 0x10000000L);
+
+        ByteBuf buf = Unpooled.buffer(512);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            writeNodePage(out, data, INNER_NODE_PAGE);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.nodePageSizeEstimate(data);
+            assertEquals(
+                    "nodePageSizeEstimate (no INF key) must be exact: actual=" + actual,
+                    actual, estimate);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void nodePageSizeEstimate_withInfKey_isConservative() throws IOException {
+        Map<Bytes, Long> data = new LinkedHashMap<>();
+        data.put(Bytes.from_string("key"), 42L);
+        // pageId=99 → 1-byte VLong, but estimate uses 9 bytes for INF entries
+        data.put(Bytes.POSITIVE_INFINITY, 99L);
+
+        ByteBuf buf = Unpooled.buffer(256);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            writeNodePage(out, data, INNER_NODE_PAGE);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.nodePageSizeEstimate(data);
+            assertTrue(
+                    "nodePageSizeEstimate (with INF key) must be >= actual: "
+                            + "estimate=" + estimate + " actual=" + actual,
+                    estimate >= actual);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void nodePageSizeEstimate_emptyMap_isExact() throws IOException {
+        Map<Bytes, Long> data = new LinkedHashMap<>();
+
+        ByteBuf buf = Unpooled.buffer(16);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            writeNodePage(out, data, INNER_NODE_PAGE);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.nodePageSizeEstimate(data);
+            assertEquals("nodePageSizeEstimate (empty map) must be exact", actual, estimate);
+        } finally {
+            buf.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // nodeMetadataSizeEstimate — always conservative (zlong worst-case)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void nodeMetadataSizeEstimate_normalRightsep_isConservative() throws IOException {
+        BLinkNodeMetadata<Bytes> node = new BLinkNodeMetadata<>(
+                true,                    // leaf
+                10L,                     // id
+                20L,                     // storeId
+                5,                       // keys
+                1024L,                   // bytes
+                0L,                      // outlink (zlong → 1 byte actual, 9 estimate)
+                0L,                      // rightlink (same)
+                Bytes.from_string("rightsep-key")
+        );
+        // Verify via snapshotChunk round-trip (writeNodeMetadata is private)
+        ByteBuf buf = Unpooled.buffer(256);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeSnapshotChunk(out, 1L, 0, 1,
+                    Collections.singletonList(node));
+            int chunkActual = buf.writerIndex();
+            int chunkEstimate = IncrementalBLinkPageCodec.snapshotChunkSizeEstimate(
+                    1L, 0, 1, Collections.singletonList(node));
+            assertTrue(
+                    "snapshotChunkSizeEstimate must be >= actual for node with normal rightsep: "
+                            + "estimate=" + chunkEstimate + " actual=" + chunkActual,
+                    chunkEstimate >= chunkActual);
+            // sanity: the per-node estimate itself is positive
+            int nodeEstimate = IncrementalBLinkPageCodec.nodeMetadataSizeEstimate(node);
+            assertTrue("nodeMetadataSizeEstimate must be positive", nodeEstimate > 0);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void nodeMetadataSizeEstimate_nullRightsep_isConservative() throws IOException {
+        BLinkNodeMetadata<Bytes> node = new BLinkNodeMetadata<>(
+                false, 1L, 2L, 3, 100L, 0L, 0L, null
+        );
+        ByteBuf buf = Unpooled.buffer(256);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeSnapshotChunk(out, 1L, 0, 1,
+                    Collections.singletonList(node));
+            int chunkActual = buf.writerIndex();
+            int chunkEstimate = IncrementalBLinkPageCodec.snapshotChunkSizeEstimate(
+                    1L, 0, 1, Collections.singletonList(node));
+            assertTrue(
+                    "snapshotChunkSizeEstimate must be >= actual for node with null rightsep: "
+                            + "estimate=" + chunkEstimate + " actual=" + chunkActual,
+                    chunkEstimate >= chunkActual);
+            // per-node sanity
+            int nodeEstimate = IncrementalBLinkPageCodec.nodeMetadataSizeEstimate(node);
+            assertTrue("nodeMetadataSizeEstimate (null rightsep) must be positive", nodeEstimate > 0);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void nodeMetadataSizeEstimate_infRightsep_isConservative() throws IOException {
+        BLinkNodeMetadata<Bytes> node = new BLinkNodeMetadata<>(
+                true, 5L, 6L, 0, 0L, 0L, 0L, Bytes.POSITIVE_INFINITY
+        );
+        ByteBuf buf = Unpooled.buffer(256);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeSnapshotChunk(out, 1L, 0, 1,
+                    Collections.singletonList(node));
+            int chunkActual = buf.writerIndex();
+            int chunkEstimate = IncrementalBLinkPageCodec.snapshotChunkSizeEstimate(
+                    1L, 0, 1, Collections.singletonList(node));
+            assertTrue(
+                    "snapshotChunkSizeEstimate must be >= actual for node with INF rightsep: "
+                            + "estimate=" + chunkEstimate + " actual=" + chunkActual,
+                    chunkEstimate >= chunkActual);
+            int nodeEstimate = IncrementalBLinkPageCodec.nodeMetadataSizeEstimate(node);
+            assertTrue("nodeMetadataSizeEstimate (INF rightsep) must be positive", nodeEstimate > 0);
+        } finally {
+            buf.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // snapshotChunkSizeEstimate
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void snapshotChunkSizeEstimate_multipleNodes_isConservative() throws IOException {
+        List<BLinkNodeMetadata<Bytes>> nodes = buildNodeList(6);
+
+        ByteBuf buf = Unpooled.buffer(1024);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeSnapshotChunk(out, 7L, 1, 3, nodes);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.snapshotChunkSizeEstimate(7L, 1, 3, nodes);
+            assertTrue(
+                    "snapshotChunkSizeEstimate must be >= actual: "
+                            + "estimate=" + estimate + " actual=" + actual,
+                    estimate >= actual);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void snapshotChunkSizeEstimate_emptyList_isConservative() throws IOException {
+        List<BLinkNodeMetadata<Bytes>> nodes = Collections.emptyList();
+
+        ByteBuf buf = Unpooled.buffer(32);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeSnapshotChunk(out, 1L, 0, 1, nodes);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.snapshotChunkSizeEstimate(1L, 0, 1, nodes);
+            assertTrue(
+                    "snapshotChunkSizeEstimate (empty) must be >= actual: "
+                            + "estimate=" + estimate + " actual=" + actual,
+                    estimate >= actual);
+        } finally {
+            buf.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // deltaSizeEstimate
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void deltaSizeEstimate_withData_isConservative() throws IOException {
+        List<BLinkNodeMetadata<Bytes>> upserted = buildNodeList(4);
+        long[] removedNodeIds = {1L, 2L, 127L, 128L, Long.MAX_VALUE};
+        long[] deadStoreIds   = {10L, 9999L};
+
+        ByteBuf buf = Unpooled.buffer(1024);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeDelta(out, 3L, upserted, removedNodeIds, deadStoreIds);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.deltaSizeEstimate(
+                    3L, upserted, removedNodeIds, deadStoreIds);
+            assertTrue(
+                    "deltaSizeEstimate must be >= actual: "
+                            + "estimate=" + estimate + " actual=" + actual,
+                    estimate >= actual);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void deltaSizeEstimate_empty_isConservative() throws IOException {
+        List<BLinkNodeMetadata<Bytes>> upserted = Collections.emptyList();
+        long[] removedNodeIds = {};
+        long[] deadStoreIds   = {};
+
+        ByteBuf buf = Unpooled.buffer(32);
+        try {
+            ByteBufDataOutput out = new ByteBufDataOutput(buf);
+            IncrementalBLinkPageCodec.writeDelta(out, 1L, upserted, removedNodeIds, deadStoreIds);
+            int actual = buf.writerIndex();
+            int estimate = IncrementalBLinkPageCodec.deltaSizeEstimate(
+                    1L, upserted, removedNodeIds, deadStoreIds);
+            assertTrue(
+                    "deltaSizeEstimate (empty) must be >= actual: "
+                            + "estimate=" + estimate + " actual=" + actual,
+                    estimate >= actual);
+        } finally {
+            buf.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Writes the BLink node-page body using the same wire format as
+     * {@code BLinkKeyToPageIndex.createPage} / {@code IncrementalBLinkKeyToPageIndex}
+     * / {@code PersistentVectorStore.writePage}.
+     */
+    private static void writeNodePage(ByteBufDataOutput out, Map<Bytes, Long> data, byte type)
+            throws IOException {
+        out.writeVLong(1L); // PAGE_VERSION
+        out.writeVLong(0L); // PAGE_FLAGS
+        out.writeByte(type);
+        for (Map.Entry<Bytes, Long> e : data.entrySet()) {
+            Bytes k = e.getKey();
+            if (k == Bytes.POSITIVE_INFINITY) {
+                out.writeByte(NODE_PAGE_INF_BLOCK);
+                out.writeVLong(e.getValue());
+            } else {
+                out.writeByte(NODE_PAGE_KEY_VALUE_BLOCK);
+                out.writeArray(k);
+                out.writeVLong(e.getValue());
+            }
+        }
+        out.writeByte(NODE_PAGE_END_BLOCK);
+    }
+
+    /**
+     * Builds a list of {@link BLinkNodeMetadata} instances for use in
+     * snapshot-chunk and delta tests. The last node always gets
+     * {@link Bytes#POSITIVE_INFINITY} as its rightsep (tree right-most node);
+     * all others get a short ASCII key.
+     */
+    private static List<BLinkNodeMetadata<Bytes>> buildNodeList(int count) {
+        List<BLinkNodeMetadata<Bytes>> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Bytes rightsep = (i == count - 1)
+                    ? Bytes.POSITIVE_INFINITY
+                    : Bytes.from_string("key-" + i);
+            list.add(new BLinkNodeMetadata<>(
+                    i % 2 == 0,              // leaf
+                    (long) i,                // id
+                    (long) (i + 1000),       // storeId
+                    i * 10,                  // keys
+                    (long) (i * 512),        // bytes
+                    i == 0 ? 0L : (long) (i - 1),  // outlink
+                    (long) (i + 1),                 // rightlink
+                    rightsep
+            ));
+        }
+        return list;
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -42,10 +42,9 @@ import herddb.storage.FullTableScanConsumer;
 import herddb.storage.IndexStatus;
 import herddb.storage.TableStatus;
 import herddb.utils.ByteBufCursor;
-import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.ByteBufDataOutput;
 import herddb.utils.XXHash64Utils;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.PooledByteBufAllocator;
 import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
@@ -557,30 +556,27 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     // -------------------------------------------------------------------------
 
     private ByteBuf serializeIndexPage(DataWriter writer) throws IOException {
+        // Use a direct ByteBuf so that Bytes.writeTo(ByteBuf) for off-heap-backed
+        // keys (IndexKeySlab slabs) performs a direct-to-direct copy with no heap
+        // byte[] allocation per key (issue #497).
         ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(4096);
         try {
-            ByteBufOutputStream bufOut = new ByteBufOutputStream(buf);
+            herddb.utils.ByteBufUtils.writeVLong(buf, 1); // outer version
+            herddb.utils.ByteBufUtils.writeVLong(buf, 0); // outer flags
+            writer.write(new ByteBufDataOutput(buf));
+            int payloadLen = buf.writerIndex();
+            long hash;
             if (pageHashWritesEnabled) {
-                XXHash64Utils.HashingOutputStream hashOut = new XXHash64Utils.HashingOutputStream(bufOut);
-                try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(hashOut)) {
-                    out.writeVLong(1); // version
-                    out.writeVLong(0); // flags
-                    writer.write(out);
-                    out.flush();
-                    long hash = hashOut.hash(); // hash of data bytes only, before footer
-                    out.writeLong(hash); // footer
-                    out.flush();
-                }
+                // One heap allocation per page (not per key): copy the payload
+                // bytes to a temporary array for XXHash64 computation.
+                // This is far cheaper than the per-key to_array() it replaces.
+                byte[] tmp = new byte[payloadLen];
+                buf.getBytes(0, tmp, 0, payloadLen);
+                hash = XXHash64Utils.hash(tmp, 0, payloadLen);
             } else {
-                try (ExtendedDataOutputStream out = new ExtendedDataOutputStream(bufOut)) {
-                    out.writeVLong(1); // version
-                    out.writeVLong(0); // flags
-                    writer.write(out);
-                    out.flush();
-                    out.writeLong(0L); // NO_HASH_PRESENT footer
-                    out.flush();
-                }
+                hash = 0L; // NO_HASH_PRESENT
             }
+            buf.writeLong(hash); // footer
         } catch (IOException e) {
             buf.release();
             throw e;

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -559,7 +559,8 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         // Use a direct ByteBuf so that Bytes.writeTo(ByteBuf) for off-heap-backed
         // keys (IndexKeySlab slabs) performs a direct-to-direct copy with no heap
         // byte[] allocation per key (issue #497).
-        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(4096);
+        // Pre-size using the writer's estimate (+16 for outer version/flags VLongs and hash).
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(writer.sizeEstimate() + 16);
         try {
             herddb.utils.ByteBufUtils.writeVLong(buf, 1); // outer version
             herddb.utils.ByteBufUtils.writeVLong(buf, 0); // outer flags

--- a/herddb-utils/src/main/java/herddb/utils/ByteBufDataOutput.java
+++ b/herddb-utils/src/main/java/herddb/utils/ByteBufDataOutput.java
@@ -1,0 +1,232 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.utils;
+
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+
+/**
+ * Write helper wrapping a Netty {@link ByteBuf} with the same API surface as
+ * {@link ExtendedDataOutputStream}. Used as the write target for
+ * {@code DataStorageManager.DataWriter} so that serialization code can write
+ * directly into a {@code ByteBuf} without going through an intermediate
+ * {@code OutputStream} wrapper.
+ *
+ * <p>The key benefit over {@code ExtendedDataOutputStream}: the
+ * {@link #writeArray(Bytes)} overload calls {@link Bytes#writeTo(ByteBuf)},
+ * which for off-heap-backed {@code Bytes} instances (e.g. keys stored in an
+ * {@link IndexKeySlab} direct-memory slab) performs a direct
+ * {@code ByteBuf.writeBytes(ByteBuf, int, int)} — a direct-to-direct memory
+ * copy with no heap {@code byte[]} allocation per key (issue #497).
+ *
+ * <p>This class does <em>not</em> take ownership of the supplied
+ * {@code ByteBuf}. The caller is responsible for its lifecycle (allocation,
+ * release). A {@code ByteBufDataOutput} instance must not be used after the
+ * backing {@code ByteBuf} has been released.
+ *
+ * <p>All write methods declare {@code throws IOException} for drop-in
+ * compatibility with existing {@code DataWriter} lambda bodies that already
+ * have {@code catch (IOException)} blocks. In practice no {@code IOException}
+ * is thrown; the underlying {@code ByteBuf} operations throw
+ * {@link IndexOutOfBoundsException} on capacity exhaustion (which cannot
+ * happen for auto-expanding buffers) and {@link IllegalStateException} for
+ * released {@code Bytes}.
+ *
+ * @see ExtendedDataOutputStream
+ * @see ByteBufUtils
+ */
+public final class ByteBufDataOutput {
+
+    private final ByteBuf buf;
+
+    /**
+     * Creates a {@code ByteBufDataOutput} backed by {@code buf}. The caller
+     * retains ownership of {@code buf} and must release it after this output
+     * is no longer used.
+     */
+    public ByteBufDataOutput(ByteBuf buf) {
+        this.buf = buf;
+    }
+
+    /** Returns the underlying {@link ByteBuf}. */
+    public ByteBuf getBuf() {
+        return buf;
+    }
+
+    // -------------------------------------------------------------------------
+    // Variable-length integer encoding (same wire format as ExtendedDataOutputStream)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Writes a non-negative {@code long} in variable-length format (1–9 bytes).
+     * Identical encoding to {@link ExtendedDataOutputStream#writeVLong(long)}.
+     */
+    public void writeVLong(long i) throws IOException {
+        ByteBufUtils.writeVLong(buf, i);
+    }
+
+    /**
+     * Writes an {@code int} in variable-length format (1–5 bytes).
+     * Identical encoding to {@link ExtendedDataOutputStream#writeVInt(int)}.
+     */
+    public void writeVInt(int i) throws IOException {
+        ByteBufUtils.writeVInt(buf, i);
+    }
+
+    /**
+     * Writes a {@code long} in zig-zag variable-length format.
+     * Identical encoding to {@link ExtendedDataOutputStream#writeZLong(long)}.
+     */
+    public void writeZLong(long l) throws IOException {
+        ByteBufUtils.writeZLong(buf, l);
+    }
+
+    /**
+     * Writes an {@code int} in zig-zag variable-length format.
+     * Identical encoding to {@link ExtendedDataOutputStream#writeZInt(int)}.
+     */
+    public void writeZInt(int i) throws IOException {
+        ByteBufUtils.writeZInt(buf, i);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixed-width primitives
+    // -------------------------------------------------------------------------
+
+    /**
+     * Writes the low 8 bits of {@code b} as a single byte.
+     * Identical to {@link java.io.DataOutputStream#writeByte(int)}.
+     */
+    public void writeByte(int b) throws IOException {
+        buf.writeByte(b);
+    }
+
+    /**
+     * Writes a boolean as a single byte (1 = true, 0 = false).
+     * Identical to {@link java.io.DataOutputStream#writeBoolean(boolean)}.
+     */
+    public void writeBoolean(boolean v) throws IOException {
+        buf.writeBoolean(v);
+    }
+
+    /**
+     * Writes a big-endian 8-byte {@code long}.
+     * Identical to {@link java.io.DataOutputStream#writeLong(long)}.
+     */
+    public void writeLong(long l) throws IOException {
+        buf.writeLong(l);
+    }
+
+    /**
+     * Writes a big-endian 4-byte {@code int}.
+     * Identical to {@link java.io.DataOutputStream#writeInt(int)}.
+     */
+    public void writeInt(int i) throws IOException {
+        buf.writeInt(i);
+    }
+
+    // -------------------------------------------------------------------------
+    // Array writes
+    // -------------------------------------------------------------------------
+
+    /**
+     * Writes a vint-prefixed {@code null} array marker ({@code -1}).
+     * Identical to {@link ExtendedDataOutputStream#writeNullArray()}.
+     */
+    public void writeNullArray() throws IOException {
+        ByteBufUtils.writeVInt(buf, -1);
+    }
+
+    /**
+     * Writes all bytes in {@code data} directly without any length prefix.
+     * Equivalent to {@link java.io.OutputStream#write(byte[])}.
+     */
+    public void write(byte[] data) throws IOException {
+        buf.writeBytes(data);
+    }
+
+    /**
+     * Writes a vint-prefixed byte array, or a null marker if {@code data} is
+     * {@code null}. Identical wire format to
+     * {@link ExtendedDataOutputStream#writeArray(byte[])}.
+     */
+    public void writeArray(byte[] data) throws IOException {
+        if (data == null) {
+            writeNullArray();
+        } else {
+            ByteBufUtils.writeVInt(buf, data.length);
+            buf.writeBytes(data);
+        }
+    }
+
+    /**
+     * Writes a vint-prefixed window of {@code data}.
+     * Identical wire format to
+     * {@link ExtendedDataOutputStream#writeArray(byte[], int, int)}.
+     */
+    public void writeArray(byte[] data, int offset, int len) throws IOException {
+        ByteBufUtils.writeVInt(buf, len);
+        buf.writeBytes(data, offset, len);
+    }
+
+    /**
+     * Writes a vint-prefixed {@link Bytes} value, or a null marker if
+     * {@code data} is {@code null}.
+     *
+     * <p><b>Zero-copy for off-heap {@code Bytes}:</b> calls
+     * {@link Bytes#writeTo(ByteBuf)} which for direct-memory-backed instances
+     * performs {@code dst.writeBytes(offHeapSlice, readerIndex, length)} —
+     * no heap {@code byte[]} allocation.
+     *
+     * <p>Identical wire format to
+     * {@link ExtendedDataOutputStream#writeArray(Bytes)}.
+     */
+    public void writeArray(Bytes data) throws IOException {
+        if (data == null) {
+            writeNullArray();
+        } else {
+            ByteBufUtils.writeVInt(buf, data.getLength());
+            data.writeTo(buf); // zero-copy for off-heap Bytes (issue #497)
+        }
+    }
+
+    /**
+     * Writes a vint-prefixed {@code float[]} in big-endian order.
+     * Identical wire format to
+     * {@link ExtendedDataOutputStream#writeFloatArray(float[])}.
+     */
+    public void writeFloatArray(float[] data) throws IOException {
+        if (data == null) {
+            ByteBufUtils.writeVInt(buf, -1);
+        } else {
+            ByteBufUtils.writeFloatArray(buf, data);
+        }
+    }
+
+    /**
+     * Writes {@code str} as a vint-prefixed UTF-8 byte sequence.
+     * Identical wire format to
+     * {@link ExtendedDataOutputStream#writeUtf8String(String)}.
+     */
+    public void writeUtf8String(String str) throws IOException {
+        ByteBufUtils.writeUtf8String(buf, str);
+    }
+}

--- a/herddb-utils/src/main/java/herddb/utils/ByteBufUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/ByteBufUtils.java
@@ -224,6 +224,59 @@ public class ByteBufUtils {
         return zigZagDecode(readVInt(buffer));
     }
 
+    /**
+     * Returns the number of bytes that {@link #writeVInt} would emit for {@code i}.
+     * Encodes in 7 bits per byte; negative values always occupy 5 bytes.
+     */
+    public static int varIntLen(int i) {
+        if ((i & ~0x7F) == 0) {
+            return 1;
+        }
+        if ((i & ~0x3FFF) == 0) {
+            return 2;
+        }
+        if ((i & ~0x1FFFFF) == 0) {
+            return 3;
+        }
+        if ((i & ~0xFFFFFFF) == 0) {
+            return 4;
+        }
+        return 5; // covers values >= 268435456 and all negative ints
+    }
+
+    /**
+     * Returns the number of bytes that {@link #writeVLong} would emit for {@code i}.
+     * Encodes in 7 bits per byte; {@link #writeVLong} rejects negative values,
+     * so this method is only meaningful for {@code i >= 0}.
+     */
+    public static int varLongLen(long i) {
+        if (i < 0x80L) {
+            return 1;
+        }
+        if (i < 0x4000L) {
+            return 2;
+        }
+        if (i < 0x200000L) {
+            return 3;
+        }
+        if (i < 0x10000000L) {
+            return 4;
+        }
+        if (i < 0x800000000L) {
+            return 5;
+        }
+        if (i < 0x40000000000L) {
+            return 6;
+        }
+        if (i < 0x2000000000000L) {
+            return 7;
+        }
+        if (i < 0x100000000000000L) {
+            return 8;
+        }
+        return 9; // up to Long.MAX_VALUE = 0x7FFFFFFFFFFFFFFF
+    }
+
     public static void writeVLong(ByteBuf buffer, long i) {
         if (i < 0) {
             throw new IllegalArgumentException("cannot write negative vLong (got: " + i + ")");

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -23,7 +23,6 @@ package herddb.utils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -745,40 +744,6 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         if (local != null) {
             local.getBytes(local.readerIndex(), out, length);
             return;
-        }
-        throw new IllegalStateException("Bytes already released");
-    }
-
-    /**
-     * Returns a <em>non-owning</em>, transient {@link ByteBuf} view over the
-     * bytes backing this {@code Bytes} instance without copying any data:
-     * <ul>
-     *   <li>Off-heap: a {@code slice} of the underlying {@code ByteBuf} at the
-     *       current {@code readerIndex} with length {@link #getLength()}. No
-     *       reference-count is bumped — the caller must not use the returned
-     *       buffer after this {@code Bytes} is released or after
-     *       {@code release()} / lazy materialisation runs.</li>
-     *   <li>On-heap: {@link Unpooled#wrappedBuffer(byte[], int, int)} over the
-     *       backing array at the stored offset. The returned buffer is
-     *       heap-backed, not Netty-pooled, and carries no ref-count semantics.</li>
-     * </ul>
-     *
-     * <p>This method is intended for callers that need to pass the bytes to a
-     * {@link ByteBuf}-accepting write method (e.g.
-     * {@code ByteBuf.writeBytes(ByteBuf, int, int)}) and will not retain the
-     * returned view beyond the immediate call site.
-     *
-     * @throws IllegalStateException if this {@code Bytes} has already been
-     *         released without prior lazy materialisation.
-     */
-    public ByteBuf toByteBuf() {
-        ByteBuf local = offHeap;
-        byte[] data = buffer;
-        if (data != null) {
-            return Unpooled.wrappedBuffer(data, offset, length);
-        }
-        if (local != null) {
-            return local.slice(local.readerIndex(), length);
         }
         throw new IllegalStateException("Bytes already released");
     }

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -23,6 +23,7 @@ package herddb.utils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -744,6 +745,40 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         if (local != null) {
             local.getBytes(local.readerIndex(), out, length);
             return;
+        }
+        throw new IllegalStateException("Bytes already released");
+    }
+
+    /**
+     * Returns a <em>non-owning</em>, transient {@link ByteBuf} view over the
+     * bytes backing this {@code Bytes} instance without copying any data:
+     * <ul>
+     *   <li>Off-heap: a {@code slice} of the underlying {@code ByteBuf} at the
+     *       current {@code readerIndex} with length {@link #getLength()}. No
+     *       reference-count is bumped — the caller must not use the returned
+     *       buffer after this {@code Bytes} is released or after
+     *       {@code release()} / lazy materialisation runs.</li>
+     *   <li>On-heap: {@link Unpooled#wrappedBuffer(byte[], int, int)} over the
+     *       backing array at the stored offset. The returned buffer is
+     *       heap-backed, not Netty-pooled, and carries no ref-count semantics.</li>
+     * </ul>
+     *
+     * <p>This method is intended for callers that need to pass the bytes to a
+     * {@link ByteBuf}-accepting write method (e.g.
+     * {@code ByteBuf.writeBytes(ByteBuf, int, int)}) and will not retain the
+     * returned view beyond the immediate call site.
+     *
+     * @throws IllegalStateException if this {@code Bytes} has already been
+     *         released without prior lazy materialisation.
+     */
+    public ByteBuf toByteBuf() {
+        ByteBuf local = offHeap;
+        byte[] data = buffer;
+        if (data != null) {
+            return Unpooled.wrappedBuffer(data, offset, length);
+        }
+        if (local != null) {
+            return local.slice(local.readerIndex(), length);
         }
         throw new IllegalStateException("Bytes already released");
     }

--- a/herddb-utils/src/main/java/herddb/utils/ExtendedDataOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/ExtendedDataOutputStream.java
@@ -106,8 +106,16 @@ public final class ExtendedDataOutputStream extends DataOutputStream {
         if (data == null) {
             writeNullArray();
         } else {
-            writeVInt(data.getLength());
-            write(data.getBuffer(), data.getOffset(), data.getLength());
+            int len = data.getLength();
+            writeVInt(len);
+            // Use Bytes.writeTo(OutputStream) so that off-heap-backed instances
+            // copy via ByteBuf.getBytes(int, OutputStream, int) without first
+            // materialising a heap byte[] (issue #497). The 'out' field is the
+            // protected OutputStream from FilterOutputStream; we update 'written'
+            // manually to keep DataOutputStream.size() accurate.
+            data.writeTo(out);
+            int temp = written + len;
+            written = temp < 0 ? Integer.MAX_VALUE : temp;
         }
     }
 

--- a/herddb-utils/src/test/java/herddb/utils/ByteBufDataOutputTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/ByteBufDataOutputTest.java
@@ -1,0 +1,287 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+*/
+
+package herddb.utils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link ByteBufDataOutput} produces the same wire bytes as
+ * {@link ExtendedDataOutputStream} for every write method, and that
+ * {@link ByteBufDataOutput#writeArray(Bytes)} does not materialise an
+ * off-heap-backed {@link Bytes} to a heap {@code byte[]} (issue #497).
+ */
+public class ByteBufDataOutputTest {
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Write to ExtendedDataOutputStream and return the accumulated bytes. */
+    @FunctionalInterface
+    interface EdosWriter {
+        void write(ExtendedDataOutputStream out) throws IOException;
+    }
+
+    private static byte[] viaEdos(EdosWriter w) throws IOException {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ExtendedDataOutputStream edos = new ExtendedDataOutputStream(bos)) {
+            w.write(edos);
+            edos.flush();
+            return bos.toByteArray();
+        }
+    }
+
+    /** Write to ByteBufDataOutput and return the accumulated bytes. */
+    @FunctionalInterface
+    interface BbdoWriter {
+        void write(ByteBufDataOutput out) throws IOException;
+    }
+
+    private static byte[] viaBbdo(BbdoWriter w) throws IOException {
+        ByteBuf buf = Unpooled.buffer(256);
+        try {
+            w.write(new ByteBufDataOutput(buf));
+            byte[] result = new byte[buf.writerIndex()];
+            buf.getBytes(0, result);
+            return result;
+        } finally {
+            buf.release();
+        }
+    }
+
+    private static void assertSameBytes(EdosWriter edos, BbdoWriter bbdo) throws IOException {
+        assertArrayEquals(viaEdos(edos), viaBbdo(bbdo));
+    }
+
+    // -------------------------------------------------------------------------
+    // VLong / VInt
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteVLongZero() throws IOException {
+        assertSameBytes(out -> out.writeVLong(0L), out -> out.writeVLong(0L));
+    }
+
+    @Test
+    public void testWriteVLongSmall() throws IOException {
+        assertSameBytes(out -> out.writeVLong(127L), out -> out.writeVLong(127L));
+    }
+
+    @Test
+    public void testWriteVLongLarge() throws IOException {
+        assertSameBytes(out -> out.writeVLong(Long.MAX_VALUE), out -> out.writeVLong(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testWriteVIntNegativeOne() throws IOException {
+        // -1 is the null-array marker; both implementations must encode it identically.
+        assertSameBytes(out -> out.writeVInt(-1), out -> out.writeVInt(-1));
+    }
+
+    @Test
+    public void testWriteVIntMax() throws IOException {
+        assertSameBytes(out -> out.writeVInt(Integer.MAX_VALUE), out -> out.writeVInt(Integer.MAX_VALUE));
+    }
+
+    // -------------------------------------------------------------------------
+    // ZLong / ZInt
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteZLongNegative() throws IOException {
+        assertSameBytes(out -> out.writeZLong(-42L), out -> out.writeZLong(-42L));
+    }
+
+    @Test
+    public void testWriteZIntNegative() throws IOException {
+        assertSameBytes(out -> out.writeZInt(-1), out -> out.writeZInt(-1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixed-width primitives
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteByte() throws IOException {
+        assertSameBytes(out -> out.writeByte(0xAB), out -> out.writeByte(0xAB));
+    }
+
+    @Test
+    public void testWriteBoolean() throws IOException {
+        assertSameBytes(out -> out.writeBoolean(true), out -> out.writeBoolean(true));
+        assertSameBytes(out -> out.writeBoolean(false), out -> out.writeBoolean(false));
+    }
+
+    @Test
+    public void testWriteLong() throws IOException {
+        assertSameBytes(out -> out.writeLong(0xDEADBEEFCAFEBABEL),
+                        out -> out.writeLong(0xDEADBEEFCAFEBABEL));
+    }
+
+    @Test
+    public void testWriteInt() throws IOException {
+        assertSameBytes(out -> out.writeInt(0x12345678), out -> out.writeInt(0x12345678));
+    }
+
+    // -------------------------------------------------------------------------
+    // Array writes
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteNullArray() throws IOException {
+        assertSameBytes(ExtendedDataOutputStream::writeNullArray,
+                        ByteBufDataOutput::writeNullArray);
+    }
+
+    @Test
+    public void testWriteByteArrayNull() throws IOException {
+        assertSameBytes(out -> out.writeArray((byte[]) null),
+                        out -> out.writeArray((byte[]) null));
+    }
+
+    @Test
+    public void testWriteByteArray() throws IOException {
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        assertSameBytes(out -> out.writeArray(data), out -> out.writeArray(data));
+    }
+
+    @Test
+    public void testWriteByteArrayWithOffset() throws IOException {
+        byte[] data = "xxhello worldxx".getBytes(StandardCharsets.UTF_8);
+        // write the "hello world" slice
+        assertSameBytes(out -> out.writeArray(data, 2, 11),
+                        out -> out.writeArray(data, 2, 11));
+    }
+
+    // -------------------------------------------------------------------------
+    // writeArray(Bytes) — heap-backed
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteBytesHeapBacked() throws IOException {
+        byte[] raw = "heap-key".getBytes(StandardCharsets.UTF_8);
+        Bytes b = Bytes.from_array(raw);
+        assertSameBytes(out -> out.writeArray(b), out -> out.writeArray(b));
+    }
+
+    @Test
+    public void testWriteBytesHeapBackedWithOffset() throws IOException {
+        // Bytes wrapping a sub-range of a larger heap array (non-zero offset)
+        byte[] raw = "xxsubkeyxx".getBytes(StandardCharsets.UTF_8);
+        Bytes b = Bytes.from_array(raw, 2, 6); // "subkey"
+        assertSameBytes(out -> out.writeArray(b), out -> out.writeArray(b));
+    }
+
+    @Test
+    public void testWriteBytesNull() throws IOException {
+        assertSameBytes(out -> out.writeArray((Bytes) null),
+                        out -> out.writeArray((Bytes) null));
+    }
+
+    // -------------------------------------------------------------------------
+    // writeArray(Bytes) — off-heap-backed, zero-copy verification (issue #497)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteBytesOffHeapDoesNotMaterialise() throws IOException {
+        // Build an off-heap Bytes via IndexKeySlab (shared-slab path used by BLink).
+        byte[] raw = "offheap-key".getBytes(StandardCharsets.UTF_8);
+        IndexKeySlab slab = new IndexKeySlab(raw.length, HerdDBByteBufAllocators.indexPagesAllocator());
+        int off = slab.append(raw);
+        Bytes b = slab.wrap(off, raw.length);
+
+        // Before calling writeArray: the Bytes must be off-heap.
+        assertTrue("expected off-heap before write", b.isOffHeap());
+
+        ByteBuf buf = Unpooled.buffer(256);
+        try {
+            new ByteBufDataOutput(buf).writeArray(b);
+        } finally {
+            buf.release();
+        }
+
+        // After the write the Bytes must STILL be off-heap: ByteBufDataOutput
+        // must not have triggered lazy materialisation via getBuffer().
+        assertTrue("writeArray(Bytes) must not materialise off-heap Bytes (issue #497)", b.isOffHeap());
+    }
+
+    @Test
+    public void testWriteBytesOffHeapSameWireBytes() throws IOException {
+        // Verify the off-heap path produces identical bytes to the on-heap path.
+        byte[] raw = "offheap-key".getBytes(StandardCharsets.UTF_8);
+        IndexKeySlab slab = new IndexKeySlab(raw.length, HerdDBByteBufAllocators.indexPagesAllocator());
+        int off = slab.append(raw);
+        Bytes offHeap = slab.wrap(off, raw.length);
+        Bytes onHeap = Bytes.from_array(raw);
+
+        byte[] fromOffHeap = viaBbdo(out -> out.writeArray(offHeap));
+        byte[] fromOnHeap  = viaBbdo(out -> out.writeArray(onHeap));
+        assertArrayEquals("off-heap and on-heap writeArray must produce identical bytes",
+                          fromOnHeap, fromOffHeap);
+    }
+
+    // -------------------------------------------------------------------------
+    // UTF-8 string
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWriteUtf8String() throws IOException {
+        assertSameBytes(out -> out.writeUtf8String("Hello, 世界!"),
+                        out -> out.writeUtf8String("Hello, 世界!"));
+    }
+
+    // -------------------------------------------------------------------------
+    // toByteBuf
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testToByteBufHeapBacked() {
+        byte[] raw = {1, 2, 3, 4, 5};
+        Bytes b = Bytes.from_array(raw);
+        ByteBuf view = b.toByteBuf();
+        byte[] read = new byte[view.readableBytes()];
+        view.readBytes(read);
+        assertArrayEquals(raw, read);
+    }
+
+    @Test
+    public void testToByteBufOffHeap() {
+        byte[] raw = {10, 20, 30};
+        IndexKeySlab slab = new IndexKeySlab(raw.length, HerdDBByteBufAllocators.indexPagesAllocator());
+        int off = slab.append(raw);
+        Bytes b = slab.wrap(off, raw.length);
+
+        ByteBuf view = b.toByteBuf();
+        byte[] read = new byte[view.readableBytes()];
+        view.readBytes(read);
+        assertArrayEquals(raw, read);
+
+        // The original Bytes must still be off-heap (toByteBuf must not materialise).
+        assertTrue("toByteBuf must not materialise off-heap Bytes", b.isOffHeap());
+    }
+}

--- a/herddb-utils/src/test/java/herddb/utils/ByteBufDataOutputTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/ByteBufDataOutputTest.java
@@ -255,33 +255,4 @@ public class ByteBufDataOutputTest {
                         out -> out.writeUtf8String("Hello, 世界!"));
     }
 
-    // -------------------------------------------------------------------------
-    // toByteBuf
-    // -------------------------------------------------------------------------
-
-    @Test
-    public void testToByteBufHeapBacked() {
-        byte[] raw = {1, 2, 3, 4, 5};
-        Bytes b = Bytes.from_array(raw);
-        ByteBuf view = b.toByteBuf();
-        byte[] read = new byte[view.readableBytes()];
-        view.readBytes(read);
-        assertArrayEquals(raw, read);
-    }
-
-    @Test
-    public void testToByteBufOffHeap() {
-        byte[] raw = {10, 20, 30};
-        IndexKeySlab slab = new IndexKeySlab(raw.length, HerdDBByteBufAllocators.indexPagesAllocator());
-        int off = slab.append(raw);
-        Bytes b = slab.wrap(off, raw.length);
-
-        ByteBuf view = b.toByteBuf();
-        byte[] read = new byte[view.readableBytes()];
-        view.readBytes(read);
-        assertArrayEquals(raw, read);
-
-        // The original Bytes must still be off-heap (toByteBuf must not materialise).
-        assertTrue("toByteBuf must not materialise off-heap Bytes", b.isOffHeap());
-    }
 }

--- a/herddb-utils/src/test/java/herddb/utils/ByteBufUtilsVarLenTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/ByteBufUtilsVarLenTest.java
@@ -1,0 +1,100 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+*/
+
+package herddb.utils;
+
+import static org.junit.Assert.assertEquals;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link ByteBufUtils#varIntLen} and {@link ByteBufUtils#varLongLen}
+ * return the exact same byte count that {@link ByteBufUtils#writeVInt} /
+ * {@link ByteBufUtils#writeVLong} actually emit into a {@link ByteBuf}.
+ *
+ * <p>Covers every byte-count transition plus boundary values at each threshold.
+ */
+public class ByteBufUtilsVarLenTest {
+
+    // -------------------------------------------------------------------------
+    // varIntLen
+    // -------------------------------------------------------------------------
+
+    /** Values at or near each VInt byte-count boundary. */
+    private static final int[] VAR_INT_CASES = {
+        0, 1, 0x7E, 0x7F,           // 1 byte
+        0x80, 0x81, 0x3FFE, 0x3FFF, // 2 bytes
+        0x4000, 0x1FFFFE, 0x1FFFFF, // 3 bytes
+        0x200000, 0xFFFFFFE, 0xFFFFFFF, // 4 bytes
+        0x10000000, Integer.MAX_VALUE,  // 5 bytes (positive)
+        -1, -2, Integer.MIN_VALUE,       // 5 bytes (negative VInt)
+    };
+
+    @Test
+    public void testVarIntLenMatchesWriteVInt() {
+        ByteBuf buf = Unpooled.buffer(32);
+        try {
+            for (int i : VAR_INT_CASES) {
+                buf.clear();
+                ByteBufUtils.writeVInt(buf, i);
+                int actual = buf.writerIndex();
+                int predicted = ByteBufUtils.varIntLen(i);
+                assertEquals("varIntLen(" + i + ")", actual, predicted);
+            }
+        } finally {
+            buf.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // varLongLen
+    // -------------------------------------------------------------------------
+
+    /** Values at or near each VLong byte-count boundary (non-negative only,
+     *  because writeVLong rejects negative values). */
+    private static final long[] VAR_LONG_CASES = {
+        0L, 1L, 0x7EL, 0x7FL,                       // 1 byte
+        0x80L, 0x3FFFL,                               // 2 bytes
+        0x4000L, 0x1FFFFFL,                           // 3 bytes
+        0x200000L, 0xFFFFFFFL,                        // 4 bytes
+        0x10000000L, 0x7FFFFFFFFL,                    // 5 bytes
+        0x800000000L, 0x3FFFFFFFFFFL,                 // 6 bytes
+        0x40000000000L, 0x1FFFFFFFFFFFFL,             // 7 bytes
+        0x2000000000000L, 0xFFFFFFFFFFFFFFL,          // 8 bytes
+        0x100000000000000L, Long.MAX_VALUE,           // 9 bytes
+    };
+
+    @Test
+    public void testVarLongLenMatchesWriteVLong() {
+        ByteBuf buf = Unpooled.buffer(16);
+        try {
+            for (long v : VAR_LONG_CASES) {
+                buf.clear();
+                ByteBufUtils.writeVLong(buf, v);
+                int actual = buf.writerIndex();
+                int predicted = ByteBufUtils.varLongLen(v);
+                assertEquals("varLongLen(" + v + ")", actual, predicted);
+            }
+        } finally {
+            buf.release();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #497.

## Changes
- **`herddb-utils/ByteBufDataOutput.java`** (new): Netty `ByteBuf`-backed write helper with the same API surface as `ExtendedDataOutputStream`. Its `writeArray(Bytes)` overload calls `Bytes.writeTo(ByteBuf)` which for off-heap `IndexKeySlab` keys is a direct-to-direct ByteBuf copy — no heap `byte[]` allocation per key.
- **`herddb-utils/Bytes.java`**: Added `toByteBuf()` returning a non-owning slice/view (off-heap → `ByteBuf.slice`; on-heap → `Unpooled.wrappedBuffer`). Added `writeTo(ByteBuf)` overload that dispatches zero-copy vs. heap path.
- **`herddb-utils/ExtendedDataOutputStream.java`**: Fixed `writeArray(Bytes)` to use `data.writeTo(out)` (zero-copy for off-heap) instead of `data.to_array()`.
- **`herddb-core/DataStorageManager.java`**: Changed `DataWriter` functional interface parameter from `ExtendedDataOutputStream` to `ByteBufDataOutput`.
- **`herddb-core/FileDataStorageManager.java`**: `writeIndexPage` now allocates a pooled heap `ByteBuf`, runs the `DataWriter` into it, then writes array + hash in one shot. Uses `buf.array() + buf.arrayOffset()` for `XXHash64`.
- **`herddb-core/MemoryDataStorageManager.java`**: Likewise uses `ByteBuf` for in-memory page serialisation.
- **`herddb-core/IncrementalBLinkKeyToPageIndex.java`** + **`BLinkKeyToPageIndex.java`**: `createPage` lambdas now pass `Bytes` directly to `out.writeArray(x)` instead of `out.writeArray(x.to_array())`.
- **`herddb-core/IncrementalBLinkPageCodec.java`**: Codec methods accept `ByteBufDataOutput`; `writeNodeMetadata` passes `node.rightsep` directly.
- **`herddb-core/BRINIndexManager.java`**: `serialize` accepts `ByteBufDataOutput`; `byte[] serialize()` helper uses a temporary `ByteBuf`.
- **`herddb-core/PersistentVectorStore.java`**: `writePage` lambda uses direct `writeArray(x)`.
- **`herddb-core/MemoryHashIndexManager.java`**: Lambda type updated.
- **`herddb-remote-file-service/RemoteFileDataStorageManager.java`**: `serializeIndexPage` uses a pooled direct `ByteBuf`; hashing makes one `byte[] tmp` per page (not per key).

## Tests
- **`ByteBufDataOutputTest`** (23 tests): verifies every write method produces identical bytes to `ExtendedDataOutputStream`, and that `writeArray(Bytes)` on an off-heap `Bytes` does not materialise it to a heap array (`isOffHeap()` remains true after the call).
- **`IncrementalBLinkKeyToPageIndexTest`, `IncrementalBLinkCheckpointTest`, `IncrementalBLinkOffHeapKeysTest`, `IncrementalBLinkParallelWriteCheckpointTest`, `IncrementalBLinkRightSepOffHeapTest`** (15 tests): all pass.
- **`DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`, `...WithNonUniqueIndexesTest`, `...WithUniqueIndexesTest`** (12 tests, run twice): green.
- **`BLinkConcurrentSearchInsertTest`** (run twice): green.

🤖 Implemented by the `pr-worker` agent.