### PR TITLE
issue #499: stamp legacy v3 segments on optimizer start + raise optimizer memory to 8Gi

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -1695,8 +1695,26 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // IndexStatus segments with no znode get re-registered. We catch broad
         // Exception here on purpose — reconcile is best-effort, the IS must
         // start regardless.
+        //
+        // Issue #499 Bug 2: legacy (v3) segments have null UUIDs and were previously
+        // skipped during reconcile, so the external optimizer never saw them in ZK.
+        // buildExistingSegmentsInfoForReconcile() now stamps fresh UUIDs in-place on
+        // null-UUID VectorSegments. We detect whether any were stamped by counting
+        // null UUIDs before the call, then immediately persist the IndexStatus so the
+        // new UUIDs survive the next restart. The persist runs before the store is
+        // considered fully started and before handing control to callers. We catch
+        // broad Exception on the persist too — a failure here is recoverable: the
+        // next checkpoint will re-stamp and re-persist the UUIDs.
         SegmentPublisher reconciler = this.segmentPublisher;
         if (reconciler != null) {
+            // Count segments with null UUID before the call so we know whether
+            // buildExistingSegmentsInfoForReconcile() stamped any fresh UUIDs.
+            long nullUuidCountBefore = 0;
+            for (VectorSegment seg : this.segments) {
+                if (seg.segmentUuid == null) {
+                    nullUuidCountBefore++;
+                }
+            }
             try {
                 reconciler.reconcileWithIndexStatus(buildExistingSegmentsInfoForReconcile());
             } catch (Exception e) {
@@ -1704,6 +1722,39 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         "segment publisher.reconcileWithIndexStatus failed for {0}; "
                                 + "continuing with un-reconciled state", indexName);
                 LOGGER.log(Level.WARNING, "reconcile failure detail", e);
+            }
+            // If any legacy segments were stamped with fresh UUIDs, persist the
+            // updated IndexStatus immediately so the UUIDs survive the next restart.
+            // Without this persist, a restart before the next checkpoint would lose
+            // the stamped UUIDs and force a new round of stamps (and ZK re-registrations)
+            // on the following start.
+            if (nullUuidCountBefore > 0) {
+                try {
+                    List<VectorSegment> currentSegs = this.segments;
+                    List<VectorSegment> sealedForPersist = new ArrayList<>();
+                    List<VectorSegment> mergeableForPersist = new ArrayList<>();
+                    for (VectorSegment seg : currentSegs) {
+                        if (seg.isSealed(maxSegmentSize)) {
+                            sealedForPersist.add(seg);
+                        } else {
+                            mergeableForPersist.add(seg);
+                        }
+                    }
+                    persistIndexStatusMultiSegment(sealedForPersist, mergeableForPersist,
+                            java.util.Collections.emptyList(), this.loadedLsn);
+                    LOGGER.log(Level.INFO,
+                            "persisted updated IndexStatus for {0} after stamping {1}"
+                                    + " legacy segment(s) with fresh UUIDs (issue #499)",
+                            new Object[]{indexName, nullUuidCountBefore});
+                } catch (Exception e) {
+                    // Best-effort: the next checkpoint will re-stamp and re-persist.
+                    // The IS must start regardless of this persist failure.
+                    LOGGER.log(Level.WARNING,
+                            "failed to persist UUID-stamped IndexStatus for {0}; "
+                                    + "next checkpoint will re-stamp (issue #499): {1}",
+                            new Object[]{indexName, e.getMessage()});
+                    LOGGER.log(Level.WARNING, "persist failure detail", e);
+                }
             }
         }
 
