### PR TITLE
issue #504: drop /health gates + recover ZK session in-process

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -97,7 +97,24 @@ public final class IndexOptimizerMain {
      */
     private final SegmentMerger preconfiguredMerger;
 
-    private ZooKeeper zooKeeper;
+    /**
+     * Current ZooKeeper client. Replaced atomically by {@link #reconnectZooKeeper}
+     * when the previous session expired (issue #504). Reads through
+     * {@link #zkRef} so {@link SegmentRegistryClient} and {@link OptimizerLeaderLock}
+     * always see the live client.
+     */
+    private volatile ZooKeeper zooKeeper;
+    /**
+     * Indirection used by {@link SegmentRegistryClient} and
+     * {@link OptimizerLeaderLock}: they capture a {@code Supplier<ZooKeeper>}
+     * pointing at this reference, so a session restart is transparent.
+     */
+    private final AtomicReference<ZooKeeper> zkRef = new AtomicReference<>();
+    private volatile String zkAddress;
+    private volatile int zkSessionTimeoutMs;
+    /** Coalesces concurrent reconnect attempts triggered by the bootstrap watcher. */
+    private final AtomicBoolean reconnectInFlight = new AtomicBoolean(false);
+    private final AtomicLong sessionReconnects = new AtomicLong();
     /**
      * Scheduler used by both the periodic safety-net tick and the event-driven
      * wakeup. {@code volatile} so the ZK watcher thread (which reads it without
@@ -128,23 +145,6 @@ public final class IndexOptimizerMain {
     private final AtomicLong eventDrivenTicks = new AtomicLong();
     /** Number of distinct ZK events observed by the persistent-recursive watcher. */
     private final AtomicLong watcherEvents = new AtomicLong();
-    /**
-     * Set to {@code true} when the ZooKeeper session expires (or auth
-     * fails). Once set, the persistent-recursive watch is dead, the
-     * leader-lock ephemeral znode is gone, and any registry read against
-     * {@link #zooKeeper} will fail — which means the pod is silently
-     * broken. The HTTP {@code /health} handler consults this flag and
-     * returns 503 so Helm's liveness probe restarts the pod (review item
-     * B.3 from the first pr-reviewer pass).
-     *
-     * <p>The flag is intentionally <strong>one-way</strong>: once tripped,
-     * the only recovery is process restart, which Helm performs in
-     * response to the 503 health check. We do not try to re-establish the
-     * ZK session in-process because the leader-lock would have to be
-     * re-acquired and the persistent-recursive watch re-armed under tight
-     * race conditions — far simpler and safer to let Helm replace us.
-     */
-    private final AtomicBoolean sessionExpired = new AtomicBoolean(false);
     /**
      * Debounce window for the event-driven tick. {@code volatile} for the same
      * reason as {@link #scheduler}: the ZK watcher thread reads it without
@@ -190,12 +190,12 @@ public final class IndexOptimizerMain {
     }
 
     /**
-     * Returns {@code true} when the ZooKeeper session has expired. The HTTP
-     * health handler uses this to flip {@code /health} to 503 so Helm's
-     * liveness probe restarts the pod.
+     * Number of ZooKeeper session-expiry recoveries performed since startup
+     * (issue #504). Observable by tests so they can assert that an injected
+     * session expiry was followed by a fresh session.
      */
-    public boolean isSessionExpired() {
-        return sessionExpired.get();
+    public long getSessionReconnects() {
+        return sessionReconnects.get();
     }
 
     public synchronized void start() throws Exception {
@@ -220,12 +220,16 @@ public final class IndexOptimizerMain {
                 new Object[]{streamingEnabled,
                         OptimizerConfiguration.PROPERTY_MERGE_STREAMING_ENABLED});
 
-        String zkAddress = configuration.getString(
+        this.zkAddress = configuration.getString(
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS,
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS_DEFAULT);
-        int sessionTimeout = configuration.getInt(
+        this.zkSessionTimeoutMs = configuration.getInt(
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT,
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT_DEFAULT);
+        // Local aliases keep the rest of start() readable without re-reading the
+        // configuration on every reference.
+        String zkAddress = this.zkAddress;
+        int sessionTimeout = this.zkSessionTimeoutMs;
         String basePath = configuration.getString(
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH,
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH_DEFAULT);
@@ -271,39 +275,9 @@ public final class IndexOptimizerMain {
         LOGGER.log(Level.INFO, "Resolved tablespace name ''{0}'' to UUID {1}",
                 new Object[]{tablespaceName, tablespaceUuid});
 
-        CountDownLatch zkConnected = new CountDownLatch(1);
-        AtomicReference<ZooKeeper> zkRef = new AtomicReference<>();
-        ZooKeeper zk = new ZooKeeper(zkAddress, sessionTimeout, (WatchedEvent event) -> {
-            switch (event.getState()) {
-                case SyncConnected:
-                    zkConnected.countDown();
-                    break;
-                case Expired:
-                case AuthFailed:
-                    // Session expiry kills the persistent-recursive watch and the
-                    // leader-lock ephemeral znode; AuthFailed is similarly
-                    // unrecoverable (credentials are wrong / revoked). Either way
-                    // the pod is silently broken from here on; flag /health to
-                    // 503 so Helm restarts us (review item B.3 from the first
-                    // pr-reviewer pass; AuthFailed coverage from round 2).
-                    if (sessionExpired.compareAndSet(false, true)) {
-                        LOGGER.log(Level.SEVERE,
-                                "ZooKeeper {0} — /health will return 503 so the pod is restarted.",
-                                event.getState());
-                    }
-                    break;
-                default:
-                    // Disconnected / etc. — log at FINE; the ZK client recovers
-                    // from transient disconnects on its own.
-                    break;
-            }
-        });
-        zkRef.set(zk);
-        if (!zkConnected.await(sessionTimeout, TimeUnit.MILLISECONDS)) {
-            zk.close();
-            throw new IllegalStateException("ZooKeeper connect timed out: " + zkAddress);
-        }
+        ZooKeeper zk = openZooKeeperSession();
         this.zooKeeper = zk;
+        this.zkRef.set(zk);
         this.registry = new SegmentRegistryClient(zkRef::get, basePath);
         registry.ensureRoot();
 
@@ -370,8 +344,9 @@ public final class IndexOptimizerMain {
         // restart the pod if the session ever expires).
         armPersistentRecursiveWatch();
 
-        // Admin HTTP endpoint (review item E1+E3). Disabled when port == 0; otherwise
-        // exposes /health (Helm probe target) and /metrics (Prometheus scrape).
+        // Admin HTTP endpoint. Disabled when port == 0; otherwise exposes
+        // /health (Helm probe target — always 200, see issue #504) and
+        // /metrics (Prometheus scrape).
         int httpPort = configuration.getInt(
                 OptimizerConfiguration.PROPERTY_HTTP_PORT,
                 OptimizerConfiguration.PROPERTY_HTTP_PORT_DEFAULT);
@@ -379,13 +354,7 @@ public final class IndexOptimizerMain {
             String httpHost = configuration.getString(
                     OptimizerConfiguration.PROPERTY_HTTP_HOST,
                     OptimizerConfiguration.PROPERTY_HTTP_HOST_DEFAULT);
-            // Liveness staleness = 2 × tick interval — the engine should have ticked
-            // at least once in that window unless something is stuck (review-item B6
-            // from second pr-reviewer pass).
-            this.httpServer = new OptimizerHttpServer(httpHost, httpPort, engine,
-                    /* stalenessThresholdMillis */ 2L * intervalMs,
-                    System::currentTimeMillis,
-                    /* criticalFailure */ this::isSessionExpired);
+            this.httpServer = new OptimizerHttpServer(httpHost, httpPort, engine);
             this.httpServer.start();
         }
 
@@ -405,6 +374,124 @@ public final class IndexOptimizerMain {
             // RuntimeException. Either way we log and let the next tick retry — a
             // misbehaving merger or transient ZK error must never kill the scheduler.
             LOGGER.log(Level.WARNING, "optimizer tick failed", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ZooKeeper session lifecycle (issue #504)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Opens a fresh ZooKeeper session using the configured address + session
+     * timeout, awaits the {@code SyncConnected} event, and returns the live
+     * client. Callers are responsible for publishing it via
+     * {@link #zkRef} / {@link #zooKeeper}. The watcher attached here also drives
+     * automatic reconnect on session expiry.
+     */
+    private ZooKeeper openZooKeeperSession() throws IOException, InterruptedException {
+        CountDownLatch connected = new CountDownLatch(1);
+        ZooKeeper zk = new ZooKeeper(zkAddress, zkSessionTimeoutMs,
+                (WatchedEvent event) -> handleBootstrapEvent(event, connected));
+        if (!connected.await(zkSessionTimeoutMs, TimeUnit.MILLISECONDS)) {
+            try {
+                zk.close();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalStateException("ZooKeeper connect timed out: " + zkAddress);
+        }
+        return zk;
+    }
+
+    private void handleBootstrapEvent(WatchedEvent event, CountDownLatch connectLatch) {
+        switch (event.getState()) {
+            case SyncConnected:
+                connectLatch.countDown();
+                break;
+            case Expired:
+                // The persistent-recursive watch is dead and the leader-lock
+                // ephemeral znode is gone with the old session. Schedule an
+                // in-process reconnect so the optimizer recovers without a pod
+                // restart (issue #504 — the liveness probe stays at 200 so
+                // long merges don't trip a kubelet SIGKILL).
+                LOGGER.log(Level.WARNING,
+                        "ZooKeeper session expired — scheduling in-process reconnect");
+                scheduleReconnectZooKeeper();
+                break;
+            case AuthFailed:
+                // Credentials are wrong / revoked: a reconnect with the same
+                // config will hit the same wall, so we log and stop. An
+                // operator must rotate credentials and restart the pod.
+                LOGGER.log(Level.SEVERE,
+                        "ZooKeeper AuthFailed — pod is broken until credentials are fixed.");
+                break;
+            default:
+                // Disconnected / etc. — the ZK client recovers from transient
+                // disconnects on its own.
+                break;
+        }
+    }
+
+    /**
+     * Coalesces concurrent reconnect requests onto the engine scheduler. The
+     * watcher fires from the ZK event thread; we MUST NOT block it, so the
+     * actual reconnect (which opens a fresh ZK and waits for SyncConnected)
+     * runs on the scheduler.
+     */
+    private void scheduleReconnectZooKeeper() {
+        if (!reconnectInFlight.compareAndSet(false, true)) {
+            return;
+        }
+        ScheduledExecutorService sched = scheduler;
+        if (sched == null || sched.isShutdown()) {
+            reconnectInFlight.set(false);
+            return;
+        }
+        try {
+            sched.execute(this::reconnectZooKeeper);
+        } catch (RuntimeException dispatchFailed) {
+            // Scheduler may reject if it's shutting down between our checks.
+            reconnectInFlight.set(false);
+            LOGGER.log(Level.WARNING,
+                    "could not dispatch ZK reconnect: {0}", dispatchFailed.getMessage());
+        }
+    }
+
+    private void reconnectZooKeeper() {
+        try {
+            ZooKeeper old = this.zooKeeper;
+            try {
+                if (old != null) {
+                    old.close();
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            ZooKeeper fresh;
+            try {
+                fresh = openZooKeeperSession();
+            } catch (IOException | InterruptedException openErr) {
+                if (openErr instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                LOGGER.log(Level.SEVERE,
+                        "ZooKeeper reconnect failed; will retry on next session-expiry event: {0}",
+                        openErr.getMessage());
+                return;
+            }
+            this.zooKeeper = fresh;
+            this.zkRef.set(fresh);
+            // Re-arm the persistent-recursive watch on the new session — the
+            // old session's watch died with it.
+            armPersistentRecursiveWatch();
+            // Kick a tick so the leader lock is re-acquired and any registry
+            // changes that happened during the outage are processed.
+            scheduleEventDrivenTick();
+            sessionReconnects.incrementAndGet();
+            LOGGER.log(Level.INFO, "ZooKeeper session re-established (reconnect #{0})",
+                    sessionReconnects.get());
+        } finally {
+            reconnectInFlight.set(false);
         }
     }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
@@ -27,17 +27,18 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.LongSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Minimal HTTP endpoint for observability of the optimizer service (review
- * items E1 + E3). Exposes:
+ * Minimal HTTP endpoint for observability of the optimizer service. Exposes:
  * <ul>
- *   <li>{@code GET /health} — returns 200 with {@code OK} once the engine is
- *       running. Used by Helm liveness/readiness probes.</li>
+ *   <li>{@code GET /health} — always returns 200 OK. Used by Helm
+ *       liveness/readiness probes; the probe must only fire when the JVM
+ *       itself is unresponsive, not when a long merge tick is running
+ *       (issue #504). Engine progress is tracked via the
+ *       {@code herddb_optimizer_last_run_at_seconds} gauge on /metrics
+ *       for alerting.</li>
  *   <li>{@code GET /metrics} — returns Prometheus-style plain-text counters
  *       (runs, segments_merged, segments_deprecated, segments_deleted,
  *       ticks_skipped_not_leader). Scrape-friendly.</li>
@@ -53,58 +54,9 @@ public final class OptimizerHttpServer implements AutoCloseable {
 
     private final HttpServer server;
     private final IndexOptimizerEngine engine;
-    /**
-     * Heartbeat-staleness threshold for {@code /health} (review-item B6 from second
-     * pr-reviewer pass). When the engine's run counter has not advanced within this
-     * window, /health returns 503 so the Helm liveness probe restarts the pod.
-     * The default is twice the optimizer's tick interval — set via
-     * {@link OptimizerHttpServer#OptimizerHttpServer(String, int, IndexOptimizerEngine, long, LongSupplier)}.
-     */
-    private final long stalenessThresholdMillis;
-    private final LongSupplier clock;
-    /**
-     * Predicate consulted by the {@code /health} handler. When it returns
-     * {@code true}, the handler short-circuits to 503 — the optimizer's ZK
-     * session has expired (or some other unrecoverable lifecycle event has
-     * fired), so Helm should restart the pod regardless of the heartbeat
-     * counter (review item B.3 from the first pr-reviewer pass).
-     */
-    private final java.util.function.BooleanSupplier criticalFailure;
-    private final AtomicLong lastObservedRuns = new AtomicLong(-1);
-    private final AtomicLong lastObservedRunsAtMillis = new AtomicLong(0);
 
-    /**
-     * Convenience constructor with a 2 × intervalMs default staleness threshold and the
-     * system clock. Equivalent to the test-friendly constructor with stalenessThreshold
-     * disabled (Long.MAX_VALUE) — kept for source compatibility with earlier code.
-     */
     public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine) throws IOException {
-        this(bindHost, port, engine, Long.MAX_VALUE, System::currentTimeMillis,
-                /* criticalFailure */ () -> false);
-    }
-
-    /**
-     * Three-arg constructor wiring the heartbeat-staleness threshold and a clock
-     * for tests. Equivalent to the four-arg constructor with no critical-failure
-     * gate.
-     */
-    public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine,
-                               long stalenessThresholdMillis, LongSupplier clock) throws IOException {
-        this(bindHost, port, engine, stalenessThresholdMillis, clock,
-                /* criticalFailure */ () -> false);
-    }
-
-    /**
-     * Full constructor wiring the heartbeat-staleness threshold, a clock, and a
-     * critical-failure gate (e.g. ZK session expiry detection).
-     */
-    public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine,
-                               long stalenessThresholdMillis, LongSupplier clock,
-                               java.util.function.BooleanSupplier criticalFailure) throws IOException {
         this.engine = engine;
-        this.stalenessThresholdMillis = stalenessThresholdMillis;
-        this.clock = clock;
-        this.criticalFailure = criticalFailure == null ? () -> false : criticalFailure;
         this.server = HttpServer.create(new InetSocketAddress(bindHost, port), 0);
         server.createContext("/health", new HealthHandler());
         server.createContext("/metrics", new MetricsHandler());
@@ -133,68 +85,15 @@ public final class OptimizerHttpServer implements AutoCloseable {
         server.stop(0);
     }
 
-    private final class HealthHandler implements HttpHandler {
+    private static final class HealthHandler implements HttpHandler {
+        private static final byte[] OK_BODY = "OK\n".getBytes(StandardCharsets.UTF_8);
+
         @Override
         public void handle(HttpExchange exchange) throws IOException {
-            // Critical-failure gate (review item B.3 from the first pr-reviewer
-            // pass): when the ZooKeeper session has expired, the pod is
-            // silently broken — the persistent-recursive watch is dead and the
-            // leader-lock znode is gone. Force 503 so Helm restarts us.
-            if (criticalFailure.getAsBoolean()) {
-                byte[] body = "FAILED: critical lifecycle failure (e.g. ZK session expired)\n"
-                        .getBytes(StandardCharsets.UTF_8);
-                exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
-                exchange.sendResponseHeaders(503, body.length);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(body);
-                }
-                return;
-            }
-            // Liveness check (review-item B6): the engine's run counter must advance
-            // within stalenessThresholdMillis. We compare the current value against
-            // the last observation; when it has progressed we update both the
-            // counter snapshot and the timestamp. When it has NOT progressed for
-            // longer than the threshold, the pod is stuck and we return 503 so Helm
-            // restarts it.
-            long currentRuns = engine.getRuns();
-            long now = clock.getAsLong();
-            long observedRuns = lastObservedRuns.get();
-            long observedAt = lastObservedRunsAtMillis.get();
-            boolean healthy;
-            String reason;
-            if (stalenessThresholdMillis == Long.MAX_VALUE) {
-                // Liveness gating disabled — preserve the legacy "always 200" behavior.
-                healthy = true;
-                reason = "OK\n";
-            } else if (observedRuns == -1L) {
-                // First call: arm the heartbeat with the current value but mark fresh.
-                lastObservedRuns.set(currentRuns);
-                lastObservedRunsAtMillis.set(now);
-                healthy = true;
-                reason = "OK\n";
-            } else if (currentRuns > observedRuns) {
-                // Engine ticked since last health check — refresh the heartbeat.
-                lastObservedRuns.set(currentRuns);
-                lastObservedRunsAtMillis.set(now);
-                healthy = true;
-                reason = "OK\n";
-            } else {
-                long staleFor = now - observedAt;
-                if (staleFor > stalenessThresholdMillis) {
-                    healthy = false;
-                    reason = "STALE: engine has not ticked for " + staleFor + " ms (threshold "
-                            + stalenessThresholdMillis + " ms)\n";
-                } else {
-                    healthy = true;
-                    reason = "OK (stale " + staleFor + " ms)\n";
-                }
-            }
-
-            byte[] body = reason.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
-            exchange.sendResponseHeaders(healthy ? 200 : 503, body.length);
+            exchange.sendResponseHeaders(200, OK_BODY.length);
             try (OutputStream os = exchange.getResponseBody()) {
-                os.write(body);
+                os.write(OK_BODY);
             }
         }
     }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerSessionExpiredTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerSessionExpiredTest.java
@@ -19,6 +19,7 @@
  */
 package herddb.indexing.optimizer;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.cluster.ZookeeperMetadataStorageManager;
@@ -39,15 +40,20 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * End-to-end test verifying the ZK-session-expiry → {@code /health} 503
- * wiring on a real {@link IndexOptimizerMain} instance (issue #484, round-2
- * review item B.6).
+ * End-to-end test for the optimizer's in-process ZooKeeper session-recovery
+ * path (issue #504). Forces a real {@code KeeperState.Expired} event by
+ * hijacking the optimizer's session id and closing it from a second client
+ * (the canonical "kill ZK session" pattern), then asserts:
+ * <ul>
+ *   <li>{@link IndexOptimizerMain#getSessionReconnects()} crosses zero,</li>
+ *   <li>the optimizer's internal {@link ZooKeeper} reference is replaced with
+ *       a fresh client (different session id),</li>
+ *   <li>the engine can complete a tick after the reconnect.</li>
+ * </ul>
  *
- * <p>The test does not rely on a synthetic predicate; it triggers an actual
- * {@code KeeperState.Expired} event by hijacking the optimizer's session id
- * and closing it from a second client (the canonical "kill ZK session"
- * pattern). The test then asserts {@link IndexOptimizerMain#isSessionExpired}
- * flips within a deadline.
+ * <p>The fix replaces the old "trip /health to 503 so Helm restarts us"
+ * behavior with in-process recovery — long merges no longer race the
+ * liveness probe, and a transient ZK outage does not require a pod restart.
  */
 public class IndexOptimizerSessionExpiredTest {
 
@@ -100,13 +106,15 @@ public class IndexOptimizerSessionExpiredTest {
     }
 
     @Test
-    public void zkSessionExpiryTrippedAndDetected() throws Exception {
+    public void zkSessionExpiryTriggersInProcessReconnect() throws Exception {
         Properties props = new Properties();
         props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
         // Short ZK session timeout so we can force an expiry quickly.
         props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "4000");
         props.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
         props.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        // Long periodic interval — we drive ticks via the event-driven path that
+        // the reconnect schedules so the test does not depend on timing.
         props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "60000");
         props.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
         props.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
@@ -117,17 +125,19 @@ public class IndexOptimizerSessionExpiredTest {
         try {
             main.start();
             assertNotNull(main.getEngine());
-            assertTrue("session must NOT be expired immediately after start",
-                    !main.isSessionExpired());
+            assertTrue("baseline reconnect counter must be 0",
+                    main.getSessionReconnects() == 0L);
+
+            ZooKeeper firstZk = extractZkClient(main);
+            long firstSessionId = firstZk.getSessionId();
+            assertTrue("first session must have a non-zero id", firstSessionId != 0L);
 
             // Hijack the optimizer's ZK session id + password and close that
             // session from a second client. ZooKeeper considers this "session
             // moved" — the original client's next operation gets
-            // SessionExpired, which fires the watcher with KeeperState.Expired.
-            ZooKeeper victimSession = extractZkClient(main);
-            long sessionId = victimSession.getSessionId();
-            byte[] passwd = victimSession.getSessionPasswd();
-
+            // SessionExpired, which fires the bootstrap watcher with
+            // KeeperState.Expired and triggers an in-process reconnect.
+            byte[] passwd = firstZk.getSessionPasswd();
             CountDownLatch kicked = new CountDownLatch(1);
             ZooKeeper kicker = new ZooKeeper(zkServer.getConnectString(), 4000,
                     (WatchedEvent ev) -> {
@@ -135,22 +145,33 @@ public class IndexOptimizerSessionExpiredTest {
                             kicked.countDown();
                         }
                     },
-                    sessionId, passwd);
+                    firstSessionId, passwd);
             assertTrue("kicker session must establish",
                     kicked.await(10, TimeUnit.SECONDS));
-            // Closing the kicker session also kills the optimizer's session
-            // (same session id) — the original watcher fires Expired.
             kicker.close();
 
-            // Wait up to 10 s for the optimizer's watcher to observe Expired
-            // and flip the flag. (The timeout is generous because session
-            // expiry detection waits for the next ZK keepalive round-trip.)
-            long deadline = System.currentTimeMillis() + 10_000L;
-            while (System.currentTimeMillis() < deadline && !main.isSessionExpired()) {
+            // Wait up to 30 s for the reconnect to land. The bootstrap watcher
+            // first sees Expired (after the next ZK keepalive round-trip),
+            // schedules the reconnect on the engine scheduler, then opens a
+            // fresh session and increments getSessionReconnects().
+            long deadline = System.currentTimeMillis() + 30_000L;
+            while (System.currentTimeMillis() < deadline && main.getSessionReconnects() == 0L) {
                 Thread.sleep(50);
             }
-            assertTrue("ZK session expiry must trip IndexOptimizerMain.isSessionExpired",
-                    main.isSessionExpired());
+            assertTrue("ZK session expiry must trigger an in-process reconnect; reconnects="
+                            + main.getSessionReconnects(),
+                    main.getSessionReconnects() >= 1L);
+
+            // The second ZK client must be a different session.
+            ZooKeeper secondZk = extractZkClient(main);
+            assertNotNull("post-reconnect ZK reference must be non-null", secondZk);
+            assertNotEquals("post-reconnect session id must differ from the expired one",
+                    firstSessionId, secondZk.getSessionId());
+
+            // Verify the engine is functional after the reconnect by running a tick
+            // directly. If the registry / leader-lock are wired to the new ZK,
+            // this should succeed without throwing.
+            main.getEngine().runOnce();
         } finally {
             main.shutdown();
         }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
@@ -110,9 +110,16 @@ public class OptimizerHttpServerTest {
     }
 
     @Test
-    public void healthEndpointReturnsOk() throws Exception {
-        String body = fetch("/health");
-        assertEquals("OK\n", body);
+    public void healthEndpointAlwaysReturnsOk() throws Exception {
+        // Issue #504: /health is a pure liveness signal — it must return 200
+        // regardless of engine state. Verify it returns OK before the engine
+        // ticks once, then again after several ticks. The previous staleness
+        // gate would have flipped to 503 in the second window; the new
+        // contract keeps it at 200 so long merges don't trip a kubelet SIGKILL.
+        assertEquals("OK\n", fetch("/health"));
+        engine.runOnce();
+        engine.runOnce();
+        assertEquals("OK\n", fetch("/health"));
     }
 
     @Test
@@ -142,99 +149,4 @@ public class OptimizerHttpServerTest {
         assertTrue("bound port should be > 0", http.getBoundPort() > 0);
     }
 
-    @Test
-    public void healthReturns503WhenEngineHasNotTicked() throws Exception {
-        // Review-item B6: bring up a separate server with an aggressive 100ms staleness
-        // threshold + a manual clock. Run the engine once to seed the heartbeat, then
-        // advance the clock past the threshold WITHOUT ticking again — the next /health
-        // call must return 503.
-        java.util.concurrent.atomic.AtomicLong fakeClock =
-                new java.util.concurrent.atomic.AtomicLong(0L);
-        OptimizerHttpServer livenessHttp = new OptimizerHttpServer("127.0.0.1", 0, engine,
-                /* stalenessThresholdMillis */ 100L, fakeClock::get);
-        try {
-            livenessHttp.start();
-            // First call seeds the heartbeat.
-            engine.runOnce();
-            int code = headStatus("http://127.0.0.1:" + livenessHttp.getBoundPort() + "/health");
-            assertEquals(200, code);
-
-            // Advance the fake clock past the threshold without further ticks.
-            fakeClock.addAndGet(500L);
-            int code2 = headStatus("http://127.0.0.1:" + livenessHttp.getBoundPort() + "/health");
-            assertEquals("/health must return 503 when engine is stale", 503, code2);
-
-            // Tick the engine again, then advance the fake clock past the staleness
-            // threshold AGAIN. With the engine's run counter strictly higher than the
-            // last observation, the heartbeat-refresh branch (currentRuns > observedRuns)
-            // must reset the timer and return 200. Without the new tick the call
-            // would return 503 — which means a passing assertion here exclusively
-            // validates the heartbeat-refresh branch (review-pass-3 P3-2).
-            engine.runOnce();
-            fakeClock.addAndGet(700L);
-            int code3 = headStatus("http://127.0.0.1:" + livenessHttp.getBoundPort() + "/health");
-            assertEquals("after a fresh tick, /health must refresh and return 200 even"
-                    + " though the absolute clock is past the threshold",
-                    200, code3);
-        } finally {
-            livenessHttp.close();
-        }
-    }
-
-    @Test
-    public void healthReturns503WhenCriticalFailureFlagSet() throws Exception {
-        // Issue #484 (review item B.3 from the first pr-reviewer pass): the
-        // /health endpoint must consult an injected critical-failure
-        // predicate so a ZK session expiry can trip Helm's liveness probe
-        // even if the engine is still ticking on the periodic safety-net.
-        java.util.concurrent.atomic.AtomicBoolean criticalFailure =
-                new java.util.concurrent.atomic.AtomicBoolean(false);
-        OptimizerHttpServer http2 = new OptimizerHttpServer("127.0.0.1", 0, engine,
-                /* stalenessThresholdMillis */ Long.MAX_VALUE,
-                System::currentTimeMillis,
-                criticalFailure::get);
-        try {
-            http2.start();
-            // Pre-condition: engine OK, no critical failure → 200.
-            engine.runOnce();
-            int ok = headStatus("http://127.0.0.1:" + http2.getBoundPort() + "/health");
-            assertEquals(200, ok);
-
-            // Trip the critical-failure flag (simulating ZK session expiry).
-            criticalFailure.set(true);
-            int failed = headStatus("http://127.0.0.1:" + http2.getBoundPort() + "/health");
-            assertEquals("/health must return 503 when critical-failure flag is set",
-                    503, failed);
-
-            // Clearing the flag returns the endpoint to 200.
-            criticalFailure.set(false);
-            int recovered = headStatus("http://127.0.0.1:" + http2.getBoundPort() + "/health");
-            assertEquals("/health must recover to 200 once the flag clears",
-                    200, recovered);
-        } finally {
-            http2.close();
-        }
-    }
-
-    private static int headStatus(String url) throws Exception {
-        java.net.HttpURLConnection conn = (java.net.HttpURLConnection)
-                new java.net.URL(url).openConnection();
-        conn.setRequestMethod("GET");
-        conn.setConnectTimeout(2000);
-        conn.setReadTimeout(2000);
-        conn.connect();
-        int code = conn.getResponseCode();
-        try {
-            conn.getInputStream().close();
-        } catch (Exception ignored) {
-            // 503 path produces an error stream; drain it.
-            try {
-                if (conn.getErrorStream() != null) {
-                    conn.getErrorStream().close();
-                }
-            } catch (Exception ignored2) {
-            }
-        }
-        return code;
-    }
 }

--- a/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-statefulset.yaml
@@ -91,9 +91,13 @@ spec:
             - name: http
               containerPort: {{ .Values.indexOptimizer.httpPort | default 9853 }}
               protocol: TCP
-          # Liveness + readiness probes against the JDK HttpServer admin endpoint
-          # (review item E1+E3). The endpoint is single-threaded but only handles
-          # /health and /metrics so it stays responsive even under heavy ZK load.
+          # Liveness + readiness probes against the JDK HttpServer admin endpoint.
+          # /health unconditionally returns 200 (issue #504) so a long merge tick
+          # cannot race the kubelet's failureThreshold and trigger a SIGKILL, and
+          # a transient ZK session expiry is recovered in-process via
+          # IndexOptimizerMain.reconnectZooKeeper() rather than a pod restart.
+          # Engine staleness alerting belongs on the
+          # herddb_optimizer_last_run_at_seconds gauge from /metrics.
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## Summary

Fixes #504. The optimizer pod was SIGKILL'd by the kubelet during long merges (15-17 min for gist1m M=16) because `/health` returned HTTP 503 once the engine hadn't completed a tick in >600 s. The staleness gate, plus the ZK session-expiry gate that flipped `/health` to 503, both forced a full pod recycle for what should have been a transient condition.

This change makes `/health` always return 200 OK (probes only fire when the JVM itself is unresponsive) and recovers ZK session expiry in-process instead of via pod restart.

- `OptimizerHttpServer.HealthHandler` strips the staleness + critical-failure gates; the multi-arg constructors and supporting fields are deleted.
- `IndexOptimizerMain` now opens fresh ZK sessions via `openZooKeeperSession()` and reconnects automatically on `KeeperState.Expired`: the new client is swapped into `zkRef` (so `SegmentRegistryClient` + `OptimizerLeaderLock` pick it up transparently), the persistent-recursive watch is re-armed, and a tick is scheduled to re-acquire the leader lock. `AuthFailed` stays log-only (the same credentials can't recover).
- `getSessionReconnects()` exposes a counter for tests + observability.
- The `index-optimizer-statefulset.yaml` probe block keeps the same hardcoded defaults; the comment now documents the always-200 contract and points operators to the `herddb_optimizer_last_run_at_seconds` gauge for staleness alerting.

## Test plan

- [x] `mvn -pl herddb-indexing-service -Dtest='OptimizerHttpServerTest,IndexOptimizerSessionExpiredTest,IndexOptimizerEventDrivenTest,IndexOptimizerMainTest,OptimizerObservabilityMetricsTest' test` — 19/19 green
- [x] Re-ran `IndexOptimizerSessionExpiredTest` 3× back-to-back to gate against ZK-keepalive-timing flake — 3/3 green
- [x] `mvn -B checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci` — clean

`IndexOptimizerSessionExpiredTest` was rewritten: it hijacks + closes the optimizer's ZK session (canonical "kill ZK session" pattern) and asserts (1) `getSessionReconnects()` crosses zero, (2) the underlying `ZooKeeper` reference is swapped to a fresh session id, and (3) `engine.runOnce()` succeeds against the new session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)