### PR TITLE
issue #503: GET /status, /merge-history, per-phase metrics and JVM memory gauges

### DIFF
--- a/excludeFindBugsFilter.xml
+++ b/excludeFindBugsFilter.xml
@@ -86,4 +86,27 @@
         <Class name="herddb.indexing.optimizer.IndexOptimizerMain"/>
         <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>
+    <!--
+      RemoteSegmentGraphMerger (issue #503): batchListener is a LongBinaryOperator used
+      purely for its side effect (updating MergeProgress batch counters via a lambda).
+      The return value is deliberately ignored — the interface has no void-returning
+      primitive-specialized consumer equivalent in the JDK. The lambda always returns 0L
+      as a documented no-op return. Scoped to this class to avoid suppressing the rule
+      globally.
+    -->
+    <Match>
+        <Class name="herddb.index.vector.RemoteSegmentGraphMerger"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    </Match>
+    <!--
+      RemoteSegmentMerger.readCgroupMemoryLimitGib() (issue #503): reads the cgroup v2
+      container memory limit from /sys/fs/cgroup/memory.max, which is a well-known Linux
+      kernel pseudo-filesystem path, not a user-configurable absolute file path. The
+      DMI_HARDCODED_ABSOLUTE_FILENAME rule is a false positive here — the path is
+      intentional and required by the kernel ABI. Scoped to the specific method.
+    -->
+    <Match>
+        <Class name="herddb.indexing.optimizer.RemoteSegmentMerger"/>
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    </Match>
 </FindBugsFilter>

--- a/excludeFindBugsFilter.xml
+++ b/excludeFindBugsFilter.xml
@@ -87,15 +87,16 @@
         <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>
     <!--
-      RemoteSegmentGraphMerger (issue #503): batchListener is a LongBinaryOperator used
-      purely for its side effect (updating MergeProgress batch counters via a lambda).
-      The return value is deliberately ignored — the interface has no void-returning
-      primitive-specialized consumer equivalent in the JDK. The lambda always returns 0L
-      as a documented no-op return. Scoped to this class to avoid suppressing the rule
-      globally.
+      RemoteSegmentGraphMerger.buildGraph() (issue #503): batchListener is a
+      LongBinaryOperator used purely for its side effect (updating MergeProgress batch
+      counters via a lambda). The return value is deliberately ignored — the JDK has no
+      void-returning primitive-specialised consumer for two longs (no LongBiConsumer).
+      The lambda always returns 0L as a documented no-op return. Scoped to the exact
+      method that fires the callback to avoid suppressing the rule across the whole class.
     -->
     <Match>
         <Class name="herddb.index.vector.RemoteSegmentGraphMerger"/>
+        <Method name="buildGraph"/>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
     <!--
@@ -107,6 +108,7 @@
     -->
     <Match>
         <Class name="herddb.indexing.optimizer.RemoteSegmentMerger"/>
+        <Method name="readCgroupMemoryLimitGib"/>
         <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
     </Match>
 </FindBugsFilter>

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -163,23 +163,30 @@ public final class RemoteSegmentGraphMerger {
 
     /**
      * Optional phase-change callback. Receives the new phase name as a
-     * {@code String} at each major transition within the merge. Not thread-safe
-     * — must be set from the same thread that calls {@link #merge}. The HTTP
-     * server thread only reads the effects through the caller-managed
-     * {@code MergeProgress} object that receives the callbacks.
+     * {@code String} at each major transition within the merge.
+     *
+     * <p>Written by the caller from the optimizer thread immediately before
+     * each {@link #merge} call (via {@link #setPhaseListener}), and cleared
+     * from the same thread in a {@code finally} block after {@link #merge}
+     * returns. The HTTP server thread reads the effects only through the
+     * {@code MergeProgress} object that receives callbacks, not this field
+     * directly. Declared {@code volatile} so the assignment is visible to the
+     * optimizer thread's own subsequent reads within {@link #merge} if it were
+     * ever called from a thread that set the listener on a different thread;
+     * also guards any accidental double-checked read inside the merge logic.
      */
-    private Consumer<String> phaseListener;
+    private volatile Consumer<String> phaseListener;
 
     /**
      * Optional batch-progress callback. Receives {@code (written, total)} as
      * a pair of {@code long}s fired every {@value #BATCH_PROGRESS_INTERVAL}
-     * vectors during the legacy graph-build phase. Not thread-safe — same
-     * constraint as {@link #phaseListener}.
+     * vectors during the legacy graph-build phase. Same lifecycle as
+     * {@link #phaseListener}; declared {@code volatile} for the same reason.
      *
      * <p>{@link LongBinaryOperator} is used here purely as a convenient
      * two-{@code long} consumer; the return value is ignored.
      */
-    private LongBinaryOperator batchListener;
+    private volatile LongBinaryOperator batchListener;
 
     /**
      * Timing breakdown of the last completed merge. Written at the end of

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -62,7 +62,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
+import java.util.function.LongBinaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -97,9 +99,14 @@ import java.util.logging.Logger;
  * layout, same map-file format — so the indexing-service tier can load it
  * with {@code OnDiskGraphIndex.load(...)} as it would any other segment.
  *
- * <p>This class is stateless and thread-hostile (every {@link #merge} call
- * builds its own state and tears it down before returning). The caller is
- * responsible for serialising calls if it really wants to.
+ * <p>This class is nominally stateless and thread-hostile (every {@link #merge}
+ * call builds its own local state and tears it down before returning). The two
+ * optional callback fields ({@link #phaseListener} and {@link #batchListener})
+ * are written by the caller immediately before each {@link #merge} call and
+ * cleared after — no concurrency between writers. The HTTP-server thread reads
+ * {@link #lastMergeTimings} after the merge is complete; the field is
+ * {@code volatile} to ensure the write is visible without synchronisation.
+ * Callers are responsible for serialising calls.
  */
 public final class RemoteSegmentGraphMerger {
 
@@ -115,6 +122,14 @@ public final class RemoteSegmentGraphMerger {
 
     /** Block size used for streaming downloads via the multipart reader. */
     private static final int DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024;
+
+    /**
+     * How often (in vectors) the batch-progress callback fires during the
+     * legacy graph-build phase. Chosen to be large enough that the callback
+     * overhead is negligible, and small enough to give sub-1 % granularity for
+     * a 1 M-vector merge.
+     */
+    public static final int BATCH_PROGRESS_INTERVAL = 5_000;
 
     /**
      * Sanity caps for the input map-file header values. A corrupt or partially
@@ -141,6 +156,104 @@ public final class RemoteSegmentGraphMerger {
     private final float neighborOverflow;
     private final float alpha;
     private final VectorSimilarityFunction similarity;
+
+    // -------------------------------------------------------------------------
+    // Progress / observability hooks (set by caller before each merge call).
+    // -------------------------------------------------------------------------
+
+    /**
+     * Optional phase-change callback. Receives the new phase name as a
+     * {@code String} at each major transition within the merge. Not thread-safe
+     * — must be set from the same thread that calls {@link #merge}. The HTTP
+     * server thread only reads the effects through the caller-managed
+     * {@code MergeProgress} object that receives the callbacks.
+     */
+    private Consumer<String> phaseListener;
+
+    /**
+     * Optional batch-progress callback. Receives {@code (written, total)} as
+     * a pair of {@code long}s fired every {@value #BATCH_PROGRESS_INTERVAL}
+     * vectors during the legacy graph-build phase. Not thread-safe — same
+     * constraint as {@link #phaseListener}.
+     *
+     * <p>{@link LongBinaryOperator} is used here purely as a convenient
+     * two-{@code long} consumer; the return value is ignored.
+     */
+    private LongBinaryOperator batchListener;
+
+    /**
+     * Timing breakdown of the last completed merge. Written at the end of
+     * {@link #merge} (either path) and visible to the HTTP-server thread via
+     * the {@code volatile} guarantee.
+     */
+    private volatile MergePhaseTimings lastMergeTimings;
+
+    // -------------------------------------------------------------------------
+    // Accessors for the callbacks and timing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sets the phase-change listener. Pass {@code null} to remove. Must be
+     * called from the same thread that calls {@link #merge}.
+     */
+    public void setPhaseListener(Consumer<String> listener) {
+        this.phaseListener = listener;
+    }
+
+    /**
+     * Sets the batch-progress listener. Pass {@code null} to remove. Must be
+     * called from the same thread that calls {@link #merge}.
+     */
+    public void setBatchListener(LongBinaryOperator listener) {
+        this.batchListener = listener;
+    }
+
+    /**
+     * Returns the timing breakdown of the last completed merge, or {@code null}
+     * if {@link #merge} has never been called on this instance.
+     */
+    public MergePhaseTimings getLastMergeTimings() {
+        return lastMergeTimings;
+    }
+
+    /** Returns the configured graph degree M. Used for /tmp-usage estimation in log messages. */
+    public int getGraphM() {
+        return graphM;
+    }
+
+    // -------------------------------------------------------------------------
+    // Timing breakdown value object
+    // -------------------------------------------------------------------------
+
+    /**
+     * Per-phase wall-clock durations (in milliseconds) from the most recently
+     * completed merge. All times are for the merge path that was actually
+     * taken; unused fields are zero.
+     */
+    public static final class MergePhaseTimings {
+        /** Time downloading input map (+ graph for streaming) files. */
+        public final long downloadMs;
+        /**
+         * Time for PQ K-means training + vector encoding (legacy path only;
+         * 0 for the streaming path and for shards below the FusedPQ threshold).
+         */
+        public final long pqTrainingMs;
+        /**
+         * Time building / compacting the graph (legacy: authority-map + GraphIndexBuilder;
+         * streaming: OnDiskGraphIndexCompactor + output map-file write).
+         */
+        public final long compactionMs;
+        /** Time uploading output graph + map files. */
+        public final long uploadMs;
+
+        public MergePhaseTimings(long downloadMs, long pqTrainingMs,
+                                 long compactionMs, long uploadMs) {
+            this.downloadMs   = downloadMs;
+            this.pqTrainingMs = pqTrainingMs;
+            this.compactionMs = compactionMs;
+            this.uploadMs     = uploadMs;
+        }
+    }
 
     public RemoteSegmentGraphMerger(DataStorageManager dataStorageManager,
                                     Path tmpDirectory,
@@ -360,6 +473,7 @@ public final class RemoteSegmentGraphMerger {
         // 1. Stream each input's map file to a local temp file. We never hold
         //    every map in memory — even for a 1M-vector merge that would be
         //    a few GiB. The temp files are all deleted at the end of merge().
+        notifyPhase("downloading");
         List<Path> mapTempFiles = new ArrayList<>(inputs.size());
         long droppedTombstones = 0;
         long droppedDuplicates = 0;
@@ -367,12 +481,14 @@ public final class RemoteSegmentGraphMerger {
             for (RemoteSegmentInput in : inputs) {
                 mapTempFiles.add(downloadMapFile(in));
             }
+            long downloadNanos = System.nanoTime();
 
             // 2. First pass: walk every map file and decide which (pk, vec) to keep.
             //    Authority map: pk -> (generation, vector). Higher generation wins.
             //    PERF: the inner reads are sequential against the BufferedInputStream;
             //    the de-duplication HashMap is bounded by the union of input PKs (which
             //    is also the upper bound on the merged segment's vector count).
+            notifyPhase("compacting");
             Map<Bytes, AuthorityEntry> authority = new HashMap<>();
             for (int i = 0; i < inputs.size(); i++) {
                 RemoteSegmentInput in = inputs.get(i);
@@ -399,10 +515,12 @@ public final class RemoteSegmentGraphMerger {
             //    because the consumer only cares about (pk -> ordinal -> vector)
             //    consistency, not about a specific layout.
             BuildArtefacts artefacts = buildGraph(authority, dim, keptCount);
+            long compactionNanos = System.nanoTime();
 
             // 4. Write the graph and map files locally. Allocate inside the
             //    outer try so a failure on the second createTempFile call
             //    doesn't leak the first one (issue #485 review item B.7#2).
+            notifyPhase("pq-training");
             Path graphTempFile = null;
             Path mapOutTempFile = null;
             boolean uploadedGraph = false;
@@ -411,19 +529,24 @@ public final class RemoteSegmentGraphMerger {
             String mapPath = null;
             long graphSize;
             long mapSize;
+            long pqNanos = 0L; // assigned inside the try block on the success path
             String multipartUuid = outputIndexUuid + "_seg" + outputSegmentId;
             try {
                 graphTempFile = Files.createTempFile(tmpDirectory,
                         "herddb-merger-graph-", ".idx");
                 mapOutTempFile = Files.createTempFile(tmpDirectory,
                         "herddb-merger-map-", ".tmp");
+                // writeGraph performs PQ training internally; we notify the phase
+                // before and record the elapsed time after.
                 writeGraph(artefacts, dim, graphTempFile);
+                pqNanos = System.nanoTime();
                 graphSize = Files.size(graphTempFile);
                 writeMapFile(artefacts, mapOutTempFile);
                 mapSize = Files.size(mapOutTempFile);
 
                 // 5. Upload both. If the second upload fails we delete the first
                 //    so we don't leak partial output.
+                notifyPhase("uploading");
                 graphPath = dataStorageManager.writeMultipartIndexFile(
                         outputTablespaceUuid, multipartUuid, "graph",
                         graphTempFile, /* progress */ null);
@@ -460,13 +583,23 @@ public final class RemoteSegmentGraphMerger {
                 }
             }
 
-            long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+            long uploadNanos = System.nanoTime();
+            long elapsedMs = (uploadNanos - startNanos) / 1_000_000L;
+            lastMergeTimings = new MergePhaseTimings(
+                    (downloadNanos - startNanos) / 1_000_000L,
+                    (pqNanos - compactionNanos) / 1_000_000L,
+                    (compactionNanos - downloadNanos) / 1_000_000L,
+                    (uploadNanos - pqNanos) / 1_000_000L);
             LOGGER.log(Level.INFO,
                     "RemoteSegmentGraphMerger: merged {0} inputs into segment {1}/{2}_seg{3}"
-                            + " ({4} kept, {5} tombstoned, {6} duplicates dropped, {7} ms)",
+                            + " ({4} kept, {5} tombstoned, {6} duplicates dropped,"
+                            + " total={7} ms, download={8} ms, compaction={9} ms,"
+                            + " pqTraining={10} ms, upload={11} ms)",
                     new Object[]{inputs.size(), outputTablespaceUuid, outputIndexUuid,
                             outputSegmentId, keptCount, droppedTombstones, droppedDuplicates,
-                            elapsedMs});
+                            elapsedMs, lastMergeTimings.downloadMs,
+                            lastMergeTimings.compactionMs, lastMergeTimings.pqTrainingMs,
+                            lastMergeTimings.uploadMs});
             return new MergeOutput(outputTablespaceUuid, outputIndexUuid, outputSegmentId,
                     graphPath, graphSize, mapPath, mapSize,
                     keptCount, droppedTombstones, droppedDuplicates);
@@ -562,10 +695,12 @@ public final class RemoteSegmentGraphMerger {
 
         try {
             // 1. Download every input's graph + map files.
+            notifyPhase("downloading");
             for (RemoteSegmentInput in : inputs) {
                 mapTemps.add(downloadMapFile(in));
                 graphTemps.add(downloadGraphFile(in));
             }
+            long downloadNanos = System.nanoTime();
 
             // 2. Walk every map file once: per-source PK arrays + per-source size.
             //    Validates the same wire-level invariants accumulateAuthority does
@@ -686,6 +821,7 @@ public final class RemoteSegmentGraphMerger {
             //    Allocate both temp files before the inner try so a failure
             //    on the second allocation doesn't leak the first; allocations
             //    happen inside the outer try so the existing finally cleans up.
+            notifyPhase("compacting");
             Path graphOutTemp = null;
             Path mapOutTemp = null;
             String multipartUuid = outputIndexUuid + "_seg" + outputSegmentId;
@@ -714,10 +850,12 @@ public final class RemoteSegmentGraphMerger {
                         mapOutTemp, dim);
                 graphSize = Files.size(graphOutTemp);
                 mapSize = Files.size(mapOutTemp);
+                long compactionNanos = System.nanoTime();
 
                 // 8. Upload. On a partial upload (graph succeeded, map failed)
                 //    best-effort delete the orphan graph so the caller's
                 //    abandon path doesn't see a half-published output.
+                notifyPhase("uploading");
                 graphPath = dataStorageManager.writeMultipartIndexFile(
                         outputTablespaceUuid, multipartUuid, "graph",
                         graphOutTemp, /* progress */ null);
@@ -726,6 +864,12 @@ public final class RemoteSegmentGraphMerger {
                         outputTablespaceUuid, multipartUuid, "map",
                         mapOutTemp, /* progress */ null);
                 uploadedMap = true;
+                long uploadNanos = System.nanoTime();
+                lastMergeTimings = new MergePhaseTimings(
+                        (downloadNanos - startNanos) / 1_000_000L,
+                        /* pqTrainingMs */ 0L,
+                        (compactionNanos - downloadNanos) / 1_000_000L,
+                        (uploadNanos - compactionNanos) / 1_000_000L);
             } finally {
                 if (graphOutTemp != null) {
                     try {
@@ -756,14 +900,19 @@ public final class RemoteSegmentGraphMerger {
                 }
             }
 
+            MergePhaseTimings timings = lastMergeTimings; // set inside inner try
             long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
             LOGGER.log(Level.INFO,
                     "RemoteSegmentGraphMerger (streaming): merged {0} inputs into segment"
                             + " {1}/{2}_seg{3} ({4} kept, {5} tombstoned, {6} duplicates"
-                            + " dropped, {7} ms)",
+                            + " dropped, total={7} ms, download={8} ms, compaction={9} ms,"
+                            + " upload={10} ms)",
                     new Object[]{n, outputTablespaceUuid, outputIndexUuid,
                             outputSegmentId, keptCount, droppedTombstones, droppedDuplicates,
-                            elapsedMs});
+                            elapsedMs,
+                            timings != null ? timings.downloadMs : -1,
+                            timings != null ? timings.compactionMs : -1,
+                            timings != null ? timings.uploadMs : -1});
             return new MergeOutput(outputTablespaceUuid, outputIndexUuid, outputSegmentId,
                     graphPath, graphSize, mapPath, mapSize,
                     keptCount, droppedTombstones, droppedDuplicates);
@@ -1206,6 +1355,7 @@ public final class RemoteSegmentGraphMerger {
                 ForkJoinPool.commonPool(), ForkJoinPool.commonPool(), keptCount);
         List<Bytes> ordinalToPk = new ArrayList<>(keptCount);
         int ord = 0;
+        LongBinaryOperator batchCb = batchListener;
         for (Map.Entry<Bytes, AuthorityEntry> e : authority.entrySet()) {
             ordinalToPk.add(e.getKey());
             storage.set(ord, e.getValue().vector);
@@ -1218,7 +1368,16 @@ public final class RemoteSegmentGraphMerger {
                         "GraphIndexBuilder.addGraphNode failed at ordinal " + ord
                                 + " (" + keptCount + " total)", re);
             }
+            // Fire batch-progress callback every BATCH_PROGRESS_INTERVAL vectors
+            // so the HTTP /status endpoint can show fine-grained build progress.
+            if (batchCb != null && (ord % BATCH_PROGRESS_INTERVAL == 0)) {
+                batchCb.applyAsLong(ord, keptCount);
+            }
             ord++;
+        }
+        // Final batch-progress notification at 100%.
+        if (batchCb != null) {
+            batchCb.applyAsLong(keptCount, keptCount);
         }
         try {
             builder.cleanup();
@@ -1237,10 +1396,26 @@ public final class RemoteSegmentGraphMerger {
         // Mirror PersistentVectorStore.getOrTrainPQ's defaults verbatim
         // (clusterCount=256, centerData=true) so the merged segment is
         // PQ-compatible with everything the IS-side writer produces.
-        ProductQuantization pq = useFusedPQ
-                ? ProductQuantization.compute(art.ravv, pqSubspaces,
-                        /* clusterCount */ 256, /* centerData */ true)
-                : null;
+        ProductQuantization pq;
+        if (useFusedPQ) {
+            // Task #3 (issue #503): emit a start log so operators can distinguish
+            // "PQ K-means is running" from "process is hung / GC-stalled". The
+            // jvector ProductQuantization.compute() runs K-means internally and
+            // does not expose per-iteration callbacks, so we log start + elapsed.
+            LOGGER.log(Level.INFO,
+                    "PQ training starting: {0} vectors, dim={1}, subspaces={2},"
+                            + " clusters=256 — this may take several minutes",
+                    new Object[]{shardSize, dim, pqSubspaces});
+            long pqStartNanos = System.nanoTime();
+            pq = ProductQuantization.compute(art.ravv, pqSubspaces,
+                    /* clusterCount */ 256, /* centerData */ true);
+            long pqElapsedMs = (System.nanoTime() - pqStartNanos) / 1_000_000L;
+            LOGGER.log(Level.INFO,
+                    "PQ training complete in {0} ms ({1} subspaces, {2} clusters)",
+                    new Object[]{pqElapsedMs, pqSubspaces, 256});
+        } else {
+            pq = null;
+        }
         PQVectors pqv = (pq != null) ? pq.encodeAll(art.ravv, ForkJoinPool.commonPool()) : null;
 
         OnDiskGraphIndexWriter.Builder writerBuilder = new OnDiskGraphIndexWriter.Builder(
@@ -1292,6 +1467,21 @@ public final class RemoteSegmentGraphMerger {
                     dos.writeInt(Float.floatToIntBits(vec.get(j)));
                 }
             }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal callback helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fires the phase-change listener if one is set. No-op when
+     * {@link #phaseListener} is {@code null}.
+     */
+    private void notifyPhase(String phase) {
+        Consumer<String> cb = phaseListener;
+        if (cb != null) {
+            cb.accept(phase);
         }
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -24,6 +24,7 @@ import herddb.auth.oidc.OidcBootstrap;
 import herddb.auth.oidc.OidcTokenValidator;
 import herddb.auth.oidc.grpc.JwtAuthServerInterceptor;
 import herddb.core.MemoryManager;
+import herddb.core.stats.NettyMemoryMetrics;
 import herddb.file.FileDataStorageManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.metadata.IndexingServiceInstanceDescriptor;
@@ -339,6 +340,9 @@ public class IndexingServer implements AutoCloseable {
         statsConfig.setProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_HTTP_ENABLE, false);
         statsProvider.start(statsConfig);
         StatsLogger statsLogger = statsProvider.getStatsLogger("");
+        // Register Netty direct-memory gauges so the JVM dashboard can show
+        // pool-arena footprint for this service (issue #503).
+        NettyMemoryMetrics.register(statsLogger);
 
         engine.setStatsLogger(statsLogger);
         IndexingServiceImpl serviceImpl = new IndexingServiceImpl(engine, statsLogger);

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
@@ -19,6 +19,7 @@
  */
 package herddb.indexing.optimizer;
 
+import herddb.index.vector.RemoteSegmentGraphMerger;
 import herddb.indexing.segment.SegmentMetadata;
 import herddb.indexing.segment.SegmentRegistryClient;
 import herddb.indexing.segment.SegmentRegistryException;
@@ -27,10 +28,16 @@ import herddb.indexing.segment.TombstoneOverlayManager;
 import herddb.indexing.segment.VersionedSegmentMetadata;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
+import io.netty.util.internal.PlatformDependent;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
@@ -151,6 +158,39 @@ public final class IndexOptimizerEngine {
     private final AtomicLong relocationsInitiatedTotal = new AtomicLong();
     private final AtomicLong relocationsCompletedTotal = new AtomicLong();
     private final AtomicLong relocationsAbortedTotal = new AtomicLong();
+
+    // -------------------------------------------------------------------------
+    // Extended observability (issue #503)
+    // -------------------------------------------------------------------------
+
+    private static final MemoryMXBean MEMORY_MX = ManagementFactory.getMemoryMXBean();
+
+    /**
+     * Per-phase cumulative timing counters (milliseconds). Updated after each
+     * successful merge cycle; exposed via {@code GET /metrics}.
+     */
+    private final AtomicLong phaseDownloadMsTotal    = new AtomicLong();
+    private final AtomicLong phaseCompactionMsTotal  = new AtomicLong();
+    private final AtomicLong phasePqTrainingMsTotal  = new AtomicLong();
+    private final AtomicLong phaseUploadMsTotal      = new AtomicLong();
+    private final AtomicLong phaseZkRegisterMsTotal  = new AtomicLong();
+    private final AtomicLong phaseDeprecateMsTotal   = new AtomicLong();
+
+    /**
+     * Live-state holder for the current merge. Read by the HTTP server thread
+     * for {@code GET /status}; written by the optimizer thread (single-threaded
+     * scheduler). Created at construction so the HTTP server always gets a
+     * non-null reference.
+     */
+    private final MergeProgress mergeProgress = new MergeProgress();
+
+    /**
+     * Bounded history of the last {@value #MERGE_HISTORY_MAX} completed merges
+     * (including declined and failed ones). Guarded by {@code synchronized}
+     * on {@code mergeHistory} for thread-safe access from the HTTP server.
+     */
+    private static final int MERGE_HISTORY_MAX = 20;
+    private final Deque<MergeRecord> mergeHistory = new ArrayDeque<>(MERGE_HISTORY_MAX + 1);
 
     public IndexOptimizerEngine(SegmentRegistryClient registry,
                                 SegmentMerger merger,
@@ -330,6 +370,48 @@ public final class IndexOptimizerEngine {
         return ticksSkippedNotLeader.get();
     }
 
+    // --- Extended observability getters (issue #503) ---
+
+    public long getPhaseDownloadMsTotal() {
+        return phaseDownloadMsTotal.get();
+    }
+
+    public long getPhaseCompactionMsTotal() {
+        return phaseCompactionMsTotal.get();
+    }
+
+    public long getPhasePqTrainingMsTotal() {
+        return phasePqTrainingMsTotal.get();
+    }
+
+    public long getPhaseUploadMsTotal() {
+        return phaseUploadMsTotal.get();
+    }
+
+    public long getPhaseZkRegisterMsTotal() {
+        return phaseZkRegisterMsTotal.get();
+    }
+
+    public long getPhaseDeprecateMsTotal() {
+        return phaseDeprecateMsTotal.get();
+    }
+
+    /** Returns the live-merge state (never null). Safe to read from any thread. */
+    public MergeProgress getMergeProgress() {
+        return mergeProgress;
+    }
+
+    /**
+     * Returns a snapshot of the merge history (most-recent-last order).
+     * Thread-safe; returns a copy so the caller is not affected by subsequent
+     * writes.
+     */
+    public List<MergeRecord> getMergeHistory() {
+        synchronized (mergeHistory) {
+            return new ArrayList<>(mergeHistory);
+        }
+    }
+
     /**
      * Runs one optimizer tick. Throws {@link SegmentRegistryException} only on
      * top-level registry failures (e.g. ZK session expiry while listing indexes);
@@ -430,23 +512,48 @@ public final class IndexOptimizerEngine {
 
         // 3. Run the merger.
         List<SegmentMetadata> inputMetadata = new ArrayList<>(candidates.size());
+        long totalInputVectors = 0;
         for (VersionedSegmentMetadata v : candidates) {
             inputMetadata.add(v.metadata());
+            totalInputVectors += v.metadata().getVectorCount();
         }
+
+        // Assign a merge ID and update the live-state holder.
+        String mergeId = UUID.randomUUID().toString();
+        long peakHeapUsed = MEMORY_MX.getHeapMemoryUsage().getUsed();
+        long peakDirectUsed = PlatformDependent.usedDirectMemory();
+        mergeProgress.enterMerge(mergeId, candidates.size(), totalInputVectors);
+        if (merger instanceof RemoteSegmentMerger) {
+            ((RemoteSegmentMerger) merger).setMergeProgress(mergeProgress);
+        }
+
         SegmentMetadata output;
         long mergeStartMs = clock.getAsLong();
         try {
             output = merger.merge(inputMetadata, ownerSelector.getAsInt());
         } catch (Exception e) {
             mergeFailuresTotal.incrementAndGet();
+            long mergeEndMs2 = clock.getAsLong();
             LOGGER.log(Level.WARNING,
                     "merger failed for index " + indexUuid + " (" + candidates.size()
                             + " candidates); leaving inputs untouched", e);
+            recordMergeHistory(mergeId, indexUuid, mergeStartMs, mergeEndMs2, "failed",
+                    candidates.size(), totalInputVectors, 0L, peakHeapUsed, peakDirectUsed);
+            mergeProgress.enterIdle();
             return observed;
+        } finally {
+            if (merger instanceof RemoteSegmentMerger) {
+                ((RemoteSegmentMerger) merger).setMergeProgress(null);
+            }
         }
+
         if (output == null) {
             // Merger declined this batch (e.g., not enough live entries); skip publishing.
             mergeDeclinedTotal.incrementAndGet();
+            long mergeEndMs2 = clock.getAsLong();
+            recordMergeHistory(mergeId, indexUuid, mergeStartMs, mergeEndMs2, "declined",
+                    candidates.size(), totalInputVectors, 0L, peakHeapUsed, peakDirectUsed);
+            mergeProgress.enterIdle();
             return observed;
         }
 
@@ -473,6 +580,10 @@ public final class IndexOptimizerEngine {
                         "merger.abandon failed for {0}: {1}",
                         new Object[]{output.getSegmentUuid(), abandonFailed.getMessage()});
             }
+            long mergeEndMs2 = clock.getAsLong();
+            recordMergeHistory(mergeId, indexUuid, mergeStartMs, mergeEndMs2, "aborted",
+                    candidates.size(), totalInputVectors, 0L, peakHeapUsed, peakDirectUsed);
+            mergeProgress.enterIdle();
             return observed;
         }
 
@@ -483,6 +594,8 @@ public final class IndexOptimizerEngine {
         //      new segment; the inputs are still ACTIVE so they get re-merged with
         //      the (now larger) output. We accept that re-merge cost.
         //    - if create failed: nothing happens; inputs remain candidates.
+        mergeProgress.updatePhase("registering-zk");
+        long zkRegisterStartMs = clock.getAsLong();
         try {
             registry.createSegment(output);
             segmentsMerged.incrementAndGet();
@@ -492,6 +605,8 @@ public final class IndexOptimizerEngine {
             LOGGER.log(Level.INFO, "merged segment {0} already registered (idempotent)",
                     output.getSegmentUuid());
         }
+        long zkRegisterMs = Math.max(0L, clock.getAsLong() - zkRegisterStartMs);
+        phaseZkRegisterMsTotal.addAndGet(zkRegisterMs);
 
         // Test hook for review-item R2 (second pr-reviewer pass): inject drift in the
         // narrow window between createSegment-of-output and deprecate-of-inputs.
@@ -500,6 +615,8 @@ public final class IndexOptimizerEngine {
             hook.run();
         }
 
+        mergeProgress.updatePhase("deprecating-inputs");
+        long deprecateStartMs = clock.getAsLong();
         long retentionUntil = (retentionMillis == 0L)
                 ? SegmentMetadata.NO_RETENTION
                 : now + retentionMillis;
@@ -517,11 +634,31 @@ public final class IndexOptimizerEngine {
                         v.metadata().getSegmentUuid());
             }
         }
+        long deprecateMs = Math.max(0L, clock.getAsLong() - deprecateStartMs);
+        phaseDeprecateMsTotal.addAndGet(deprecateMs);
+
         // Record successful merge duration. We capture it AFTER deprecate so
         // the duration reflects the full publish-and-deprecate cycle visible
         // to operators, not just the merger.merge() span.
         long mergeEndMs = clock.getAsLong();
         lastMergeDurationMs.set(Math.max(0L, mergeEndMs - mergeStartMs));
+
+        // Accumulate per-phase totals from the merger's timing breakdown.
+        RemoteSegmentGraphMerger.MergePhaseTimings timings = null;
+        if (merger instanceof RemoteSegmentMerger) {
+            timings = ((RemoteSegmentMerger) merger).getLastMergeTimings();
+        }
+        if (timings != null) {
+            phaseDownloadMsTotal.addAndGet(timings.downloadMs);
+            phaseCompactionMsTotal.addAndGet(timings.compactionMs);
+            phasePqTrainingMsTotal.addAndGet(timings.pqTrainingMs);
+            phaseUploadMsTotal.addAndGet(timings.uploadMs);
+        }
+
+        recordMergeHistory(mergeId, indexUuid, mergeStartMs, mergeEndMs, "success",
+                candidates.size(), totalInputVectors, output.getVectorCount(),
+                peakHeapUsed, peakDirectUsed, timings, zkRegisterMs, deprecateMs);
+        mergeProgress.enterIdle();
         return observed;
     }
 
@@ -672,6 +809,49 @@ public final class IndexOptimizerEngine {
             LOGGER.log(Level.WARNING,
                     "deleteMultipartIndexFile({0},{1},{2}) failed for segment {3}: {4}",
                     new Object[]{tableSpace, uuid, fileType, segmentUuid, e.getMessage()});
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Merge history helpers (issue #503)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Convenience overload for non-success outcomes where no phase timings are
+     * available (failed / declined / aborted).
+     */
+    private void recordMergeHistory(String mergeId, String indexUuid, long startMs, long endMs,
+                                    String outcome, int inputSegments, long inputVectors,
+                                    long outputVectors, long peakHeapUsed, long peakDirectUsed) {
+        recordMergeHistory(mergeId, indexUuid, startMs, endMs, outcome, inputSegments, inputVectors,
+                outputVectors, peakHeapUsed, peakDirectUsed, null, 0L, 0L);
+    }
+
+    /**
+     * Full overload used for the "success" outcome where per-phase timings,
+     * ZK-register duration, and deprecate duration are available.
+     */
+    private void recordMergeHistory(String mergeId, String indexUuid, long startMs, long endMs,
+                                    String outcome, int inputSegments, long inputVectors,
+                                    long outputVectors, long peakHeapUsed, long peakDirectUsed,
+                                    RemoteSegmentGraphMerger.MergePhaseTimings timings,
+                                    long zkRegisterMs, long deprecateMs) {
+        long downloadMs  = timings != null ? timings.downloadMs   : 0L;
+        long pqMs        = timings != null ? timings.pqTrainingMs : 0L;
+        long compactMs   = timings != null ? timings.compactionMs : 0L;
+        long uploadMs    = timings != null ? timings.uploadMs     : 0L;
+
+        MergeRecord record = new MergeRecord(
+                mergeId, indexUuid, startMs, endMs, outcome,
+                inputSegments, inputVectors, outputVectors,
+                downloadMs, pqMs, compactMs, uploadMs,
+                zkRegisterMs, deprecateMs,
+                peakHeapUsed, peakDirectUsed);
+        synchronized (mergeHistory) {
+            mergeHistory.addLast(record);
+            while (mergeHistory.size() > MERGE_HISTORY_MAX) {
+                mergeHistory.pollFirst();
+            }
         }
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerEngine.java
@@ -522,13 +522,17 @@ public final class IndexOptimizerEngine {
         String mergeId = UUID.randomUUID().toString();
         long peakHeapUsed = MEMORY_MX.getHeapMemoryUsage().getUsed();
         long peakDirectUsed = PlatformDependent.usedDirectMemory();
-        mergeProgress.enterMerge(mergeId, candidates.size(), totalInputVectors);
+        // Source the start timestamp from the injected clock before calling
+        // enterMerge so the /status snapshot reflects the same clock as the
+        // duration accounting below, and so tests with fake clocks see the
+        // correct mergeStartMs value in the MergeProgress snapshot.
+        long mergeStartMs = clock.getAsLong();
+        mergeProgress.enterMerge(mergeId, candidates.size(), totalInputVectors, mergeStartMs);
         if (merger instanceof RemoteSegmentMerger) {
             ((RemoteSegmentMerger) merger).setMergeProgress(mergeProgress);
         }
 
         SegmentMetadata output;
-        long mergeStartMs = clock.getAsLong();
         try {
             output = merger.merge(inputMetadata, ownerSelector.getAsInt());
         } catch (Exception e) {
@@ -543,7 +547,17 @@ public final class IndexOptimizerEngine {
             return observed;
         } finally {
             if (merger instanceof RemoteSegmentMerger) {
-                ((RemoteSegmentMerger) merger).setMergeProgress(null);
+                // Clear the progress holder in the finally block so the HTTP thread
+                // stops receiving stale callbacks after the merge call returns.
+                // Wrapped in its own try/catch so a failure here cannot mask the
+                // original merge exception thrown above.
+                try {
+                    ((RemoteSegmentMerger) merger).setMergeProgress(null);
+                } catch (RuntimeException clearFailed) {
+                    LOGGER.log(Level.WARNING,
+                            "setMergeProgress(null) threw unexpectedly; "
+                                    + "original exception (if any) is preserved", clearFailed);
+                }
             }
         }
 
@@ -594,71 +608,102 @@ public final class IndexOptimizerEngine {
         //      new segment; the inputs are still ACTIVE so they get re-merged with
         //      the (now larger) output. We accept that re-merge cost.
         //    - if create failed: nothing happens; inputs remain candidates.
-        mergeProgress.updatePhase("registering-zk");
-        long zkRegisterStartMs = clock.getAsLong();
+        //
+        // Wrapped in a try/catch so any SegmentRegistryException or RuntimeException
+        // in the publish/deprecate phase (e.g. ZK session loss between merge completion
+        // and createSegment) still resets the live progress state and records a "failed"
+        // history entry before propagating.
+        long zkRegisterMs = 0L;
+        long deprecateMs = 0L;
         try {
-            registry.createSegment(output);
-            segmentsMerged.incrementAndGet();
-        } catch (SegmentRegistryException.SegmentAlreadyExists ok) {
-            // Should not happen with random UUIDs, but if it ever did the merged file
-            // is already published; fall through to deprecate inputs.
-            LOGGER.log(Level.INFO, "merged segment {0} already registered (idempotent)",
-                    output.getSegmentUuid());
-        }
-        long zkRegisterMs = Math.max(0L, clock.getAsLong() - zkRegisterStartMs);
-        phaseZkRegisterMsTotal.addAndGet(zkRegisterMs);
-
-        // Test hook for review-item R2 (second pr-reviewer pass): inject drift in the
-        // narrow window between createSegment-of-output and deprecate-of-inputs.
-        Runnable hook = postRevalidatePreDeprecateHookForTests;
-        if (hook != null) {
-            hook.run();
-        }
-
-        mergeProgress.updatePhase("deprecating-inputs");
-        long deprecateStartMs = clock.getAsLong();
-        long retentionUntil = (retentionMillis == 0L)
-                ? SegmentMetadata.NO_RETENTION
-                : now + retentionMillis;
-        for (VersionedSegmentMetadata v : candidates) {
+            mergeProgress.updatePhase("registering-zk");
+            long zkRegisterStartMs = clock.getAsLong();
             try {
-                deprecateInputSegment(v, output.getSegmentUuid(), retentionUntil);
-                segmentsDeprecated.incrementAndGet();
-            } catch (SegmentRegistryException.VersionMismatch retry) {
-                // Someone else (a transfer? another optimizer?) bumped the znode under us
-                // BETWEEN the revalidation and the deprecate CAS. This is rare given how
-                // close together the two reads are, but if it happens we've already
-                // published the output — leave the input ACTIVE; the next tick will
-                // notice the orphan output covering it and fold it in. Acceptable cost.
-                LOGGER.log(Level.INFO, "input segment {0} CAS bumped; will retry next tick",
-                        v.metadata().getSegmentUuid());
+                registry.createSegment(output);
+                segmentsMerged.incrementAndGet();
+            } catch (SegmentRegistryException.SegmentAlreadyExists ok) {
+                // Should not happen with random UUIDs, but if it ever did the merged file
+                // is already published; fall through to deprecate inputs.
+                LOGGER.log(Level.INFO, "merged segment {0} already registered (idempotent)",
+                        output.getSegmentUuid());
             }
-        }
-        long deprecateMs = Math.max(0L, clock.getAsLong() - deprecateStartMs);
-        phaseDeprecateMsTotal.addAndGet(deprecateMs);
+            zkRegisterMs = Math.max(0L, clock.getAsLong() - zkRegisterStartMs);
+            phaseZkRegisterMsTotal.addAndGet(zkRegisterMs);
 
-        // Record successful merge duration. We capture it AFTER deprecate so
-        // the duration reflects the full publish-and-deprecate cycle visible
-        // to operators, not just the merger.merge() span.
-        long mergeEndMs = clock.getAsLong();
-        lastMergeDurationMs.set(Math.max(0L, mergeEndMs - mergeStartMs));
+            // Test hook for review-item R2 (second pr-reviewer pass): inject drift in the
+            // narrow window between createSegment-of-output and deprecate-of-inputs.
+            Runnable hook = postRevalidatePreDeprecateHookForTests;
+            if (hook != null) {
+                hook.run();
+            }
 
-        // Accumulate per-phase totals from the merger's timing breakdown.
-        RemoteSegmentGraphMerger.MergePhaseTimings timings = null;
-        if (merger instanceof RemoteSegmentMerger) {
-            timings = ((RemoteSegmentMerger) merger).getLastMergeTimings();
-        }
-        if (timings != null) {
-            phaseDownloadMsTotal.addAndGet(timings.downloadMs);
-            phaseCompactionMsTotal.addAndGet(timings.compactionMs);
-            phasePqTrainingMsTotal.addAndGet(timings.pqTrainingMs);
-            phaseUploadMsTotal.addAndGet(timings.uploadMs);
-        }
+            mergeProgress.updatePhase("deprecating-inputs");
+            long deprecateStartMs = clock.getAsLong();
+            long retentionUntil = (retentionMillis == 0L)
+                    ? SegmentMetadata.NO_RETENTION
+                    : now + retentionMillis;
+            for (VersionedSegmentMetadata v : candidates) {
+                try {
+                    deprecateInputSegment(v, output.getSegmentUuid(), retentionUntil);
+                    segmentsDeprecated.incrementAndGet();
+                } catch (SegmentRegistryException.VersionMismatch retry) {
+                    // Someone else (a transfer? another optimizer?) bumped the znode under us
+                    // BETWEEN the revalidation and the deprecate CAS. This is rare given how
+                    // close together the two reads are, but if it happens we've already
+                    // published the output — leave the input ACTIVE; the next tick will
+                    // notice the orphan output covering it and fold it in. Acceptable cost.
+                    LOGGER.log(Level.INFO, "input segment {0} CAS bumped; will retry next tick",
+                            v.metadata().getSegmentUuid());
+                }
+            }
+            deprecateMs = Math.max(0L, clock.getAsLong() - deprecateStartMs);
+            phaseDeprecateMsTotal.addAndGet(deprecateMs);
 
-        recordMergeHistory(mergeId, indexUuid, mergeStartMs, mergeEndMs, "success",
-                candidates.size(), totalInputVectors, output.getVectorCount(),
-                peakHeapUsed, peakDirectUsed, timings, zkRegisterMs, deprecateMs);
-        mergeProgress.enterIdle();
+            // Record successful merge duration. We capture it AFTER deprecate so
+            // the duration reflects the full publish-and-deprecate cycle visible
+            // to operators, not just the merger.merge() span.
+            long mergeEndMs = clock.getAsLong();
+            lastMergeDurationMs.set(Math.max(0L, mergeEndMs - mergeStartMs));
+
+            // Accumulate per-phase totals from the merger's timing breakdown.
+            RemoteSegmentGraphMerger.MergePhaseTimings timings = null;
+            if (merger instanceof RemoteSegmentMerger) {
+                timings = ((RemoteSegmentMerger) merger).getLastMergeTimings();
+            }
+            if (timings != null) {
+                phaseDownloadMsTotal.addAndGet(timings.downloadMs);
+                phaseCompactionMsTotal.addAndGet(timings.compactionMs);
+                phasePqTrainingMsTotal.addAndGet(timings.pqTrainingMs);
+                phaseUploadMsTotal.addAndGet(timings.uploadMs);
+            }
+
+            recordMergeHistory(mergeId, indexUuid, mergeStartMs, mergeEndMs, "success",
+                    candidates.size(), totalInputVectors, output.getVectorCount(),
+                    peakHeapUsed, peakDirectUsed, timings, zkRegisterMs, deprecateMs);
+            mergeProgress.enterIdle();
+        } catch (RuntimeException postMergeFailed) {
+            mergeFailuresTotal.incrementAndGet();
+            long failedAt = clock.getAsLong();
+            LOGGER.log(Level.WARNING,
+                    "post-merge publish/deprecate failed for index " + indexUuid
+                            + " (output=" + output.getSegmentUuid()
+                            + "); progress reset, recording failure", postMergeFailed);
+            recordMergeHistory(mergeId, indexUuid, mergeStartMs, failedAt, "failed",
+                    candidates.size(), totalInputVectors, 0L, peakHeapUsed, peakDirectUsed);
+            mergeProgress.enterIdle();
+            throw postMergeFailed;
+        } catch (SegmentRegistryException postMergeFailed) {
+            mergeFailuresTotal.incrementAndGet();
+            long failedAt = clock.getAsLong();
+            LOGGER.log(Level.WARNING,
+                    "post-merge publish/deprecate failed for index " + indexUuid
+                            + " (output=" + output.getSegmentUuid()
+                            + "); progress reset, recording failure", postMergeFailed);
+            recordMergeHistory(mergeId, indexUuid, mergeStartMs, failedAt, "failed",
+                    candidates.size(), totalInputVectors, 0L, peakHeapUsed, peakDirectUsed);
+            mergeProgress.enterIdle();
+            throw postMergeFailed;
+        }
         return observed;
     }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -354,7 +354,18 @@ public final class IndexOptimizerMain {
             String httpHost = configuration.getString(
                     OptimizerConfiguration.PROPERTY_HTTP_HOST,
                     OptimizerConfiguration.PROPERTY_HTTP_HOST_DEFAULT);
-            this.httpServer = new OptimizerHttpServer(httpHost, httpPort, engine);
+            // Pass the resolved tmp directory so /metrics can emit
+            // herddb_optimizer_tmp_disk_free_bytes and _total_bytes (issue #503).
+            Path tmpDirForHttp;
+            try {
+                tmpDirForHttp = resolveTmpDirectory();
+            } catch (IOException tmpErr) {
+                LOGGER.log(Level.WARNING,
+                        "could not resolve tmp directory for HTTP metrics; tmp-disk gauges"
+                                + " will be omitted: {0}", tmpErr.getMessage());
+                tmpDirForHttp = null;
+            }
+            this.httpServer = new OptimizerHttpServer(httpHost, httpPort, engine, tmpDirForHttp);
             this.httpServer.start();
         }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergeProgress.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergeProgress.java
@@ -1,0 +1,242 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import io.netty.util.internal.PlatformDependent;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.util.List;
+
+/**
+ * Thread-safe (via {@code volatile} fields) live state of the current or most
+ * recent merge cycle. Written by the single-threaded optimizer scheduler;
+ * read concurrently by the HTTP server thread for {@code GET /status}.
+ *
+ * <p>All fields are {@code volatile} so a plain read from the HTTP thread sees
+ * a consistent, up-to-date value without synchronisation overhead. There is no
+ * atomicity guarantee across <em>multiple</em> fields — the snapshot captures a
+ * point-in-time picture that may straddle two sequential writes, but for a
+ * monitoring endpoint this is acceptable.
+ */
+public final class MergeProgress {
+
+    private static final MemoryMXBean MEMORY_MX = ManagementFactory.getMemoryMXBean();
+    private static final List<GarbageCollectorMXBean> GC_BEANS =
+            ManagementFactory.getGarbageCollectorMXBeans();
+
+    // -------------------------------------------------------------------------
+    // Live-state fields — written by optimizer thread, read by HTTP thread.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Current phase. One of: {@code "idle"}, {@code "downloading"},
+     * {@code "pq-training"}, {@code "compacting"}, {@code "uploading"},
+     * {@code "registering-zk"}, {@code "deprecating-inputs"}.
+     */
+    volatile String phase = "idle";
+
+    /** UUID assigned to the merge cycle at start; {@code null} when idle. */
+    volatile String mergeId = null;
+
+    /** Number of input segments being merged (0 when idle). */
+    volatile int inputSegments = 0;
+
+    /**
+     * Total vector count across all input segments (0 when idle).
+     * Summed from {@code SegmentMetadata.getVectorCount()} at the start of the
+     * merge; used as {@code batches_total} during the graph-build phase.
+     */
+    volatile long inputVectors = 0;
+
+    /**
+     * Vectors (or download batches) completed so far in the current phase.
+     * Updated by the merger's batch-progress callback every
+     * {@value RemoteSegmentGraphMerger#BATCH_PROGRESS_INTERVAL} vectors during
+     * the legacy graph-build phase.
+     */
+    volatile long batchesWritten = 0;
+
+    /** Total batches for the current phase; 0 when unknown (e.g. PQ-training). */
+    volatile long batchesTotal = 0;
+
+    /** Wall-clock epoch-ms when the current merge started; 0 when idle. */
+    volatile long mergeStartMs = 0;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle helpers (called from the optimizer thread)
+    // -------------------------------------------------------------------------
+
+    void enterIdle() {
+        phase = "idle";
+        mergeId = null;
+        inputSegments = 0;
+        inputVectors = 0;
+        batchesWritten = 0;
+        batchesTotal = 0;
+        mergeStartMs = 0;
+    }
+
+    void enterMerge(String id, int segments, long vectors) {
+        mergeId = id;
+        inputSegments = segments;
+        inputVectors = vectors;
+        batchesWritten = 0;
+        batchesTotal = vectors;
+        mergeStartMs = System.currentTimeMillis();
+        phase = "downloading";
+    }
+
+    void updatePhase(String newPhase) {
+        phase = newPhase;
+        batchesWritten = 0;
+    }
+
+    void updateBatchProgress(long written, long total) {
+        batchesWritten = written;
+        batchesTotal = total;
+    }
+
+    // -------------------------------------------------------------------------
+    // Snapshot (called from the HTTP thread)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Captures a consistent-ish snapshot of the current state, augmented with
+     * a live JVM memory reading. Safe to call from any thread.
+     */
+    Snapshot snapshot() {
+        // Capture volatile fields in locals to reduce visibility hazards.
+        String snapPhase       = phase;
+        String snapMergeId     = mergeId;
+        int    snapSegments    = inputSegments;
+        long   snapVectors     = inputVectors;
+        long   snapWritten     = batchesWritten;
+        long   snapTotal       = batchesTotal;
+        long   snapStartMs     = mergeStartMs;
+
+        long heapUsed = MEMORY_MX.getHeapMemoryUsage().getUsed();
+        long heapMax  = MEMORY_MX.getHeapMemoryUsage().getMax();
+        // Netty's direct-memory counter: -1 when Netty defers to JDK accounting.
+        long directUsed = PlatformDependent.usedDirectMemory();
+        long directMax  = PlatformDependent.maxDirectMemory();
+
+        long gcCount = 0;
+        long gcTimeMs = 0;
+        for (GarbageCollectorMXBean gc : GC_BEANS) {
+            long cnt = gc.getCollectionCount();
+            long t   = gc.getCollectionTime();
+            if (cnt >= 0) {
+                gcCount += cnt;
+            }
+            if (t >= 0) {
+                gcTimeMs += t;
+            }
+        }
+
+        long elapsedMs = (snapStartMs > 0 && !"idle".equals(snapPhase))
+                ? System.currentTimeMillis() - snapStartMs
+                : 0;
+        long etaMs = estimateEta(snapWritten, snapTotal, elapsedMs);
+
+        return new Snapshot(snapPhase, snapMergeId, snapSegments, snapVectors,
+                snapWritten, snapTotal, snapStartMs, elapsedMs, etaMs,
+                heapUsed, heapMax, directUsed, directMax, gcCount, gcTimeMs);
+    }
+
+    private static long estimateEta(long written, long total, long elapsedMs) {
+        if (written <= 0 || total <= 0 || written >= total) {
+            return -1;
+        }
+        return elapsedMs * (total - written) / written;
+    }
+
+    // -------------------------------------------------------------------------
+    // Snapshot value object
+    // -------------------------------------------------------------------------
+
+    /**
+     * Point-in-time snapshot of the merge progress, including a fresh JVM
+     * memory reading. Immutable; safe to share across threads.
+     */
+    static final class Snapshot {
+        final String phase;
+        final String mergeId;
+        final int inputSegments;
+        final long inputVectors;
+        final long batchesWritten;
+        final long batchesTotal;
+        final long mergeStartMs;
+        final long elapsedMs;
+        final long etaMs;
+        final long heapUsedBytes;
+        final long heapMaxBytes;
+        final long directUsedBytes;
+        final long directMaxBytes;
+        final long gcCount;
+        final long gcTimeMs;
+
+        Snapshot(String phase, String mergeId, int inputSegments, long inputVectors,
+                 long batchesWritten, long batchesTotal, long mergeStartMs,
+                 long elapsedMs, long etaMs,
+                 long heapUsedBytes, long heapMaxBytes,
+                 long directUsedBytes, long directMaxBytes,
+                 long gcCount, long gcTimeMs) {
+            this.phase = phase;
+            this.mergeId = mergeId;
+            this.inputSegments = inputSegments;
+            this.inputVectors = inputVectors;
+            this.batchesWritten = batchesWritten;
+            this.batchesTotal = batchesTotal;
+            this.mergeStartMs = mergeStartMs;
+            this.elapsedMs = elapsedMs;
+            this.etaMs = etaMs;
+            this.heapUsedBytes = heapUsedBytes;
+            this.heapMaxBytes = heapMaxBytes;
+            this.directUsedBytes = directUsedBytes;
+            this.directMaxBytes = directMaxBytes;
+            this.gcCount = gcCount;
+            this.gcTimeMs = gcTimeMs;
+        }
+
+        double pctComplete() {
+            if (batchesTotal <= 0) {
+                return 0.0;
+            }
+            return Math.min(100.0, batchesWritten * 100.0 / batchesTotal);
+        }
+
+        long heapUsedMb() {
+            return heapUsedBytes / (1024 * 1024);
+        }
+
+        long heapMaxMb() {
+            return heapMaxBytes / (1024 * 1024);
+        }
+
+        long directUsedMb() {
+            return directUsedBytes < 0 ? -1L : directUsedBytes / (1024 * 1024);
+        }
+
+        long directMaxMb() {
+            return directMaxBytes < 0 ? -1L : directMaxBytes / (1024 * 1024);
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergeProgress.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergeProgress.java
@@ -94,19 +94,33 @@ public final class MergeProgress {
         mergeStartMs = 0;
     }
 
-    void enterMerge(String id, int segments, long vectors) {
+    /**
+     * Transitions from idle to the active merge state.
+     *
+     * @param startMs wall-clock epoch milliseconds obtained from the engine's
+     *                injected clock ({@code clock.getAsLong()}); the caller must
+     *                source this rather than calling {@code System.currentTimeMillis()}
+     *                here so tests that inject a fake clock observe a consistent
+     *                timestamp in {@link Snapshot#mergeStartMs}.
+     */
+    void enterMerge(String id, int segments, long vectors, long startMs) {
         mergeId = id;
         inputSegments = segments;
         inputVectors = vectors;
         batchesWritten = 0;
         batchesTotal = vectors;
-        mergeStartMs = System.currentTimeMillis();
+        mergeStartMs = startMs;
         phase = "downloading";
     }
 
     void updatePhase(String newPhase) {
         phase = newPhase;
         batchesWritten = 0;
+        // Reset batchesTotal as well: the new phase has an unknown total until
+        // the first updateBatchProgress callback fires (or stays at 0 if the
+        // phase does not expose progress). Leaving a stale total from the
+        // previous phase would make pctComplete() return a misleading value.
+        batchesTotal = 0;
     }
 
     void updateBatchProgress(long written, long total) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergeRecord.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergeRecord.java
@@ -1,0 +1,129 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+/**
+ * Immutable record of a completed (or aborted / declined) merge cycle.
+ * Stored in the engine's bounded merge history ({@link IndexOptimizerEngine#getMergeHistory})
+ * and returned as a JSON array by {@code GET /merge-history}.
+ *
+ * <p>All time fields are in milliseconds. Timing fields that are not
+ * applicable to a particular merge path (e.g. {@link #pqTrainingMs} on the
+ * streaming path) are zero.
+ */
+public final class MergeRecord {
+
+    /** UUID assigned to this merge cycle at start. */
+    public final String mergeId;
+
+    /** Index UUID that was the merge target. */
+    public final String indexUuid;
+
+    /** Wall-clock epoch-ms when the merge started. */
+    public final long startedAtMs;
+
+    /** Wall-clock epoch-ms when the merge finished (success or failure). */
+    public final long finishedAtMs;
+
+    /**
+     * Outcome of the merge. One of:
+     * <ul>
+     *   <li>{@code "success"} — merged, published, inputs deprecated.</li>
+     *   <li>{@code "failed"} — merger.merge() threw an exception.</li>
+     *   <li>{@code "declined"} — merger returned null (all vectors tombstoned).</li>
+     *   <li>{@code "aborted"} — post-merge revalidation found inputs drifted.</li>
+     * </ul>
+     */
+    public final String outcome;
+
+    /** Number of input segments. */
+    public final int inputSegments;
+
+    /** Total vector count across all input segments. */
+    public final long inputVectors;
+
+    /** Vector count in the merged output; 0 on non-success outcomes. */
+    public final long outputVectors;
+
+    /** Time spent downloading input graph/map files from remote storage. */
+    public final long downloadMs;
+
+    /**
+     * Time spent in PQ K-means training (legacy in-memory path only; 0 for
+     * the streaming path and for small shards below the FusedPQ threshold).
+     */
+    public final long pqTrainingMs;
+
+    /**
+     * Time spent building / compacting the graph (legacy: GraphIndexBuilder;
+     * streaming: OnDiskGraphIndexCompactor). Includes the legacy in-memory
+     * authority-map build but NOT PQ training or upload.
+     */
+    public final long compactionMs;
+
+    /** Time spent uploading the graph + map files to remote storage. */
+    public final long uploadMs;
+
+    /**
+     * Time spent calling {@code registry.createSegment()} (ZooKeeper write
+     * for the merged output). 0 on non-success outcomes.
+     */
+    public final long zkRegisterMs;
+
+    /**
+     * Time spent deprecating input segments via {@code casUpdateSegment()} CAS
+     * calls. 0 on non-success outcomes.
+     */
+    public final long deprecateMs;
+
+    /** Heap used (bytes) sampled at the start of the merge. */
+    public final long peakHeapUsedBytes;
+
+    /** Netty direct-memory used (bytes) sampled at the start of the merge; -1 if unavailable. */
+    public final long peakDirectUsedBytes;
+
+    public MergeRecord(String mergeId, String indexUuid, long startedAtMs, long finishedAtMs,
+                       String outcome, int inputSegments, long inputVectors, long outputVectors,
+                       long downloadMs, long pqTrainingMs, long compactionMs, long uploadMs,
+                       long zkRegisterMs, long deprecateMs,
+                       long peakHeapUsedBytes, long peakDirectUsedBytes) {
+        this.mergeId = mergeId;
+        this.indexUuid = indexUuid;
+        this.startedAtMs = startedAtMs;
+        this.finishedAtMs = finishedAtMs;
+        this.outcome = outcome;
+        this.inputSegments = inputSegments;
+        this.inputVectors = inputVectors;
+        this.outputVectors = outputVectors;
+        this.downloadMs = downloadMs;
+        this.pqTrainingMs = pqTrainingMs;
+        this.compactionMs = compactionMs;
+        this.uploadMs = uploadMs;
+        this.zkRegisterMs = zkRegisterMs;
+        this.deprecateMs = deprecateMs;
+        this.peakHeapUsedBytes = peakHeapUsedBytes;
+        this.peakDirectUsedBytes = peakDirectUsedBytes;
+    }
+
+    /** Total wall-clock duration of the merge. */
+    public long totalMs() {
+        return finishedAtMs - startedAtMs;
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
@@ -30,7 +30,9 @@ import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -63,6 +65,8 @@ public final class OptimizerHttpServer implements AutoCloseable {
 
     private final HttpServer server;
     private final IndexOptimizerEngine engine;
+    /** Single-threaded executor backing the JDK HttpServer; shut down in {@link #close()}. */
+    private final ExecutorService executor;
     /** Optional: when non-null, disk-free gauges are computed for this path. */
     private final Path tmpDirectory;
 
@@ -96,11 +100,13 @@ public final class OptimizerHttpServer implements AutoCloseable {
         server.createContext("/status", new StatusHandler());
         server.createContext("/merge-history", new MergeHistoryHandler());
         // Single-threaded executor — these endpoints are admin-grade, not on the hot path.
-        server.setExecutor(Executors.newSingleThreadExecutor(r -> {
+        // Kept in a field so close() can shut it down cleanly.
+        this.executor = Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r, "optimizer-http");
             t.setDaemon(true);
             return t;
-        }));
+        });
+        server.setExecutor(executor);
     }
 
     public void start() {
@@ -116,8 +122,17 @@ public final class OptimizerHttpServer implements AutoCloseable {
 
     @Override
     public void close() {
-        // Stop with a 0-second grace; this is a daemon admin endpoint.
+        // Stop the server with a 0-second grace; this is a daemon admin endpoint.
         server.stop(0);
+        // Shut down the executor so the HTTP thread exits cleanly.
+        executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                LOGGER.log(Level.WARNING, "optimizer-http executor did not terminate within 5s");
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerHttpServer.java
@@ -26,6 +26,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,9 +43,14 @@ import java.util.logging.Logger;
  *       (issue #504). Engine progress is tracked via the
  *       {@code herddb_optimizer_last_run_at_seconds} gauge on /metrics
  *       for alerting.</li>
- *   <li>{@code GET /metrics} — returns Prometheus-style plain-text counters
- *       (runs, segments_merged, segments_deprecated, segments_deleted,
- *       ticks_skipped_not_leader). Scrape-friendly.</li>
+ *   <li>{@code GET /metrics} — returns Prometheus-style plain-text counters.
+ *       Includes per-phase timing totals, current merge progress gauges,
+ *       JVM heap/direct-memory gauges, and tmp-disk gauges (issue #503).</li>
+ *   <li>{@code GET /status} — returns a JSON snapshot of the live merge
+ *       progress (phase, vectors written, ETA, JVM memory) (issue #503).</li>
+ *   <li>{@code GET /merge-history} — returns a JSON array of the last 20
+ *       completed merge
+ *       records with per-phase timings and outcome (issue #503).</li>
  * </ul>
  *
  * <p>Built on the JDK's {@link HttpServer} so the optimizer doesn't drag in
@@ -54,12 +63,38 @@ public final class OptimizerHttpServer implements AutoCloseable {
 
     private final HttpServer server;
     private final IndexOptimizerEngine engine;
+    /** Optional: when non-null, disk-free gauges are computed for this path. */
+    private final Path tmpDirectory;
 
-    public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine) throws IOException {
+    /**
+     * Backward-compatible constructor that does not emit tmp-disk metrics.
+     * Use {@link #OptimizerHttpServer(String, int, IndexOptimizerEngine, Path)}
+     * to enable tmp-disk gauges.
+     */
+    public OptimizerHttpServer(String bindHost, int port, IndexOptimizerEngine engine)
+            throws IOException {
+        this(bindHost, port, engine, null);
+    }
+
+    /**
+     * Full constructor.
+     *
+     * @param tmpDirectory  when non-null, the {@code herddb_optimizer_tmp_disk_*}
+     *                      gauges in {@code /metrics} report the free / total bytes
+     *                      of the file-store backing this directory. Pass
+     *                      {@code null} to omit those metrics (e.g. in unit tests
+     *                      that don't set up a real tmp dir).
+     */
+    public OptimizerHttpServer(String bindHost, int port,
+                               IndexOptimizerEngine engine,
+                               Path tmpDirectory) throws IOException {
         this.engine = engine;
+        this.tmpDirectory = tmpDirectory;
         this.server = HttpServer.create(new InetSocketAddress(bindHost, port), 0);
         server.createContext("/health", new HealthHandler());
         server.createContext("/metrics", new MetricsHandler());
+        server.createContext("/status", new StatusHandler());
+        server.createContext("/merge-history", new MergeHistoryHandler());
         // Single-threaded executor — these endpoints are admin-grade, not on the hot path.
         server.setExecutor(Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r, "optimizer-http");
@@ -85,6 +120,10 @@ public final class OptimizerHttpServer implements AutoCloseable {
         server.stop(0);
     }
 
+    // -------------------------------------------------------------------------
+    // /health
+    // -------------------------------------------------------------------------
+
     private static final class HealthHandler implements HttpHandler {
         private static final byte[] OK_BODY = "OK\n".getBytes(StandardCharsets.UTF_8);
 
@@ -98,74 +137,57 @@ public final class OptimizerHttpServer implements AutoCloseable {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // /metrics (Prometheus text format)
+    // -------------------------------------------------------------------------
+
     private final class MetricsHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
-            StringBuilder sb = new StringBuilder(256);
-            // Prometheus exposition format. HELP/TYPE comments are optional but cheap.
-            sb.append("# HELP herddb_optimizer_runs_total Total optimizer ticks attempted.\n");
-            sb.append("# TYPE herddb_optimizer_runs_total counter\n");
-            sb.append("herddb_optimizer_runs_total ").append(engine.getRuns()).append('\n');
+            StringBuilder sb = new StringBuilder(1024);
 
-            sb.append("# HELP herddb_optimizer_segments_merged_total Output segments produced.\n");
-            sb.append("# TYPE herddb_optimizer_segments_merged_total counter\n");
-            sb.append("herddb_optimizer_segments_merged_total ")
-                    .append(engine.getSegmentsMerged()).append('\n');
+            // ----- Counters: runs / merges / segments -----
+            appendCounter(sb, "herddb_optimizer_runs_total",
+                    "Total optimizer ticks attempted.",
+                    engine.getRuns());
+            appendCounter(sb, "herddb_optimizer_segments_merged_total",
+                    "Output segments produced.",
+                    engine.getSegmentsMerged());
+            appendCounter(sb, "herddb_optimizer_segments_deprecated_total",
+                    "Inputs marked DEPRECATED.",
+                    engine.getSegmentsDeprecated());
+            appendCounter(sb, "herddb_optimizer_segments_deleted_total",
+                    "Reaped segments after retention.",
+                    engine.getSegmentsDeleted());
+            appendCounter(sb, "herddb_optimizer_ticks_skipped_not_leader_total",
+                    "Ticks short-circuited because we lost the leader lock.",
+                    engine.getTicksSkippedNotLeader());
 
-            sb.append("# HELP herddb_optimizer_segments_deprecated_total Inputs marked DEPRECATED.\n");
-            sb.append("# TYPE herddb_optimizer_segments_deprecated_total counter\n");
-            sb.append("herddb_optimizer_segments_deprecated_total ")
-                    .append(engine.getSegmentsDeprecated()).append('\n');
+            // ----- Counters: merge outcomes -----
+            appendCounter(sb, "herddb_optimizer_merge_failures_total",
+                    "Merger.merge() invocations that threw.",
+                    engine.getMergeFailuresTotal());
+            appendCounter(sb, "herddb_optimizer_merge_aborts_revalidate_failed_total",
+                    "Merges aborted because input drifted under the optimizer"
+                            + " between candidate-pick and the post-merge revalidate.",
+                    engine.getMergeAbortsRevalidateFailedTotal());
+            appendCounter(sb, "herddb_optimizer_merge_declined_total",
+                    "Merger declined a candidate batch (e.g. not enough live entries).",
+                    engine.getMergeDeclinedTotal());
 
-            sb.append("# HELP herddb_optimizer_segments_deleted_total Reaped segments after retention.\n");
-            sb.append("# TYPE herddb_optimizer_segments_deleted_total counter\n");
-            sb.append("herddb_optimizer_segments_deleted_total ")
-                    .append(engine.getSegmentsDeleted()).append('\n');
-
-            sb.append("# HELP herddb_optimizer_ticks_skipped_not_leader_total Ticks short-circuited because we lost the leader lock.\n");
-            sb.append("# TYPE herddb_optimizer_ticks_skipped_not_leader_total counter\n");
-            sb.append("herddb_optimizer_ticks_skipped_not_leader_total ")
-                    .append(engine.getTicksSkippedNotLeader()).append('\n');
-
-            // ----- Compaction failure / abort breakdown -----
-            sb.append("# HELP herddb_optimizer_merge_failures_total Merger.merge() invocations that threw.\n");
-            sb.append("# TYPE herddb_optimizer_merge_failures_total counter\n");
-            sb.append("herddb_optimizer_merge_failures_total ")
-                    .append(engine.getMergeFailuresTotal()).append('\n');
-
-            sb.append("# HELP herddb_optimizer_merge_aborts_revalidate_failed_total"
-                    + " Merges aborted because input drifted under the optimizer between"
-                    + " candidate-pick and the post-merge revalidate.\n");
-            sb.append("# TYPE herddb_optimizer_merge_aborts_revalidate_failed_total counter\n");
-            sb.append("herddb_optimizer_merge_aborts_revalidate_failed_total ")
-                    .append(engine.getMergeAbortsRevalidateFailedTotal()).append('\n');
-
-            sb.append("# HELP herddb_optimizer_merge_declined_total"
-                    + " Merger declined a candidate batch (e.g., not enough live entries).\n");
-            sb.append("# TYPE herddb_optimizer_merge_declined_total counter\n");
-            sb.append("herddb_optimizer_merge_declined_total ")
-                    .append(engine.getMergeDeclinedTotal()).append('\n');
-
-            sb.append("# HELP herddb_optimizer_last_merge_duration_ms"
-                    + " Wall-clock millis of the last completed merge cycle (-1 if never run).\n");
-            sb.append("# TYPE herddb_optimizer_last_merge_duration_ms gauge\n");
-            sb.append("herddb_optimizer_last_merge_duration_ms ")
-                    .append(engine.getLastMergeDurationMs()).append('\n');
-
-            sb.append("# HELP herddb_optimizer_last_run_at_seconds"
-                    + " Unix-time seconds at which the last tick body started (-1 if never run).\n");
-            sb.append("# TYPE herddb_optimizer_last_run_at_seconds gauge\n");
+            // ----- Gauge: last merge / last run -----
+            appendGauge(sb, "herddb_optimizer_last_merge_duration_ms",
+                    "Wall-clock millis of the last completed merge cycle (-1 if never run).",
+                    engine.getLastMergeDurationMs());
             long lastRunMs = engine.getLastRunAtMillis();
-            sb.append("herddb_optimizer_last_run_at_seconds ")
-                    .append(lastRunMs >= 0 ? lastRunMs / 1000L : -1L).append('\n');
+            appendGauge(sb, "herddb_optimizer_last_run_at_seconds",
+                    "Unix-time seconds at which the last tick body started (-1 if never run).",
+                    lastRunMs >= 0 ? lastRunMs / 1000L : -1L);
 
-            // ----- Observed segments (last-tick snapshot, by state) -----
-            sb.append("# HELP herddb_optimizer_observed_indexes"
-                    + " Number of indexes seen in the most recent tick.\n");
-            sb.append("# TYPE herddb_optimizer_observed_indexes gauge\n");
-            sb.append("herddb_optimizer_observed_indexes ")
-                    .append(engine.getObservedIndexes()).append('\n');
-
+            // ----- Gauge: observed segment counts -----
+            appendGauge(sb, "herddb_optimizer_observed_indexes",
+                    "Number of indexes seen in the most recent tick.",
+                    engine.getObservedIndexes());
             sb.append("# HELP herddb_optimizer_observed_segments"
                     + " Per-state segment count from the most recent tick across all"
                     + " observed indexes. Labels: state in {active, deprecated, transferring,"
@@ -180,30 +202,95 @@ public final class OptimizerHttpServer implements AutoCloseable {
             sb.append("herddb_optimizer_observed_segments{state=\"provisional\"} ")
                     .append(engine.getObservedProvisionalSegments()).append('\n');
 
-            // ----- Segment relocations (ownership transfers driven by the optimizer) -----
-            // Counters are wired but stay at 0 until the production relocate-trigger
-            // path is enabled — the panel in Grafana is plumbed now so it lights up
-            // automatically when the wiring lands.
-            sb.append("# HELP herddb_optimizer_relocations_initiated_total"
-                    + " Ownership-transfer initiate (ACTIVE -> TRANSFERRING) CAS calls"
-                    + " issued by the optimizer.\n");
-            sb.append("# TYPE herddb_optimizer_relocations_initiated_total counter\n");
-            sb.append("herddb_optimizer_relocations_initiated_total ")
-                    .append(engine.getRelocationsInitiatedTotal()).append('\n');
+            // ----- Counters: ownership relocations -----
+            appendCounter(sb, "herddb_optimizer_relocations_initiated_total",
+                    "Ownership-transfer initiate (ACTIVE -> TRANSFERRING) CAS calls"
+                            + " issued by the optimizer.",
+                    engine.getRelocationsInitiatedTotal());
+            appendCounter(sb, "herddb_optimizer_relocations_completed_total",
+                    "Ownership-transfer complete (TRANSFERRING -> ACTIVE) CAS calls"
+                            + " observed at the registry.",
+                    engine.getRelocationsCompletedTotal());
+            appendCounter(sb, "herddb_optimizer_relocations_aborted_total",
+                    "Transfer attempts that aborted before complete() fired"
+                            + " (revalidate failure, takeover-side timeout, optimizer crash).",
+                    engine.getRelocationsAbortedTotal());
 
-            sb.append("# HELP herddb_optimizer_relocations_completed_total"
-                    + " Ownership-transfer complete (TRANSFERRING -> ACTIVE) CAS calls"
-                    + " observed at the registry.\n");
-            sb.append("# TYPE herddb_optimizer_relocations_completed_total counter\n");
-            sb.append("herddb_optimizer_relocations_completed_total ")
-                    .append(engine.getRelocationsCompletedTotal()).append('\n');
+            // ----- Counters: per-phase cumulative timing (issue #503) -----
+            sb.append("# HELP herddb_optimizer_phase_ms_total"
+                    + " Cumulative time spent in each merge phase (milliseconds)."
+                    + " Labels: phase in {download, compaction, pq_training, upload,"
+                    + " zk_register, deprecate}.\n");
+            sb.append("# TYPE herddb_optimizer_phase_ms_total counter\n");
+            sb.append("herddb_optimizer_phase_ms_total{phase=\"download\"} ")
+                    .append(engine.getPhaseDownloadMsTotal()).append('\n');
+            sb.append("herddb_optimizer_phase_ms_total{phase=\"compaction\"} ")
+                    .append(engine.getPhaseCompactionMsTotal()).append('\n');
+            sb.append("herddb_optimizer_phase_ms_total{phase=\"pq_training\"} ")
+                    .append(engine.getPhasePqTrainingMsTotal()).append('\n');
+            sb.append("herddb_optimizer_phase_ms_total{phase=\"upload\"} ")
+                    .append(engine.getPhaseUploadMsTotal()).append('\n');
+            sb.append("herddb_optimizer_phase_ms_total{phase=\"zk_register\"} ")
+                    .append(engine.getPhaseZkRegisterMsTotal()).append('\n');
+            sb.append("herddb_optimizer_phase_ms_total{phase=\"deprecate\"} ")
+                    .append(engine.getPhaseDeprecateMsTotal()).append('\n');
 
-            sb.append("# HELP herddb_optimizer_relocations_aborted_total"
-                    + " Transfer attempts that aborted before {@code complete()} fired"
-                    + " (revalidate failure, takeover-side timeout, optimizer crash).\n");
-            sb.append("# TYPE herddb_optimizer_relocations_aborted_total counter\n");
-            sb.append("herddb_optimizer_relocations_aborted_total ")
-                    .append(engine.getRelocationsAbortedTotal()).append('\n');
+            // ----- Gauges: current merge progress (issue #503) -----
+            MergeProgress.Snapshot snap = engine.getMergeProgress().snapshot();
+            sb.append("# HELP herddb_optimizer_current_phase"
+                    + " 1 when the optimizer is in the labeled phase; 0 otherwise.\n");
+            sb.append("# TYPE herddb_optimizer_current_phase gauge\n");
+            for (String phase : new String[]{"idle", "downloading", "pq-training",
+                    "compacting", "uploading", "registering-zk", "deprecating-inputs"}) {
+                sb.append("herddb_optimizer_current_phase{phase=\"").append(phase).append("\"} ")
+                        .append(phase.equals(snap.phase) ? 1 : 0).append('\n');
+            }
+            appendGauge(sb, "herddb_optimizer_merge_input_segments",
+                    "Number of input segments in the current (or last) merge.",
+                    snap.inputSegments);
+            appendGauge(sb, "herddb_optimizer_merge_input_vectors",
+                    "Total input vectors in the current (or last) merge.",
+                    snap.inputVectors);
+            appendGauge(sb, "herddb_optimizer_merge_batches_written",
+                    "Vectors (or batches) written so far in the current phase.",
+                    snap.batchesWritten);
+            appendGauge(sb, "herddb_optimizer_merge_batches_total",
+                    "Total batches for the current phase (0 when unknown).",
+                    snap.batchesTotal);
+            appendGauge(sb, "herddb_optimizer_merge_elapsed_ms",
+                    "Elapsed milliseconds since the current merge started (0 when idle).",
+                    snap.elapsedMs);
+            appendGauge(sb, "herddb_optimizer_merge_eta_ms",
+                    "Estimated remaining milliseconds for the current phase (-1 when unknown).",
+                    snap.etaMs);
+
+            // ----- Gauges: JVM heap (issue #503) -----
+            appendGauge(sb, "herddb_jvm_heap_used_bytes",
+                    "JVM heap memory currently in use (bytes).",
+                    snap.heapUsedBytes);
+            appendGauge(sb, "herddb_jvm_heap_max_bytes",
+                    "JVM heap memory maximum (bytes).",
+                    snap.heapMaxBytes);
+
+            // ----- Gauges: JVM direct memory via Netty PlatformDependent (issue #503) -----
+            appendGauge(sb, "netty_used_direct_memory_bytes",
+                    "Netty direct (off-heap) memory currently allocated (bytes);"
+                            + " -1 when Netty defers to JDK accounting.",
+                    snap.directUsedBytes);
+            appendGauge(sb, "netty_max_direct_memory_bytes",
+                    "JVM maximum direct memory permitted (bytes).",
+                    snap.directMaxBytes);
+
+            // ----- Gauges: JVM GC (issue #503) -----
+            appendCounter(sb, "herddb_jvm_gc_count_total",
+                    "Total garbage-collection count across all collectors.",
+                    snap.gcCount);
+            appendCounter(sb, "herddb_jvm_gc_time_ms_total",
+                    "Total garbage-collection wall-clock time across all collectors (milliseconds).",
+                    snap.gcTimeMs);
+
+            // ----- Gauges: tmp disk (issue #503) -----
+            appendTmpDiskMetrics(sb);
 
             byte[] body = sb.toString().getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
@@ -212,5 +299,177 @@ public final class OptimizerHttpServer implements AutoCloseable {
                 os.write(body);
             }
         }
+
+        private void appendTmpDiskMetrics(StringBuilder sb) {
+            if (tmpDirectory == null) {
+                return;
+            }
+            try {
+                FileStore fs = Files.getFileStore(tmpDirectory);
+                long free  = fs.getUsableSpace();
+                long total = fs.getTotalSpace();
+                appendGauge(sb, "herddb_optimizer_tmp_disk_free_bytes",
+                        "Usable free bytes on the file-store backing the optimizer's tmp directory.",
+                        free);
+                appendGauge(sb, "herddb_optimizer_tmp_disk_total_bytes",
+                        "Total bytes on the file-store backing the optimizer's tmp directory.",
+                        total);
+            } catch (IOException e) {
+                LOGGER.log(Level.FINE, "could not read tmp dir file-store stats: {0}", e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // /status — JSON live merge state (issue #503)
+    // -------------------------------------------------------------------------
+
+    private final class StatusHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            MergeProgress.Snapshot snap = engine.getMergeProgress().snapshot();
+            StringBuilder sb = new StringBuilder(512);
+            sb.append("{\n");
+            appendJsonStr(sb, "phase", snap.phase, true);
+            appendJsonStr(sb, "merge_id", snap.mergeId, true);
+            appendJsonNum(sb, "input_segments", snap.inputSegments, true);
+            appendJsonNum(sb, "input_vectors", snap.inputVectors, true);
+            appendJsonNum(sb, "batches_written", snap.batchesWritten, true);
+            appendJsonNum(sb, "batches_total", snap.batchesTotal, true);
+            appendJsonDouble(sb, "pct_complete", snap.pctComplete(), true);
+            appendJsonNum(sb, "merge_start_ms", snap.mergeStartMs, true);
+            appendJsonNum(sb, "elapsed_ms", snap.elapsedMs, true);
+            appendJsonNum(sb, "eta_ms", snap.etaMs, true);
+            appendJsonNum(sb, "heap_used_bytes", snap.heapUsedBytes, true);
+            appendJsonNum(sb, "heap_max_bytes", snap.heapMaxBytes, true);
+            appendJsonNum(sb, "direct_used_bytes", snap.directUsedBytes, true);
+            appendJsonNum(sb, "direct_max_bytes", snap.directMaxBytes, true);
+            appendJsonNum(sb, "gc_count", snap.gcCount, true);
+            appendJsonNum(sb, "gc_time_ms", snap.gcTimeMs, false);
+            sb.append("}\n");
+            sendJson(exchange, sb.toString());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // /merge-history — JSON array of completed merge records (issue #503)
+    // -------------------------------------------------------------------------
+
+    private final class MergeHistoryHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            List<MergeRecord> history = engine.getMergeHistory();
+            StringBuilder sb = new StringBuilder(history.size() * 256 + 4);
+            sb.append("[\n");
+            for (int i = 0; i < history.size(); i++) {
+                MergeRecord r = history.get(i);
+                sb.append("  {\n");
+                appendJsonStr(sb, "merge_id", r.mergeId, true);
+                appendJsonStr(sb, "index_uuid", r.indexUuid, true);
+                appendJsonNum(sb, "started_at_ms", r.startedAtMs, true);
+                appendJsonNum(sb, "finished_at_ms", r.finishedAtMs, true);
+                appendJsonNum(sb, "total_ms", r.totalMs(), true);
+                appendJsonStr(sb, "outcome", r.outcome, true);
+                appendJsonNum(sb, "input_segments", r.inputSegments, true);
+                appendJsonNum(sb, "input_vectors", r.inputVectors, true);
+                appendJsonNum(sb, "output_vectors", r.outputVectors, true);
+                appendJsonNum(sb, "download_ms", r.downloadMs, true);
+                appendJsonNum(sb, "pq_training_ms", r.pqTrainingMs, true);
+                appendJsonNum(sb, "compaction_ms", r.compactionMs, true);
+                appendJsonNum(sb, "upload_ms", r.uploadMs, true);
+                appendJsonNum(sb, "zk_register_ms", r.zkRegisterMs, true);
+                appendJsonNum(sb, "deprecate_ms", r.deprecateMs, true);
+                appendJsonNum(sb, "peak_heap_used_bytes", r.peakHeapUsedBytes, true);
+                appendJsonNum(sb, "peak_direct_used_bytes", r.peakDirectUsedBytes, false);
+                sb.append("  }");
+                if (i < history.size() - 1) {
+                    sb.append(",");
+                }
+                sb.append("\n");
+            }
+            sb.append("]\n");
+            sendJson(exchange, sb.toString());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON / Prometheus helpers
+    // -------------------------------------------------------------------------
+
+    private static void appendCounter(StringBuilder sb, String name, String help, long value) {
+        sb.append("# HELP ").append(name).append(' ').append(help).append('\n');
+        sb.append("# TYPE ").append(name).append(" counter\n");
+        sb.append(name).append(' ').append(value).append('\n');
+    }
+
+    private static void appendGauge(StringBuilder sb, String name, String help, long value) {
+        sb.append("# HELP ").append(name).append(' ').append(help).append('\n');
+        sb.append("# TYPE ").append(name).append(" gauge\n");
+        sb.append(name).append(' ').append(value).append('\n');
+    }
+
+    private static void sendJson(HttpExchange exchange, String json) throws IOException {
+        byte[] body = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(200, body.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+        }
+    }
+
+    /**
+     * Appends a JSON string field with proper escaping of the value.
+     * Null values are written as {@code null} (no quotes).
+     *
+     * @param trailingComma whether to append a comma after the value
+     */
+    private static void appendJsonStr(StringBuilder sb, String key, String value,
+                                      boolean trailingComma) {
+        sb.append("  \"").append(key).append("\": ");
+        if (value == null) {
+            sb.append("null");
+        } else {
+            sb.append('"');
+            // Escape JSON special chars — values here are UUIDs / phase names,
+            // none of which contain backslash or control chars, but we handle them
+            // correctly for robustness.
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '"') {
+                    sb.append("\\\"");
+                } else if (c == '\\') {
+                    sb.append("\\\\");
+                } else {
+                    sb.append(c);
+                }
+            }
+            sb.append('"');
+        }
+        if (trailingComma) {
+            sb.append(',');
+        }
+        sb.append('\n');
+    }
+
+    private static void appendJsonNum(StringBuilder sb, String key, long value,
+                                      boolean trailingComma) {
+        sb.append("  \"").append(key).append("\": ").append(value);
+        if (trailingComma) {
+            sb.append(',');
+        }
+        sb.append('\n');
+    }
+
+    private static void appendJsonDouble(StringBuilder sb, String key, double value,
+                                         boolean trailingComma) {
+        sb.append("  \"").append(key).append("\": ");
+        // Format to 2 decimal places without bringing in a format library.
+        long hundredths = Math.round(value * 100);
+        sb.append(hundredths / 100).append('.').append(Math.abs(hundredths % 100) / 10)
+          .append(Math.abs(hundredths % 10));
+        if (trailingComma) {
+            sb.append(',');
+        }
+        sb.append('\n');
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -28,7 +28,10 @@ import herddb.log.LogSequenceNumber;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,6 +74,7 @@ import java.util.logging.Logger;
 public final class RemoteSegmentMerger implements SegmentMerger {
 
     private static final Logger LOGGER = Logger.getLogger(RemoteSegmentMerger.class.getName());
+    private static final MemoryMXBean MEMORY_MX = ManagementFactory.getMemoryMXBean();
 
     /**
      * Vector dimension used by the merger when re-building the graph. Must
@@ -83,6 +87,15 @@ public final class RemoteSegmentMerger implements SegmentMerger {
     private final DataStorageManager dataStorageManager;
     /** Cumulative count of merge invocations — exposed for observability tests. */
     private final AtomicLong invocations = new AtomicLong();
+
+    /**
+     * Optional live-state holder set by {@link IndexOptimizerEngine} before
+     * each merge call so the HTTP server can serve {@code GET /status} with
+     * sub-phase granularity. Written and cleared by the optimizer thread;
+     * read by the HTTP thread only after the optimizer thread has published
+     * updates through the {@code volatile} fields of {@link MergeProgress}.
+     */
+    private MergeProgress mergeProgress;
 
     /**
      * @param dataStorageManager  remote-backed DSM the merger uses to download inputs and
@@ -115,6 +128,34 @@ public final class RemoteSegmentMerger implements SegmentMerger {
 
     public long getInvocationCount() {
         return invocations.get();
+    }
+
+    /**
+     * Sets the live-state holder that receives phase-change and batch-progress
+     * callbacks during the next {@link #merge} call. Pass {@code null} to stop
+     * forwarding. Must be called from the same thread that calls {@link #merge}.
+     */
+    public void setMergeProgress(MergeProgress progress) {
+        this.mergeProgress = progress;
+        if (progress != null) {
+            graphMerger.setPhaseListener(progress::updatePhase);
+            graphMerger.setBatchListener((written, total) -> {
+                progress.updateBatchProgress(written, total);
+                return 0L; // return value ignored
+            });
+        } else {
+            graphMerger.setPhaseListener(null);
+            graphMerger.setBatchListener(null);
+        }
+    }
+
+    /**
+     * Returns the per-phase timing breakdown of the last completed merge
+     * (delegated from the wrapped {@link RemoteSegmentGraphMerger}), or
+     * {@code null} if no merge has been performed yet.
+     */
+    public RemoteSegmentGraphMerger.MergePhaseTimings getLastMergeTimings() {
+        return graphMerger.getLastMergeTimings();
     }
 
     @Override
@@ -208,6 +249,13 @@ public final class RemoteSegmentMerger implements SegmentMerger {
         }
 
         long outputSegmentId = newRandomSegmentId();
+
+        // Task #4 (issue #503): log JVM memory snapshot + estimated /tmp usage
+        // at the start of each merge so operators can sanity-check
+        //   jvm_rss_estimate + tmp_estimate < container_limit
+        // without needing a profiler attached to the pod.
+        logMemoryBudgetAtMergeStart(inputs, tablespaceUuid, indexUuid, outputSegmentId);
+
         RemoteSegmentGraphMerger.MergeOutput output = graphMerger.merge(
                 graphInputs, tablespaceUuid, indexUuid, outputSegmentId, dim);
         if (output == null) {
@@ -273,6 +321,105 @@ public final class RemoteSegmentMerger implements SegmentMerger {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Logs the JVM memory snapshot and estimated /tmp usage at merge start so
+     * operators can sanity-check whether the available headroom is sufficient.
+     *
+     * <p>Estimated /tmp usage formula (same as the legacy in-memory path; the
+     * streaming path is roughly the same order of magnitude):
+     * <ul>
+     *   <li>graph ≈ {@code totalVectors × graphM × 4 bytes × 1.5} (adjacency lists
+     *       plus InlineVectors)</li>
+     *   <li>map ≈ {@code totalVectors × (pkBytes + dim×4 + 12)} — 12-byte header</li>
+     * </ul>
+     * These are rough upper bounds; the actual size depends on PQ compression,
+     * de-duplication, and tombstone filtering.
+     */
+    private void logMemoryBudgetAtMergeStart(List<SegmentMetadata> inputs,
+                                              String tablespaceUuid,
+                                              String indexUuid,
+                                              long outputSegmentId) {
+        long totalVectors = 0;
+        long totalInputSizeBytes = 0;
+        for (SegmentMetadata m : inputs) {
+            totalVectors += m.getVectorCount();
+            totalInputSizeBytes += m.getSizeBytes();
+        }
+        long heapUsedMb  = MEMORY_MX.getHeapMemoryUsage().getUsed()  / (1024 * 1024);
+        long heapMaxMb   = MEMORY_MX.getHeapMemoryUsage().getMax()   / (1024 * 1024);
+        long directBytes = PlatformDependent.usedDirectMemory();
+        long directMaxBytes = PlatformDependent.maxDirectMemory();
+        long directUsedMb = directBytes >= 0 ? directBytes / (1024 * 1024) : -1L;
+        long directMaxMb  = directMaxBytes >= 0 ? directMaxBytes / (1024 * 1024) : -1L;
+
+        // Estimated /tmp disk usage for graph + map files.
+        // graph ≈ (totalVectors × graphM × 4 × 1.5) bytes
+        // map   ≈ (totalVectors × (dim×4 + 24)) bytes (ordinal + pkLen + pk + floats + header)
+        long estimatedGraphBytes = (long) (totalVectors * graphMFromConfig() * 4 * 1.5);
+        long estimatedMapBytes   = totalVectors * ((long) dim * 4 + 24);
+        long estimatedTmpGib     = (estimatedGraphBytes + estimatedMapBytes) / (1024 * 1024 * 1024);
+
+        // Container memory limit from cgroup v2 (best-effort; -1 = unavailable).
+        long cgroupLimitGib = readCgroupMemoryLimitGib();
+
+        LOGGER.log(Level.INFO,
+                "Starting merge: {0} inputs, {1} vectors, dim={2},"
+                        + " indexUuid={3}, outputSegmentId={4},"
+                        + " inputSizeBytes={5}",
+                new Object[]{inputs.size(), totalVectors, dim,
+                        indexUuid, outputSegmentId, totalInputSizeBytes});
+        LOGGER.log(Level.INFO,
+                "  estimated /tmp usage: graph≈{0} GiB, map≈{1} GiB, total≈{2} GiB",
+                new Object[]{estimatedGraphBytes / (1024 * 1024 * 1024),
+                        estimatedMapBytes / (1024 * 1024 * 1024),
+                        estimatedTmpGib});
+        LOGGER.log(Level.INFO,
+                "  JVM heap: {0} MiB used / {1} MiB max",
+                new Object[]{heapUsedMb, heapMaxMb});
+        LOGGER.log(Level.INFO,
+                "  JVM direct: {0} MiB used / {1} MiB max (Netty PlatformDependent)",
+                new Object[]{directUsedMb, directMaxMb});
+        if (cgroupLimitGib >= 0) {
+            LOGGER.log(Level.INFO,
+                    "  container memory limit: {0} GiB (from /sys/fs/cgroup/memory.max)",
+                    cgroupLimitGib);
+        }
+    }
+
+    /**
+     * Returns the configured graph degree (M) from the underlying graph merger.
+     * Used only for the /tmp estimate in the memory-budget log.
+     */
+    private int graphMFromConfig() {
+        // Reflection-free: we know graphMerger is a RemoteSegmentGraphMerger
+        // with graphM stored. Expose it via a package-accessible getter.
+        return graphMerger.getGraphM();
+    }
+
+    /**
+     * Reads the container memory limit from the cgroup v2 file
+     * {@code /sys/fs/cgroup/memory.max}. Returns -1 when the file is not
+     * accessible (non-Linux hosts, cgroup v1) or when its value is
+     * {@code "max"} (unlimited). Best-effort: any I/O failure is swallowed.
+     */
+    private static long readCgroupMemoryLimitGib() {
+        try {
+            java.nio.file.Path p = java.nio.file.Paths.get("/sys/fs/cgroup/memory.max");
+            if (!java.nio.file.Files.exists(p)) {
+                return -1L;
+            }
+            String raw = new String(java.nio.file.Files.readAllBytes(p),
+                    java.nio.charset.StandardCharsets.UTF_8).trim();
+            if ("max".equalsIgnoreCase(raw)) {
+                return -1L;
+            }
+            return Long.parseLong(raw) / (1024L * 1024 * 1024);
+        } catch (IOException | NumberFormatException e) {
+            // Best-effort: silently swallow; the log line is just advisory.
+            return -1L;
+        }
+    }
 
     /**
      * Bounded probe window for loading legacy ({@code overlayGeneration == 0})

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -89,15 +89,6 @@ public final class RemoteSegmentMerger implements SegmentMerger {
     private final AtomicLong invocations = new AtomicLong();
 
     /**
-     * Optional live-state holder set by {@link IndexOptimizerEngine} before
-     * each merge call so the HTTP server can serve {@code GET /status} with
-     * sub-phase granularity. Written and cleared by the optimizer thread;
-     * read by the HTTP thread only after the optimizer thread has published
-     * updates through the {@code volatile} fields of {@link MergeProgress}.
-     */
-    private MergeProgress mergeProgress;
-
-    /**
      * @param dataStorageManager  remote-backed DSM the merger uses to download inputs and
      *                            upload the merged graph + map files
      * @param tmpDirectory        local scratch directory for staging
@@ -134,9 +125,16 @@ public final class RemoteSegmentMerger implements SegmentMerger {
      * Sets the live-state holder that receives phase-change and batch-progress
      * callbacks during the next {@link #merge} call. Pass {@code null} to stop
      * forwarding. Must be called from the same thread that calls {@link #merge}.
+     *
+     * <p>Note: this method only wires callbacks into the wrapped
+     * {@link RemoteSegmentGraphMerger}; it does not store {@code progress} as
+     * a field (the lambdas below capture the parameter directly). As a result
+     * the method cannot throw a {@link RuntimeException} in any reachable
+     * execution path — the {@code try/catch} in the engine's {@code finally}
+     * block is a compile-time safety net for hypothetical future subclasses or
+     * overrides, not a code path exercised by the production implementation.
      */
     public void setMergeProgress(MergeProgress progress) {
-        this.mergeProgress = progress;
         if (progress != null) {
             graphMerger.setPhaseListener(progress::updatePhase);
             graphMerger.setBatchListener((written, total) -> {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/MergeProgressObservabilityTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/MergeProgressObservabilityTest.java
@@ -1,0 +1,258 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for the {@link MergeProgress} observability contract (issue #503).
+ *
+ * <p>Verifies the field-level semantics of {@code enterMerge}, {@code updatePhase},
+ * {@code updateBatchProgress}, and {@code enterIdle} in isolation — no ZooKeeper,
+ * storage layer, or real merge required.
+ *
+ * <p>Also covers the {@link RemoteSegmentMerger#setMergeProgress} and
+ * {@code getLastMergeTimings} API contract to confirm the wiring does not throw
+ * and that the contract holds without running a full merge.
+ */
+public class MergeProgressObservabilityTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    // -------------------------------------------------------------------------
+    // MergeProgress lifecycle — enterMerge
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void freshInstanceIsIdle() {
+        MergeProgress p = new MergeProgress();
+        MergeProgress.Snapshot snap = p.snapshot();
+        assertEquals("fresh instance must be idle", "idle", snap.phase);
+        assertNull("mergeId must be null when idle", snap.mergeId);
+        assertEquals(0, snap.inputSegments);
+        assertEquals(0L, snap.inputVectors);
+        assertEquals(0L, snap.batchesWritten);
+        assertEquals(0L, snap.batchesTotal);
+        assertEquals(0L, snap.mergeStartMs);
+        assertEquals(0L, snap.elapsedMs);
+    }
+
+    @Test
+    public void enterMergeUsesProvidedTimestampNotSystemClock() {
+        // Review item 6: enterMerge must use the caller-supplied startMs so
+        // that tests with fake clocks observe a consistent timestamp, and the
+        // engine's duration accounting is self-consistent.
+        MergeProgress p = new MergeProgress();
+        long fakeStart = 123_456_789L;
+        p.enterMerge("test-id", 3, 200L, fakeStart);
+
+        MergeProgress.Snapshot snap = p.snapshot();
+        assertEquals("phase must be 'downloading' after enterMerge", "downloading", snap.phase);
+        assertEquals("mergeId must match", "test-id", snap.mergeId);
+        assertEquals("inputSegments must match", 3, snap.inputSegments);
+        assertEquals("inputVectors must match", 200L, snap.inputVectors);
+        assertEquals("batchesTotal is initialised to inputVectors", 200L, snap.batchesTotal);
+        assertEquals("batchesWritten is 0 at start", 0L, snap.batchesWritten);
+        // The key assertion: mergeStartMs must equal the supplied value, not
+        // System.currentTimeMillis() at call time.
+        assertEquals(
+                "mergeStartMs must equal the supplied startMs — NOT System.currentTimeMillis()",
+                fakeStart, snap.mergeStartMs);
+    }
+
+    // -------------------------------------------------------------------------
+    // updatePhase — both batchesWritten and batchesTotal reset
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void updatePhaseResetsBothBatchCounters() {
+        // Review item 7: updatePhase must reset BOTH batchesWritten and batchesTotal.
+        // Leaving a stale batchesTotal from the previous phase would make
+        // pctComplete() return a misleading value for the new phase.
+        MergeProgress p = new MergeProgress();
+        p.enterMerge("x", 2, 1000L, 1_000L);
+        // Simulate batch progress in the downloading phase.
+        p.updateBatchProgress(500L, 1000L);
+        assertEquals(500L, p.snapshot().batchesWritten);
+        assertEquals(1000L, p.snapshot().batchesTotal);
+
+        // Transition to a new phase.
+        p.updatePhase("pq-training");
+        MergeProgress.Snapshot snap = p.snapshot();
+        assertEquals("phase must be updated", "pq-training", snap.phase);
+        assertEquals("batchesWritten must be reset on phase transition", 0L, snap.batchesWritten);
+        assertEquals(
+                "batchesTotal must ALSO be reset on phase transition (review item 7): "
+                        + "stale total would make pctComplete misleading for the new phase",
+                0L, snap.batchesTotal);
+    }
+
+    @Test
+    public void updateBatchProgressUpdatesBothFields() {
+        MergeProgress p = new MergeProgress();
+        p.enterMerge("y", 1, 100L, 2_000L);
+        p.updateBatchProgress(37L, 100L);
+        MergeProgress.Snapshot snap = p.snapshot();
+        assertEquals(37L, snap.batchesWritten);
+        assertEquals(100L, snap.batchesTotal);
+    }
+
+    // -------------------------------------------------------------------------
+    // pctComplete
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void pctCompleteUsesCurrentBatchCounters() {
+        MergeProgress p = new MergeProgress();
+        p.enterMerge("z", 1, 100L, 3_000L);
+        p.updateBatchProgress(50L, 100L);
+        assertEquals("50/100 = 50.0%", 50.0, p.snapshot().pctComplete(), 0.001);
+    }
+
+    @Test
+    public void pctCompleteIsZeroWhenTotalIsZero() {
+        MergeProgress p = new MergeProgress();
+        p.enterMerge("z2", 1, 0L, 4_000L); // 0 vectors => batchesTotal=0
+        assertEquals("pctComplete must be 0 when batchesTotal=0",
+                0.0, p.snapshot().pctComplete(), 0.001);
+    }
+
+    // -------------------------------------------------------------------------
+    // enterIdle
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void enterIdleResetsAllFields() {
+        MergeProgress p = new MergeProgress();
+        p.enterMerge("abc", 5, 500L, 9_999L);
+        p.updateBatchProgress(100L, 500L);
+        p.enterIdle();
+
+        MergeProgress.Snapshot snap = p.snapshot();
+        assertEquals("phase must be idle", "idle", snap.phase);
+        assertNull("mergeId must be null after enterIdle", snap.mergeId);
+        assertEquals(0, snap.inputSegments);
+        assertEquals(0L, snap.inputVectors);
+        assertEquals(0L, snap.batchesWritten);
+        assertEquals(0L, snap.batchesTotal);
+        assertEquals(0L, snap.mergeStartMs);
+        assertEquals(0L, snap.elapsedMs);
+    }
+
+    @Test
+    public void snapshotElapsedMsIsZeroWhenIdle() {
+        MergeProgress p = new MergeProgress();
+        // Fresh / after enterIdle: elapsedMs must be 0 regardless of when we snapshot.
+        assertEquals(0L, p.snapshot().elapsedMs);
+    }
+
+    @Test
+    public void snapshotElapsedMsIsPositiveDuringMerge() {
+        MergeProgress p = new MergeProgress();
+        long startMs = System.currentTimeMillis() - 50L; // started 50ms ago
+        p.enterMerge("dur", 1, 10L, startMs);
+        assertTrue("elapsedMs must be positive during a merge",
+                p.snapshot().elapsedMs > 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // RemoteSegmentMerger.setMergeProgress API contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getLastMergeTimingsIsNullBeforeAnyMerge() throws Exception {
+        // Before a merge completes, getLastMergeTimings() must return null.
+        Path tmpDir = tmp.newFolder("rsm-obs").toPath();
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                new MemoryDataStorageManager(), tmpDir,
+                /* dim */ 8, /* graphM */ 4, /* beamWidth */ 20,
+                /* neighborOverflow */ 1.2f, /* alpha */ 1.2f,
+                VectorSimilarityFunction.DOT_PRODUCT);
+
+        assertNull("getLastMergeTimings() must return null before any merge",
+                merger.getLastMergeTimings());
+    }
+
+    @Test
+    public void setMergeProgressNullDoesNotThrow() throws Exception {
+        // setMergeProgress(null) is called in the engine's finally block to clear
+        // the callbacks; it must never throw regardless of the merger's state.
+        Path tmpDir = tmp.newFolder("rsm-null").toPath();
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                new MemoryDataStorageManager(), tmpDir,
+                8, 4, 20, 1.2f, 1.2f,
+                VectorSimilarityFunction.DOT_PRODUCT);
+
+        // setMergeProgress(null) when already null — must not throw.
+        merger.setMergeProgress(null);
+
+        // Set a non-null progress, then clear it — must not throw.
+        MergeProgress progress = new MergeProgress();
+        progress.enterMerge("wire", 1, 10L, 1L);
+        merger.setMergeProgress(progress);
+        merger.setMergeProgress(null);
+
+        // After clearing, callbacks in the graph merger are also null;
+        // getLastMergeTimings() is still null (no merge was run).
+        assertNull("getLastMergeTimings() must still be null after setMergeProgress(null)",
+                merger.getLastMergeTimings());
+    }
+
+    @Test
+    public void setMergeProgressWiresPhaseAndBatchCallbacks() throws Exception {
+        // After setMergeProgress(progress), calling progress.updatePhase() from
+        // the phaseListener lambda updates progress.phase correctly. Verified by
+        // manually calling progress.updatePhase (which is what the phaseListener
+        // lambda delegates to).
+        Path tmpDir = tmp.newFolder("rsm-wire").toPath();
+        RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                new MemoryDataStorageManager(), tmpDir,
+                8, 4, 20, 1.2f, 1.2f,
+                VectorSimilarityFunction.DOT_PRODUCT);
+
+        MergeProgress progress = new MergeProgress();
+        progress.enterMerge("wired-merge", 2, 50L, 100L);
+        merger.setMergeProgress(progress);
+
+        // The phaseListener wired by setMergeProgress delegates to
+        // progress.updatePhase(...); simulate what the graph merger calls.
+        progress.updatePhase("uploading");
+        assertEquals("uploading", progress.snapshot().phase);
+        // batchesTotal reset to 0 by updatePhase (review item 7)
+        assertEquals(0L, progress.snapshot().batchesTotal);
+
+        // Batch progress callback: directly exercise the counter.
+        progress.updateBatchProgress(25L, 50L);
+        assertEquals(25L, progress.snapshot().batchesWritten);
+        assertEquals(50L, progress.snapshot().batchesTotal);
+
+        // Clear — must not throw.
+        merger.setMergeProgress(null);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
@@ -324,6 +324,53 @@ public class OptimizerHttpServerTest {
     }
 
     // -------------------------------------------------------------------------
+    // Issue #503 review item 8: executor lifecycle
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void closeShutsDownExecutorThread() throws Exception {
+        // Verify that close() terminates the optimizer-http executor thread
+        // within a bounded time. A regression that drops the executor.shutdownNow()
+        // call would cause the thread to linger across rolling restarts.
+        //
+        // Strategy: start a fresh OptimizerHttpServer on an ephemeral port,
+        // capture the thread name, call close(), then poll for the thread to
+        // disappear from the live thread set within 5 s.
+        OptimizerHttpServer closeHttp = new OptimizerHttpServer("127.0.0.1", 0, engine);
+        closeHttp.start();
+
+        // The optimizer-http thread is spawned lazily (on first request or by
+        // the executor's thread factory). Trigger one request to ensure the
+        // thread is alive before we call close().
+        fetch(closeHttp, "/health");
+
+        // Locate the optimizer-http thread.
+        Thread httpThread = null;
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if ("optimizer-http".equals(t.getName())) {
+                httpThread = t;
+                break;
+            }
+        }
+        // It may not yet exist if the executor hasn't started it yet (the
+        // single-threaded executor creates the thread on its first task).
+        // In either case close() must terminate it.
+        closeHttp.close();
+
+        if (httpThread != null) {
+            Thread finalThread = httpThread;
+            long deadline = System.currentTimeMillis() + 5_000L;
+            while (finalThread.isAlive() && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50);
+            }
+            assertTrue("optimizer-http thread must terminate within 5s after close()",
+                    !finalThread.isAlive());
+        }
+        // If httpThread was null the executor had not yet created its thread;
+        // close() still succeeds without throwing — verified by reaching here.
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
@@ -21,7 +21,10 @@ package herddb.indexing.optimizer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.indexing.segment.SegmentMetadata;
 import herddb.indexing.segment.SegmentRegistryClient;
+import herddb.indexing.segment.SegmentState;
+import herddb.log.LogSequenceNumber;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -149,4 +152,172 @@ public class OptimizerHttpServerTest {
         assertTrue("bound port should be > 0", http.getBoundPort() > 0);
     }
 
+    // -------------------------------------------------------------------------
+    // Issue #503: /status endpoint
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void statusEndpointReturnsJsonWhenIdle() throws Exception {
+        String body = fetch("/status");
+        // When idle, phase should be "idle" and key fields should be present.
+        assertTrue("/status must return JSON with phase field: " + body,
+                body.contains("\"phase\""));
+        assertTrue("/status must contain 'idle' when no merge running: " + body,
+                body.contains("\"idle\""));
+        assertTrue("/status must include input_segments: " + body,
+                body.contains("\"input_segments\""));
+        assertTrue("/status must include elapsed_ms: " + body,
+                body.contains("\"elapsed_ms\""));
+        assertTrue("/status must include heap_used_bytes: " + body,
+                body.contains("\"heap_used_bytes\""));
+        assertTrue("/status must include gc_count: " + body,
+                body.contains("\"gc_count\""));
+    }
+
+    @Test
+    public void statusEndpointReturnsApplicationJson() throws Exception {
+        URL url = new URL("http://127.0.0.1:" + http.getBoundPort() + "/status");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setConnectTimeout(2000);
+        conn.setReadTimeout(2000);
+        assertEquals(200, conn.getResponseCode());
+        String contentType = conn.getContentType();
+        assertTrue("Content-Type must be application/json: " + contentType,
+                contentType != null && contentType.startsWith("application/json"));
+        conn.disconnect();
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #503: /merge-history endpoint
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void mergeHistoryEndpointReturnsEmptyArrayInitially() throws Exception {
+        String body = fetch("/merge-history");
+        assertTrue("/merge-history must return a JSON array: " + body,
+                body.trim().startsWith("[") && body.trim().endsWith("]"));
+        // Engine hasn't run yet — history should be empty.
+        assertTrue("/merge-history must be empty before any merge: " + body,
+                body.trim().equals("[]") || body.trim().equals("[\n]"));
+    }
+
+    @Test
+    public void mergeHistoryEndpointContainsDeclinedEntryAfterNoopMerge() throws Exception {
+        // Register two segments so the policy fires, then let InMemorySegmentMerger
+        // decline by returning null.
+        SegmentMetadata seg1 = SegmentMetadata.builder()
+                .segmentUuid("http-hist-seg-a").tablespaceUuid(TS_UUID).tableName("docs")
+                .indexUuid("http-hist-idx").indexName("docs_v1")
+                .state(SegmentState.ACTIVE).ownerInstanceId(0)
+                .graphPath("g/a").mapPath("m/a")
+                .baseLsn(new LogSequenceNumber(1L, 1L))
+                .sizeBytes(100L).vectorCount(5L).generation(1L).createdAtEpochMillis(0L)
+                .build();
+        SegmentMetadata seg2 = seg1.toBuilder()
+                .segmentUuid("http-hist-seg-b")
+                .graphPath("g/b").mapPath("m/b")
+                .build();
+        registry.createSegment(seg1);
+        registry.createSegment(seg2);
+
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        merger.setReturnNull(true);   // declined merge
+
+        IndexOptimizerEngine histEngine = new IndexOptimizerEngine(registry, merger,
+                TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0);
+        OptimizerHttpServer histHttp = new OptimizerHttpServer("127.0.0.1", 0, histEngine);
+        histHttp.start();
+        try {
+            histEngine.runOnce();
+
+            String body = fetch(histHttp, "/merge-history");
+            assertTrue("/merge-history must not be empty after a run: " + body,
+                    body.contains("\"outcome\""));
+            assertTrue("outcome must be 'declined': " + body,
+                    body.contains("\"declined\""));
+            assertTrue("/merge-history must include merge_id: " + body,
+                    body.contains("\"merge_id\""));
+            assertTrue("/merge-history must include input_segments: " + body,
+                    body.contains("\"input_segments\""));
+            assertTrue("/merge-history must include started_at_ms: " + body,
+                    body.contains("\"started_at_ms\""));
+        } finally {
+            histHttp.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #503: /metrics extended fields
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void metricsEndpointIncludesPhaseTimingAndMemoryGauges() throws Exception {
+        engine.runOnce();
+        String body = fetch("/metrics");
+
+        // Per-phase timing counters
+        assertTrue("phase_ms_total download expected: " + body,
+                body.contains("herddb_optimizer_phase_ms_total{phase=\"download\"}"));
+        assertTrue("phase_ms_total compaction expected: " + body,
+                body.contains("herddb_optimizer_phase_ms_total{phase=\"compaction\"}"));
+        assertTrue("phase_ms_total pq_training expected: " + body,
+                body.contains("herddb_optimizer_phase_ms_total{phase=\"pq_training\"}"));
+        assertTrue("phase_ms_total upload expected: " + body,
+                body.contains("herddb_optimizer_phase_ms_total{phase=\"upload\"}"));
+        assertTrue("phase_ms_total zk_register expected: " + body,
+                body.contains("herddb_optimizer_phase_ms_total{phase=\"zk_register\"}"));
+        assertTrue("phase_ms_total deprecate expected: " + body,
+                body.contains("herddb_optimizer_phase_ms_total{phase=\"deprecate\"}"));
+
+        // Current phase gauges
+        assertTrue("current_phase idle expected: " + body,
+                body.contains("herddb_optimizer_current_phase{phase=\"idle\"} 1"));
+
+        // JVM heap / direct memory
+        assertTrue("heap_used_bytes expected: " + body,
+                body.contains("herddb_jvm_heap_used_bytes"));
+        assertTrue("heap_max_bytes expected: " + body,
+                body.contains("herddb_jvm_heap_max_bytes"));
+        assertTrue("netty_used_direct_memory_bytes expected: " + body,
+                body.contains("netty_used_direct_memory_bytes"));
+        assertTrue("netty_max_direct_memory_bytes expected: " + body,
+                body.contains("netty_max_direct_memory_bytes"));
+
+        // GC metrics
+        assertTrue("gc_count_total expected: " + body,
+                body.contains("herddb_jvm_gc_count_total"));
+        assertTrue("gc_time_ms_total expected: " + body,
+                body.contains("herddb_jvm_gc_time_ms_total"));
+
+        // Current merge progress gauges
+        assertTrue("merge_input_segments expected: " + body,
+                body.contains("herddb_optimizer_merge_input_segments"));
+        assertTrue("merge_elapsed_ms expected: " + body,
+                body.contains("herddb_optimizer_merge_elapsed_ms"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private String fetch(OptimizerHttpServer target, String path) throws Exception {
+        URL url = new URL("http://127.0.0.1:" + target.getBoundPort() + path);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setConnectTimeout(2000);
+        conn.setReadTimeout(2000);
+        assertEquals(200, conn.getResponseCode());
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = r.readLine()) != null) {
+                sb.append(line).append('\n');
+            }
+            return sb.toString();
+        }
+    }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerHttpServerTest.java
@@ -234,6 +234,7 @@ public class OptimizerHttpServerTest {
             histEngine.runOnce();
 
             String body = fetch(histHttp, "/merge-history");
+            // Basic presence checks
             assertTrue("/merge-history must not be empty after a run: " + body,
                     body.contains("\"outcome\""));
             assertTrue("outcome must be 'declined': " + body,
@@ -244,6 +245,29 @@ public class OptimizerHttpServerTest {
                     body.contains("\"input_segments\""));
             assertTrue("/merge-history must include started_at_ms: " + body,
                     body.contains("\"started_at_ms\""));
+            // All per-phase timing fields must be present (zero for declined, but present)
+            assertTrue("/merge-history must include finished_at_ms: " + body,
+                    body.contains("\"finished_at_ms\""));
+            assertTrue("/merge-history must include total_ms: " + body,
+                    body.contains("\"total_ms\""));
+            assertTrue("/merge-history must include output_vectors: " + body,
+                    body.contains("\"output_vectors\""));
+            assertTrue("/merge-history must include download_ms: " + body,
+                    body.contains("\"download_ms\""));
+            assertTrue("/merge-history must include pq_training_ms: " + body,
+                    body.contains("\"pq_training_ms\""));
+            assertTrue("/merge-history must include compaction_ms: " + body,
+                    body.contains("\"compaction_ms\""));
+            assertTrue("/merge-history must include upload_ms: " + body,
+                    body.contains("\"upload_ms\""));
+            assertTrue("/merge-history must include zk_register_ms: " + body,
+                    body.contains("\"zk_register_ms\""));
+            assertTrue("/merge-history must include deprecate_ms: " + body,
+                    body.contains("\"deprecate_ms\""));
+            assertTrue("/merge-history must include peak_heap_used_bytes: " + body,
+                    body.contains("\"peak_heap_used_bytes\""));
+            assertTrue("/merge-history must include peak_direct_used_bytes: " + body,
+                    body.contains("\"peak_direct_used_bytes\""));
         } finally {
             histHttp.close();
         }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerObservabilityMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerObservabilityMetricsTest.java
@@ -470,6 +470,64 @@ public class OptimizerObservabilityMetricsTest {
     }
 
     @Test
+    public void postMergePublishFailureResetsMergeProgressAndRecordsFailed() throws Exception {
+        // Verify the safety net added in review item 1 (second pass): if a
+        // SegmentRegistryException escapes the post-merge publish/deprecate
+        // phase (e.g. ZK session loss between merger.merge() and
+        // registry.createSegment()), the engine must:
+        //   (a) reset MergeProgress to "idle"
+        //   (b) bump mergeFailuresTotal by 1
+        //   (c) record a "failed" entry in the merge history
+        //
+        // Mechanism: the postRevalidatePreDeprecateHookForTests field fires
+        // between createSegment(output) and deprecateInputSegment(). Closing
+        // the ZK client there causes the first deprecateInputSegment CAS to
+        // throw a SegmentRegistryException (not VersionMismatch), which
+        // propagates to the outer try/catch added in this PR.
+        registry.createSegment(sample("pmf-a", 100L));
+        registry.createSegment(sample("pmf-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+
+        // Close ZK in the hook to force deprecateInputSegment to fail with a
+        // SegmentRegistryException. The exception is swallowed by runOnce()'s
+        // per-index catch so runOnce() returns normally — we then inspect the
+        // engine's observable state.
+        engine.postRevalidatePreDeprecateHookForTests = () -> {
+            try {
+                zk.close();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        // runOnce() swallows the per-index SegmentRegistryException; we check
+        // the engine's observable state after the call.
+        engine.runOnce();
+
+        // (a) MergeProgress must be idle after the failure.
+        assertEquals("MergeProgress must be idle after post-merge failure",
+                "idle", engine.getMergeProgress().snapshot().phase);
+        assertNull("mergeId must be null when idle",
+                engine.getMergeProgress().snapshot().mergeId);
+
+        // (b) mergeFailuresTotal must have advanced.
+        assertEquals("mergeFailuresTotal must be 1 after one post-merge failure",
+                1L, engine.getMergeFailuresTotal());
+
+        // (c) merge history must contain one "failed" record.
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertEquals("exactly one history entry after the failure", 1, history.size());
+        assertEquals("outcome must be 'failed'", "failed", history.get(0).outcome);
+        assertNotNull("mergeId must be set in the failed record",
+                history.get(0).mergeId);
+        assertEquals("indexUuid must match", IDX_UUID, history.get(0).indexUuid);
+    }
+
+    @Test
     public void mergeHistoryEvictsOldestAtCap() throws Exception {
         // Register 2 segments so the policy fires on each tick, then run the
         // engine 21 times (1 above the MERGE_HISTORY_MAX=20 cap) and assert:
@@ -482,32 +540,58 @@ public class OptimizerObservabilityMetricsTest {
         InMemorySegmentMerger merger = new InMemorySegmentMerger();
         merger.setReturnNull(true); // declined every time — no ZK state changes
 
-        // Use a clock that advances by 1 ms per call so mergeId ordering
-        // is deterministic in the history list.
+        // Advance the clock by 1 ms before each tick so every record gets a
+        // distinct, monotonically-increasing startedAtMs value.
         IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
                 new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
                 60_000L, () -> 0, fakeClock::get);
 
-        // Run 21 times to exceed MERGE_HISTORY_MAX=20.
-        for (int i = 0; i < 21; i++) {
+        // Capture the timestamp that will be used by the FIRST tick (tick index 0).
+        // After exactly 21 ticks the 21st-cap forces eviction of the first entry.
+        long firstTickClockMs = fakeClock.incrementAndGet();
+        engine.runOnce();
+        // Record the startedAtMs of the first history entry so we can assert
+        // it was evicted after 20 more ticks land.
+        long firstEntryStartMs = engine.getMergeHistory().get(0).startedAtMs;
+        assertEquals("first entry's startedAtMs must match the first-tick clock value",
+                firstTickClockMs, firstEntryStartMs);
+
+        // Run 20 more ticks to fill the cap exactly…
+        for (int i = 1; i < 20; i++) {
             fakeClock.incrementAndGet();
             engine.runOnce();
         }
+        assertEquals("history must be exactly 20 after 20 ticks", 20,
+                engine.getMergeHistory().size());
+
+        // …then one more tick to trigger eviction of the first entry.
+        fakeClock.incrementAndGet();
+        engine.runOnce();
 
         List<MergeRecord> history = engine.getMergeHistory();
-        assertEquals("history must be capped at 20", 20, history.size());
+        assertEquals("history must be capped at 20 after 21 ticks", 20, history.size());
 
         // Verify all retained entries are "declined".
         for (MergeRecord r : history) {
             assertEquals("all retained entries must be declined", "declined", r.outcome);
         }
 
-        // FIFO: the first entry in the list is the 2nd merge (the 1st was evicted);
-        // the last is the 21st merge. Since fakeClock advances monotonically, the
-        // retained entries should have strictly increasing startedAtMs values.
+        // The first entry from tick 0 must have been evicted: its startedAtMs
+        // must NOT appear anywhere in the retained history.
+        for (MergeRecord r : history) {
+            assertTrue("first-tick entry must have been evicted by FIFO: found startedAtMs="
+                            + r.startedAtMs + " == firstEntryStartMs=" + firstEntryStartMs,
+                    r.startedAtMs != firstEntryStartMs);
+        }
+
+        // FIFO: retained entries must be in strictly ascending order by startedAtMs.
+        // (Each tick increments the clock by 1 ms before calling runOnce, so
+        //  every entry gets a unique, increasing timestamp.)
         for (int i = 1; i < history.size(); i++) {
-            assertTrue("history must be in FIFO order (older entries first)",
-                    history.get(i).startedAtMs >= history.get(i - 1).startedAtMs);
+            assertTrue("history must be in strict FIFO order (older entries first): "
+                            + history.get(i - 1).startedAtMs + " >= "
+                            + history.get(i).startedAtMs,
+                    history.get(i).startedAtMs > history.get(i - 1).startedAtMs);
         }
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerObservabilityMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerObservabilityMetricsTest.java
@@ -20,6 +20,8 @@
 package herddb.indexing.optimizer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import herddb.indexing.segment.SegmentMetadata;
 import herddb.indexing.segment.SegmentRegistryClient;
@@ -27,6 +29,7 @@ import herddb.indexing.segment.SegmentRegistryException;
 import herddb.indexing.segment.SegmentState;
 import herddb.indexing.segment.VersionedSegmentMetadata;
 import herddb.log.LogSequenceNumber;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -296,6 +299,174 @@ public class OptimizerObservabilityMetricsTest {
         } finally {
             http.close();
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #503: merge history and phase counters
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void mergeHistoryIsEmptyBeforeFirstRun() {
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertNotNull("getMergeHistory() must never return null", history);
+        assertTrue("history must be empty before first run", history.isEmpty());
+    }
+
+    @Test
+    public void mergeHistoryRecordsDeclinedOutcome() throws Exception {
+        registry.createSegment(sample("hist-a", 100L));
+        registry.createSegment(sample("hist-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        merger.setReturnNull(true);
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+        engine.runOnce();
+
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertEquals("exactly one history entry after one declined merge", 1, history.size());
+        MergeRecord r = history.get(0);
+        assertEquals("outcome must be declined", "declined", r.outcome);
+        assertNotNull("mergeId must be set", r.mergeId);
+        assertEquals("indexUuid must match", IDX_UUID, r.indexUuid);
+        assertEquals("inputSegments must be 2", 2, r.inputSegments);
+        assertEquals("inputVectors must be sum of segment vector counts", 20L, r.inputVectors);
+        assertEquals("outputVectors is 0 on declined", 0L, r.outputVectors);
+        assertTrue("startedAtMs must be positive", r.startedAtMs > 0);
+        assertTrue("finishedAtMs >= startedAtMs", r.finishedAtMs >= r.startedAtMs);
+        assertEquals("totalMs() = finishedAtMs - startedAtMs",
+                r.finishedAtMs - r.startedAtMs, r.totalMs());
+    }
+
+    @Test
+    public void mergeHistoryRecordsFailedOutcome() throws Exception {
+        registry.createSegment(sample("fail-a", 100L));
+        registry.createSegment(sample("fail-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        merger.setFailureMode(true);
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+        engine.runOnce();
+
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertEquals(1, history.size());
+        assertEquals("outcome must be failed", "failed", history.get(0).outcome);
+    }
+
+    @Test
+    public void mergeHistoryRecordsSuccessOutcomeWithTimings() throws Exception {
+        registry.createSegment(sample("ok-a", 100L));
+        registry.createSegment(sample("ok-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        // Advance the clock by 200 ms during merge so lastMergeDuration = 200.
+        merger.setHook(() -> fakeClock.addAndGet(200));
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+        engine.runOnce();
+
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertEquals(1, history.size());
+        MergeRecord r = history.get(0);
+        assertEquals("outcome must be success", "success", r.outcome);
+        assertTrue("outputVectors should be positive on success", r.outputVectors > 0);
+        assertTrue("totalMs should be positive", r.totalMs() >= 0);
+        // Phase timings are 0 for InMemorySegmentMerger (no RemoteSegmentGraphMerger),
+        // but they should be present without NPE.
+        assertTrue("downloadMs >= 0", r.downloadMs >= 0);
+        assertTrue("compactionMs >= 0", r.compactionMs >= 0);
+        assertTrue("zkRegisterMs >= 0", r.zkRegisterMs >= 0);
+        assertTrue("deprecateMs >= 0", r.deprecateMs >= 0);
+    }
+
+    @Test
+    public void mergeHistoryRecordsAbortedOutcome() throws Exception {
+        registry.createSegment(sample("abort-a", 100L));
+        registry.createSegment(sample("abort-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+
+        // Inject drift so revalidation fails.
+        merger.setHook(() -> {
+            try {
+                VersionedSegmentMetadata v = registry.getSegment(TS_UUID, IDX_UUID, "abort-a")
+                        .orElseThrow();
+                registry.casUpdateSegment(v, v.metadata().toBuilder()
+                        .state(SegmentState.DEPRECATED)
+                        .replacedBy(java.util.Collections.singletonList("other"))
+                        .retentionUntilEpochMillis(System.currentTimeMillis() + 60_000L)
+                        .build());
+            } catch (SegmentRegistryException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        engine.runOnce();
+
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertEquals(1, history.size());
+        assertEquals("outcome must be aborted", "aborted", history.get(0).outcome);
+    }
+
+    @Test
+    public void mergeProgressIsIdleBeforeAndAfterRun() throws Exception {
+        registry.createSegment(sample("prog-a", 100L));
+        registry.createSegment(sample("prog-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+
+        // Before any run the progress must be in idle state.
+        MergeProgress.Snapshot before = engine.getMergeProgress().snapshot();
+        assertEquals("phase must be idle before run", "idle", before.phase);
+        assertNull("mergeId must be null when idle", before.mergeId);
+        assertEquals(0, before.inputSegments);
+
+        engine.runOnce();
+
+        // After the run the progress must return to idle.
+        MergeProgress.Snapshot after = engine.getMergeProgress().snapshot();
+        assertEquals("phase must return to idle after run", "idle", after.phase);
+        assertNull("mergeId must be null after run", after.mergeId);
+    }
+
+    @Test
+    public void phaseTimingCountersAccumulateAcrossSuccessfulMerges() throws Exception {
+        // Two separate merge cycles each with the InMemorySegmentMerger.
+        // Phase timing for InMemorySegmentMerger is zero (no RemoteSegmentGraphMerger),
+        // but zkRegister and deprecate timings should be present.
+        registry.createSegment(sample("pt-a1", 100L));
+        registry.createSegment(sample("pt-a2", 100L));
+
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+        engine.runOnce();
+
+        // ZK register + deprecate durations are non-negative.
+        assertTrue("phaseZkRegisterMsTotal >= 0",
+                engine.getPhaseZkRegisterMsTotal() >= 0);
+        assertTrue("phaseDeprecateMsTotal >= 0",
+                engine.getPhaseDeprecateMsTotal() >= 0);
+        // download/compaction/pqTraining/upload are zero since no RemoteSegmentGraphMerger.
+        assertEquals(0L, engine.getPhaseDownloadMsTotal());
+        assertEquals(0L, engine.getPhaseCompactionMsTotal());
+        assertEquals(0L, engine.getPhasePqTrainingMsTotal());
+        assertEquals(0L, engine.getPhaseUploadMsTotal());
     }
 
     private static String readBody(String urlString) throws Exception {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerObservabilityMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerObservabilityMetricsTest.java
@@ -469,6 +469,48 @@ public class OptimizerObservabilityMetricsTest {
         assertEquals(0L, engine.getPhaseUploadMsTotal());
     }
 
+    @Test
+    public void mergeHistoryEvictsOldestAtCap() throws Exception {
+        // Register 2 segments so the policy fires on each tick, then run the
+        // engine 21 times (1 above the MERGE_HISTORY_MAX=20 cap) and assert:
+        //   1. getMergeHistory().size() never exceeds 20.
+        //   2. FIFO order is preserved — the oldest entry is evicted first.
+        // We use InMemorySegmentMerger with returnNull=true (declined) so no
+        // ZK state changes and we can run 21 identical ticks without rebuilding.
+        registry.createSegment(sample("cap-a", 100L));
+        registry.createSegment(sample("cap-b", 100L));
+        InMemorySegmentMerger merger = new InMemorySegmentMerger();
+        merger.setReturnNull(true); // declined every time — no ZK state changes
+
+        // Use a clock that advances by 1 ms per call so mergeId ordering
+        // is deterministic in the history list.
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(registry, merger, TS_UUID,
+                new MergePolicy.SmallestFirstPolicy(2, 1000, 0L, Long.MAX_VALUE),
+                60_000L, () -> 0, fakeClock::get);
+
+        // Run 21 times to exceed MERGE_HISTORY_MAX=20.
+        for (int i = 0; i < 21; i++) {
+            fakeClock.incrementAndGet();
+            engine.runOnce();
+        }
+
+        List<MergeRecord> history = engine.getMergeHistory();
+        assertEquals("history must be capped at 20", 20, history.size());
+
+        // Verify all retained entries are "declined".
+        for (MergeRecord r : history) {
+            assertEquals("all retained entries must be declined", "declined", r.outcome);
+        }
+
+        // FIFO: the first entry in the list is the 2nd merge (the 1st was evicted);
+        // the last is the 21st merge. Since fakeClock advances monotonically, the
+        // retained entries should have strictly increasing startedAtMs values.
+        for (int i = 1; i < history.size(); i++) {
+            assertTrue("history must be in FIFO order (older entries first)",
+                    history.get(i).startedAtMs >= history.get(i - 1).startedAtMs);
+        }
+    }
+
     private static String readBody(String urlString) throws Exception {
         java.net.URL url = new java.net.URL(urlString);
         java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/index-optimizer-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/index-optimizer-dashboard.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Dashboard for the HerdDB index-optimizer — compaction activity, observed segments by state, ownership relocations.",
+  "description": "Dashboard for the HerdDB index-optimizer — compaction activity, observed segments by state, ownership relocations, live merge progress, per-phase timing breakdown, JVM memory, and tmp-disk usage (issue #503).",
   "editable": true,
   "graphTooltip": 1,
   "id": null,
@@ -332,6 +332,398 @@
         }
       ],
       "title": "Segment Relocations"
+    },
+    {
+      "collapse": false,
+      "height": 300,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "id": 1150,
+          "title": "Current Merge Phase",
+          "description": "1 = the optimizer is currently in this phase; 0 = it is not. All phases are 0 and 'idle' is 1 when no merge is running.",
+          "type": "graph",
+          "fill": 2,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "herddb_optimizer_current_phase{job=\"index-optimizer\",instance=~\"$instance\",phase=\"downloading\"}",
+              "format": "time_series",
+              "legendFormat": "downloading — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "herddb_optimizer_current_phase{job=\"index-optimizer\",instance=~\"$instance\",phase=\"pq-training\"}",
+              "format": "time_series",
+              "legendFormat": "pq-training — {{instance}}",
+              "refId": "B"
+            },
+            {
+              "expr": "herddb_optimizer_current_phase{job=\"index-optimizer\",instance=~\"$instance\",phase=\"compacting\"}",
+              "format": "time_series",
+              "legendFormat": "compacting — {{instance}}",
+              "refId": "C"
+            },
+            {
+              "expr": "herddb_optimizer_current_phase{job=\"index-optimizer\",instance=~\"$instance\",phase=\"uploading\"}",
+              "format": "time_series",
+              "legendFormat": "uploading — {{instance}}",
+              "refId": "D"
+            },
+            {
+              "expr": "herddb_optimizer_current_phase{job=\"index-optimizer\",instance=~\"$instance\",phase=\"registering-zk\"}",
+              "format": "time_series",
+              "legendFormat": "registering-zk — {{instance}}",
+              "refId": "E"
+            },
+            {
+              "expr": "herddb_optimizer_current_phase{job=\"index-optimizer\",instance=~\"$instance\",phase=\"deprecating-inputs\"}",
+              "format": "time_series",
+              "legendFormat": "deprecating-inputs — {{instance}}",
+              "refId": "F"
+            }
+          ],
+          "yaxes": [{"format": "short", "max": 1, "min": 0}, {"format": "short"}]
+        },
+        {
+          "datasource": "Prometheus",
+          "id": 1151,
+          "title": "Merge Progress",
+          "description": "Vectors written vs. total in the current phase. Only non-zero during the graph-build phase (legacy path); streaming path does not report batch progress.",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "herddb_optimizer_merge_batches_written{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "written — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "herddb_optimizer_merge_batches_total{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "total — {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "yaxes": [{"format": "short"}, {"format": "short"}]
+        }
+      ],
+      "title": "Current Merge Status"
+    },
+    {
+      "collapse": false,
+      "height": 280,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "id": 1152,
+          "title": "Merge Elapsed & ETA",
+          "description": "Elapsed milliseconds since the current merge started and the linear-extrapolated ETA. Both are 0 when idle.",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "herddb_optimizer_merge_elapsed_ms{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "elapsed_ms — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "herddb_optimizer_merge_eta_ms{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "eta_ms — {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "yaxes": [{"format": "ms"}, {"format": "short"}]
+        },
+        {
+          "datasource": "Prometheus",
+          "id": 1153,
+          "title": "Merge Input Size",
+          "description": "Number of input segments and total input vectors in the current (or last completed) merge cycle.",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "herddb_optimizer_merge_input_segments{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "input segments — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "herddb_optimizer_merge_input_vectors{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "input vectors — {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "yaxes": [{"format": "short"}, {"format": "short"}]
+        }
+      ],
+      "title": "Merge Progress Detail"
+    },
+    {
+      "collapse": false,
+      "height": 280,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "id": 1160,
+          "title": "Per-Phase Timing Rate (ms/min)",
+          "description": "Per-minute rate of cumulative time spent in each merge phase. Longer bars = more time in that phase. Compaction dominates on the legacy path; download/upload dominate on the streaming path.",
+          "type": "graph",
+          "fill": 2,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 12,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "rate(herddb_optimizer_phase_ms_total{job=\"index-optimizer\",instance=~\"$instance\",phase=\"download\"}[5m]) * 60",
+              "format": "time_series",
+              "legendFormat": "download ms/min — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(herddb_optimizer_phase_ms_total{job=\"index-optimizer\",instance=~\"$instance\",phase=\"compaction\"}[5m]) * 60",
+              "format": "time_series",
+              "legendFormat": "compaction ms/min — {{instance}}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(herddb_optimizer_phase_ms_total{job=\"index-optimizer\",instance=~\"$instance\",phase=\"pq_training\"}[5m]) * 60",
+              "format": "time_series",
+              "legendFormat": "pq_training ms/min — {{instance}}",
+              "refId": "C"
+            },
+            {
+              "expr": "rate(herddb_optimizer_phase_ms_total{job=\"index-optimizer\",instance=~\"$instance\",phase=\"upload\"}[5m]) * 60",
+              "format": "time_series",
+              "legendFormat": "upload ms/min — {{instance}}",
+              "refId": "D"
+            },
+            {
+              "expr": "rate(herddb_optimizer_phase_ms_total{job=\"index-optimizer\",instance=~\"$instance\",phase=\"zk_register\"}[5m]) * 60",
+              "format": "time_series",
+              "legendFormat": "zk_register ms/min — {{instance}}",
+              "refId": "E"
+            },
+            {
+              "expr": "rate(herddb_optimizer_phase_ms_total{job=\"index-optimizer\",instance=~\"$instance\",phase=\"deprecate\"}[5m]) * 60",
+              "format": "time_series",
+              "legendFormat": "deprecate ms/min — {{instance}}",
+              "refId": "F"
+            }
+          ],
+          "yaxes": [{"format": "ms"}, {"format": "short"}]
+        }
+      ],
+      "title": "Per-Phase Timing"
+    },
+    {
+      "collapse": false,
+      "height": 280,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "id": 1170,
+          "title": "Optimizer JVM Heap",
+          "description": "Heap used vs. max. A heap-used curve that climbs close to heap-max without GC relief ⇒ the optimizer is OOM-prone. Typical budget is 8 Gi (set by Helm values.yaml).",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "herddb_jvm_heap_used_bytes{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "heap used — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "herddb_jvm_heap_max_bytes{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "heap max — {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "yaxes": [{"format": "bytes"}, {"format": "short"}]
+        },
+        {
+          "datasource": "Prometheus",
+          "id": 1171,
+          "title": "Optimizer Netty Direct Memory",
+          "description": "Netty-tracked direct (off-heap) memory. The streaming compaction path loads large graph chunks into direct buffers; a rising baseline that doesn't return to zero after the merge completes indicates a direct-memory leak. Value is -1 when Netty defers to JDK accounting.",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "netty_used_direct_memory_bytes{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "direct used — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "netty_max_direct_memory_bytes{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "direct max — {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "yaxes": [{"format": "bytes"}, {"format": "short"}]
+        }
+      ],
+      "title": "Optimizer JVM Memory"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "id": 1180,
+          "title": "Optimizer Tmp Disk",
+          "description": "Free and total bytes on the file-store backing the optimizer's tmp directory. The merge writes graph and map temp files here; free bytes dropping near zero will cause the merge to fail. Typical tmp budget should be at least 3× the size of the largest expected merged graph file.",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 8,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "herddb_optimizer_tmp_disk_free_bytes{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "free — {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "herddb_optimizer_tmp_disk_total_bytes{job=\"index-optimizer\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "legendFormat": "total — {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "yaxes": [{"format": "bytes"}, {"format": "short"}]
+        },
+        {
+          "datasource": "Prometheus",
+          "id": 1181,
+          "title": "Optimizer GC Activity",
+          "description": "Rate of GC collections and pause time. Spikes during compaction are expected (in-memory path builds the full graph in heap); sustained high GC pause ⇒ consider increasing heap or switching to the streaming path.",
+          "type": "graph",
+          "fill": 1,
+          "lines": true,
+          "linewidth": 1,
+          "stack": false,
+          "span": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "show": true,
+            "values": true
+          },
+          "targets": [
+            {
+              "expr": "rate(herddb_jvm_gc_time_ms_total{job=\"index-optimizer\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "legendFormat": "gc ms/s — {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "yaxes": [{"format": "ms"}, {"format": "short"}]
+        }
+      ],
+      "title": "Optimizer Disk & GC"
     }
   ],
   "schemaVersion": 14,
@@ -387,6 +779,6 @@
   },
   "timezone": "",
   "title": "HerdDB Index Optimizer",
-  "version": 1,
+  "version": 2,
   "uid": "index-optimizer"
 }


### PR DESCRIPTION
Fixes #503.

## Changes

### New endpoints (optimizer HTTP server)
- **`GET /status`** — JSON snapshot of live merge progress: current `phase`, `merge_id`, `input_segments`, `input_vectors`, `batches_written`, `batches_total`, `pct_complete`, `elapsed_ms`, `eta_ms`, JVM heap used/max, Netty direct used/max, GC count/time
- **`GET /merge-history`** — JSON array of the last 20 completed merges with `outcome` (success/failed/declined/aborted), per-phase timing (`download_ms`, `pq_training_ms`, `compaction_ms`, `upload_ms`, `zk_register_ms`, `deprecate_ms`), `peak_heap_used_bytes`, `peak_direct_used_bytes`

### Extended `/metrics` (Prometheus format)
- Per-phase cumulative counters: `herddb_optimizer_phase_ms_total{phase="download|compaction|pq_training|upload|zk_register|deprecate"}`
- Current-phase indicator: `herddb_optimizer_current_phase{phase="..."}` = 1/0
- Merge progress gauges: `merge_input_segments`, `merge_input_vectors`, `merge_batches_written`, `merge_batches_total`, `merge_elapsed_ms`, `merge_eta_ms`
- JVM gauges: `herddb_jvm_heap_used_bytes`, `herddb_jvm_heap_max_bytes`, `netty_used_direct_memory_bytes`, `netty_max_direct_memory_bytes`, `herddb_jvm_gc_count_total`, `herddb_jvm_gc_time_ms_total`
- Tmp disk gauges (when tmp dir is known): `herddb_optimizer_tmp_disk_free_bytes`, `herddb_optimizer_tmp_disk_total_bytes`

### Core changes
- **`RemoteSegmentGraphMerger`**: phase callbacks (`Consumer<String>`), batch-progress callbacks (`LongBinaryOperator`) every 5000 vectors during legacy graph build, `MergePhaseTimings` result class, PQ training start/end log messages (task #3), `getLastMergeTimings()`, `getGraphM()`
- **`RemoteSegmentMerger`**: wires `MergeProgress` callbacks into graph merger; `logMemoryBudgetAtMergeStart()` logs heap/direct/estimated-/tmp/cgroup limit at each merge start (task #4)
- **`IndexOptimizerEngine`**: per-phase `AtomicLong` counters, `MergeProgress` live state, bounded merge history (20 entries), `recordMergeHistory()` helpers for all outcomes
- **`IndexingServer`**: calls `NettyMemoryMetrics.register(statsLogger)` so `netty_used_direct_memory_bytes` and `netty_max_direct_memory_bytes` appear in the JVM Prometheus endpoint (jvm-unified-dashboard shows these for all services)
- **`IndexOptimizerMain`**: passes resolved `tmpDirectory` to `OptimizerHttpServer` for tmp-disk gauges

### Grafana dashboard
- Updated `index-optimizer-dashboard.json` with 5 new rows / 8 new panels:
  - **Current Merge Status**: phase timeline (0/1 per phase), batches written vs total
  - **Merge Progress Detail**: elapsed/eta, input segments/vectors
  - **Per-Phase Timing**: rate of time spent per phase (ms/min) across merges
  - **Optimizer JVM Memory**: heap used/max, Netty direct used/max
  - **Optimizer Disk & GC**: tmp disk free/total, GC pause rate

### SpotBugs filter
- Scoped exclusion for `LongBinaryOperator` used as a side-effect batch callback (no JDK `LongBiConsumer`)
- Scoped exclusion for hardcoded `/sys/fs/cgroup/memory.max` path (Linux kernel ABI, not a user path)

## Tasks implemented
- ✅ Task #1: `GET /status` live merge progress (JSON)
- ✅ Task #2: Extended `/metrics` per-phase timing and JVM memory
- ✅ Task #3: Richer PQ training log messages
- ✅ Task #4: Memory-budget log at merge start
- ✅ Task #6: `GET /merge-history` with timing and outcome
- ✅ Bonus: `NettyMemoryMetrics.register()` in `IndexingServer` so `netty_*` gauges appear in jvm-unified-dashboard

**Skipped per user request:** Task #5 (OOM diagnostic at merge failure), Task #7 (container RSS via /proc/self/status)

## Tests
- `OptimizerHttpServerTest`: 8 tests — `/health`, `/metrics` counters, `/status` JSON + Content-Type, `/merge-history` empty array + declined-outcome content, extended metrics with phase/memory/GC fields
- `OptimizerObservabilityMetricsTest`: 14 tests — initial counter sentinels, successful merge history (success/failed/declined/aborted outcomes), `MergeProgress` idle state before/after run, phase timing accumulation

🤖 Implemented by the `pr-worker` agent.