@@ -4814,15 +4865,36 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /**
      * Walks the in-memory segments (loaded from IndexStatus) and produces a
      * {@link NewSegmentInfo} list suitable for {@link SegmentPublisher#reconcileWithIndexStatus}.
-     * Only segments with a non-null UUID participate (legacy segments are skipped).
-     * Called once at {@link #start()} when a publisher is attached.
+     *
+     * <p>Segments that already carry a non-null UUID (v4 IndexStatus) are included as-is.
+     * Legacy (v3 IndexStatus) segments whose {@code segmentUuid} field is {@code null} are
+     * stamped with a fresh {@link java.util.UUID#randomUUID()} in-place on the
+     * {@link VectorSegment} object so that:
+     * <ol>
+     *   <li>The ZK segment registry is populated on the very first optimizer-enabled IS
+     *       start, making existing segments visible to the external optimizer (issue #499
+     *       Bug 2).</li>
+     *   <li>The caller ({@link #start()}) detects the stamp and immediately persists the
+     *       updated IndexStatus so the same UUID survives the next restart (the stamp is
+     *       idempotent: on the second start the UUID is already non-null and is reused).</li>
+     * </ol>
+     *
+     * @return the list of {@link NewSegmentInfo} entries to pass to
+     *     {@link SegmentPublisher#reconcileWithIndexStatus}; never {@code null}
      */
     private List<NewSegmentInfo> buildExistingSegmentsInfoForReconcile() {
         List<NewSegmentInfo> info = new ArrayList<>(segments.size());
         long generation = currentIndexStatusGeneration.get();
         for (VectorSegment seg : segments) {
             if (seg.segmentUuid == null) {
-                continue;
+                // Legacy (v3) segment — stamp a fresh UUID so the external optimizer
+                // can see it in ZK. The UUID is stored on the VectorSegment in memory;
+                // start() will call persistIndexStatusMultiSegment to make it durable
+                // before the IS becomes fully operational (issue #499 Bug 2).
+                seg.segmentUuid = java.util.UUID.randomUUID().toString();
+                LOGGER.log(Level.INFO,
+                        "stamped legacy segment {0} with UUID {1} for reconcile (index {2})",
+                        new Object[]{seg.segmentId, seg.segmentUuid, indexName});
             }
             // baseLsn for already-loaded segments is unknown post-restart (the
             // sequence-number was an attribute of the IndexStatus snapshot, not of

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/LegacySegmentUuidStampOnOptimizerStartTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/LegacySegmentUuidStampOnOptimizerStartTest.java
@@ -1,0 +1,245 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.segment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.file.FileDataStorageManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #499 Bug 2: legacy v3-format segments (produced by
+ * an IS that ran without the external optimizer) must be stamped with fresh UUIDs
+ * and registered in the external ZK segment registry on the first optimizer-enabled
+ * IS startup.
+ *
+ * <p>Scenario:
+ * <ol>
+ *   <li>Boot a {@link PersistentVectorStore} WITHOUT a {@link SegmentRegistryPublisher}
+ *       (legacy IS mode, no optimizer). Insert vectors and checkpoint — produces a v3
+ *       IndexStatus with no per-segment UUIDs.</li>
+ *   <li>Reopen the same store WITH a publisher (first optimizer-enabled start).
+ *       Assert that all previously-null-UUID segments are now stamped, registered in ZK
+ *       as ACTIVE, and that the updated IndexStatus is persisted to disk immediately
+ *       (so the stamps survive the next restart without a checkpoint).</li>
+ *   <li>Reopen a second time with a fresh publisher instance. Assert idempotency: the
+ *       same UUIDs are reused, no duplicate registrations are created, and the registry
+ *       still contains exactly the same entries as after step 2.</li>
+ * </ol>
+ */
+public class LegacySegmentUuidStampOnOptimizerStartTest {
+
+    private static final String BASE_PATH = "/herd-test-499";
+    private static final String TABLE_SPACE = "tstblspace";
+    private static final String TABLE_NAME = "docs";
+    private static final String INDEX_NAME = "docs_vidx";
+    private static final String INDEX_UUID = "testidx-499";
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+    private SegmentRegistryClient registry;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30000, event -> {
+            if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue("ZK connect timed out", connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registry = new SegmentRegistryClient(() -> zk, BASE_PATH);
+        registry.ensureRoot();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    /** Creates a store backed by a real {@link FileDataStorageManager} for IndexStatus persistence. */
+    private PersistentVectorStore createStore(Path tmpDir, FileDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore(INDEX_NAME, TABLE_NAME, TABLE_SPACE,
+                "vector_col", INDEX_UUID, tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+    }
+
+    private float[] randomVector(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Main scenario: v3 index (no UUID) → first optimizer-enabled start stamps and
+     * registers all segments → second start is idempotent.
+     */
+    @Test
+    public void legacySegmentsStampedAndRegisteredOnFirstOptimizerStart() throws Exception {
+        Path baseDir = tmpFolder.newFolder("data").toPath();
+        Path tmpDir = tmpFolder.newFolder("tmp").toPath();
+        FileDataStorageManager dsm = new FileDataStorageManager(baseDir);
+        dsm.initTablespace(TABLE_SPACE);
+
+        int dim = 32;
+        int vectorCount = 400;
+
+        // === Step 1: boot WITHOUT publisher — produces v3 IndexStatus (no UUIDs).
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            // No setSegmentPublisher → no UUID stamping during checkpoint.
+            store.start();
+            for (int i = 0; i < vectorCount; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(new Random(i), dim));
+            }
+            store.checkpoint();
+        }
+
+        // Confirm ZK is empty — no publisher was active during the first boot.
+        List<VersionedSegmentMetadata> afterLegacyBoot = registry.listSegments(TABLE_SPACE, INDEX_UUID);
+        assertTrue("ZK must be empty after legacy (no-publisher) boot; got: " + afterLegacyBoot,
+                afterLegacyBoot.isEmpty());
+
+        // === Step 2: reopen WITH publisher (first optimizer-enabled start).
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TABLE_SPACE, TABLE_NAME, INDEX_UUID, INDEX_NAME, /* instanceId= */ 0);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.setSegmentPublisher(publisher);
+            store.start();
+            // start() must have stamped UUIDs on the legacy segments AND persisted the
+            // updated IndexStatus AND registered them in ZK via reconcileWithIndexStatus().
+        }
+
+        List<VersionedSegmentMetadata> afterFirstOptimizerStart =
+                registry.listSegments(TABLE_SPACE, INDEX_UUID);
+        assertFalse("ZK must contain segments after the first optimizer-enabled start",
+                afterFirstOptimizerStart.isEmpty());
+
+        // All registered segments must be ACTIVE.
+        for (VersionedSegmentMetadata v : afterFirstOptimizerStart) {
+            assertEquals("segment must be ACTIVE after reconcile; got: " + v.metadata(),
+                    SegmentState.ACTIVE, v.metadata().getState());
+            assertNotNull("segment UUID must not be null", v.metadata().getSegmentUuid());
+        }
+
+        Set<String> uuidsAfterFirst = new HashSet<>();
+        for (VersionedSegmentMetadata v : afterFirstOptimizerStart) {
+            assertTrue("duplicate UUID detected: " + v.metadata().getSegmentUuid(),
+                    uuidsAfterFirst.add(v.metadata().getSegmentUuid()));
+        }
+        int segCountAfterFirst = afterFirstOptimizerStart.size();
+
+        // === Step 3: second start — must be idempotent (same UUIDs, same count).
+        SegmentRegistryPublisher publisher2 = new SegmentRegistryPublisher(
+                registry, TABLE_SPACE, TABLE_NAME, INDEX_UUID, INDEX_NAME, 0);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.setSegmentPublisher(publisher2);
+            store.start();
+            // No new inserts or checkpoints — only reconcile runs.
+        }
+
+        List<VersionedSegmentMetadata> afterSecondStart =
+                registry.listSegments(TABLE_SPACE, INDEX_UUID);
+
+        // The count must be unchanged — reconcile must not create duplicate entries.
+        assertEquals("segment count must be unchanged after the second optimizer-enabled start;"
+                        + " first=" + segCountAfterFirst + " second=" + afterSecondStart.size(),
+                segCountAfterFirst, afterSecondStart.size());
+
+        // The same UUIDs must still be present — no new UUIDs were issued.
+        Set<String> uuidsAfterSecond = new HashSet<>();
+        for (VersionedSegmentMetadata v : afterSecondStart) {
+            uuidsAfterSecond.add(v.metadata().getSegmentUuid());
+        }
+        assertEquals("UUID set must be identical after the second optimizer-enabled start",
+                uuidsAfterFirst, uuidsAfterSecond);
+
+        // All segments must still be ACTIVE.
+        for (VersionedSegmentMetadata v : afterSecondStart) {
+            assertEquals("segment must still be ACTIVE after second start; got: " + v.metadata(),
+                    SegmentState.ACTIVE, v.metadata().getState());
+        }
+    }
+
+    /**
+     * A store that never had any segments (empty IndexStatus) must produce no ZK
+     * entries on the first optimizer-enabled start.
+     */
+    @Test
+    public void emptyIndexProducesNoZkEntriesOnOptimizerStart() throws Exception {
+        Path baseDir = tmpFolder.newFolder("data-empty").toPath();
+        Path tmpDir = tmpFolder.newFolder("tmp-empty").toPath();
+        FileDataStorageManager dsm = new FileDataStorageManager(baseDir);
+        dsm.initTablespace(TABLE_SPACE);
+
+        // Boot without publisher (no checkpoint → no IndexStatus written at all).
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+            // no addVector, no checkpoint
+        }
+
+        // First optimizer-enabled start on a completely empty store.
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TABLE_SPACE, TABLE_NAME, INDEX_UUID, INDEX_NAME, 0);
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.setSegmentPublisher(publisher);
+            store.start();
+        }
+
+        assertTrue("empty index must produce no ZK entries",
+                registry.listSegments(TABLE_SPACE, INDEX_UUID).isEmpty());
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -391,6 +391,27 @@ indexOptimizer:
     neighborOverflow: 1.2
     alpha: 1.4
     similarity: "DOT_PRODUCT"
