### PR TITLE
issue #508: remove IS apply queue from all benchmark agent TICK SUMMARYs

### DIFF
--- a/.claude/agents/herddb-cluster-monitor.md
+++ b/.claude/agents/herddb-cluster-monitor.md
@@ -111,12 +111,20 @@ For each replica 0 to IS_REPLICAS-1, extract and report:
 - `jvm_heap_used_pct` — IS JVM heap utilisation
 - Parse memory in GiB (divide by 1e9)
 
+Do NOT extract or report `apply_queue_size` or `apply_queue_max` from `engine-stats` output.
+The apply queue is intentionally full during high-throughput ingestion and is not a diagnostic
+signal — it adds noise to the TICK SUMMARY without conveying actionable information.
+
 **IS checkpoint status**: also tail the IS log for these keywords (tail 10 lines):
 ```bash
 kubectl logs --tail=10 herddb-indexing-service-<N>
 ```
 Report if any of these appear: `memory back-pressure`, `checkpoint in progress`,
 `Phase A`, `Phase B`, `Phase C`, `back-pressure released`.
+When reporting a checkpoint-phase keyword, include **only** the phase name and
+back-pressure state — do NOT copy the full log line. Strip any `apply queue X/Y`
+detail before reporting (the apply queue is always near-full during bulk operations
+and adds no diagnostic value).
 
 **Server checkpoint status**: scan the last 5 server log lines for
 `local checkpoint finish` to extract the last completed LSN and duration.

--- a/.claude/agents/herddb-gke-bench.md
+++ b/.claude/agents/herddb-gke-bench.md
@@ -426,7 +426,7 @@ Agent(
   IS-0: vectors=X (X% of rows), mem=X GiB — <OK|WARN>
   IS-1: vectors=X (X% of rows), mem=X GiB — <OK|WARN>
   ServerCkpt: last LSN=(<ledger>,<offset>) <N>m ago  [or: in progress]
-  ISCkpt: <none active | back-pressure Xs, Phase B in progress | etc.>
+  ISCkpt: <none active | back-pressure Xs, Phase B in progress>
   Bookie: [OMIT this line entirely unless blocked>0 or rejected>0 or skipThr>0]
   LogErrors: <none detected | verbatim error lines>
   Verdict: <healthy|warning|fatal>
@@ -443,6 +443,9 @@ Agent(
 - **IS-N mem**: `total_estimated_memory_bytes` from `engine-stats`, in GiB. Warn if > 18 GiB.
 - **ServerCkpt**: last `local checkpoint finish` line from server logs — LSN + age.
 - **ISCkpt**: any active back-pressure or checkpoint phase from IS logs. Omit if nothing active.
+  Report only the phase letter (A/B/C) and back-pressure duration — do NOT include apply queue
+  size (e.g. `apply queue 1997/2000 (full)`). The apply queue is always near-full during bulk
+  ingestion and is not a diagnostic signal.
 - **Bookie line**: omit entirely when `blocked=0`, `rejected=0`, `skipThr=0`.
   Only surface it when at least one of those counters is non-zero.
 

--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -406,7 +406,7 @@ Agent(
   IS-0: vectors=X (X% of rows), mem=X GiB — <OK|WARN>
   IS-1: vectors=X (X% of rows), mem=X GiB — <OK|WARN>
   ServerCkpt: last LSN=(<ledger>,<offset>) <N>m ago  [or: in progress]
-  ISCkpt: <none active | back-pressure Xs, Phase B in progress | etc.>
+  ISCkpt: <none active | back-pressure Xs, Phase B in progress>
   Bookie: [OMIT this line entirely unless blocked>0 or rejected>0 or skipThr>0]
   LogErrors: <none detected | verbatim error lines>
   Verdict: <healthy|warning|fatal>
@@ -423,6 +423,9 @@ Agent(
 - **IS-N mem**: `total_estimated_memory_bytes` from `engine-stats`, in GiB. Warn if > 18 GiB (limit is 20 GiB in values.yaml).
 - **ServerCkpt**: last `local checkpoint finish` line from server logs — LSN + age.
 - **ISCkpt**: any active back-pressure or checkpoint phase from IS logs. Omit line if nothing active.
+  Report only the phase letter (A/B/C) and back-pressure duration — do NOT include apply queue
+  size (e.g. `apply queue 1997/2000 (full)`). The apply queue is always near-full during bulk
+  ingestion and is not a diagnostic signal.
 - **Bookie line**: omit entirely when `blocked=0`, `rejected=0`, `skipThr=0`.
   Only surface it when at least one of those counters is non-zero.
 

--- a/.claude/agents/herddb-local-bench.md
+++ b/.claude/agents/herddb-local-bench.md
@@ -322,10 +322,14 @@ Phase: <phase>  rows=X/total (X%)  rate=X rows/s  commits=X (recovered=X)
 Processes: server pid=X RSS=X MB ; indexing-service pid=X RSS=X MB
 IS: vectors=X (X% of rows), mem=X GiB — <OK|WARN>
 ServerCkpt: last LSN=(<ledger>,<offset>) <N>m ago  [or: in progress]
-ISCkpt: <none active | back-pressure Xs, Phase B in progress | etc.>
+ISCkpt: <none active | back-pressure Xs, Phase B in progress>
 LogErrors: <none detected | verbatim error lines>
 Verdict: <healthy|warning|fatal>
 ```
+
+ISCkpt field rule: report only the active phase letter (A/B/C) and back-pressure duration — do
+NOT include apply queue size (e.g. `apply queue 1997/2000 (full)`). The apply queue runs
+intentionally full during bulk ingestion and is not a diagnostic signal.
 
 Verdicts:
 - `healthy` — continue to next tick


### PR DESCRIPTION
Fixes #508.

## Changes
- `.claude/agents/herddb-cluster-monitor.md`: Explicitly instructs the monitor not to extract or report `apply_queue_size`/`apply_queue_max` from `indexing-admin engine-stats --json`. Also instructs it to strip any `apply queue X/Y` detail from IS log lines when reporting the `ISCkpt:` field — only the phase letter (A/B/C) and back-pressure state should appear.
- `.claude/agents/herddb-k3s-bench.md`: Removes `| etc.>` from the `ISCkpt:` placeholder in the cluster-monitor invocation prompt. Adds an explicit tick-rule note that apply queue size must not appear in the `ISCkpt` line.
- `.claude/agents/herddb-gke-bench.md`: Same two changes as k3s-bench.
- `.claude/agents/herddb-local-bench.md`: Removes `| etc.>` from the `ISCkpt:` format line in the local tick-summary template and adds an explicit rule that apply queue size must be omitted.

## Tests
No Java code changed — this is a pure agent-instruction fix. The affected agent files are Markdown and are excluded from all static analysis checks (`**/*.md` is in the RAT exclusion list; checkstyle and SpotBugs do not apply). Pre-PR validation (`checkstyle:check apache-rat:check spotbugs:check install -DskipTests -Pci`) passed with BUILD SUCCESS.

🤖 Implemented by the `pr-worker` agent.