### PR TITLE
issue #507: fix NoopMerger startup race — ZK discovery retry + tick-time upgrade

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
@@ -70,7 +70,15 @@ public final class IndexOptimizerEngine {
     private static final Logger LOGGER = Logger.getLogger(IndexOptimizerEngine.class.getName());
 
     private final SegmentRegistryClient registry;
-    private final SegmentMerger merger;
+    /**
+     * Active merger. {@code volatile} to allow {@link #upgradeMerger} to replace
+     * a startup-time {@link IndexOptimizerMain.NoopMerger} with a real
+     * {@link RemoteSegmentMerger} once ZK discovers a file server (issue #507, Option B).
+     * All writes go through {@link #upgradeMerger} which is {@code synchronized};
+     * reads are unsynchronized but visibility is guaranteed by the {@code volatile}
+     * keyword.
+     */
+    private volatile SegmentMerger merger;
     private final String tablespaceUuid;
     private final MergePolicy mergePolicy;
     private final long retentionMillis;
@@ -82,8 +90,12 @@ public final class IndexOptimizerEngine {
      * current tombstone-overlay files of every reaped segment (review item A8).
      * Pass {@code null} to skip physical-file deletion — useful when the test fakes
      * the storage layer or doesn't care about file residue.
+     *
+     * <p>{@code volatile} so that {@link #upgradeMerger} can update it together
+     * with the merger reference when the optimizer self-heals from NoopMerger
+     * (issue #507, Option B).
      */
-    private final DataStorageManager dataStorageManager;
+    private volatile DataStorageManager dataStorageManager;
     /**
      * Optional: when non-null, every {@link #runOnce()} invocation tries to acquire
      * this lock first and skips the tick if it can't. Enforces the singleton
@@ -328,6 +340,32 @@ public final class IndexOptimizerEngine {
 
     public long getTicksSkippedNotLeader() {
         return ticksSkippedNotLeader.get();
+    }
+
+    /**
+     * Atomically replaces the active merger and the associated
+     * {@link DataStorageManager} (used by the reaper for physical file deletion).
+     * Called by {@link IndexOptimizerMain#maybeUpgradeMerger()} when ZK discovery
+     * finds a file server after the optimizer started with a
+     * {@link IndexOptimizerMain.NoopMerger} due to a startup-ordering race
+     * (issue #507, Option B).
+     *
+     * <p>Synchronisation note: both fields are {@code volatile} so concurrent
+     * readers (the periodic-tick path) always observe either the old or the new
+     * values — never a partial update. {@code synchronized} here serialises
+     * concurrent upgrade attempts from the single-threaded scheduler, but the
+     * {@code volatile} keyword is what ensures visibility on the read side.
+     *
+     * @param newMerger the new merger — must not be {@code null}
+     * @param newDsm    the DataStorageManager embedded in the new merger (may be
+     *                  {@code null} when the reaper's physical-file deletion is still
+     *                  in safe mode)
+     */
+    public synchronized void upgradeMerger(SegmentMerger newMerger, DataStorageManager newDsm) {
+        Objects.requireNonNull(newMerger, "newMerger");
+        this.merger = newMerger;
+        this.dataStorageManager = newDsm;
+        LOGGER.log(Level.INFO, "engine merger upgraded to {0}", newMerger.getClass().getSimpleName());
     }
 
     /**

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
@@ -338,6 +338,14 @@ public final class IndexOptimizerEngine {
         return relocationsAbortedTotal.get();
     }
 
+    /**
+     * Returns the currently active merger. {@code volatile} read; safe to call
+     * from any thread without synchronization.
+     */
+    public SegmentMerger getMerger() {
+        return merger;
+    }
+
     public long getTicksSkippedNotLeader() {
         return ticksSkippedNotLeader.get();
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -22,6 +22,7 @@ package herddb.indexing.optimizer;
 import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.indexing.segment.SegmentRegistryClient;
 import herddb.metadata.MetadataStorageManagerException;
+import herddb.metadata.ServiceDiscoveryListener;
 import herddb.model.TableSpace;
 import herddb.server.RemoteFileClient;
 import herddb.server.RemoteFileServiceFactory;
@@ -123,11 +124,31 @@ public final class IndexOptimizerMain {
     private volatile int zkSessionTimeoutMs;
     /**
      * ZooKeeper base path (e.g. {@code /herd}). Stored as a field so that
-     * {@link #maybeUpgradeMerger()} can open a short-lived
-     * {@link herddb.cluster.ZookeeperMetadataStorageManager} for ZK discovery
-     * retries at tick time without re-reading the configuration (issue #507).
+     * {@link #buildRemoteSegmentMerger} can access it without re-reading the
+     * configuration (issue #507).
      */
     private volatile String zkBasePath;
+
+    /**
+     * Long-lived metadata manager used for:
+     * <ol>
+     *   <li>Resolving the tablespace UUID from the human-readable name at startup.</li>
+     *   <li>Discovering remote file servers via {@code listFileServers()} — which
+     *       installs a ZK children-watch on {@code /herd/fileServers}.</li>
+     *   <li>Reacting to file-server registration events via the
+     *       {@link ServiceDiscoveryListener} registered in {@link #start}: whenever
+     *       {@code onFileServersChanged} fires, the optimizer schedules an upgrade
+     *       tick so a {@link NoopMerger} is replaced as soon as the file server
+     *       appears in ZooKeeper.</li>
+     * </ol>
+     *
+     * <p>Unlike the previous short-lived instance (opened + closed in
+     * {@link #start}), this instance is kept alive for the lifetime of the
+     * optimizer pod so the built-in watcher machinery in
+     * {@link ZookeeperMetadataStorageManager} continuously re-discovers file
+     * servers without any polling (issue #507). Closed by {@link #shutdown}.
+     */
+    private ZookeeperMetadataStorageManager zkMeta;
     /** Coalesces concurrent reconnect attempts triggered by the bootstrap watcher. */
     private final AtomicBoolean reconnectInFlight = new AtomicBoolean(false);
     private final AtomicLong sessionReconnects = new AtomicLong();
@@ -258,87 +279,78 @@ public final class IndexOptimizerMain {
                     OptimizerConfiguration.PROPERTY_TABLESPACE_NAME + " must be set");
         }
 
-        // Resolve the tablespace UUID from the human-readable name by consulting
-        // the HerdDB cluster metadata in ZooKeeper.  We open a short-lived
-        // ZookeeperMetadataStorageManager exclusively for this lookup and close
-        // it immediately after so that the optimizer's permanent ZK connection
-        // (used by SegmentRegistryClient and OptimizerLeaderLock) is separate
-        // and independently reconnectable.
+        // Open the long-lived ZookeeperMetadataStorageManager used for:
+        //   1. Resolving the tablespace UUID from the human-readable name.
+        //   2. Discovering remote file servers via listFileServers() — which
+        //      installs a ZK children-watch on /herd/fileServers.
+        //   3. Reacting to file-server registration events via ServiceDiscoveryListener
+        //      so a startup-time NoopMerger is replaced as soon as the file server
+        //      appears in ZooKeeper (issue #507).
+        // Unlike the previous short-lived instance, this one stays open for the
+        // pod's lifetime. The ZookeeperMetadataStorageManager's built-in
+        // fileServersWatcher re-installs itself on every listFileServers() call,
+        // so the optimizer continuously re-discovers file servers reactively.
+        this.zkMeta = new ZookeeperMetadataStorageManager(zkAddress, sessionTimeout, basePath);
+        try {
+            zkMeta.start(false); // read-only: do not create/format cluster metadata paths
+        } catch (MetadataStorageManagerException e) {
+            throw new IllegalStateException(
+                    "Failed to start ZookeeperMetadataStorageManager: " + e.getMessage(), e);
+        }
+
+        // Register before listFileServers() so that if file servers appear
+        // between the getChildren call and the watcher registration (highly
+        // unlikely but theoretically possible), the watcher fires after
+        // start() returns and schedules a tick.
+        zkMeta.addServiceDiscoveryListener(new ServiceDiscoveryListener() {
+            @Override
+            public void onFileServersChanged(List<String> addresses) {
+                // Called on the ZK watcher thread — do NOT block it with heavy work.
+                // Schedule a tick on the optimizer scheduler: tickSafe() calls
+                // maybeUpgradeMerger() which builds the real merger if needed.
+                if (addresses == null || addresses.isEmpty()) {
+                    return;
+                }
+                synchronized (IndexOptimizerMain.this) {
+                    if (!(merger instanceof NoopMerger)) {
+                        return; // already upgraded, nothing to do
+                    }
+                }
+                LOGGER.log(Level.INFO,
+                        "onFileServersChanged: {0} server(s) discovered; scheduling merger upgrade",
+                        addresses.size());
+                scheduleEventDrivenTick();
+            }
+        });
+
         List<String> discoveredFileServers = new ArrayList<>();
-        try (ZookeeperMetadataStorageManager zkmeta =
-                new ZookeeperMetadataStorageManager(zkAddress, sessionTimeout, basePath)) {
-            zkmeta.start(false); // read-only: do not create/format cluster metadata paths
-            TableSpace ts = zkmeta.describeTableSpace(tablespaceName);
-            if (ts == null) {
-                throw new IllegalStateException(
-                        "No tablespace named '" + tablespaceName + "' found under "
-                        + basePath + "/tableSpaces — ensure the HerdDB cluster has started "
-                        + "and created its default tablespace before starting the optimizer.");
-            }
-            tablespaceUuid = ts.uuid;
-            try {
-                discoveredFileServers.addAll(zkmeta.listFileServers());
-            } catch (MetadataStorageManagerException listErr) {
-                LOGGER.log(Level.WARNING,
-                        "could not discover remote file servers via ZK; the optimizer"
-                                + " will fall back to NoopMerger if the static server list"
-                                + " is also empty: {0}",
-                        listErr.getMessage());
-            }
+        TableSpace ts;
+        try {
+            ts = zkMeta.describeTableSpace(tablespaceName);
         } catch (MetadataStorageManagerException e) {
             throw new IllegalStateException(
                     "Failed to resolve tablespace '" + tablespaceName + "' from ZooKeeper: "
                     + e.getMessage(), e);
         }
-
-        // Issue #507 — Option A: startup retry loop.
-        // If both the static server list and the initial ZK discovery are empty, the
-        // file server may not have finished registering yet (startup-ordering race).
-        // Retry up to PROPERTY_ZK_DISCOVERY_RETRIES times with the configured interval
-        // before falling back to NoopMerger. The tick-time upgrade (Option B,
-        // maybeUpgradeMerger) will self-heal even if all retries are exhausted, so
-        // these retries are an optimisation rather than the sole safety net.
-        String staticServersCheck = configuration.getString(
-                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS,
-                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS_DEFAULT);
-        if (discoveredFileServers.isEmpty() && (staticServersCheck == null || staticServersCheck.isEmpty())) {
-            int retries = configuration.getInt(
-                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES,
-                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES_DEFAULT);
-            long retryIntervalMs = configuration.getLong(
-                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS,
-                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS_DEFAULT);
-            for (int attempt = 0; attempt < retries && discoveredFileServers.isEmpty(); attempt++) {
-                LOGGER.log(Level.INFO,
-                        "ZK discovery returned no file servers; retrying in {0} ms "
-                                + "(attempt {1}/{2}) — file server may still be starting",
-                        new Object[]{retryIntervalMs, attempt + 1, retries});
-                // Use wait() instead of Thread.sleep() so the monitor is released
-                // during the pause — any concurrent thread that needs this lock
-                // (e.g. shutdown()) can proceed without waiting the full retry interval.
-                // Spurious early wake-ups from wait() are harmless: we simply retry
-                // ZK discovery sooner than planned.
-                try {
-                    wait(retryIntervalMs);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-                try (ZookeeperMetadataStorageManager zkRetry =
-                        new ZookeeperMetadataStorageManager(zkAddress, sessionTimeout, basePath)) {
-                    zkRetry.start(false);
-                    discoveredFileServers.addAll(zkRetry.listFileServers());
-                    if (!discoveredFileServers.isEmpty()) {
-                        LOGGER.log(Level.INFO,
-                                "ZK discovery retry {0}/{1} found file servers: {2}",
-                                new Object[]{attempt + 1, retries, discoveredFileServers});
-                    }
-                } catch (MetadataStorageManagerException retryErr) {
-                    LOGGER.log(Level.WARNING,
-                            "ZK discovery retry {0}/{1} failed: {2}",
-                            new Object[]{attempt + 1, retries, retryErr.getMessage()});
-                }
-            }
+        if (ts == null) {
+            throw new IllegalStateException(
+                    "No tablespace named '" + tablespaceName + "' found under "
+                    + basePath + "/tableSpaces — ensure the HerdDB cluster has started "
+                    + "and created its default tablespace before starting the optimizer.");
+        }
+        tablespaceUuid = ts.uuid;
+        try {
+            // listFileServers() installs the ZK children-watch on /herd/fileServers.
+            // Even if it returns empty (file server not yet registered), the watch
+            // will fire when the file server registers and onFileServersChanged above
+            // will schedule an upgrade tick automatically.
+            discoveredFileServers.addAll(zkMeta.listFileServers());
+        } catch (MetadataStorageManagerException listErr) {
+            LOGGER.log(Level.WARNING,
+                    "could not discover remote file servers via ZK; the optimizer"
+                            + " will fall back to NoopMerger until the ZK watcher fires"
+                            + " or the static server list is configured: {0}",
+                    listErr.getMessage());
         }
         LOGGER.log(Level.INFO, "Resolved tablespace name ''{0}'' to UUID {1}",
                 new Object[]{tablespaceName, tablespaceUuid});
@@ -701,17 +713,15 @@ public final class IndexOptimizerMain {
             }
         }
         if (servers.isEmpty()) {
-            // Re-attempt ZK discovery.
-            String addr = this.zkAddress;
-            int timeout = this.zkSessionTimeoutMs;
-            String basePath = this.zkBasePath;
-            if (addr == null || basePath == null) {
+            // Re-attempt ZK discovery via the long-lived zkMeta instance (issue #507).
+            // This reuses the already-open ZK session — no new session overhead —
+            // and also re-arms the fileServersWatcher so future file-server changes
+            // continue to trigger onFileServersChanged callbacks.
+            if (zkMeta == null) {
                 return; // start() not yet complete
             }
-            try (ZookeeperMetadataStorageManager zkmeta =
-                    new ZookeeperMetadataStorageManager(addr, timeout, basePath)) {
-                zkmeta.start(false);
-                servers.addAll(zkmeta.listFileServers());
+            try {
+                servers.addAll(zkMeta.listFileServers());
             } catch (MetadataStorageManagerException zkErr) {
                 LOGGER.log(Level.FINE,
                         "maybeUpgradeMerger: ZK discovery failed, will retry on next tick: {0}",
@@ -836,16 +846,10 @@ public final class IndexOptimizerMain {
                         OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES,
                         OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES_DEFAULT));
 
-        RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
-        this.mergerFileClient = factory.createClient(servers, clientConfig);
-        Path tmpDir = resolveTmpDirectory();
-        Path metaDir = tmpDir.resolve("merger-metadata");
-        Path remoteTmp = tmpDir.resolve("merger-remote-tmp");
-        Files.createDirectories(metaDir);
-        Files.createDirectories(remoteTmp);
-        this.mergerDataStorageManager = factory.createDataStorageManager(
-                metaDir, remoteTmp, Integer.MAX_VALUE, mergerFileClient);
-
+        // Validate all configuration BEFORE allocating any resources (gRPC channel,
+        // DataStorageManager) to avoid resource leaks when validation fails. Previously
+        // the dim check came after factory.createClient(), leaking a file client on every
+        // failed call (issue #507, reviewer finding).
         int dim = configuration.getInt("indexoptimizer.merge.dim", 0);
         if (dim <= 0) {
             // The merger needs the dimension up front. Fall back: we don't
@@ -875,6 +879,17 @@ public final class IndexOptimizerMain {
                             + " (expected one of " + Arrays.toString(VectorSimilarityFunction.values())
                             + ")", badName);
         }
+
+        RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
+        this.mergerFileClient = factory.createClient(servers, clientConfig);
+        Path tmpDir = resolveTmpDirectory();
+        Path metaDir = tmpDir.resolve("merger-metadata");
+        Path remoteTmp = tmpDir.resolve("merger-remote-tmp");
+        Files.createDirectories(metaDir);
+        Files.createDirectories(remoteTmp);
+        this.mergerDataStorageManager = factory.createDataStorageManager(
+                metaDir, remoteTmp, Integer.MAX_VALUE, mergerFileClient);
+
         return new RemoteSegmentMerger(mergerDataStorageManager, tmpDir,
                 dim, graphM, beamWidth, neighborOverflow, alpha, similarity);
     }
@@ -934,6 +949,19 @@ public final class IndexOptimizerMain {
                 // an earlier exception.
                 LOGGER.log(Level.WARNING, "merger file client close failed: {0}",
                         e.getMessage());
+            }
+        }
+        // Close the long-lived ZookeeperMetadataStorageManager last. Its ZK session
+        // must stay open until after the leader lock is released and the primary ZK
+        // session is closed, so file-server watchers don't fire spuriously during
+        // orderly shutdown.
+        if (zkMeta != null) {
+            try {
+                zkMeta.close();
+            } catch (Exception e) {
+                // Broad catch: MetadataStorageManager.close() declares Exception.
+                // Best-effort cleanup during shutdown — log and proceed.
+                LOGGER.log(Level.WARNING, "zkMeta close failed: {0}", e.getMessage());
             }
         }
         shutdownLatch.countDown();

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.zookeeper.AddWatchMode;
@@ -105,7 +106,7 @@ public final class IndexOptimizerMain {
      * {@code herddb.indexing.optimizer} can inject a synthetic factory (e.g.
      * returning {@link InMemorySegmentMerger}) without needing a live file server.
      */
-    java.util.function.Function<List<String>, SegmentMerger> mergerBuilderForTests;
+    Function<List<String>, SegmentMerger> mergerBuilderForTests;
 
     /**
      * Current ZooKeeper client. Replaced atomically by {@link #reconnectZooKeeper}
@@ -165,8 +166,19 @@ public final class IndexOptimizerMain {
     private OptimizerLeaderLock leaderLock;
     private IndexOptimizerEngine engine;
     private OptimizerHttpServer httpServer;
-    private SegmentMerger merger;
-    private DataStorageManager mergerDataStorageManager;
+    /**
+     * Currently active merger. {@code volatile} so that the unsynchronized
+     * {@link #getMerger()} method (used by tests and future monitoring endpoints)
+     * always sees the latest value written by {@link #maybeUpgradeMerger()} under
+     * {@code synchronized(this)} (JMM visibility guarantee).
+     */
+    private volatile SegmentMerger merger;
+    /**
+     * DataStorageManager wired to the current merger. {@code volatile} for the
+     * same reason as {@link #merger}; both fields are always updated together
+     * inside {@link #maybeUpgradeMerger()} under {@code synchronized(this)}.
+     */
+    private volatile DataStorageManager mergerDataStorageManager;
     private RemoteFileClient mergerFileClient;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
@@ -312,8 +324,14 @@ public final class IndexOptimizerMain {
                     return;
                 }
                 synchronized (IndexOptimizerMain.this) {
-                    if (!(merger instanceof NoopMerger)) {
-                        return; // already upgraded, nothing to do
+                    // merger is null between addServiceDiscoveryListener() (line above) and
+                    // this.merger = resolveMerger() later in start(). start() holds the
+                    // IndexOptimizerMain monitor the entire time, so this listener will
+                    // block on the synchronized block until start() completes — at which
+                    // point merger is non-null. The null guard is a belt-and-suspenders
+                    // defensive check in case of unexpected future refactoring.
+                    if (merger == null || !(merger instanceof NoopMerger)) {
+                        return; // not yet initialised, or already upgraded — nothing to do
                     }
                 }
                 LOGGER.log(Level.INFO,
@@ -395,6 +413,24 @@ public final class IndexOptimizerMain {
         boolean safeModeFileDeletion = configuration.getBoolean(
                 OptimizerConfiguration.PROPERTY_SAFE_MODE_FILE_DELETION,
                 OptimizerConfiguration.PROPERTY_SAFE_MODE_FILE_DELETION_DEFAULT);
+        // When safeModeFileDeletion=false the engine requires a non-null DataStorageManager.
+        // If no file servers were discovered at startup (startup-ordering race), the DSM is
+        // null and the engine constructor would throw IllegalArgumentException — defeating the
+        // self-healing intent of this fix. Coerce to safe mode for this run and log SEVERE so
+        // the operator is aware. Physical file deletion will remain disabled until the pod is
+        // restarted after file servers are visible in ZooKeeper. The merger itself upgrades
+        // reactively via maybeUpgradeMerger() once file servers appear, so merging still works.
+        boolean effectiveSafeMode = safeModeFileDeletion;
+        if (!effectiveSafeMode && mergerDataStorageManager == null) {
+            LOGGER.log(Level.SEVERE,
+                    "safeModeFileDeletion=false was requested but no DataStorageManager is "
+                    + "available (no file servers were discovered at startup). Coercing to "
+                    + "safeModeFileDeletion=true for this run; physical file deletion will "
+                    + "remain disabled until a pod restart after file servers are visible in "
+                    + "ZooKeeper. Ensure the file-server pod starts before the optimizer to "
+                    + "avoid this fallback.");
+            effectiveSafeMode = true;
+        }
         // The merger constructs its own DSM for the merge path. The reaper
         // can use the same DSM to physically delete files at retention if
         // safeMode is opted out (the operator's responsibility).
@@ -403,7 +439,7 @@ public final class IndexOptimizerMain {
                 System::currentTimeMillis,
                 mergerDataStorageManager,
                 leaderLock,
-                safeModeFileDeletion);
+                effectiveSafeMode);
 
         this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
             FastThreadLocalThread t = new FastThreadLocalThread(r, "index-optimizer-engine");
@@ -447,10 +483,10 @@ public final class IndexOptimizerMain {
 
     private void tickSafe() {
         try {
-            // Issue #507, Option B: if the optimizer started with a NoopMerger (because
-            // ZK discovery was empty and the startup retries were exhausted), attempt to
-            // upgrade to a real merger before each tick. This self-heals the startup-
-            // ordering race without requiring a pod restart.
+            // Issue #507: if the optimizer started with a NoopMerger (because ZK discovery
+            // was empty at startup), attempt to upgrade to a real merger before each tick.
+            // This is the safety-net path; the primary upgrade path is the ZK watcher
+            // in onFileServersChanged() → scheduleEventDrivenTick() registered in start().
             maybeUpgradeMerger();
             engine.runOnce();
         } catch (herddb.indexing.segment.SegmentRegistryException | RuntimeException e) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -98,6 +98,15 @@ public final class IndexOptimizerMain {
     private final SegmentMerger preconfiguredMerger;
 
     /**
+     * Test seam: when non-null, {@link #maybeUpgradeMerger()} builds the upgraded
+     * merger using this factory instead of {@link #buildRemoteSegmentMerger}.
+     * Never set in production code; package-private so unit tests in
+     * {@code herddb.indexing.optimizer} can inject a synthetic factory (e.g.
+     * returning {@link InMemorySegmentMerger}) without needing a live file server.
+     */
+    java.util.function.Function<List<String>, SegmentMerger> mergerBuilderForTests;
+
+    /**
      * Current ZooKeeper client. Replaced atomically by {@link #reconnectZooKeeper}
      * when the previous session expired (issue #504). Reads through
      * {@link #zkRef} so {@link SegmentRegistryClient} and {@link OptimizerLeaderLock}
@@ -112,6 +121,13 @@ public final class IndexOptimizerMain {
     private final AtomicReference<ZooKeeper> zkRef = new AtomicReference<>();
     private volatile String zkAddress;
     private volatile int zkSessionTimeoutMs;
+    /**
+     * ZooKeeper base path (e.g. {@code /herd}). Stored as a field so that
+     * {@link #maybeUpgradeMerger()} can open a short-lived
+     * {@link herddb.cluster.ZookeeperMetadataStorageManager} for ZK discovery
+     * retries at tick time without re-reading the configuration (issue #507).
+     */
+    private volatile String zkBasePath;
     /** Coalesces concurrent reconnect attempts triggered by the bootstrap watcher. */
     private final AtomicBoolean reconnectInFlight = new AtomicBoolean(false);
     private final AtomicLong sessionReconnects = new AtomicLong();
@@ -233,6 +249,8 @@ public final class IndexOptimizerMain {
         String basePath = configuration.getString(
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH,
                 OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH_DEFAULT);
+        // Store as a field so maybeUpgradeMerger() can access it at tick time.
+        this.zkBasePath = basePath;
         String tablespaceName = configuration.getString(
                 OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, null);
         if (tablespaceName == null || tablespaceName.isEmpty()) {
@@ -271,6 +289,56 @@ public final class IndexOptimizerMain {
             throw new IllegalStateException(
                     "Failed to resolve tablespace '" + tablespaceName + "' from ZooKeeper: "
                     + e.getMessage(), e);
+        }
+
+        // Issue #507 — Option A: startup retry loop.
+        // If both the static server list and the initial ZK discovery are empty, the
+        // file server may not have finished registering yet (startup-ordering race).
+        // Retry up to PROPERTY_ZK_DISCOVERY_RETRIES times with the configured interval
+        // before falling back to NoopMerger. The tick-time upgrade (Option B,
+        // maybeUpgradeMerger) will self-heal even if all retries are exhausted, so
+        // these retries are an optimisation rather than the sole safety net.
+        String staticServersCheck = configuration.getString(
+                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS,
+                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS_DEFAULT);
+        if (discoveredFileServers.isEmpty() && (staticServersCheck == null || staticServersCheck.isEmpty())) {
+            int retries = configuration.getInt(
+                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES,
+                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES_DEFAULT);
+            long retryIntervalMs = configuration.getLong(
+                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS,
+                    OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS_DEFAULT);
+            for (int attempt = 0; attempt < retries && discoveredFileServers.isEmpty(); attempt++) {
+                LOGGER.log(Level.INFO,
+                        "ZK discovery returned no file servers; retrying in {0} ms "
+                                + "(attempt {1}/{2}) — file server may still be starting",
+                        new Object[]{retryIntervalMs, attempt + 1, retries});
+                // Use wait() instead of Thread.sleep() so the monitor is released
+                // during the pause — any concurrent thread that needs this lock
+                // (e.g. shutdown()) can proceed without waiting the full retry interval.
+                // Spurious early wake-ups from wait() are harmless: we simply retry
+                // ZK discovery sooner than planned.
+                try {
+                    wait(retryIntervalMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                try (ZookeeperMetadataStorageManager zkRetry =
+                        new ZookeeperMetadataStorageManager(zkAddress, sessionTimeout, basePath)) {
+                    zkRetry.start(false);
+                    discoveredFileServers.addAll(zkRetry.listFileServers());
+                    if (!discoveredFileServers.isEmpty()) {
+                        LOGGER.log(Level.INFO,
+                                "ZK discovery retry {0}/{1} found file servers: {2}",
+                                new Object[]{attempt + 1, retries, discoveredFileServers});
+                    }
+                } catch (MetadataStorageManagerException retryErr) {
+                    LOGGER.log(Level.WARNING,
+                            "ZK discovery retry {0}/{1} failed: {2}",
+                            new Object[]{attempt + 1, retries, retryErr.getMessage()});
+                }
+            }
         }
         LOGGER.log(Level.INFO, "Resolved tablespace name ''{0}'' to UUID {1}",
                 new Object[]{tablespaceName, tablespaceUuid});
@@ -367,6 +435,11 @@ public final class IndexOptimizerMain {
 
     private void tickSafe() {
         try {
+            // Issue #507, Option B: if the optimizer started with a NoopMerger (because
+            // ZK discovery was empty and the startup retries were exhausted), attempt to
+            // upgrade to a real merger before each tick. This self-heals the startup-
+            // ordering race without requiring a pod restart.
+            maybeUpgradeMerger();
             engine.runOnce();
         } catch (herddb.indexing.segment.SegmentRegistryException | RuntimeException e) {
             // Narrow catch (review item H1): the engine's runOnce now declares a typed
@@ -581,8 +654,100 @@ public final class IndexOptimizerMain {
     }
 
     // -------------------------------------------------------------------------
-    // Merger resolution
+    // Merger resolution and late-binding upgrade (issue #507)
     // -------------------------------------------------------------------------
+
+    /**
+     * Issue #507, Option B — tick-time late-binding merger upgrade.
+     *
+     * <p>If the optimizer started with a {@link NoopMerger} (because both the static
+     * {@link OptimizerConfiguration#PROPERTY_REMOTE_FILE_SERVERS} and the startup-time
+     * ZK discovery were empty), this method is called at the top of every
+     * {@link #tickSafe()} to retry ZK discovery and, if file servers are now visible,
+     * build a real {@link RemoteSegmentMerger} and install it atomically via
+     * {@link IndexOptimizerEngine#upgradeMerger}.
+     *
+     * <p>Synchronised on {@code this} for two reasons: (a) the single-threaded
+     * scheduler serialises ticks, but the ZK-session-expiry reconnect path can
+     * also call {@link #scheduleEventDrivenTick} from a different thread, potentially
+     * racing with this path; (b) {@link #merger} and {@link #mergerDataStorageManager}
+     * are both updated here and must be seen together by any subsequent read.
+     *
+     * <p>Skipped entirely when:
+     * <ul>
+     *   <li>The current merger is already a real merger (not {@link NoopMerger}).</li>
+     *   <li>A merger was pre-configured via the constructor (test/SPI path) — the
+     *       pre-configured merger takes priority unconditionally.</li>
+     *   <li>{@link #engine} is not yet initialised (called defensively before
+     *       {@link #start()} completes).</li>
+     * </ul>
+     */
+    private synchronized void maybeUpgradeMerger() {
+        if (preconfiguredMerger != null || engine == null || !(merger instanceof NoopMerger)) {
+            return;
+        }
+        // Re-check static config first — faster than a ZK round-trip and avoids the
+        // network if the operator added the static key after the optimizer started.
+        String staticServers = configuration.getString(
+                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS,
+                OptimizerConfiguration.PROPERTY_REMOTE_FILE_SERVERS_DEFAULT);
+        List<String> servers = new ArrayList<>();
+        if (staticServers != null && !staticServers.isEmpty()) {
+            for (String s : staticServers.split(",")) {
+                String trimmed = s.trim();
+                if (!trimmed.isEmpty()) {
+                    servers.add(trimmed);
+                }
+            }
+        }
+        if (servers.isEmpty()) {
+            // Re-attempt ZK discovery.
+            String addr = this.zkAddress;
+            int timeout = this.zkSessionTimeoutMs;
+            String basePath = this.zkBasePath;
+            if (addr == null || basePath == null) {
+                return; // start() not yet complete
+            }
+            try (ZookeeperMetadataStorageManager zkmeta =
+                    new ZookeeperMetadataStorageManager(addr, timeout, basePath)) {
+                zkmeta.start(false);
+                servers.addAll(zkmeta.listFileServers());
+            } catch (MetadataStorageManagerException zkErr) {
+                LOGGER.log(Level.FINE,
+                        "maybeUpgradeMerger: ZK discovery failed, will retry on next tick: {0}",
+                        zkErr.getMessage());
+                return;
+            }
+        }
+        if (servers.isEmpty()) {
+            return; // still nothing — skip and try again on the next tick
+        }
+        LOGGER.log(Level.INFO,
+                "maybeUpgradeMerger: discovered file servers {0}; upgrading from NoopMerger",
+                servers);
+        try {
+            SegmentMerger upgraded;
+            if (mergerBuilderForTests != null) {
+                // Test seam: use the injected factory instead of the real RemoteSegmentMerger
+                // constructor (which requires a live file server and dim config).
+                upgraded = mergerBuilderForTests.apply(servers);
+            } else {
+                upgraded = buildRemoteSegmentMerger(servers, zkAddress, zkBasePath);
+            }
+            this.merger = upgraded;
+            engine.upgradeMerger(upgraded, mergerDataStorageManager);
+            LOGGER.log(Level.INFO,
+                    "maybeUpgradeMerger: successfully upgraded to {0}",
+                    upgraded.getClass().getSimpleName());
+        } catch (IOException | RuntimeException buildErr) {
+            // Building the merger failed (bad config, unreachable server, etc.).
+            // Log and stay with NoopMerger — the next tick will retry.
+            LOGGER.log(Level.WARNING,
+                    "maybeUpgradeMerger: failed to build RemoteSegmentMerger; "
+                            + "will retry on next tick: {0}",
+                    buildErr.getMessage());
+        }
+    }
 
     /**
      * Resolves the {@link SegmentMerger} for this optimizer. Resolution order:
@@ -634,6 +799,11 @@ public final class IndexOptimizerMain {
             return new NoopMerger();
         }
         try {
+            if (mergerBuilderForTests != null) {
+                // Test seam: use the injected factory instead of the real RemoteSegmentMerger
+                // constructor (which requires a live file server and dim config).
+                return mergerBuilderForTests.apply(servers);
+            }
             return buildRemoteSegmentMerger(servers, zkAddress, basePath);
         } catch (RuntimeException buildErr) {
             // Building the DSM is the plugin boundary — surface and fall back rather

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -196,6 +196,23 @@ public final class OptimizerConfiguration {
     public static final String PROPERTY_REMOTE_FILE_SERVERS = "indexoptimizer.remote.file.servers";
     public static final String PROPERTY_REMOTE_FILE_SERVERS_DEFAULT = "";
 
+    /**
+     * Number of ZK discovery retries at startup if the initial {@code listFileServers()} call
+     * returns an empty list and no static servers are configured (issue #507, Option A).
+     * Each retry is separated by {@link #PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS} milliseconds.
+     * Set to 0 to disable startup retries and rely solely on tick-time upgrade (Option B).
+     */
+    public static final String PROPERTY_ZK_DISCOVERY_RETRIES = "indexoptimizer.zk.discovery.retries";
+    public static final int PROPERTY_ZK_DISCOVERY_RETRIES_DEFAULT = 3;
+
+    /**
+     * Wait interval between ZK discovery retries at startup, in milliseconds (issue #507).
+     * Defaults to 2 s; use a much shorter value in unit tests to keep tests fast.
+     */
+    public static final String PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS =
+            "indexoptimizer.zk.discovery.retry.interval.ms";
+    public static final long PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS_DEFAULT = 2000L;
+
     /** Per-call deadline for the remote-file client, in seconds. */
     public static final String PROPERTY_REMOTE_FILE_TIMEOUT = "indexoptimizer.remote.file.client.timeout";
     public static final long PROPERTY_REMOTE_FILE_TIMEOUT_DEFAULT = 60L;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -192,26 +192,19 @@ public final class OptimizerConfiguration {
     // {@code /herd/file-servers} path.
     // -------------------------------------------------------------------------
 
-    /** Comma-separated list of remote file-service endpoints. Empty → ZK discovery. */
+    /**
+     * Comma-separated list of remote file-service endpoints.
+     * When empty (the default), the optimizer discovers file servers via the
+     * long-lived {@link herddb.cluster.ZookeeperMetadataStorageManager} that stays
+     * open for the pod's lifetime. The built-in {@code fileServersWatcher} in
+     * {@code ZookeeperMetadataStorageManager} reacts to ZK children-changed events
+     * under {@code /herd/fileServers} and calls the optimizer's
+     * {@link herddb.metadata.ServiceDiscoveryListener}, which schedules a merger
+     * upgrade tick so a startup-time {@code NoopMerger} is replaced as soon as
+     * the file server appears in ZooKeeper (issue #507).
+     */
     public static final String PROPERTY_REMOTE_FILE_SERVERS = "indexoptimizer.remote.file.servers";
     public static final String PROPERTY_REMOTE_FILE_SERVERS_DEFAULT = "";
-
-    /**
-     * Number of ZK discovery retries at startup if the initial {@code listFileServers()} call
-     * returns an empty list and no static servers are configured (issue #507, Option A).
-     * Each retry is separated by {@link #PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS} milliseconds.
-     * Set to 0 to disable startup retries and rely solely on tick-time upgrade (Option B).
-     */
-    public static final String PROPERTY_ZK_DISCOVERY_RETRIES = "indexoptimizer.zk.discovery.retries";
-    public static final int PROPERTY_ZK_DISCOVERY_RETRIES_DEFAULT = 3;
-
-    /**
-     * Wait interval between ZK discovery retries at startup, in milliseconds (issue #507).
-     * Defaults to 2 s; use a much shorter value in unit tests to keep tests fast.
-     */
-    public static final String PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS =
-            "indexoptimizer.zk.discovery.retry.interval.ms";
-    public static final long PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS_DEFAULT = 2000L;
 
     /** Per-call deadline for the remote-file client, in seconds. */
     public static final String PROPERTY_REMOTE_FILE_TIMEOUT = "indexoptimizer.remote.file.client.timeout";

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -198,10 +198,17 @@ public final class OptimizerConfiguration {
      * long-lived {@link herddb.cluster.ZookeeperMetadataStorageManager} that stays
      * open for the pod's lifetime. The built-in {@code fileServersWatcher} in
      * {@code ZookeeperMetadataStorageManager} reacts to ZK children-changed events
-     * under {@code /herd/fileServers} and calls the optimizer's
-     * {@link herddb.metadata.ServiceDiscoveryListener}, which schedules a merger
-     * upgrade tick so a startup-time {@code NoopMerger} is replaced as soon as
-     * the file server appears in ZooKeeper (issue #507).
+     * under {@code /<zookeeper-path>/fileServers} (e.g. {@code /herd/fileServers})
+     * and calls the optimizer's {@link herddb.metadata.ServiceDiscoveryListener},
+     * which schedules a merger upgrade tick so a startup-time {@code NoopMerger}
+     * is replaced as soon as the file server appears in ZooKeeper (issue #507).
+     *
+     * <p><b>Note on {@code safeModeFileDeletion=false}</b>: if no file servers are
+     * visible at optimizer startup, the engine is constructed with
+     * {@code safeModeFileDeletion=true} regardless of this property, and a
+     * {@code SEVERE} log is emitted. Physical file deletion will remain disabled
+     * until a pod restart. Ensure the file-server pod starts before the optimizer
+     * to avoid this fallback.
      */
     public static final String PROPERTY_REMOTE_FILE_SERVERS = "indexoptimizer.remote.file.servers";
     public static final String PROPERTY_REMOTE_FILE_SERVERS_DEFAULT = "";

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
@@ -1,0 +1,241 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.model.TableSpace;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies the two-layer fix for the NoopMerger startup-race (issue #507):
+ *
+ * <ul>
+ *   <li><b>Option A</b> — startup retry: if the initial ZK discovery returns
+ *       empty and no static servers are configured, the optimizer retries
+ *       {@code listFileServers()} up to {@code PROPERTY_ZK_DISCOVERY_RETRIES}
+ *       times. A file server that registers in ZK during the retry window is
+ *       picked up and the optimizer resolves a non-NoopMerger at startup.</li>
+ *   <li><b>Option B</b> — tick-time upgrade: if all startup retries are
+ *       exhausted and the optimizer starts with {@link IndexOptimizerMain.NoopMerger},
+ *       each subsequent tick calls {@link IndexOptimizerMain#maybeUpgradeMerger()}.
+ *       Once a file server appears in ZK, the engine's merger is replaced
+ *       atomically with the upgraded merger.</li>
+ * </ul>
+ *
+ * <p>Both tests use the package-private {@code mergerBuilderForTests} seam
+ * (a {@link java.util.function.Function}) so they can inject an
+ * {@link InMemorySegmentMerger} without needing a live remote file server.
+ */
+public class OptimizerMergerLateBindingTest {
+
+    private static final String BASE_PATH = "/herd-test-late-binding";
+    private static final String TS_NAME = "herd";
+    private static final String TS_UUID = "ts-late-bind";
+    private static final String FILE_SERVER_ID = "file-server-0";
+    private static final String FILE_SERVER_ADDR = "herddb-file-server-0.svc:9846";
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue("ZK connect timed out", connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registerTablespace(TS_NAME, TS_UUID);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    private void registerTablespace(String name, String uuid) throws Exception {
+        Set<String> replicas = new HashSet<>();
+        replicas.add("test-instance");
+        TableSpace ts = TableSpace.builder()
+                .name(name)
+                .uuid(uuid)
+                .leader("test-instance")
+                .replicas(replicas)
+                .expectedReplicaCount(1)
+                .build();
+        try (ZookeeperMetadataStorageManager zkmeta =
+                new ZookeeperMetadataStorageManager(zkServer.getConnectString(), 30000, BASE_PATH)) {
+            zkmeta.start(true);
+            zkmeta.registerTableSpace(ts);
+        }
+    }
+
+    private void registerFileServer() throws Exception {
+        try (ZookeeperMetadataStorageManager zkmeta =
+                new ZookeeperMetadataStorageManager(zkServer.getConnectString(), 30000, BASE_PATH)) {
+            zkmeta.start(false);
+            zkmeta.registerFileServer(FILE_SERVER_ID, FILE_SERVER_ADDR);
+        }
+    }
+
+    private Properties baseProps() {
+        Properties p = new Properties();
+        p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkServer.getConnectString());
+        p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
+        p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
+        p.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
+        // Long periodic interval; we drive the engine manually via the tick or with a short interval.
+        p.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
+        p.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
+        p.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
+        return p;
+    }
+
+    /**
+     * Option A: the file server registers in ZK while {@code start()} is
+     * blocked in its retry loop. The retry picks it up and the optimizer
+     * resolves a real (non-NoopMerger) merger at startup.
+     *
+     * <p>The test sets {@code PROPERTY_ZK_DISCOVERY_RETRIES=5} and
+     * {@code PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS=100}. A background
+     * thread registers the file server 120 ms after the retry loop starts
+     * (so the first retry misses it, the second or later retries catch it).
+     * {@code start()} is run in the foreground — the test asserts on the
+     * merger that was resolved before any tick runs.
+     */
+    @Test
+    public void startupRetryPicksUpFileServerRegisteredDuringRetryWindow() throws Exception {
+        Properties props = baseProps();
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES, "5");
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS, "100");
+
+        // The merger builder test seam: returns an InMemorySegmentMerger when servers are discovered.
+        AtomicBoolean builderCalled = new AtomicBoolean(false);
+        IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
+        main.mergerBuilderForTests = servers -> {
+            builderCalled.set(true);
+            return new InMemorySegmentMerger();
+        };
+
+        // Register the file server 120 ms from now — the first retry (at 100 ms) will miss
+        // it, subsequent retries will find it.
+        Thread registrar = new Thread(() -> {
+            try {
+                Thread.sleep(120);
+                registerFileServer();
+            } catch (Exception e) {
+                throw new RuntimeException("file server registration failed", e);
+            }
+        }, "test-file-server-registrar");
+        registrar.setDaemon(true);
+        registrar.start();
+
+        try {
+            main.start();
+            assertNotNull("engine must be initialised", main.getEngine());
+            assertTrue("merger builder test seam must have been called: file server was found by retry",
+                    builderCalled.get());
+            assertFalse("merger must NOT be a NoopMerger after startup retry picked up the file server",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    /**
+     * Option B: the optimizer starts with {@link IndexOptimizerMain.NoopMerger}
+     * (no file server in ZK at startup, retries exhausted). After startup, a
+     * file server registers in ZK. The next tick call upgrades the merger from
+     * NoopMerger to the real merger via {@link IndexOptimizerMain#maybeUpgradeMerger()}.
+     *
+     * <p>The test disables the startup retry loop ({@code retries=0}) so the
+     * optimizer always starts with NoopMerger. It then registers the file server
+     * and triggers a short-interval tick to observe the upgrade.
+     */
+    @Test
+    public void tickTimeUpgradeReplacesNoopMergerOnceFileServerAppears() throws Exception {
+        Properties props = baseProps();
+        // Disable startup retries so the optimizer always starts with NoopMerger.
+        props.setProperty(OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES, "0");
+        // Short tick so the upgrade fires quickly.
+        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "100");
+
+        AtomicBoolean builderCalled = new AtomicBoolean(false);
+        IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
+        main.mergerBuilderForTests = servers -> {
+            builderCalled.set(true);
+            return new InMemorySegmentMerger();
+        };
+
+        try {
+            main.start();
+            assertNotNull("engine must be initialised", main.getEngine());
+            // At this point, no file server is in ZK and retries are disabled:
+            // the optimizer must have fallen back to NoopMerger.
+            assertTrue("merger must be NoopMerger immediately after startup with no file server",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+
+            // Now register the file server in ZK.
+            registerFileServer();
+
+            // Wait for the tick-time upgrade to fire (up to 10 s).
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline) {
+                if (!(main.getMerger() instanceof IndexOptimizerMain.NoopMerger)) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+
+            assertTrue("merger builder test seam must have been called by maybeUpgradeMerger()",
+                    builderCalled.get());
+            assertFalse("merger must NOT be a NoopMerger after tick-time upgrade",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+            assertTrue("upgraded merger must be an InMemorySegmentMerger (injected via test seam)",
+                    main.getMerger() instanceof InMemorySegmentMerger);
+        } finally {
+            main.shutdown();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
@@ -40,24 +39,25 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Verifies the two-layer fix for the NoopMerger startup-race (issue #507):
+ * Verifies the fix for the {@code NoopMerger} startup race (issue #507):
  *
- * <ul>
- *   <li><b>Option A</b> — startup retry: if the initial ZK discovery returns
- *       empty and no static servers are configured, the optimizer retries
- *       {@code listFileServers()} up to {@code PROPERTY_ZK_DISCOVERY_RETRIES}
- *       times. A file server that registers in ZK during the retry window is
- *       picked up and the optimizer resolves a non-NoopMerger at startup.</li>
- *   <li><b>Option B</b> — tick-time upgrade: if all startup retries are
- *       exhausted and the optimizer starts with {@link IndexOptimizerMain.NoopMerger},
- *       each subsequent tick calls {@link IndexOptimizerMain#maybeUpgradeMerger()}.
- *       Once a file server appears in ZK, the engine's merger is replaced
- *       atomically with the upgraded merger.</li>
- * </ul>
+ * <p>The root cause: the optimizer called {@code listFileServers()} exactly once at
+ * startup. If the file-server pod had not yet written its ZK znode, the list was
+ * empty and {@code resolveMerger()} fell back to {@code NoopMerger} permanently.
  *
- * <p>Both tests use the package-private {@code mergerBuilderForTests} seam
- * (a {@link java.util.function.Function}) so they can inject an
- * {@link InMemorySegmentMerger} without needing a live remote file server.
+ * <p>The fix uses a single long-lived {@link ZookeeperMetadataStorageManager} that:
+ * <ol>
+ *   <li>Performs the initial {@code listFileServers()} call, which arms a ZK
+ *       children-watch on {@code /herd/fileServers}.</li>
+ *   <li>When a file server registers, the watch fires → {@code notifyFileServersChanged}
+ *       → {@link IndexOptimizerMain}'s {@code ServiceDiscoveryListener} schedules an
+ *       event-driven tick.</li>
+ *   <li>The tick's {@code maybeUpgradeMerger()} upgrades the engine from
+ *       {@code NoopMerger} to a real merger atomically.</li>
+ * </ol>
+ *
+ * <p>Both tests use the package-private {@code mergerBuilderForTests} seam so they
+ * can inject an {@link InMemorySegmentMerger} without needing a live remote file server.
  */
 public class OptimizerMergerLateBindingTest {
 
@@ -125,7 +125,7 @@ public class OptimizerMergerLateBindingTest {
         p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
         p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
         p.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
-        // Long periodic interval; we drive the engine manually via the tick or with a short interval.
+        // Long periodic interval; the watcher-driven tick handles the upgrade.
         p.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
         p.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
         p.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
@@ -133,93 +133,40 @@ public class OptimizerMergerLateBindingTest {
     }
 
     /**
-     * Option A: the file server registers in ZK while {@code start()} is
-     * blocked in its retry loop. The retry picks it up and the optimizer
-     * resolves a real (non-NoopMerger) merger at startup.
+     * Issue #507 — watcher-driven upgrade (primary fix):
      *
-     * <p>The test sets {@code PROPERTY_ZK_DISCOVERY_RETRIES=5} and
-     * {@code PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS=100}. A background
-     * thread registers the file server 120 ms after the retry loop starts
-     * (so the first retry misses it, the second or later retries catch it).
-     * {@code start()} is run in the foreground — the test asserts on the
-     * merger that was resolved before any tick runs.
+     * <p>The optimizer starts with no file server in ZK → resolves {@link IndexOptimizerMain.NoopMerger}.
+     * The long-lived {@link ZookeeperMetadataStorageManager}'s children-watch on
+     * {@code /herd/fileServers} is armed by the initial {@code listFileServers()} call.
+     * When a file server registers, the watch fires → {@code ServiceDiscoveryListener.onFileServersChanged}
+     * schedules an event-driven tick → {@code maybeUpgradeMerger()} upgrades the merger
+     * to {@link InMemorySegmentMerger} (via the test seam).
+     *
+     * <p>No timing hacks: the upgrade is driven by the reactive ZK watcher, so the
+     * test only needs to wait for the upgrade to complete (up to 10 s).
      */
     @Test
-    public void startupRetryPicksUpFileServerRegisteredDuringRetryWindow() throws Exception {
+    public void watcherDrivenUpgradeReplacesNoopMergerWhenFileServerRegisters() throws Exception {
         Properties props = baseProps();
-        props.setProperty(OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES, "5");
-        props.setProperty(OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRY_INTERVAL_MS, "100");
+        // Short debounce so the watcher-triggered tick fires quickly.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "50");
 
-        // The merger builder test seam: returns an InMemorySegmentMerger when servers are discovered.
-        AtomicBoolean builderCalled = new AtomicBoolean(false);
         IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
-        main.mergerBuilderForTests = servers -> {
-            builderCalled.set(true);
-            return new InMemorySegmentMerger();
-        };
-
-        // Register the file server 120 ms from now — the first retry (at 100 ms) will miss
-        // it, subsequent retries will find it.
-        Thread registrar = new Thread(() -> {
-            try {
-                Thread.sleep(120);
-                registerFileServer();
-            } catch (Exception e) {
-                throw new RuntimeException("file server registration failed", e);
-            }
-        }, "test-file-server-registrar");
-        registrar.setDaemon(true);
-        registrar.start();
+        main.mergerBuilderForTests = servers -> new InMemorySegmentMerger();
 
         try {
             main.start();
             assertNotNull("engine must be initialised", main.getEngine());
-            assertTrue("merger builder test seam must have been called: file server was found by retry",
-                    builderCalled.get());
-            assertFalse("merger must NOT be a NoopMerger after startup retry picked up the file server",
-                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
-        } finally {
-            main.shutdown();
-        }
-    }
 
-    /**
-     * Option B: the optimizer starts with {@link IndexOptimizerMain.NoopMerger}
-     * (no file server in ZK at startup, retries exhausted). After startup, a
-     * file server registers in ZK. The next tick call upgrades the merger from
-     * NoopMerger to the real merger via {@link IndexOptimizerMain#maybeUpgradeMerger()}.
-     *
-     * <p>The test disables the startup retry loop ({@code retries=0}) so the
-     * optimizer always starts with NoopMerger. It then registers the file server
-     * and triggers a short-interval tick to observe the upgrade.
-     */
-    @Test
-    public void tickTimeUpgradeReplacesNoopMergerOnceFileServerAppears() throws Exception {
-        Properties props = baseProps();
-        // Disable startup retries so the optimizer always starts with NoopMerger.
-        props.setProperty(OptimizerConfiguration.PROPERTY_ZK_DISCOVERY_RETRIES, "0");
-        // Short tick so the upgrade fires quickly.
-        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "100");
-
-        AtomicBoolean builderCalled = new AtomicBoolean(false);
-        IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
-        main.mergerBuilderForTests = servers -> {
-            builderCalled.set(true);
-            return new InMemorySegmentMerger();
-        };
-
-        try {
-            main.start();
-            assertNotNull("engine must be initialised", main.getEngine());
-            // At this point, no file server is in ZK and retries are disabled:
-            // the optimizer must have fallen back to NoopMerger.
+            // No file server in ZK at startup → NoopMerger.
             assertTrue("merger must be NoopMerger immediately after startup with no file server",
                     main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
 
-            // Now register the file server in ZK.
+            // Now register the file server: ZK watch fires → ServiceDiscoveryListener
+            // schedules an event-driven tick → maybeUpgradeMerger() upgrades.
             registerFileServer();
 
-            // Wait for the tick-time upgrade to fire (up to 10 s).
+            // Wait for the watcher-driven upgrade to complete (up to 10 s).
             long deadline = System.currentTimeMillis() + 10_000L;
             while (System.currentTimeMillis() < deadline) {
                 if (!(main.getMerger() instanceof IndexOptimizerMain.NoopMerger)) {
@@ -228,8 +175,55 @@ public class OptimizerMergerLateBindingTest {
                 Thread.sleep(50);
             }
 
-            assertTrue("merger builder test seam must have been called by maybeUpgradeMerger()",
-                    builderCalled.get());
+            assertFalse("merger must NOT be a NoopMerger after watcher-driven upgrade",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+            assertTrue("upgraded merger must be an InMemorySegmentMerger (injected via test seam)",
+                    main.getMerger() instanceof InMemorySegmentMerger);
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    /**
+     * Issue #507 — tick-time safety-net upgrade (Option B):
+     *
+     * <p>Same scenario as above, but here we verify that the periodic tick's
+     * {@code maybeUpgradeMerger()} call also upgrades the merger. This covers the
+     * case where the ZK session-expiry causes the watcher to be lost and a new
+     * {@code listFileServers()} re-arms it at tick time.
+     *
+     * <p>We trigger the upgrade explicitly by waiting for the short-interval periodic
+     * tick rather than registering AFTER the watcher is armed.
+     */
+    @Test
+    public void tickTimeUpgradeReplacesNoopMergerOnceFileServerAppears() throws Exception {
+        Properties props = baseProps();
+        // Short periodic tick so the safety-net upgrade fires quickly.
+        props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "100");
+
+        IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
+        main.mergerBuilderForTests = servers -> new InMemorySegmentMerger();
+
+        try {
+            main.start();
+            assertNotNull("engine must be initialised", main.getEngine());
+
+            // No file server at startup → NoopMerger.
+            assertTrue("merger must be NoopMerger immediately after startup with no file server",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+
+            // Register the file server. The next periodic tick calls tickSafe()
+            // → maybeUpgradeMerger() → zkMeta.listFileServers() → upgrade.
+            registerFileServer();
+
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline) {
+                if (!(main.getMerger() instanceof IndexOptimizerMain.NoopMerger)) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+
             assertFalse("merger must NOT be a NoopMerger after tick-time upgrade",
                     main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
             assertTrue("upgraded merger must be an InMemorySegmentMerger (injected via test seam)",

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
@@ -42,22 +42,20 @@ import org.junit.Test;
  * Verifies the fix for the {@code NoopMerger} startup race (issue #507):
  *
  * <p>The root cause: the optimizer called {@code listFileServers()} exactly once at
- * startup. If the file-server pod had not yet written its ZK znode, the list was
- * empty and {@code resolveMerger()} fell back to {@code NoopMerger} permanently.
+ * startup via a throw-away {@link ZookeeperMetadataStorageManager}. If the file-server
+ * pod had not yet written its ZK znode, the list was empty and {@code resolveMerger()}
+ * fell back to {@code NoopMerger} permanently.
  *
- * <p>The fix uses a single long-lived {@link ZookeeperMetadataStorageManager} that:
- * <ol>
- *   <li>Performs the initial {@code listFileServers()} call, which arms a ZK
- *       children-watch on {@code /herd/fileServers}.</li>
- *   <li>When a file server registers, the watch fires → {@code notifyFileServersChanged}
- *       → {@link IndexOptimizerMain}'s {@code ServiceDiscoveryListener} schedules an
- *       event-driven tick.</li>
- *   <li>The tick's {@code maybeUpgradeMerger()} upgrades the engine from
- *       {@code NoopMerger} to a real merger atomically.</li>
- * </ol>
+ * <p>The fix keeps a single long-lived {@link ZookeeperMetadataStorageManager} open for
+ * the pod's lifetime. {@code listFileServers()} arms a ZK children-watch on
+ * {@code /herd/fileServers}. When a file server registers, the watch fires →
+ * {@code notifyFileServersChanged} → {@link IndexOptimizerMain}'s
+ * {@code ServiceDiscoveryListener} schedules an event-driven tick →
+ * {@code maybeUpgradeMerger()} replaces the {@link IndexOptimizerMain.NoopMerger}.
+ * The periodic tick also calls {@code maybeUpgradeMerger()} as a safety net.
  *
- * <p>Both tests use the package-private {@code mergerBuilderForTests} seam so they
- * can inject an {@link InMemorySegmentMerger} without needing a live remote file server.
+ * <p>All tests use the package-private {@code mergerBuilderForTests} seam to inject an
+ * {@link InMemorySegmentMerger} without needing a live remote file server.
  */
 public class OptimizerMergerLateBindingTest {
 
@@ -66,6 +64,8 @@ public class OptimizerMergerLateBindingTest {
     private static final String TS_UUID = "ts-late-bind";
     private static final String FILE_SERVER_ID = "file-server-0";
     private static final String FILE_SERVER_ADDR = "herddb-file-server-0.svc:9846";
+    private static final String FILE_SERVER_ID_2 = "file-server-1";
+    private static final String FILE_SERVER_ADDR_2 = "herddb-file-server-1.svc:9846";
 
     private TestingServer zkServer;
     private ZooKeeper zk;
@@ -111,11 +111,11 @@ public class OptimizerMergerLateBindingTest {
         }
     }
 
-    private void registerFileServer() throws Exception {
+    private void registerFileServer(String id, String addr) throws Exception {
         try (ZookeeperMetadataStorageManager zkmeta =
                 new ZookeeperMetadataStorageManager(zkServer.getConnectString(), 30000, BASE_PATH)) {
             zkmeta.start(false);
-            zkmeta.registerFileServer(FILE_SERVER_ID, FILE_SERVER_ADDR);
+            zkmeta.registerFileServer(id, addr);
         }
     }
 
@@ -125,7 +125,7 @@ public class OptimizerMergerLateBindingTest {
         p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_SESSION_TIMEOUT, "30000");
         p.setProperty(OptimizerConfiguration.PROPERTY_ZOOKEEPER_PATH, BASE_PATH);
         p.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, TS_NAME);
-        // Long periodic interval; the watcher-driven tick handles the upgrade.
+        // Long periodic interval; the watcher-driven tick handles the upgrade in test 1.
         p.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "3600000");
         p.setProperty(OptimizerConfiguration.PROPERTY_RETENTION_MS, "60000");
         p.setProperty(OptimizerConfiguration.PROPERTY_HTTP_PORT, "0");
@@ -133,17 +133,19 @@ public class OptimizerMergerLateBindingTest {
     }
 
     /**
-     * Issue #507 — watcher-driven upgrade (primary fix):
+     * Issue #507 — watcher-driven upgrade (primary fix path):
      *
-     * <p>The optimizer starts with no file server in ZK → resolves {@link IndexOptimizerMain.NoopMerger}.
-     * The long-lived {@link ZookeeperMetadataStorageManager}'s children-watch on
+     * <p>The optimizer starts with no file server in ZK → resolves
+     * {@link IndexOptimizerMain.NoopMerger}. The long-lived
+     * {@link ZookeeperMetadataStorageManager}'s children-watch on
      * {@code /herd/fileServers} is armed by the initial {@code listFileServers()} call.
-     * When a file server registers, the watch fires → {@code ServiceDiscoveryListener.onFileServersChanged}
-     * schedules an event-driven tick → {@code maybeUpgradeMerger()} upgrades the merger
-     * to {@link InMemorySegmentMerger} (via the test seam).
+     * When a file server registers, the watch fires →
+     * {@code ServiceDiscoveryListener.onFileServersChanged} schedules an event-driven
+     * tick → {@code maybeUpgradeMerger()} upgrades the merger to
+     * {@link InMemorySegmentMerger} (via the test seam).
      *
-     * <p>No timing hacks: the upgrade is driven by the reactive ZK watcher, so the
-     * test only needs to wait for the upgrade to complete (up to 10 s).
+     * <p>No timing hacks: the upgrade is driven by the reactive ZK watcher, so the test
+     * only needs to wait for the upgrade to complete (up to 10 s).
      */
     @Test
     public void watcherDrivenUpgradeReplacesNoopMergerWhenFileServerRegisters() throws Exception {
@@ -164,7 +166,7 @@ public class OptimizerMergerLateBindingTest {
 
             // Now register the file server: ZK watch fires → ServiceDiscoveryListener
             // schedules an event-driven tick → maybeUpgradeMerger() upgrades.
-            registerFileServer();
+            registerFileServer(FILE_SERVER_ID, FILE_SERVER_ADDR);
 
             // Wait for the watcher-driven upgrade to complete (up to 10 s).
             long deadline = System.currentTimeMillis() + 10_000L;
@@ -179,27 +181,41 @@ public class OptimizerMergerLateBindingTest {
                     main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
             assertTrue("upgraded merger must be an InMemorySegmentMerger (injected via test seam)",
                     main.getMerger() instanceof InMemorySegmentMerger);
+            // Also verify the engine itself received the new merger so that merge()
+            // calls during runOnce() will actually use it (that's the whole point of
+            // issue #507 — the engine's call to merger.merge() must not hit NoopMerger).
+            assertTrue("engine.getMerger() must also be an InMemorySegmentMerger after upgrade",
+                    main.getEngine().getMerger() instanceof InMemorySegmentMerger);
         } finally {
             main.shutdown();
         }
     }
 
     /**
-     * Issue #507 — tick-time safety-net upgrade (Option B):
+     * Issue #507 — periodic-tick safety-net upgrade path:
      *
-     * <p>Same scenario as above, but here we verify that the periodic tick's
-     * {@code maybeUpgradeMerger()} call also upgrades the merger. This covers the
-     * case where the ZK session-expiry causes the watcher to be lost and a new
-     * {@code listFileServers()} re-arms it at tick time.
+     * <p>Same scenario (no file server at startup → {@link IndexOptimizerMain.NoopMerger}),
+     * but here we verify that the periodic tick's {@code maybeUpgradeMerger()} call upgrades
+     * the merger independently of the ZK watcher.
      *
-     * <p>We trigger the upgrade explicitly by waiting for the short-interval periodic
-     * tick rather than registering AFTER the watcher is armed.
+     * <p>The watcher path is deliberately disabled by setting a very large
+     * {@code EVENT_DEBOUNCE_MS} (one hour), so the watcher-triggered scheduled tick
+     * cannot fire within the 10 s test window. The periodic tick (every 100 ms)
+     * fires {@code tickSafe()} → {@code maybeUpgradeMerger()} → upgrade.
+     *
+     * <p>This covers the recovery scenario where the ZK session expires and the
+     * watcher is lost: the periodic tick re-arms the watch via
+     * {@code zkMeta.listFileServers()} and picks up any newly registered file servers.
      */
     @Test
     public void tickTimeUpgradeReplacesNoopMergerOnceFileServerAppears() throws Exception {
         Properties props = baseProps();
         // Short periodic tick so the safety-net upgrade fires quickly.
         props.setProperty(OptimizerConfiguration.PROPERTY_INTERVAL_MS, "100");
+        // Very large debounce prevents the watcher-triggered (onFileServersChanged)
+        // tick from completing within the 10 s test window. This forces the test
+        // to exercise the periodic-tick path exclusively.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "3600000");
 
         IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
         main.mergerBuilderForTests = servers -> new InMemorySegmentMerger();
@@ -214,7 +230,8 @@ public class OptimizerMergerLateBindingTest {
 
             // Register the file server. The next periodic tick calls tickSafe()
             // → maybeUpgradeMerger() → zkMeta.listFileServers() → upgrade.
-            registerFileServer();
+            // The watcher-triggered tick is suppressed by the huge debounce above.
+            registerFileServer(FILE_SERVER_ID, FILE_SERVER_ADDR);
 
             long deadline = System.currentTimeMillis() + 10_000L;
             while (System.currentTimeMillis() < deadline) {
@@ -228,6 +245,62 @@ public class OptimizerMergerLateBindingTest {
                     main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
             assertTrue("upgraded merger must be an InMemorySegmentMerger (injected via test seam)",
                     main.getMerger() instanceof InMemorySegmentMerger);
+            assertTrue("engine.getMerger() must also be an InMemorySegmentMerger after upgrade",
+                    main.getEngine().getMerger() instanceof InMemorySegmentMerger);
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    /**
+     * Issue #507 — churn resilience: the merger stays real after file-server churn.
+     *
+     * <p>Once the optimizer upgrades from {@link IndexOptimizerMain.NoopMerger} to a real
+     * merger it must not downgrade even when additional {@code onFileServersChanged}
+     * callbacks arrive. This test registers a second file server after the initial upgrade
+     * and verifies the merger remains an {@link InMemorySegmentMerger} (not re-created or
+     * reset to {@link IndexOptimizerMain.NoopMerger}).
+     */
+    @Test
+    public void mergerStaysRealAfterFileServerChurn() throws Exception {
+        Properties props = baseProps();
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "50");
+
+        IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
+        main.mergerBuilderForTests = servers -> new InMemorySegmentMerger();
+
+        try {
+            main.start();
+            assertNotNull("engine must be initialised", main.getEngine());
+            assertTrue("should start as NoopMerger",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+
+            // Register first file server → watcher fires → upgrade.
+            registerFileServer(FILE_SERVER_ID, FILE_SERVER_ADDR);
+
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline) {
+                if (!(main.getMerger() instanceof IndexOptimizerMain.NoopMerger)) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+            assertFalse("merger should be real after first registration",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+            SegmentMerger mergerAfterFirstUpgrade = main.getMerger();
+
+            // Register a second file server (simulates churn / scale-out). The
+            // onFileServersChanged callback fires again. Because the merger is already
+            // a real merger (not NoopMerger), the listener short-circuits and no
+            // upgrade attempt is made. The existing merger must remain unchanged.
+            registerFileServer(FILE_SERVER_ID_2, FILE_SERVER_ADDR_2);
+            // Give the watcher event a moment to propagate.
+            Thread.sleep(500);
+
+            assertFalse("merger must still be real after second file-server registration",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+            assertTrue("merger must be the same InMemorySegmentMerger instance (not re-created)",
+                    main.getMerger() == mergerAfterFirstUpgrade);
         } finally {
             main.shutdown();
         }


### PR DESCRIPTION
Fixes #507.

## Root cause

`IndexOptimizerMain.start()` called `listFileServers()` once at startup via a
throw-away `ZookeeperMetadataStorageManager`. If the file-server pod had not yet
written its ZK znode (startup-ordering race), the list was empty and
`resolveMerger()` fell back to `NoopMerger` permanently — no retry, no
self-healing.

## Fix

Keep a single **long-lived** `ZookeeperMetadataStorageManager` (`zkMeta`) open
for the optimizer pod's lifetime. This reuses the existing
`fileServersWatcher` / `ServiceDiscoveryListener` machinery already used by
`Server.java`:

1. `listFileServers()` on `zkMeta` arms a ZK children-watch on
   `/<basePath>/fileServers`.
2. When a file server registers, `onFileServersChanged` fires on the ZK watcher
   thread → `scheduleEventDrivenTick()` enqueues an upgrade tick.
3. `maybeUpgradeMerger()` runs inside that tick (also inside every periodic
   tick as a safety net), calls `zkMeta.listFileServers()` again, and
   atomically replaces `NoopMerger` with a real merger via
   `IndexOptimizerEngine.upgradeMerger()`.

## Changes

- `IndexOptimizerMain`: replace the short-lived `ZookeeperMetadataStorageManager`
  with a persistent `zkMeta` field; register a `ServiceDiscoveryListener` for
  reactive file-server discovery; add `maybeUpgradeMerger()` called at every
  tick; make `merger` and `mergerDataStorageManager` `volatile`; add
  `safeModeFileDeletion=false` guard (coerces to safe mode when no DSM is
  available at startup rather than crashing with `IllegalArgumentException`);
  add null guard in `onFileServersChanged`; fix stale comment in `tickSafe()`
- `IndexOptimizerEngine`: make `merger`/`dataStorageManager` `volatile`;
  add `upgradeMerger()` synchronized method; expose `getMerger()` for tests
- `OptimizerConfiguration`: updated javadoc for `PROPERTY_REMOTE_FILE_SERVERS`
  to document the watcher-based discovery flow and the `safeModeFileDeletion=false`
  interaction; unified `/<basePath>/fileServers` path naming

## Tests

- `watcherDrivenUpgradeReplacesNoopMergerWhenFileServerRegisters`: starts with
  no file server → NoopMerger; registers file server → ZK watch fires →
  `onFileServersChanged` schedules a debounced tick → merger upgrades within
  10 s; asserts both `main.getMerger()` and `engine.getMerger()` are upgraded
- `tickTimeUpgradeReplacesNoopMergerOnceFileServerAppears`: same scenario but
  with `EVENT_DEBOUNCE_MS=3600000` (watcher-triggered tick suppressed) and
  `INTERVAL_MS=100`; the periodic tick must fire `maybeUpgradeMerger()` and
  upgrade within 10 s; confirms the tick-time safety-net path works independently
- `mergerStaysRealAfterFileServerChurn`: registers file server A → awaits
  upgrade; then registers file server B; asserts merger stays as
  `InMemorySegmentMerger` (not re-created or reset to `NoopMerger`)

🤖 Implemented by the `pr-worker` agent.