+  # Memory budget for gist1m M=16 merges (issue #499 Bug 1).
+  #
+  # For a full 8-segment gist1m merge (8 × ~125k vectors, 960-dim):
+  #   PQ codebook retraining reservoir: 96k samples × 960 × 4 B = 353 MB
+  #   jvector OnDiskGraphIndexCompactor working set: ~2–4 GiB
+  #   JVM overhead (code cache, metaspace, thread stacks): ~1 GiB
+  # Total peak: ≈ 6 GiB heap + 1 GiB direct → 8 GiB container.
+  # The previous 4 GiB container caused OOMKill at PQ training time.
+  #
+  #   -Xms6g -Xmx6g: heap fixed at 6 g to avoid GC pauses during long merges
+  #   --add-modules jdk.incubator.vector: Panama Vector API for SIMD kernels
+  #   -XX:MaxDirectMemorySize=1g: cap for non-Netty JVM direct buffers
+  #   -Djava.net.preferIPv4Stack=true: avoids IPv6 resolution in k3s-local
+  javaOpts: "-Xms6g -Xmx6g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector -XX:MaxDirectMemorySize=1g"
+  resources:
+    requests:
+      memory: "8Gi"
+      cpu: "2"
+    limits:
+      memory: "8Gi"
+      cpu: "2"
 
 tools:
   enabled: true

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -391,7 +391,21 @@ indexOptimizer:
     maxInflightReadBytes: "268435456"   # 256 MiB
     maxInflightWriteBytes: "268435456"  # 256 MiB
   zkSessionTimeout: 40000
