### PR TITLE
issue #499: drop v3 IndexStatus format + raise optimizer memory to 8Gi

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -269,17 +269,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
     static final int CHUNK_SIZE = 1_048_576;
 
     /**
-     * Multi-segment multipart metadata format. Carries per-segment
-     * {@code generation}, a per-IndexStatus monotonic generation
-     * counter, and a {@code pendingDeletes} list driving the
-     * graph-merge compaction retention protocol.
-     */
-    private static final int METADATA_VERSION_MULTI_SEGMENT = 3;
-    /**
-     * Format version 4 adds a per-segment {@code segmentUuid} string. Written when ANY
-     * segment in the IndexStatus carries a non-null UUID (i.e. the index is in
-     * segmented-v2 mode); otherwise we keep writing v3 to preserve binary-compatible
-     * rollback for legacy clusters. The reader supports both versions.
+     * Multi-segment multipart metadata format, version 4. Carries per-segment
+     * {@code generation}, a per-IndexStatus monotonic generation counter, a
+     * {@code pendingDeletes} list driving the graph-merge compaction retention
+     * protocol, and a mandatory per-segment {@code segmentUuid} string used by
+     * the external optimizer's ZooKeeper segment registry.
+     *
+     * <p>Version 3 (which lacked the {@code segmentUuid} field) is no longer
+     * supported for reading or writing. Any attempt to load a v3 index will
+     * result in a clear boot failure with instructions to delete and re-create
+     * the index.
      */
     private static final int METADATA_VERSION_MULTI_SEGMENT_V4 = 4;
 
@@ -412,14 +411,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     private volatile boolean externalCompactionEnabled;
 
-    /**
-     * Cached "this index is segmented-v2 (has at least one UUID-stamped segment)"
-     * flag (review-item N1 from second pr-reviewer pass). Once flipped to
-     * {@code true} it stays true — even legacy v3 segments coexisting with a
-     * v4 segment in the same IndexStatus must be persisted in v4 format. Avoids
-     * re-scanning all sealed/mergeable/new lists on every checkpoint.
-     */
-    private volatile boolean segmentedV2Cached;
+    // segmentedV2Cached removed: v3 format is no longer supported; all indexes
+    // are written in v4 format (which always includes segmentUuid per segment).
 
     /**
      * Test hook (package-private) — runs in Phase B AFTER the staged publish and
@@ -1548,11 +1541,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
         /** Number of live vectors written to this segment. */
         final long vectorCount;
         /**
-         * Stable UUID stamped onto this segment for segmented-v2 indexes. Populated
-         * by {@link #stampSegmentUuid(String)} in Phase B once we know we will publish
-         * to a {@link SegmentPublisher}; carried through to {@link NewSegmentInfo} and
-         * persisted in v4 IndexStatus so the same UUID survives restarts. {@code null}
-         * for legacy (v3) indexes.
+         * Stable UUID stamped onto this segment once we know we will publish to a
+         * {@link SegmentPublisher}. Populated by {@link #stampSegmentUuid(String)} in
+         * Phase B; carried through to {@link NewSegmentInfo} and persisted in the v4
+         * IndexStatus so the same UUID survives restarts. {@code null} when no publisher
+         * is attached (i.e. the external optimizer is not enabled for this store).
          */
         String segmentUuid;
 