-  javaOpts: ""
+  # JVM options for the optimizer process. The optimizer needs enough heap and
+  # direct memory to execute PQ retraining + graph-merge in a single JVM:
+  #   -Xms/-Xmx: heap for PQ codebook training, intermediate graph structures,
+  #     and the jvector merge working set. For gist1m M=16 (1M × 960-dim) the
+  #     PQ training reservoir alone requires ~350 MB; the graph merge adds
+  #     several more GB of working set. 6 g is the minimum for gist1m-class
+  #     merges without OOMKill (issue #499 Bug 1).
+  #   --add-modules jdk.incubator.vector: enables Panama Vector API for
+  #     jvector's SIMD distance kernels.
+  #   -XX:MaxDirectMemorySize: cap for non-Netty JVM direct buffers.
+  #   -Djava.net.preferIPv4Stack=true: avoids IPv6 resolution delays in
+  #     Kubernetes pods that only have IPv4 routes.
+  # Default: 6 g heap + 1 g direct. Override per-bench if the input segments
+  # are larger (e.g. bigann-100M M=16 needs at least 12 g heap).
+  javaOpts: "-Xms6g -Xmx6g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector -XX:MaxDirectMemorySize=1g"
   javaOptsExtra: ""
   loggingProperties: ""
   extraConfig: {}
@@ -405,12 +419,16 @@ indexOptimizer:
   pdb:
     enabled: false
     minAvailable: 0
+  # Memory sized to hold the optimizer's heap (javaOpts -Xmx) plus JVM
+  # non-heap overhead (~1 GiB for code-cache, metaspace, thread stacks)
+  # plus direct memory (MaxDirectMemorySize). For the default 6 g heap
+  # + 1 g direct: 6 + 1 + 1 = 8 GiB container (issue #499 Bug 1).
   resources:
     requests:
-      memory: "1Gi"
+      memory: "8Gi"
       cpu: "2"
     limits:
-      memory: "1Gi"
+      memory: "8Gi"
       cpu: "2"
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Fixes #499.

## Changes

- **`herddb-core/.../PersistentVectorStore.java`** — Bug 2 fix: `buildExistingSegmentsInfoForReconcile()` previously skipped legacy (v3-format) segments whose `segmentUuid` was `null`, so existing segments were never visible to the external optimizer's ZK registry. The method now stamps fresh UUIDs on null-UUID `VectorSegment` objects in-place. `start()` detects that legacy segments were stamped and immediately calls `persistIndexStatusMultiSegment` to make the UUIDs durable — so a restart before the next checkpoint still reuses the same UUIDs and does not re-register.

- **`herddb-kubernetes/.../values.yaml`** — Bug 1 fix: raise `indexOptimizer.resources.requests/limits.memory` from `1Gi` to `8Gi` and add `javaOpts` (`-Xms6g -Xmx6g --add-modules jdk.incubator.vector -XX:MaxDirectMemorySize=1g -Djava.net.preferIPv4Stack=true`) to prevent OOMKill during PQ codebook retraining on gist1m M=16 merges.

- **`herddb-kubernetes/.../examples/k3s-local/values.yaml`** — Same memory and JVM option additions as the chart defaults, sized specifically for gist1m M=16 benchmarks running in k3s-local.

## Tests

- **`LegacySegmentUuidStampOnOptimizerStartTest`** — Two test cases:
  1. `legacySegmentsStampedAndRegisteredOnFirstOptimizerStart`: boots a store without a publisher (produces v3 IndexStatus with no UUIDs), then reopens with a `SegmentRegistryPublisher` and verifies all segments are ACTIVE in ZK; a second restart is idempotent (same UUID set, same count, all ACTIVE).
  2. `emptyIndexProducesNoZkEntriesOnOptimizerStart`: an empty index with no checkpointed segments produces no ZK entries on optimizer-enabled start.

- All existing segment registry tests (`SegmentUuidRestartDurabilityTest`, `SegmentRegistryReconcileTest`, `SegmentRegistryPublisherMapFileSizeTest`) continue to pass.

🤖 Implemented by the `pr-worker` agent.