@@ -2545,6 +2538,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
         if (publisherSnapshot != null && mergedOutput != null) {
             // Stamp UUID — same flow as Phase B: durable UUID survives a
             // restart so we cannot double-register the same physical file.
+            // mergedOutput.segmentUuid should always be null here (freshly merged),
+            // but guard defensively in case a future caller pre-stamps it.
             if (mergedOutput.segmentUuid == null) {
                 mergedOutput.segmentUuid = java.util.UUID.randomUUID().toString();
             }
@@ -2559,9 +2554,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
             inputInfosForRegistry = new ArrayList<>(inputs.size());
             for (VectorSegment in : inputs) {
-                // Legacy (v3) inputs without a UUID are not in the registry —
-                // skip them in the validate/deprecate set. The in-memory swap
-                // still happens below.
+                // All segments in v4-format indexes carry a UUID. A null UUID here
+                // means a segment was checkpointed before a publisher was ever attached
+                // (the very first checkpoint after the publisher feature was enabled).
+                // Such segments are not registered in ZK yet; they will be picked up by
+                // the next reconcile pass. Skip them in the validate/deprecate set.
                 if (in.segmentUuid != null) {
                     inputInfosForRegistry.add(new NewSegmentInfo(
                             in.segmentId, in.segmentUuid,
@@ -4749,6 +4746,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * {@link SegmentWriteResult}s. Used both by {@link #stageNewSegmentsBestEffort}
      * (before IndexStatus persist) and {@link #commitStagedSegmentsBestEffort}
      * (after) so the same identity flows through both phases.
+     *
+     * <p>All {@link SegmentWriteResult}s passed here must already have their
+     * {@code segmentUuid} stamped by the caller (the Phase B publish block).
+     * Any entry with a null UUID is skipped with a warning — this should not
+     * happen in normal operation.
      */
     private List<NewSegmentInfo> buildPublishInfo(
             List<SegmentWriteResult> newSegmentResults, LogSequenceNumber sequenceNumber,
@@ -4756,6 +4758,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
         List<NewSegmentInfo> info = new ArrayList<>(newSegmentResults.size());
         for (SegmentWriteResult swr : newSegmentResults) {
             if (swr.segmentUuid == null) {
+                // Defensive: should not occur because the Phase B loop stamps
+                // every UUID before calling this method.
                 LOGGER.log(Level.WARNING,
                         "skipping publish of segment {0} (segmentId={1}) — UUID was not stamped",
                         new Object[]{indexName, swr.segmentId});
@@ -4816,14 +4820,25 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /**
      * Walks the in-memory segments (loaded from IndexStatus) and produces a
      * {@link NewSegmentInfo} list suitable for {@link SegmentPublisher#reconcileWithIndexStatus}.
-     * Only segments with a non-null UUID participate (legacy segments are skipped).
      * Called once at {@link #start()} when a publisher is attached.
+     *
+     * <p>All segments in a v4 IndexStatus should carry a UUID. A null UUID can only
+     * appear for a segment checkpointed before the publisher was first attached (the
+     * first checkpoint after the optimizer feature was enabled writes UUIDs only for
+     * newly-emitted segments, not for pre-existing ones loaded from a v4 status). Such
+     * segments are skipped here; they will be picked up by the next checkpoint that
+     * re-seals them with a freshly assigned UUID.
      */
     private List<NewSegmentInfo> buildExistingSegmentsInfoForReconcile() {
         List<NewSegmentInfo> info = new ArrayList<>(segments.size());
         long generation = currentIndexStatusGeneration.get();
         for (VectorSegment seg : segments) {
             if (seg.segmentUuid == null) {
+                // No UUID: this segment was checkpointed before the publisher was
+                // attached. Skip it — the next checkpoint will assign a UUID.
+                LOGGER.log(Level.FINE,
+                        "segment {0} (index {1}) has no UUID; skipping reconcile entry",
+                        new Object[]{seg.segmentId, indexName});
                 continue;
             }
             // baseLsn for already-loaded segments is unknown post-restart (the
@@ -5487,23 +5502,26 @@ public class PersistentVectorStore extends AbstractVectorStore {
         ByteBuffer metaBuf = ByteBuffer.wrap(status.indexData);
 
         int version = metaBuf.getInt();
-        if (version != METADATA_VERSION_MULTI_SEGMENT && version != METADATA_VERSION_MULTI_SEGMENT_V4) {
-            // Review-item B4 (second pr-reviewer pass): on rollback to a binary that
-            // doesn't know about a newer format version, the previous behaviour was to
-            // log SEVERE and "start empty" — i.e. silently drop every segment from the
-            // in-memory state while the underlying graph/map files still exist on
-            // remote storage. That makes queries return an empty result set without
-            // any indication to the operator that something went wrong. Fail-fast
-            // instead: an immediate boot failure is far easier to diagnose and far
-            // safer than a silent data-loss-equivalent regression.
+        if (version == 3) {
+            // v3 format (no per-segment segmentUuid) is no longer supported.
+            // v3 indexes were written before the external optimizer's ZooKeeper
+            // segment registry was introduced. Delete the index and re-create it
+            // to produce a v4 checkpoint with per-segment UUIDs.
+            throw new DataStorageManagerException(
+                    "vector index metadata version 3 is no longer supported for index " + indexName
+                            + ". The v3 format lacks per-segment UUIDs required by the external"
+                            + " optimizer. Delete the index and re-create it to produce a v4"
+                            + " checkpoint, or downgrade to a binary that supports v3.");
+        }
+        if (version != METADATA_VERSION_MULTI_SEGMENT_V4) {
+            // Unknown future version — the previous binary cannot read it.
+            // Fail fast: an immediate boot failure is far easier to diagnose
+            // than a silent data-loss-equivalent regression.
             throw new DataStorageManagerException(
                     "unsupported vector index metadata version " + version + " for " + indexName
-                            + " (supported: v" + METADATA_VERSION_MULTI_SEGMENT
-                            + ", v" + METADATA_VERSION_MULTI_SEGMENT_V4
-                            + "). This typically means the index was upgraded by a newer"
-                            + " binary and is being rolled back to one that does not yet"
-                            + " support the new format. Either re-deploy a binary that"
-                            + " supports v" + version + " OR delete the index and re-create it.");
+                            + " (this binary supports v" + METADATA_VERSION_MULTI_SEGMENT_V4
+                            + "). Either re-deploy a binary that supports v" + version
+                            + " OR delete the index and re-create it.");
         }
 
         int dim = metaBuf.getInt();
@@ -5514,20 +5532,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
         /* boolean savedAddHierarchy = */ metaBuf.get();
         /* boolean savedFusedPQ = */ metaBuf.get();
 
-        // nextNodeId is serialised as int64 after issue #256 — the in-place
-        // v3 rewrite breaks backward-compatibility on purpose.
         long savedNextNodeId = metaBuf.getLong();
 
         this.dimension = dim;
         newPageId.set(status.newPageId);
 
-        loadMultiSegmentFormat(metaBuf, dim, savedNextNodeId, savedBeamWidth, savedNeighborOverflow, savedAlpha,
-                version);
+        loadMultiSegmentFormat(metaBuf, dim, savedNextNodeId, savedBeamWidth, savedNeighborOverflow, savedAlpha);
     }
 
     private void loadMultiSegmentFormat(ByteBuffer metaBuf, int dim, long savedNextNodeId,
-                                         int savedBeamWidth, float savedNeighborOverflow, float savedAlpha,
-                                         int formatVersion)
+                                         int savedBeamWidth, float savedNeighborOverflow, float savedAlpha)
             throws IOException, DataStorageManagerException {
         java.io.DataInputStream dis = new java.io.DataInputStream(
                 new java.io.ByteArrayInputStream(metaBuf.array(), metaBuf.position(),
@@ -5562,7 +5576,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             String mapFilePath;
             long mapFileSize;
             long generation;
-            String segmentUuid = null;
+            String segmentUuid;
             try {
                 segId = dis.readInt();
                 estimatedSize = dis.readLong();
@@ -5571,10 +5585,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 mapFilePath = dis.readUTF();
                 mapFileSize = dis.readLong();
                 generation = dis.readLong();
-                if (formatVersion >= METADATA_VERSION_MULTI_SEGMENT_V4) {
-                    String raw = dis.readUTF();
-                    segmentUuid = raw.isEmpty() ? null : raw;
-                }
+                // v4 format always includes a segmentUuid field. An empty string
+                // means the segment has no UUID (should not occur in v4 except during
+                // a checkpoint that was written before the publisher was first attached;
+                // treated as null for reconcile purposes).
+                String raw = dis.readUTF();
+                segmentUuid = raw.isEmpty() ? null : raw;
             } catch (IOException e) {
                 throw new DataStorageManagerException("Failed to read segment metadata", e);
             }
@@ -5586,9 +5602,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             seg.mapFileSize = mapFileSize;
             seg.generation = generation;
             seg.segmentUuid = segmentUuid;
-            if (segmentUuid != null) {
-                segmentedV2Cached = true;
-            }
             segList.add(seg);
         }
 
@@ -6131,49 +6144,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // Existing (sealed/mergeable) segments keep their stored generation.
         long newGeneration = currentIndexStatusGeneration.get() + 1;
 
-        // Decide format version: v4 if any segment carries a non-null UUID (i.e. the index
-        // is in segmented-v2 mode), otherwise v3 to keep binary-compatible rollback for
-        // legacy clusters that never opted into the optimizer. Once we've seen a UUID we
-        // remember it (segmentedV2Cached) so subsequent checkpoints skip the scan
-        // entirely (review-item N1 from second pr-reviewer pass).
-        boolean anyUuid = segmentedV2Cached;
-        if (!anyUuid) {
-            // Fastest probe first: freshly-emitted segments (whose UUIDs were stamped at
-            // the start of Phase C). Only scan the loaded segments if necessary — those
-            // are the ones that contain UUIDs persisted from a previous run.
-            for (SegmentWriteResult swr : newSegmentResults) {
-                if (swr.segmentUuid != null) {
-                    anyUuid = true;
-                    break;
-                }
-            }
-            if (!anyUuid) {
-                for (VectorSegment seg : sealedSegments) {
-                    if (seg.segmentUuid != null) {
-                        anyUuid = true;
-                        break;
-                    }
-                }
-            }
-            if (!anyUuid) {
-                for (VectorSegment seg : mergeableSegments) {
-                    if (seg.segmentUuid != null) {
-                        anyUuid = true;
-                        break;
-                    }
-                }
-            }
-            if (anyUuid) {
-                segmentedV2Cached = true;
-            }
-        }
-        final int formatVersion = anyUuid
-                ? METADATA_VERSION_MULTI_SEGMENT_V4
-                : METADATA_VERSION_MULTI_SEGMENT;
+        // Always write v4 format: v3 (which lacked the segmentUuid field) is no
+        // longer supported for reading or writing (issue #499).
 
         VisibleByteArrayOutputStream baos = new VisibleByteArrayOutputStream(256);
         try (java.io.DataOutputStream dos = new java.io.DataOutputStream(baos)) {
-            dos.writeInt(formatVersion);
+            dos.writeInt(METADATA_VERSION_MULTI_SEGMENT_V4);
             dos.writeInt(dimension);
             dos.writeInt(m);
             dos.writeInt(beamWidth);
@@ -6181,10 +6157,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             dos.writeFloat(alpha);
             dos.writeByte(ADD_HIERARCHY ? 1 : 0);
             dos.writeByte(1); // fusedPQ
-            // nextNodeId widened to int64 after issue #256. Format version
-            // stays at v3 in legacy mode — the loader refuses unknown versions,
-            // so mixing old + new clients on the same checkpoint directory fails
-            // loud at load time rather than silently truncating the counter.
             dos.writeLong(nextNodeId.get());
             dos.writeLong(newGeneration);
             dos.writeInt(totalSegments);
@@ -6192,17 +6164,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
             for (VectorSegment seg : sealedSegments) {
                 writeSegmentMeta(dos, seg.segmentId, seg.segmentUuid, seg.estimatedSizeBytes,
                         seg.graphFilePath, seg.graphFileSize,
-                        seg.mapFilePath, seg.mapFileSize, seg.generation, formatVersion);
+                        seg.mapFilePath, seg.mapFileSize, seg.generation);
             }
             for (VectorSegment seg : mergeableSegments) {
                 writeSegmentMeta(dos, seg.segmentId, seg.segmentUuid, seg.estimatedSizeBytes,
                         seg.graphFilePath, seg.graphFileSize,
-                        seg.mapFilePath, seg.mapFileSize, seg.generation, formatVersion);
+                        seg.mapFilePath, seg.mapFileSize, seg.generation);
             }
             for (SegmentWriteResult swr : newSegmentResults) {
                 writeSegmentMeta(dos, swr.segmentId, swr.segmentUuid, swr.estimatedSizeBytes,
                         swr.graphFilePath, swr.graphFileSize,
-                        swr.mapFilePath, swr.mapFileSize, newGeneration, formatVersion);
+                        swr.mapFilePath, swr.mapFileSize, newGeneration);
             }
 
             List<PendingDelete> snapshotPending = new ArrayList<>(pendingDeletes);
@@ -6230,7 +6202,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             int segmentId, String segmentUuid, long estimatedSizeBytes,
             String graphFilePath, long graphFileSize,
             String mapFilePath, long mapFileSize,
-            long generation, int formatVersion) throws IOException {
+            long generation) throws IOException {
         dos.writeInt(segmentId);
         dos.writeLong(estimatedSizeBytes);
         dos.writeUTF(graphFilePath);
@@ -6238,12 +6210,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
         dos.writeUTF(mapFilePath != null ? mapFilePath : "");
         dos.writeLong(mapFileSize);
         dos.writeLong(generation);
-        if (formatVersion >= METADATA_VERSION_MULTI_SEGMENT_V4) {
-            // The empty string is the on-wire representation of "no UUID assigned"
-            // — the v3 reader doesn't see this byte at all, the v4 reader maps it
-            // back to null on load.
-            dos.writeUTF(segmentUuid != null ? segmentUuid : "");
-        }
+        // v4 format always includes segmentUuid. Empty string represents "no UUID assigned"
+        // (written for segments that predate the publisher attachment; read back as null).
+        dos.writeUTF(segmentUuid != null ? segmentUuid : "");
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
@@ -71,10 +71,15 @@ class VectorSegment implements Closeable {
 
     final int segmentId;
     /**
-     * Globally-unique identifier for segmented-v2 indexes. {@code null} for legacy
-     * (v3 IndexStatus) segments — kept null on read for backward compatibility,
-     * populated when reading v4 IndexStatus. Stable across IS restarts so the
-     * external segment registry can be reconciled with IndexStatus deterministically.
+     * Globally-unique identifier for this segment. Populated from the v4 IndexStatus
+     * on load. {@code null} only for segments that were written by a checkpoint that
+     * ran before a {@link herddb.index.vector.SegmentPublisher} was first attached to
+     * the store — i.e. the very first checkpoint after the external optimizer feature
+     * is enabled. Such segments will acquire a UUID on the next checkpoint that
+     * re-seals or re-writes them.
+     *
+     * <p>Stable across IS restarts so the external segment registry can be reconciled
+     * with IndexStatus deterministically.
      */
     String segmentUuid;
     volatile OnDiskGraphIndex onDiskGraph;
@@ -121,7 +126,6 @@ class VectorSegment implements Closeable {
      * Used by compaction to identify the authoritative segment for a PK
      * (latest wins) and by the retention reaper to decide when a
      * tombstoned segment file is safe to delete across shadow replicas.
-     * Defaults to 0 when loading v3 metadata (no generation field).
      */
     long generation;
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
@@ -38,17 +38,18 @@ import org.junit.rules.TemporaryFolder;
 
 /**
  * Targets the checkpoint-metadata format change from issue #256: the
- * {@code nextNodeId} field in v3 metadata is rewritten in place from
- * {@code int32} to {@code int64} (no back-compat per project decision).
+ * {@code nextNodeId} field was rewritten from {@code int32} to {@code int64}
+ * (no back-compat per project decision). Issue #499 additionally dropped v3
+ * format support entirely; all checkpoints are now written in v4 format.
  *
  * <p>Two cases:
  * <ol>
  *   <li>A large {@code nextNodeId} round-trips through {@code writeLong}
  *       / {@code readLong} unscathed.</li>
- *   <li>A checkpoint blob matching the OLD layout ({@code writeInt} for
- *       {@code nextNodeId}, same v3 magic) must not silently migrate —
- *       the loader's behaviour is locked in so a future refactor can't
- *       reintroduce a half-way back-compat path.</li>
+ *   <li>A checkpoint blob using the OLD {@code writeInt} width for
+ *       {@code nextNodeId} must not silently migrate — the loader's behaviour
+ *       is locked in so a future refactor can't reintroduce a half-way
+ *       back-compat path.</li>
  * </ol>
  */
 public class Issue256CheckpointFormatTest {
@@ -113,10 +114,11 @@ public class Issue256CheckpointFormatTest {
         // + bw (int) + neighborOverflow (float) + alpha (float) + addHierarchy (byte)
         // + fusedPQ (byte) + nextNodeId (long). Total header size = 4*4 + 4*2 + 2 + 8 = 34.
         // Issue #256 moved nextNodeId from writeInt to writeLong at that offset.
+        // Issue #499 dropped v3 support; all checkpoints are now written in v4 format.
         byte[] raw = readRawIndexStatus(dsm, uuid);
         ByteBuffer bb = ByteBuffer.wrap(raw);
         int version = bb.getInt();
-        assertEquals("version must still be 3 (in-place rewrite per user decision)", 3, version);
+        assertEquals("version must be 4 (v3 dropped per issue #499)", 4, version);
         bb.getInt(); // dim
         bb.getInt(); // m
         bb.getInt(); // beamWidth
@@ -139,15 +141,14 @@ public class Issue256CheckpointFormatTest {
     }
 
     /**
-     * Locks in the "no silent v3 back-compat" decision: if we hand-craft
-     * a v3 metadata blob using the OLD {@code writeInt} width for
-     * {@code nextNodeId}, the loader is NOT allowed to treat it as valid
-     * and silently promote the (now-misaligned) fields behind it. The
-     * expected outcome is either a clean "start empty" or a loud
-     * exception. The test asserts that whichever path we take, the
-     * restored {@code nextNodeId} is either zero (start empty) or a
-     * recognisably-corrupt value that would NOT compare equal to the
-     * value we would have observed under the old format.
+     * Locks in the "no silent misalignment" decision: if we hand-craft a metadata
+     * blob using the OLD {@code writeInt} width for {@code nextNodeId} (truncating
+     * the 8-byte long to 4 bytes), the loader is NOT allowed to treat it as valid
+     * and silently promote the (now-misaligned) fields behind it. The expected
+     * outcome is either a clean "start empty" or a loud exception. The test asserts
+     * that whichever path we take, the restored {@code nextNodeId} is either zero
+     * (start empty) or a recognisably-corrupt value that would NOT compare equal to
+     * the value we would have observed under the old format.
      */
     @Test
     public void oldInt32LayoutIsNotSilentlyAccepted() throws Exception {
@@ -168,15 +169,14 @@ public class Issue256CheckpointFormatTest {
             assertTrue(store.checkpoint());
         }
 
-        // Hand-craft a corrupted v3 blob that uses writeInt instead of
-        // writeLong at the nextNodeId offset. If the loader were to
-        // silently accept this layout it would mis-read all subsequent
-        // fields (generation, numSegments, ...) as a shifted view of
-        // the real bytes — likely throwing much later with a cryptic
-        // message. We want it to either reject cleanly OR yield
-        // nextNodeId = 0 (start empty). It must NOT yield
-        // nextNodeId == expectedOldValue, which would indicate the
-        // loader silently migrated the old format.
+        // Hand-craft a corrupted blob that uses writeInt instead of writeLong
+        // at the nextNodeId offset. If the loader were to silently accept this
+        // layout it would mis-read all subsequent fields (generation,
+        // numSegments, ...) as a shifted view of the real bytes — likely
+        // throwing much later with a cryptic message. We want it to either
+        // reject cleanly OR yield nextNodeId = 0 (start empty). It must NOT
+        // yield nextNodeId == expectedOldValue, which would indicate the loader
+        // silently migrated the old format.
         byte[] real = readRawIndexStatus(dsm, uuid);
         // Reconstruct: header fields stay the same until the nextNodeId
         // field, which becomes 4 bytes (writeInt of expectedOldValue).
@@ -280,7 +280,7 @@ public class Issue256CheckpointFormatTest {
         assertTrue("metadata blob must be at least 34 bytes (header), got " + real.length,
                 real.length >= 34);
         try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(real))) {
-            assertEquals(3, dis.readInt());                 // version
+            assertEquals(4, dis.readInt());                 // version (v4 since issue #499)
             assertEquals(16, dis.readInt());                // dim
             assertEquals(16, dis.readInt());                // m
             assertEquals(100, dis.readInt());               // beamWidth

--- a/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/k3s-local/values.yaml
@@ -391,6 +391,27 @@ indexOptimizer:
     neighborOverflow: 1.2
     alpha: 1.4
     similarity: "DOT_PRODUCT"
+  # Memory budget for gist1m M=16 merges (issue #499 Bug 1).
+  #
+  # For a full 8-segment gist1m merge (8 × ~125k vectors, 960-dim):
+  #   PQ codebook retraining reservoir: 96k samples × 960 × 4 B = 353 MB
+  #   jvector OnDiskGraphIndexCompactor working set: ~2–4 GiB
+  #   JVM overhead (code cache, metaspace, thread stacks): ~1 GiB
+  # Total peak: ≈ 6 GiB heap + 1 GiB direct → 8 GiB container.
+  # The previous 4 GiB container caused OOMKill at PQ training time.
+  #
+  #   -Xms6g -Xmx6g: heap fixed at 6 g to avoid GC pauses during long merges
+  #   --add-modules jdk.incubator.vector: Panama Vector API for SIMD kernels
+  #   -XX:MaxDirectMemorySize=1g: cap for non-Netty JVM direct buffers
+  #   -Djava.net.preferIPv4Stack=true: avoids IPv6 resolution in k3s-local
+  javaOpts: "-Xms6g -Xmx6g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector -XX:MaxDirectMemorySize=1g"
+  resources:
+    requests:
+      memory: "8Gi"
+      cpu: "2"
+    limits:
+      memory: "8Gi"
+      cpu: "2"
 
 tools:
   enabled: true

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -391,7 +391,21 @@ indexOptimizer:
     maxInflightReadBytes: "268435456"   # 256 MiB
     maxInflightWriteBytes: "268435456"  # 256 MiB
   zkSessionTimeout: 40000
-  javaOpts: ""
+  # JVM options for the optimizer process. The optimizer needs enough heap and
+  # direct memory to execute PQ retraining + graph-merge in a single JVM:
+  #   -Xms/-Xmx: heap for PQ codebook training, intermediate graph structures,
+  #     and the jvector merge working set. For gist1m M=16 (1M × 960-dim) the
+  #     PQ training reservoir alone requires ~350 MB; the graph merge adds
+  #     several more GB of working set. 6 g is the minimum for gist1m-class
+  #     merges without OOMKill (issue #499 Bug 1).
+  #   --add-modules jdk.incubator.vector: enables Panama Vector API for
+  #     jvector's SIMD distance kernels.
+  #   -XX:MaxDirectMemorySize: cap for non-Netty JVM direct buffers.
+  #   -Djava.net.preferIPv4Stack=true: avoids IPv6 resolution delays in
+  #     Kubernetes pods that only have IPv4 routes.
+  # Default: 6 g heap + 1 g direct. Override per-bench if the input segments
+  # are larger (e.g. bigann-100M M=16 needs at least 12 g heap).
+  javaOpts: "-Xms6g -Xmx6g -Djava.net.preferIPv4Stack=true --add-modules jdk.incubator.vector -XX:MaxDirectMemorySize=1g"
   javaOptsExtra: ""
   loggingProperties: ""
   extraConfig: {}
@@ -405,12 +419,16 @@ indexOptimizer:
   pdb:
     enabled: false
     minAvailable: 0
+  # Memory sized to hold the optimizer's heap (javaOpts -Xmx) plus JVM
+  # non-heap overhead (~1 GiB for code-cache, metaspace, thread stacks)
+  # plus direct memory (MaxDirectMemorySize). For the default 6 g heap
+  # + 1 g direct: 6 + 1 + 1 = 8 GiB container (issue #499 Bug 1).
   resources:
     requests:
-      memory: "1Gi"
+      memory: "8Gi"
       cpu: "2"
     limits:
-      memory: "1Gi"
+      memory: "8Gi"
       cpu: "2"
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Fixes #499.

## Changes

- **`herddb-core/.../PersistentVectorStore.java`** — Bug 2 fix: remove the v3 IndexStatus format (which lacked per-segment `segmentUuid`) entirely. The reader now rejects a v3 metadata blob at boot with a clear `DataStorageManagerException` directing the operator to delete and re-create the index. The writer always produces v4. The `segmentedV2Cached` flag and all its associated scan/update logic are deleted. The `writeSegmentMeta` helper loses its `formatVersion` parameter. In `loadMultiSegmentFormat`, the conditional `if (formatVersion >= V4)` for reading `segmentUuid` becomes unconditional. Remaining null-UUID guards (compaction path, reconcile path) are retained with updated comments — they now document the one remaining legitimate case: a segment checkpointed before a publisher was first attached rather than a legacy v3 segment.

- **`herddb-core/.../VectorSegment.java`** — Update `segmentUuid` field javadoc to remove the "null for legacy v3" language; update `generation` field javadoc similarly.

- **`herddb-core/.../Issue256CheckpointFormatTest.java`** — Update version assertions from `3` to `4` (the format version the store now always writes). Update class-level and method-level javadocs to reflect the v3 removal.

- **`herddb-kubernetes/.../values.yaml`** — Bug 1 fix: raise `indexOptimizer.resources.requests/limits.memory` from `1Gi` to `8Gi`; add `javaOpts` (`-Xms6g -Xmx6g --add-modules jdk.incubator.vector -XX:MaxDirectMemorySize=1g -Djava.net.preferIPv4Stack=true`) to prevent OOMKill during PQ codebook retraining on gist1m M=16 merges.

- **`herddb-kubernetes/.../examples/k3s-local/values.yaml`** — Same memory and JVM option additions as the chart defaults, sized specifically for gist1m M=16 benchmarks running in k3s-local.

## Tests

- **`Issue256CheckpointFormatTest`** (3 tests) — updated version assertions pass; the `largeNextNodeIdRoundTripsThroughCheckpointFormat` test now asserts `version == 4`; the `oldInt32LayoutIsNotSilentlyAccepted` and `headerOffsetArithmeticMatchesActualFormat` tests verify the same invariant under the new format.

- **`SegmentUuidRestartDurabilityTest`**, **`SegmentRegistryReconcileTest`**, **`SegmentRegistryPublisherMapFileSizeTest`** — all continue to pass (14 tests total).

- **`RemoteSegmentGraphMergerStreamingTest`** — 4 tests pass.

🤖 Implemented by the `pr-worker` agent.