### PR TITLE
issue #509: server eagerly notifies IS to clean up ZK + files on DROP TABLE/INDEX

### DIFF
--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -235,6 +235,26 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     }
 
     /**
+     * Issue #509: eagerly notifies any remote service (e.g. the IndexingService)
+     * that this index has been permanently dropped, so it can begin background
+     * cleanup of its ZK segment registry and file-server data without waiting
+     * for the commit-log tailer to catch up.
+     *
+     * <p>This method is called synchronously from {@code disposeIndexManager()}
+     * (the actual SQL DROP path) and dispatched asynchronously from there so
+     * that the DDL write lock is not held during gRPC fan-out. It is
+     * intentionally <em>not</em> called from follower-download or restore paths
+     * that invoke {@link #dropIndexData()} directly — those paths only reset
+     * local catalog storage while the index remains live in the cluster schema.
+     *
+     * <p>Default implementation is a no-op; only index types that have a remote
+     * service component (e.g. vector indexes) override this.
+     */
+    public void notifyIsOfDrop() {
+        // no-op for non-remote index types
+    }
+
+    /**
      * Truncate the index from persist storage
      * <p>
      * Differs from {@link #dropIndexData()} because it leaves in place every support structure needed by index runtime (for example if index is persisted into a directory it doesn't delete the

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -918,6 +918,13 @@ public class TableSpaceManager {
 
     private void disposeIndexManager(AbstractIndexManager indexManager) throws DataStorageManagerException {
         indexManager.dropIndexData();
+        // Issue #509: eagerly notify any remote service (e.g. the IS) that this
+        // index has been permanently dropped.  Dispatched asynchronously so the
+        // DDL write lock is released before any gRPC round-trips take place.
+        // notifyIsOfDrop() is only called here — from actual SQL DROP paths —
+        // never from follower-download or restore paths (which call
+        // dropIndexData() directly and leave the IS state intact).
+        CompletableFuture.runAsync(indexManager::notifyIsOfDrop);
         indexManager.close();
         indexes.remove(indexManager.getIndex().name);
         Map<String, AbstractIndexManager> indexesForTable =

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -919,12 +919,14 @@ public class TableSpaceManager {
     private void disposeIndexManager(AbstractIndexManager indexManager) throws DataStorageManagerException {
         indexManager.dropIndexData();
         // Issue #509: eagerly notify any remote service (e.g. the IS) that this
-        // index has been permanently dropped.  Dispatched asynchronously so the
-        // DDL write lock is released before any gRPC round-trips take place.
+        // index has been permanently dropped.  Dispatched via callbacksExecutor
+        // (bounded, lifecycle-managed) so the DDL write lock is released before
+        // any gRPC round-trips take place and notifications are not starved by
+        // ForkJoinPool.commonPool() activity.
         // notifyIsOfDrop() is only called here — from actual SQL DROP paths —
         // never from follower-download or restore paths (which call
         // dropIndexData() directly and leave the IS state intact).
-        CompletableFuture.runAsync(indexManager::notifyIsOfDrop);
+        callbacksExecutor.execute(indexManager::notifyIsOfDrop);
         indexManager.close();
         indexes.remove(indexManager.getIndex().name);
         Map<String, AbstractIndexManager> indexesForTable =

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
@@ -82,7 +82,7 @@ public interface RemoteVectorIndexService extends AutoCloseable {
     /**
      * Issue #509: eagerly notifies every IS instance to begin background
      * cleanup of the ZK segment registry and file-server data for the named
-     * index. Called by {@link herddb.index.vector.VectorIndexManager#dropIndexData()}
+     * index. Called by {@link herddb.index.vector.VectorIndexManager#notifyIsOfDrop()}
      * immediately when the HerdDB server processes a DROP TABLE / DROP INDEX,
      * before the commit-log tailer has had a chance to reach the matching
      * {@code DROP_INDEX} log entry.
@@ -98,11 +98,19 @@ public interface RemoteVectorIndexService extends AutoCloseable {
      * background {@code checkpointExecutor} and returns as soon as the
      * in-memory store reference has been removed from its tracking map.
      *
+     * <p>The {@code indexUuid} parameter is a UUID gate: if the IS has already
+     * processed both the DROP and a subsequent CREATE_INDEX for the same
+     * (table, indexName), the currently-tracked store belongs to the new index.
+     * The IS uses the UUID to detect this case and skip the removal, preventing
+     * data loss on fast DROP+CREATE cycles. An empty or null UUID means "unknown"
+     * and the gate is skipped (safe fallback for rolling upgrades).
+     *
      * @param tablespace the HerdDB tablespace UUID
      * @param table      the table name
      * @param indexName  the index name
+     * @param indexUuid  the HerdDB catalog UUID of the specific index being dropped
      */
-    void dropIndex(String tablespace, String table, String indexName);
+    void dropIndex(String tablespace, String table, String indexName, String indexUuid);
 
     /**
      * Returns the minimum LSN across all known IndexingService instances for

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteVectorIndexService.java
@@ -80,6 +80,31 @@ public interface RemoteVectorIndexService extends AutoCloseable {
     boolean waitForCatchUp(String tablespace, LogSequenceNumber sequenceNumber, long timeoutMs) throws InterruptedException;
 
     /**
+     * Issue #509: eagerly notifies every IS instance to begin background
+     * cleanup of the ZK segment registry and file-server data for the named
+     * index. Called by {@link herddb.index.vector.VectorIndexManager#dropIndexData()}
+     * immediately when the HerdDB server processes a DROP TABLE / DROP INDEX,
+     * before the commit-log tailer has had a chance to reach the matching
+     * {@code DROP_INDEX} log entry.
+     *
+     * <p>Best-effort: if an IS instance is unreachable (e.g. pod restart),
+     * the failure is logged at WARNING and the method returns normally.
+     * The commit-log tailer path remains the authoritative cleanup fallback —
+     * the IS handles both the eager RPC and the tailer entry idempotently
+     * (a second removal of a store key that is no longer tracked is a no-op).
+     *
+     * <p>The server does <em>not</em> block waiting for the actual file or
+     * ZK node deletion to complete: the IS queues the cleanup in its
+     * background {@code checkpointExecutor} and returns as soon as the
+     * in-memory store reference has been removed from its tracking map.
+     *
+     * @param tablespace the HerdDB tablespace UUID
+     * @param table      the table name
+     * @param indexName  the index name
+     */
+    void dropIndex(String tablespace, String table, String indexName);
+
+    /**
      * Returns the minimum LSN across all known IndexingService instances for
      * the given tablespace — the floor below which commit-log segments must
      * not be deleted while tailers are active.

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
@@ -640,6 +640,41 @@ public class VectorIndexManager extends AbstractIndexManager {
     }
 
     /**
+     * Issue #509: overrides the base-class no-op to also notify the IS to
+     * begin eager background cleanup of its ZK segment registry and
+     * file-server data for this index, without waiting for the commit-log
+     * tailer to catch up. Best-effort: a failure is logged at WARNING and
+     * never blocks the local storage cleanup. The IS handles both the RPC
+     * trigger and the later tailer-path {@code DROP_INDEX} log entry
+     * idempotently (second removal of an already-gone store key is a no-op).
+     */
+    @Override
+    public void dropIndexData() throws herddb.storage.DataStorageManagerException {
+        // Eagerly notify all IS instances so ZK segment registry and
+        // file-server data are cleaned up before the optimizer's next tick —
+        // which is especially important when the table is immediately
+        // recreated (DROP + CREATE cycle) because stale ZK entries from the
+        // previous run would otherwise cause optimizer merge failures against
+        // incompletely-written segment files (issue #509).
+        try {
+            RemoteVectorIndexService svc = remoteServiceSupplier.get();
+            if (svc != null) {
+                svc.dropIndex(tableSpaceUUID, index.table, index.name);
+            }
+        } catch (RuntimeException e) {
+            // Plugin boundary: IS may be transiently down (pod restart, GC
+            // pause). The tailer-based cleanup path handles the DROP_INDEX log
+            // entry once the IS recovers, so this is safe to swallow here.
+            LOGGER.log(Level.WARNING,
+                    "dropIndexData: IS drop notification failed for index {0} "
+                            + "(cleanup will proceed via commit-log tailer): {1}",
+                    new Object[]{index.name, e.getMessage()});
+        }
+        // Clean up local (HerdDB catalog) storage for this index.
+        dataStorageManager.dropIndex(tableSpaceUUID, index.uuid);
+    }
+
+    /**
      * Returns status information from the remote IndexingService.
      */
     public RemoteVectorIndexService.IndexStatusInfo getRemoteIndexStatus() {

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
@@ -664,7 +664,12 @@ public class VectorIndexManager extends AbstractIndexManager {
         try {
             RemoteVectorIndexService svc = remoteServiceSupplier.get();
             if (svc != null) {
-                svc.dropIndex(tableSpaceUUID, index.table, index.name);
+                // Pass index.uuid so the IS can gate the removal: if the IS
+                // has already processed both the DROP and a subsequent
+                // CREATE_INDEX for the same (table, name), the UUID of the
+                // currently-tracked store will differ and the IS will skip
+                // the removal, preventing data loss on fast DROP+CREATE cycles.
+                svc.dropIndex(tableSpaceUUID, index.table, index.name, index.uuid);
             }
         } catch (RuntimeException e) {
             // Plugin boundary: IS may be transiently down (pod restart, GC

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexManager.java
@@ -640,22 +640,27 @@ public class VectorIndexManager extends AbstractIndexManager {
     }
 
     /**
-     * Issue #509: overrides the base-class no-op to also notify the IS to
-     * begin eager background cleanup of its ZK segment registry and
-     * file-server data for this index, without waiting for the commit-log
-     * tailer to catch up. Best-effort: a failure is logged at WARNING and
-     * never blocks the local storage cleanup. The IS handles both the RPC
-     * trigger and the later tailer-path {@code DROP_INDEX} log entry
-     * idempotently (second removal of an already-gone store key is a no-op).
+     * Issue #509: overrides the base-class no-op to notify the IS to begin
+     * eager background cleanup of its ZK segment registry and file-server data
+     * for this index, without waiting for the commit-log tailer to catch up.
+     *
+     * <p>Called synchronously from {@code disposeIndexManager()} (the actual SQL
+     * DROP path) but dispatched from there on a background thread, so the DDL
+     * write lock is never held during gRPC fan-out. Best-effort: a failure is
+     * logged at WARNING and never propagated — the IS tailer-based cleanup path
+     * handles the {@code DROP_INDEX} log entry once the IS recovers.
+     *
+     * <p>Must <em>not</em> be called from follower-download or restore paths;
+     * those call {@link #dropIndexData()} directly and leave the IS state intact
+     * because the index remains live in the cluster schema.
      */
     @Override
-    public void dropIndexData() throws herddb.storage.DataStorageManagerException {
-        // Eagerly notify all IS instances so ZK segment registry and
-        // file-server data are cleaned up before the optimizer's next tick —
-        // which is especially important when the table is immediately
-        // recreated (DROP + CREATE cycle) because stale ZK entries from the
-        // previous run would otherwise cause optimizer merge failures against
-        // incompletely-written segment files (issue #509).
+    public void notifyIsOfDrop() {
+        // Eagerly notify all IS instances so ZK segment registry and file-server
+        // data are cleaned up before the optimizer's next tick — especially
+        // important when the table is immediately recreated (DROP + CREATE cycle)
+        // because stale ZK entries from the previous run cause optimizer merge
+        // failures against incompletely-written segment files (issue #509).
         try {
             RemoteVectorIndexService svc = remoteServiceSupplier.get();
             if (svc != null) {
@@ -666,12 +671,10 @@ public class VectorIndexManager extends AbstractIndexManager {
             // pause). The tailer-based cleanup path handles the DROP_INDEX log
             // entry once the IS recovers, so this is safe to swallow here.
             LOGGER.log(Level.WARNING,
-                    "dropIndexData: IS drop notification failed for index {0} "
+                    "notifyIsOfDrop: IS notification failed for index {0} "
                             + "(cleanup will proceed via commit-log tailer): {1}",
                     new Object[]{index.name, e.getMessage()});
         }
-        // Clean up local (HerdDB catalog) storage for this index.
-        dataStorageManager.dropIndex(tableSpaceUUID, index.uuid);
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
@@ -151,7 +151,7 @@ public class Issue355FrozenIsTailerLedgerRetentionTest {
             }
 
             @Override
-            public void dropIndex(String tablespace, String table, String indexName) {
+            public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
                 // no-op in mock
             }
 

--- a/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/Issue355FrozenIsTailerLedgerRetentionTest.java
@@ -151,6 +151,11 @@ public class Issue355FrozenIsTailerLedgerRetentionTest {
             }
 
             @Override
+            public void dropIndex(String tablespace, String table, String indexName) {
+                // no-op in mock
+            }
+
+            @Override
             public void close() { }
         };
 

--- a/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
@@ -140,6 +140,14 @@ public class MockRemoteVectorIndexService implements RemoteVectorIndexService {
     }
 
     @Override
+    public void dropIndex(String tablespace, String table, String indexName) {
+        // Best-effort no-op in the mock — tests that need to verify drop
+        // calls should use VectorIndexManagerDropNotifiesRemoteServiceTest's
+        // RecordingRemoteService instead.
+        indexes.remove(indexKey(table, indexName));
+    }
+
+    @Override
     public void close() {
         indexes.clear();
     }

--- a/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/MockRemoteVectorIndexService.java
@@ -140,7 +140,7 @@ public class MockRemoteVectorIndexService implements RemoteVectorIndexService {
     }
 
     @Override
-    public void dropIndex(String tablespace, String table, String indexName) {
+    public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
         // Best-effort no-op in the mock — tests that need to verify drop
         // calls should use VectorIndexManagerDropNotifiesRemoteServiceTest's
         // RecordingRemoteService instead.

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerDropNotifiesRemoteServiceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerDropNotifiesRemoteServiceTest.java
@@ -1,0 +1,282 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Table;
+import herddb.utils.Bytes;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Test;
+
+/**
+ * Issue #509: verifies that {@link VectorIndexManager#dropIndexData()} eagerly
+ * notifies the remote IndexingService to begin cleanup, in addition to
+ * cleaning local HerdDB catalog storage.
+ *
+ * <p>Tests cover:
+ * <ol>
+ *   <li>Normal path: IS is available, {@code dropIndex()} is called with the
+ *       correct (tablespace, table, indexName) arguments and local catalog
+ *       storage is also cleaned via {@code dataStorageManager.dropIndex()}.</li>
+ *   <li>Null-IS path: supplier returns {@code null} (no IS configured) —
+ *       {@code dropIndexData()} completes normally without NPE.</li>
+ *   <li>Failing-IS path: IS {@code dropIndex()} throws — the exception is
+ *       swallowed (logged as WARNING) and local catalog storage is still
+ *       cleaned.</li>
+ * </ol>
+ */
+public class VectorIndexManagerDropNotifiesRemoteServiceTest {
+
+    private static final String TS_UUID = "test-ts-uuid";
+    private static final String TABLE = "t1";
+    private static final String INDEX_NAME = "vidx";
+
+    private static Table buildTable() {
+        return Table.builder()
+                .name(TABLE)
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private static Index buildVectorIndex() {
+        return Index.builder()
+                .name(INDEX_NAME)
+                .table(TABLE)
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    /**
+     * Minimal stub of {@link RemoteVectorIndexService} that records the most
+     * recent {@code dropIndex} call and does nothing else. All other methods
+     * return harmless defaults so the test never fails on an unexpected path.
+     */
+    private static final class RecordingRemoteService implements RemoteVectorIndexService {
+
+        volatile String lastDropTablespace;
+        volatile String lastDropTable;
+        volatile String lastDropIndex;
+
+        @Override
+        public void dropIndex(String tablespace, String table, String indexName) {
+            this.lastDropTablespace = tablespace;
+            this.lastDropTable = table;
+            this.lastDropIndex = indexName;
+        }
+
+        @Override
+        public List<Map.Entry<Bytes, Float>> search(String tablespace, String table,
+                                                     String index, float[] vector, int topK) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public IndexStatusInfo getIndexStatus(String tablespace, String table, String index) {
+            return new IndexStatusInfo(0, 0, 0, 0, 0, 0, 0, 0, "OK", 0, 0);
+        }
+
+        @Override
+        public boolean waitForCatchUp(String tablespace, LogSequenceNumber sequenceNumber,
+                                      long timeoutMs) {
+            return true;
+        }
+
+        @Override
+        public Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /**
+     * Stub that throws on {@code dropIndex()} to exercise the "IS is down"
+     * path where the exception must be swallowed.
+     */
+    private static final class FailingRemoteService implements RemoteVectorIndexService {
+
+        volatile boolean dropCalled = false;
+
+        @Override
+        public void dropIndex(String tablespace, String table, String indexName) {
+            dropCalled = true;
+            throw new RuntimeException("simulated IS failure (pod restart)");
+        }
+
+        @Override
+        public List<Map.Entry<Bytes, Float>> search(String tablespace, String table,
+                                                     String index, float[] vector, int topK) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public IndexStatusInfo getIndexStatus(String tablespace, String table, String index) {
+            return new IndexStatusInfo(0, 0, 0, 0, 0, 0, 0, 0, "OK", 0, 0);
+        }
+
+        @Override
+        public boolean waitForCatchUp(String tablespace, LogSequenceNumber sequenceNumber,
+                                      long timeoutMs) {
+            return true;
+        }
+
+        @Override
+        public Optional<LogSequenceNumber> getMinProcessedLsn(String tablespace) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /**
+     * Normal path: IS is reachable; {@code dropIndexData()} calls
+     * {@code RemoteVectorIndexService.dropIndex()} with the correct arguments
+     * AND calls {@code dataStorageManager.dropIndex()} for local cleanup.
+     */
+    @Test
+    public void dropIndexDataNotifiesRemoteServiceWithCorrectArgs() throws Exception {
+        RecordingRemoteService mockIs = new RecordingRemoteService();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        Index ix = buildVectorIndex();
+
+        // Record calls to dsm.dropIndex so we can verify the catalog UUID.
+        AtomicReference<String[]> dsmDropCall = new AtomicReference<>();
+        MemoryDataStorageManager recordingDsm = new MemoryDataStorageManager() {
+            @Override
+            public void dropIndex(String tableSpace, String name)
+                    throws herddb.storage.DataStorageManagerException {
+                dsmDropCall.set(new String[]{tableSpace, name});
+                super.dropIndex(tableSpace, name);
+            }
+        };
+
+        VectorIndexManager vim = new VectorIndexManager(
+                ix,
+                /* tableManager   */ null,
+                /* log            */ null,
+                recordingDsm,
+                TS_UUID,
+                /* transaction    */ 0L,
+                /* writeLockTimeout */ 30_000,
+                /* readLockTimeout  */ 30_000,
+                () -> mockIs,
+                NullStatsLogger.INSTANCE);
+
+        vim.dropIndexData();
+
+        // (1) IS was notified with the correct (tablespace, table, index) triple.
+        assertEquals("IS.dropIndex tablespace", TS_UUID, mockIs.lastDropTablespace);
+        assertEquals("IS.dropIndex table", TABLE, mockIs.lastDropTable);
+        assertEquals("IS.dropIndex indexName", INDEX_NAME, mockIs.lastDropIndex);
+
+        // (2) Local catalog storage was also cleaned via dataStorageManager.dropIndex.
+        assertNotNull("dataStorageManager.dropIndex must have been called", dsmDropCall.get());
+        assertEquals("dsm.dropIndex tableSpace", TS_UUID, dsmDropCall.get()[0]);
+        // The uuid argument is the HerdDB catalog UUID of the index object.
+        assertEquals("dsm.dropIndex index UUID", ix.uuid, dsmDropCall.get()[1]);
+    }
+
+    /**
+     * Null-IS path: when the supplier returns {@code null} (no IS configured),
+     * {@code dropIndexData()} must complete without NPE and still clean up
+     * local catalog storage.
+     */
+    @Test
+    public void dropIndexDataWithNullSupplierDoesNotThrow() throws Exception {
+        AtomicReference<String[]> dsmDropCall = new AtomicReference<>();
+        MemoryDataStorageManager recordingDsm = new MemoryDataStorageManager() {
+            @Override
+            public void dropIndex(String tableSpace, String name)
+                    throws herddb.storage.DataStorageManagerException {
+                dsmDropCall.set(new String[]{tableSpace, name});
+                super.dropIndex(tableSpace, name);
+            }
+        };
+        Index ix = buildVectorIndex();
+
+        VectorIndexManager vim = new VectorIndexManager(
+                ix, null, null, recordingDsm, TS_UUID, 0L, 30_000, 30_000,
+                // Supplier explicitly returns null — no IS configured.
+                () -> null,
+                NullStatsLogger.INSTANCE);
+
+        // Must not throw.
+        vim.dropIndexData();
+
+        // Local catalog cleanup still runs.
+        assertNotNull("dsm.dropIndex must be called even without an IS",
+                dsmDropCall.get());
+        assertEquals(TS_UUID, dsmDropCall.get()[0]);
+    }
+
+    /**
+     * Failing-IS path: when {@code RemoteVectorIndexService.dropIndex()} throws
+     * (e.g. pod restart, transient gRPC error), the exception must be swallowed
+     * and logged as WARNING — {@code dropIndexData()} must still complete and
+     * still clean up local catalog storage.
+     */
+    @Test
+    public void dropIndexDataSwallowsIsFailureAndStillCleansLocalStorage() throws Exception {
+        FailingRemoteService failingIs = new FailingRemoteService();
+        AtomicReference<String[]> dsmDropCall = new AtomicReference<>();
+        MemoryDataStorageManager recordingDsm = new MemoryDataStorageManager() {
+            @Override
+            public void dropIndex(String tableSpace, String name)
+                    throws herddb.storage.DataStorageManagerException {
+                dsmDropCall.set(new String[]{tableSpace, name});
+                super.dropIndex(tableSpace, name);
+            }
+        };
+        Index ix = buildVectorIndex();
+
+        VectorIndexManager vim = new VectorIndexManager(
+                ix, null, null, recordingDsm, TS_UUID, 0L, 30_000, 30_000,
+                () -> failingIs,
+                NullStatsLogger.INSTANCE);
+
+        // Must not propagate the exception thrown by the IS.
+        vim.dropIndexData();
+
+        assertTrue("IS.dropIndex must have been called (even though it threw)",
+                failingIs.dropCalled);
+        assertNotNull("dsm.dropIndex must still run after IS failure",
+                dsmDropCall.get());
+        assertEquals(TS_UUID, dsmDropCall.get()[0]);
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerDropNotifiesRemoteServiceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerDropNotifiesRemoteServiceTest.java
@@ -20,6 +20,7 @@ package herddb.index.vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import herddb.log.LogSequenceNumber;
 import herddb.mem.MemoryDataStorageManager;
@@ -36,20 +37,31 @@ import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Test;
 
 /**
- * Issue #509: verifies that {@link VectorIndexManager#dropIndexData()} eagerly
- * notifies the remote IndexingService to begin cleanup, in addition to
- * cleaning local HerdDB catalog storage.
+ * Issue #509: verifies the two drop-cleanup methods on {@link VectorIndexManager}:
  *
- * <p>Tests cover:
+ * <ul>
+ *   <li>{@link VectorIndexManager#notifyIsOfDrop()} — eagerly notifies the remote
+ *       IndexingService to begin cleanup. This is what SQL DROP paths call
+ *       (via {@code disposeIndexManager()}), dispatched asynchronously so the
+ *       DDL write lock is not held during gRPC fan-out.</li>
+ *   <li>{@link VectorIndexManager#dropIndexData()} — cleans up only local HerdDB
+ *       catalog storage via {@code dataStorageManager.dropIndex()}. Called from
+ *       follower-download and restore paths (which must NOT fire IS cleanup because
+ *       the index remains live in the cluster schema).</li>
+ * </ul>
+ *
+ * <p>Tests:
  * <ol>
- *   <li>Normal path: IS is available, {@code dropIndex()} is called with the
- *       correct (tablespace, table, indexName) arguments and local catalog
- *       storage is also cleaned via {@code dataStorageManager.dropIndex()}.</li>
- *   <li>Null-IS path: supplier returns {@code null} (no IS configured) —
- *       {@code dropIndexData()} completes normally without NPE.</li>
+ *   <li>Normal IS path: {@code notifyIsOfDrop()} calls
+ *       {@code RemoteVectorIndexService.dropIndex()} with the correct
+ *       (tablespace, table, indexName) arguments.</li>
+ *   <li>Null-IS path: supplier returns {@code null} — {@code notifyIsOfDrop()}
+ *       completes without NPE.</li>
  *   <li>Failing-IS path: IS {@code dropIndex()} throws — the exception is
- *       swallowed (logged as WARNING) and local catalog storage is still
- *       cleaned.</li>
+ *       swallowed (logged as WARNING) and {@code notifyIsOfDrop()} returns
+ *       normally.</li>
+ *   <li>Local-only path: {@code dropIndexData()} does NOT notify the IS; it only
+ *       calls {@code dataStorageManager.dropIndex()} for catalog cleanup.</li>
  * </ol>
  */
 public class VectorIndexManagerDropNotifiesRemoteServiceTest {
@@ -80,8 +92,7 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
 
     /**
      * Minimal stub of {@link RemoteVectorIndexService} that records the most
-     * recent {@code dropIndex} call and does nothing else. All other methods
-     * return harmless defaults so the test never fails on an unexpected path.
+     * recent {@code dropIndex} call. All other methods return harmless defaults.
      */
     private static final class RecordingRemoteService implements RemoteVectorIndexService {
 
@@ -124,8 +135,8 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
     }
 
     /**
-     * Stub that throws on {@code dropIndex()} to exercise the "IS is down"
-     * path where the exception must be swallowed.
+     * Stub that throws on {@code dropIndex()} to exercise the "IS is down" path
+     * where the exception must be swallowed by {@code notifyIsOfDrop()}.
      */
     private static final class FailingRemoteService implements RemoteVectorIndexService {
 
@@ -165,17 +176,85 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
     }
 
     /**
-     * Normal path: IS is reachable; {@code dropIndexData()} calls
-     * {@code RemoteVectorIndexService.dropIndex()} with the correct arguments
-     * AND calls {@code dataStorageManager.dropIndex()} for local cleanup.
+     * Normal IS path: {@code notifyIsOfDrop()} calls
+     * {@code RemoteVectorIndexService.dropIndex()} with the correct
+     * (tablespace UUID, table name, index name) triple.
      */
     @Test
-    public void dropIndexDataNotifiesRemoteServiceWithCorrectArgs() throws Exception {
+    public void notifyIsOfDropCallsRemoteServiceWithCorrectArgs() {
         RecordingRemoteService mockIs = new RecordingRemoteService();
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         Index ix = buildVectorIndex();
 
-        // Record calls to dsm.dropIndex so we can verify the catalog UUID.
+        VectorIndexManager vim = new VectorIndexManager(
+                ix,
+                /* tableManager     */ null,
+                /* log              */ null,
+                dsm,
+                TS_UUID,
+                /* transaction      */ 0L,
+                /* writeLockTimeout */ 30_000,
+                /* readLockTimeout  */ 30_000,
+                () -> mockIs,
+                NullStatsLogger.INSTANCE);
+
+        vim.notifyIsOfDrop();
+
+        assertEquals("IS.dropIndex tablespace", TS_UUID, mockIs.lastDropTablespace);
+        assertEquals("IS.dropIndex table", TABLE, mockIs.lastDropTable);
+        assertEquals("IS.dropIndex indexName", INDEX_NAME, mockIs.lastDropIndex);
+    }
+
+    /**
+     * Null-IS path: when the supplier returns {@code null} (no IS configured),
+     * {@code notifyIsOfDrop()} must complete without NPE.
+     */
+    @Test
+    public void notifyIsOfDropWithNullServiceDoesNotThrow() {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        Index ix = buildVectorIndex();
+
+        VectorIndexManager vim = new VectorIndexManager(
+                ix, null, null, dsm, TS_UUID, 0L, 30_000, 30_000,
+                // Supplier explicitly returns null — no IS configured.
+                () -> null,
+                NullStatsLogger.INSTANCE);
+
+        // Must not throw.
+        vim.notifyIsOfDrop();
+    }
+
+    /**
+     * Failing-IS path: when {@code RemoteVectorIndexService.dropIndex()} throws
+     * (e.g. pod restart, transient gRPC error), the exception must be swallowed
+     * and logged as WARNING — {@code notifyIsOfDrop()} must still return normally.
+     */
+    @Test
+    public void notifyIsOfDropSwallowsIsRuntimeFailure() {
+        FailingRemoteService failingIs = new FailingRemoteService();
+        Index ix = buildVectorIndex();
+
+        VectorIndexManager vim = new VectorIndexManager(
+                ix, null, null, new MemoryDataStorageManager(), TS_UUID, 0L, 30_000, 30_000,
+                () -> failingIs,
+                NullStatsLogger.INSTANCE);
+
+        // Must not propagate the RuntimeException thrown by the IS.
+        vim.notifyIsOfDrop();
+
+        assertTrue("IS.dropIndex must have been called (even though it threw)",
+                failingIs.dropCalled);
+    }
+
+    /**
+     * Local-only path: {@code dropIndexData()} must NOT notify the IS — it only
+     * calls {@code dataStorageManager.dropIndex()} for local catalog cleanup.
+     * This is important because {@code dropIndexData()} is also called from
+     * follower-download and restore paths where the IS state must remain intact.
+     */
+    @Test
+    public void dropIndexDataOnlyCallsLocalDsmDropAndDoesNotNotifyIs() throws Exception {
+        RecordingRemoteService mockIs = new RecordingRemoteService();
         AtomicReference<String[]> dsmDropCall = new AtomicReference<>();
         MemoryDataStorageManager recordingDsm = new MemoryDataStorageManager() {
             @Override
@@ -185,14 +264,15 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
                 super.dropIndex(tableSpace, name);
             }
         };
+        Index ix = buildVectorIndex();
 
         VectorIndexManager vim = new VectorIndexManager(
                 ix,
-                /* tableManager   */ null,
-                /* log            */ null,
+                /* tableManager     */ null,
+                /* log              */ null,
                 recordingDsm,
                 TS_UUID,
-                /* transaction    */ 0L,
+                /* transaction      */ 0L,
                 /* writeLockTimeout */ 30_000,
                 /* readLockTimeout  */ 30_000,
                 () -> mockIs,
@@ -200,83 +280,13 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
 
         vim.dropIndexData();
 
-        // (1) IS was notified with the correct (tablespace, table, index) triple.
-        assertEquals("IS.dropIndex tablespace", TS_UUID, mockIs.lastDropTablespace);
-        assertEquals("IS.dropIndex table", TABLE, mockIs.lastDropTable);
-        assertEquals("IS.dropIndex indexName", INDEX_NAME, mockIs.lastDropIndex);
-
-        // (2) Local catalog storage was also cleaned via dataStorageManager.dropIndex.
+        // (1) Local catalog storage must be cleaned via dataStorageManager.dropIndex.
         assertNotNull("dataStorageManager.dropIndex must have been called", dsmDropCall.get());
-        assertEquals("dsm.dropIndex tableSpace", TS_UUID, dsmDropCall.get()[0]);
-        // The uuid argument is the HerdDB catalog UUID of the index object.
-        assertEquals("dsm.dropIndex index UUID", ix.uuid, dsmDropCall.get()[1]);
-    }
+        assertEquals("dsm.dropIndex tableSpace must be tableSpaceUUID", TS_UUID, dsmDropCall.get()[0]);
+        assertEquals("dsm.dropIndex name must be the index UUID", ix.uuid, dsmDropCall.get()[1]);
 
-    /**
-     * Null-IS path: when the supplier returns {@code null} (no IS configured),
-     * {@code dropIndexData()} must complete without NPE and still clean up
-     * local catalog storage.
-     */
-    @Test
-    public void dropIndexDataWithNullSupplierDoesNotThrow() throws Exception {
-        AtomicReference<String[]> dsmDropCall = new AtomicReference<>();
-        MemoryDataStorageManager recordingDsm = new MemoryDataStorageManager() {
-            @Override
-            public void dropIndex(String tableSpace, String name)
-                    throws herddb.storage.DataStorageManagerException {
-                dsmDropCall.set(new String[]{tableSpace, name});
-                super.dropIndex(tableSpace, name);
-            }
-        };
-        Index ix = buildVectorIndex();
-
-        VectorIndexManager vim = new VectorIndexManager(
-                ix, null, null, recordingDsm, TS_UUID, 0L, 30_000, 30_000,
-                // Supplier explicitly returns null — no IS configured.
-                () -> null,
-                NullStatsLogger.INSTANCE);
-
-        // Must not throw.
-        vim.dropIndexData();
-
-        // Local catalog cleanup still runs.
-        assertNotNull("dsm.dropIndex must be called even without an IS",
-                dsmDropCall.get());
-        assertEquals(TS_UUID, dsmDropCall.get()[0]);
-    }
-
-    /**
-     * Failing-IS path: when {@code RemoteVectorIndexService.dropIndex()} throws
-     * (e.g. pod restart, transient gRPC error), the exception must be swallowed
-     * and logged as WARNING — {@code dropIndexData()} must still complete and
-     * still clean up local catalog storage.
-     */
-    @Test
-    public void dropIndexDataSwallowsIsFailureAndStillCleansLocalStorage() throws Exception {
-        FailingRemoteService failingIs = new FailingRemoteService();
-        AtomicReference<String[]> dsmDropCall = new AtomicReference<>();
-        MemoryDataStorageManager recordingDsm = new MemoryDataStorageManager() {
-            @Override
-            public void dropIndex(String tableSpace, String name)
-                    throws herddb.storage.DataStorageManagerException {
-                dsmDropCall.set(new String[]{tableSpace, name});
-                super.dropIndex(tableSpace, name);
-            }
-        };
-        Index ix = buildVectorIndex();
-
-        VectorIndexManager vim = new VectorIndexManager(
-                ix, null, null, recordingDsm, TS_UUID, 0L, 30_000, 30_000,
-                () -> failingIs,
-                NullStatsLogger.INSTANCE);
-
-        // Must not propagate the exception thrown by the IS.
-        vim.dropIndexData();
-
-        assertTrue("IS.dropIndex must have been called (even though it threw)",
-                failingIs.dropCalled);
-        assertNotNull("dsm.dropIndex must still run after IS failure",
-                dsmDropCall.get());
-        assertEquals(TS_UUID, dsmDropCall.get()[0]);
+        // (2) IS must NOT have been called — dropIndexData() is only for local cleanup.
+        assertNull("IS must NOT be notified by dropIndexData() (follower-download/restore safety)",
+                mockIs.lastDropIndex);
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerDropNotifiesRemoteServiceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerDropNotifiesRemoteServiceTest.java
@@ -99,12 +99,14 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
         volatile String lastDropTablespace;
         volatile String lastDropTable;
         volatile String lastDropIndex;
+        volatile String lastDropUuid;
 
         @Override
-        public void dropIndex(String tablespace, String table, String indexName) {
+        public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
             this.lastDropTablespace = tablespace;
             this.lastDropTable = table;
             this.lastDropIndex = indexName;
+            this.lastDropUuid = indexUuid;
         }
 
         @Override
@@ -143,7 +145,7 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
         volatile boolean dropCalled = false;
 
         @Override
-        public void dropIndex(String tablespace, String table, String indexName) {
+        public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
             dropCalled = true;
             throw new RuntimeException("simulated IS failure (pod restart)");
         }
@@ -203,6 +205,9 @@ public class VectorIndexManagerDropNotifiesRemoteServiceTest {
         assertEquals("IS.dropIndex tablespace", TS_UUID, mockIs.lastDropTablespace);
         assertEquals("IS.dropIndex table", TABLE, mockIs.lastDropTable);
         assertEquals("IS.dropIndex indexName", INDEX_NAME, mockIs.lastDropIndex);
+        // The index UUID must be passed so the IS can gate the removal against
+        // concurrent DROP+CREATE cycles (issue #509 BLOCK fix).
+        assertEquals("IS.dropIndex indexUuid must equal ix.uuid", ix.uuid, mockIs.lastDropUuid);
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
@@ -119,6 +119,11 @@ public class VectorIndexManagerSearchStreamTest {
         }
 
         @Override
+        public void dropIndex(String tablespace, String table, String indexName) {
+            // no-op in stub
+        }
+
+        @Override
         public void close() {
             // no-op
         }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexManagerSearchStreamTest.java
@@ -119,7 +119,7 @@ public class VectorIndexManagerSearchStreamTest {
         }
 
         @Override
-        public void dropIndex(String tablespace, String table, String indexName) {
+        public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
             // no-op in stub
         }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -578,7 +578,7 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
      * are expected during rolling upgrades.
      */
     @Override
-    public void dropIndex(String tablespace, String table, String indexName) {
+    public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
         ServerSnapshot s = this.snapshot;
         if (s.channels.isEmpty()) {
             LOGGER.log(Level.WARNING,
@@ -587,11 +587,14 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
                     new Object[]{tablespace, indexName});
             return;
         }
-        DropIndexRequest req = DropIndexRequest.newBuilder()
+        DropIndexRequest.Builder reqBuilder = DropIndexRequest.newBuilder()
                 .setTablespace(tablespace)
                 .setTable(table)
-                .setIndex(indexName)
-                .build();
+                .setIndex(indexName);
+        if (indexUuid != null && !indexUuid.isEmpty()) {
+            reqBuilder.setDroppedIndexUuid(indexUuid);
+        }
+        DropIndexRequest req = reqBuilder.build();
 
         // Dispatch all RPCs at once; total wall-time bounded by deadline below.
         long deadlineNanos = System.nanoTime()

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -645,10 +645,19 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
                         "dropIndex: timed out waiting for IS instance {0} for index {1}",
                         new Object[]{addr, indexName});
             } catch (InterruptedException ie) {
+                // Re-set the interrupt flag and stop waiting on any remaining
+                // futures — once interrupted, further get() calls would throw
+                // immediately on every iteration.
                 Thread.currentThread().interrupt();
+                f.getValue().cancel(true);
+                for (int j = inflight.indexOf(f) + 1; j < inflight.size(); j++) {
+                    inflight.get(j).getValue().cancel(true);
+                }
                 LOGGER.log(Level.WARNING,
-                        "dropIndex: interrupted waiting for IS instance {0} for index {1}",
+                        "dropIndex: interrupted waiting for IS instance {0} for index {1}; "
+                                + "cancelling remaining in-flight RPCs",
                         new Object[]{addr, indexName});
+                break;
             }
         }
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -22,6 +22,7 @@ package herddb.indexing;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import herddb.index.vector.RemoteVectorIndexService;
+import herddb.indexing.proto.DropIndexRequest;
 import herddb.indexing.proto.GetIndexStatusRequest;
 import herddb.indexing.proto.GetIndexStatusResponse;
 import herddb.indexing.proto.IndexingServiceGrpc;
@@ -554,6 +555,55 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
             }
         }
         throw new RuntimeException("All IndexingService instances failed for GetIndexStatus");
+    }
+
+    /**
+     * Issue #509: sends a {@code DropIndex} RPC to every IS instance
+     * (not just one) so each instance can immediately begin background
+     * cleanup of its ZK segment registry and file-server data for the
+     * named index. Best-effort: failures are logged at WARNING and do not
+     * propagate — the commit-log tailer path handles cleanup when the IS
+     * recovers. Old IS pods that do not yet implement {@code DropIndex}
+     * return {@code UNIMPLEMENTED}; those failures are also treated as
+     * warnings, not errors.
+     */
+    @Override
+    public void dropIndex(String tablespace, String table, String indexName) {
+        ServerSnapshot s = this.snapshot;
+        if (s.channels.isEmpty()) {
+            LOGGER.log(Level.WARNING,
+                    "dropIndex: no IS instances available for tablespace {0}, "
+                            + "index {1} will be cleaned via commit-log tailer",
+                    new Object[]{tablespace, indexName});
+            return;
+        }
+        DropIndexRequest req = DropIndexRequest.newBuilder()
+                .setTablespace(tablespace)
+                .setTable(table)
+                .setIndex(indexName)
+                .build();
+        // Notify all instances — every IS pod may hold data for this index
+        // and should clean up eagerly.
+        for (Map.Entry<String, ManagedChannel> entry : s.channels.entrySet()) {
+            String addr = entry.getKey();
+            try {
+                IndexingServiceGrpc.IndexingServiceBlockingStub stub =
+                        IndexingServiceGrpc.newBlockingStub(entry.getValue())
+                                .withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
+                stub.dropIndex(req);
+                LOGGER.log(Level.INFO,
+                        "dropIndex: notified IS instance {0} to clean up index {1}",
+                        new Object[]{addr, indexName});
+            } catch (RuntimeException e) {
+                // Plugin boundary: UNIMPLEMENTED means old IS pod; UNAVAILABLE
+                // means the pod is restarting. In both cases the tailer is the
+                // fallback — log a warning and continue with the other instances.
+                LOGGER.log(Level.WARNING,
+                        "dropIndex: RPC to IS instance {0} failed for index {1} "
+                                + "(cleanup via commit-log tailer): {2}",
+                        new Object[]{addr, indexName, e.getMessage()});
+            }
+        }
     }
 
     private static List<Map.Entry<Bytes, Float>> toEntryList(SearchResponse response) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceClient.java
@@ -23,6 +23,7 @@ package herddb.indexing;
 import com.google.common.util.concurrent.ListenableFuture;
 import herddb.index.vector.RemoteVectorIndexService;
 import herddb.indexing.proto.DropIndexRequest;
+import herddb.indexing.proto.DropIndexResponse;
 import herddb.indexing.proto.GetIndexStatusRequest;
 import herddb.indexing.proto.GetIndexStatusResponse;
 import herddb.indexing.proto.IndexingServiceGrpc;
@@ -557,15 +558,24 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
         throw new RuntimeException("All IndexingService instances failed for GetIndexStatus");
     }
 
+    // Maximum wall-clock time for the entire dropIndex fan-out across all IS pods.
+    // All RPCs are dispatched in parallel so this is the total budget, not per-pod.
+    private static final long DROP_INDEX_TOTAL_TIMEOUT_SECONDS = 3L;
+
     /**
-     * Issue #509: sends a {@code DropIndex} RPC to every IS instance
-     * (not just one) so each instance can immediately begin background
-     * cleanup of its ZK segment registry and file-server data for the
-     * named index. Best-effort: failures are logged at WARNING and do not
-     * propagate — the commit-log tailer path handles cleanup when the IS
-     * recovers. Old IS pods that do not yet implement {@code DropIndex}
-     * return {@code UNIMPLEMENTED}; those failures are also treated as
-     * warnings, not errors.
+     * Issue #509: sends a {@code DropIndex} RPC to every IS instance in
+     * parallel so each pod can immediately begin background cleanup of its ZK
+     * segment registry and file-server data for the named index.
+     *
+     * <p>All RPCs are dispatched concurrently via future stubs; the total
+     * wall-time is bounded by {@value #DROP_INDEX_TOTAL_TIMEOUT_SECONDS}
+     * seconds regardless of pod count.
+     *
+     * <p>Best-effort: failures are logged at WARNING and do not propagate —
+     * the commit-log tailer path handles cleanup when the IS recovers. Old IS
+     * pods that have not yet implemented {@code DropIndex} return
+     * {@code UNIMPLEMENTED}; those are logged at INFO (not WARNING) since they
+     * are expected during rolling upgrades.
      */
     @Override
     public void dropIndex(String tablespace, String table, String indexName) {
@@ -582,26 +592,60 @@ public class IndexingServiceClient implements RemoteVectorIndexService {
                 .setTable(table)
                 .setIndex(indexName)
                 .build();
-        // Notify all instances — every IS pod may hold data for this index
-        // and should clean up eagerly.
+
+        // Dispatch all RPCs at once; total wall-time bounded by deadline below.
+        long deadlineNanos = System.nanoTime()
+                + TimeUnit.SECONDS.toNanos(DROP_INDEX_TOTAL_TIMEOUT_SECONDS);
+        List<Map.Entry<String, ListenableFuture<DropIndexResponse>>> inflight =
+                new ArrayList<>(s.channels.size());
         for (Map.Entry<String, ManagedChannel> entry : s.channels.entrySet()) {
-            String addr = entry.getKey();
+            long remaining = Math.max(1L, deadlineNanos - System.nanoTime());
+            IndexingServiceGrpc.IndexingServiceFutureStub stub =
+                    IndexingServiceGrpc.newFutureStub(entry.getValue())
+                            .withDeadlineAfter(remaining, TimeUnit.NANOSECONDS);
+            inflight.add(new AbstractMap.SimpleImmutableEntry<>(
+                    entry.getKey(), stub.dropIndex(req)));
+        }
+
+        // Collect results; log failures without propagating them.
+        for (Map.Entry<String, ListenableFuture<DropIndexResponse>> f : inflight) {
+            String addr = f.getKey();
+            long remaining = deadlineNanos - System.nanoTime();
+            if (remaining <= 0) {
+                f.getValue().cancel(true);
+                LOGGER.log(Level.WARNING,
+                        "dropIndex: overall deadline expired before awaiting IS "
+                                + "instance {0} for index {1}",
+                        new Object[]{addr, indexName});
+                continue;
+            }
             try {
-                IndexingServiceGrpc.IndexingServiceBlockingStub stub =
-                        IndexingServiceGrpc.newBlockingStub(entry.getValue())
-                                .withDeadlineAfter(timeoutSeconds, TimeUnit.SECONDS);
-                stub.dropIndex(req);
+                f.getValue().get(remaining, TimeUnit.NANOSECONDS);
                 LOGGER.log(Level.INFO,
                         "dropIndex: notified IS instance {0} to clean up index {1}",
                         new Object[]{addr, indexName});
-            } catch (RuntimeException e) {
-                // Plugin boundary: UNIMPLEMENTED means old IS pod; UNAVAILABLE
-                // means the pod is restarting. In both cases the tailer is the
-                // fallback — log a warning and continue with the other instances.
-                LOGGER.log(Level.WARNING,
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause();
+                // UNIMPLEMENTED = old IS pod without DropIndex support
+                // (expected during rolling upgrades) — log at INFO, not WARNING.
+                boolean isUnimplemented = (cause instanceof StatusRuntimeException)
+                        && ((StatusRuntimeException) cause).getStatus().getCode()
+                                == Status.Code.UNIMPLEMENTED;
+                LOGGER.log(isUnimplemented ? Level.INFO : Level.WARNING,
                         "dropIndex: RPC to IS instance {0} failed for index {1} "
                                 + "(cleanup via commit-log tailer): {2}",
-                        new Object[]{addr, indexName, e.getMessage()});
+                        new Object[]{addr, indexName,
+                                cause != null ? cause.getMessage() : "unknown"});
+            } catch (TimeoutException te) {
+                f.getValue().cancel(true);
+                LOGGER.log(Level.WARNING,
+                        "dropIndex: timed out waiting for IS instance {0} for index {1}",
+                        new Object[]{addr, indexName});
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOGGER.log(Level.WARNING,
+                        "dropIndex: interrupted waiting for IS instance {0} for index {1}",
+                        new Object[]{addr, indexName});
             }
         }
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1882,7 +1882,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             }
             if (requestedUuid != null && !requestedUuid.isEmpty()) {
                 String currentUuid = vectorStoreIndexUuids.get(key);
-                if (currentUuid != null && !currentUuid.equals(requestedUuid)) {
+                if (currentUuid == null) {
+                    // UUID not yet written — createVectorStoreIfNeeded writes UUID
+                    // before the store, so if a UUID is absent here the store entry
+                    // is stale from before the first UUID gate was introduced, or
+                    // we are in an unexpected state. Refuse to delete: conservatively
+                    // keep the store and let the tailer clean up (positive-match policy).
+                    LOGGER.log(Level.INFO,
+                            "dropIndexImmediate: key {0} has no tracked UUID "
+                                    + "(requested uuid={1}); refusing to remove — "
+                                    + "tailer will handle cleanup",
+                            new Object[]{key, requestedUuid});
+                    return currentStore; // keep
+                }
+                if (!currentUuid.equals(requestedUuid)) {
                     // UUID mismatch: the IS has already processed both the DROP and
                     // a subsequent CREATE_INDEX — the new store must not be removed.
                     LOGGER.log(Level.INFO,
@@ -2276,8 +2289,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // The vector column is the first (and only) column of the vector index
         String vectorColumnName = index.columnNames[0];
         AbstractVectorStore store = vectorStoreFactory.create(index.name, index.table, vectorColumnName, dataDirectory, index.properties);
-        vectorStores.put(key, store);
+        // IMPORTANT: put the UUID into vectorStoreIndexUuids BEFORE putting the
+        // store into vectorStores.  dropIndexImmediate() uses a compute() on
+        // vectorStores: if it sees currentStore != null it reads vectorStoreIndexUuids
+        // to decide whether to remove the store.  By writing the UUID first we
+        // guarantee that by the time the store is visible in vectorStores, its
+        // UUID is already visible in vectorStoreIndexUuids, making the gate
+        // race-free (issue #509 TOCTOU fix).
         vectorStoreIndexUuids.put(key, index.uuid);
+        vectorStores.put(key, store);
         registerIndexMetrics(index.tablespace, index.table, index.name, store);
         LOGGER.log(Level.INFO, "Created vector store for index {0} on column {1} with properties {2}",
                 new Object[]{index.name, vectorColumnName, index.properties});

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1825,6 +1825,58 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         }
     }
 
+    /**
+     * Issue #509: eager DROP trigger called by the IS gRPC server when the
+     * HerdDB server issues a {@code DropIndex} RPC on DROP TABLE / DROP INDEX,
+     * without waiting for the commit-log tailer to process the matching
+     * {@code DROP_INDEX} log entry.
+     *
+     * <p>Removes the vector store from the in-memory {@link #vectorStores} and
+     * {@link #vectorStoreIndexUuids} maps using the caller-supplied
+     * {@code (table, indexName)} key — no {@link SchemaTracker} access is
+     * needed, which keeps this method safe to call from the gRPC server thread
+     * (the tailer owns {@code schemaTracker}; the two maps are
+     * {@link java.util.concurrent.ConcurrentHashMap}s and are safe to mutate
+     * from any thread).
+     *
+     * <p>If a store was found, it is handed to
+     * {@link #submitVectorStoreDeletion} which:
+     * <ol>
+     *   <li>Calls {@code store.close()} to release in-memory resources.</li>
+     *   <li>Calls {@code store.dropAllRegistryEntries()} to sweep the ZK
+     *       segment-registry entries (fast — a handful of znode deletes even
+     *       for a 20B-vector index).</li>
+     *   <li>Calls {@code dataStorageManager.dropIndex()} to delete the
+     *       on-disk / MinIO segment files (may be slow; runs in the
+     *       background {@code checkpointExecutor} so the RPC returns
+     *       before file deletion completes).</li>
+     * </ol>
+     *
+     * <p>Idempotent: if the store is not tracked (already removed by a
+     * previous eager call or by the tailer's own DROP_INDEX path), this
+     * is a harmless no-op.
+     *
+     * @param table     the table name as used in {@link #storeKey}
+     * @param indexName the index name as used in {@link #storeKey}
+     */
+    public void dropIndexImmediate(String table, String indexName) {
+        String k = storeKey(table, indexName);
+        AbstractVectorStore removed = vectorStores.remove(k);
+        vectorStoreIndexUuids.remove(k);
+        if (removed != null) {
+            LOGGER.log(Level.INFO,
+                    "dropIndexImmediate: submitting eager deletion for store key {0} "
+                            + "(triggered by HerdDB server DropIndex RPC, issue #509)",
+                    k);
+            submitVectorStoreDeletion(k, removed);
+        } else {
+            LOGGER.log(Level.FINE,
+                    "dropIndexImmediate: store key {0} not tracked (already dropped or "
+                            + "never seen); no-op",
+                    k);
+        }
+    }
+
     private static boolean isDmlType(short type) {
         return type == LogEntryType.INSERT
                 || type == LogEntryType.UPDATE

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1859,20 +1859,54 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      * @param table     the table name as used in {@link #storeKey}
      * @param indexName the index name as used in {@link #storeKey}
      */
-    public void dropIndexImmediate(String table, String indexName) {
+    public void dropIndexImmediate(String table, String indexName, String requestedUuid) {
         String k = storeKey(table, indexName);
-        AbstractVectorStore removed = vectorStores.remove(k);
-        vectorStoreIndexUuids.remove(k);
-        if (removed != null) {
+        // Atomically inspect and, if appropriate, remove the store from
+        // vectorStores.  The UUID gate prevents data loss on DROP+CREATE cycles:
+        // if the IS tailer has already processed both the DROP_INDEX and a
+        // subsequent CREATE_INDEX for the same (table, indexName), the
+        // currently-tracked store has a different UUID and must not be removed.
+        //
+        // We do NOT remove from vectorStoreIndexUuids here: the tailer's own
+        // DROP_INDEX path will do that when it catches up, avoiding a secondary
+        // race where a concurrent CREATE_INDEX could put a new UUID in the map
+        // between our compute() and a separate vectorStoreIndexUuids.remove().
+        //
+        // An empty/null requestedUuid skips the UUID gate — safe fallback for
+        // IS clients built before this field was added (rolling upgrades).
+        AbstractVectorStore[] toDelete = {null};
+        vectorStores.compute(k, (key, currentStore) -> {
+            if (currentStore == null) {
+                // Already gone — tailer cleaned it up or it was never tracked.
+                return null;
+            }
+            if (requestedUuid != null && !requestedUuid.isEmpty()) {
+                String currentUuid = vectorStoreIndexUuids.get(key);
+                if (currentUuid != null && !currentUuid.equals(requestedUuid)) {
+                    // UUID mismatch: the IS has already processed both the DROP and
+                    // a subsequent CREATE_INDEX — the new store must not be removed.
+                    LOGGER.log(Level.INFO,
+                            "dropIndexImmediate: key {0} already replaced by uuid={1} "
+                                    + "(requested uuid={2}); no-op "
+                                    + "(DROP+CREATE race resolved correctly)",
+                            new Object[]{key, currentUuid, requestedUuid});
+                    return currentStore; // keep the new store
+                }
+            }
+            toDelete[0] = currentStore;
+            return null; // remove atomically
+        });
+
+        if (toDelete[0] != null) {
             LOGGER.log(Level.INFO,
                     "dropIndexImmediate: submitting eager deletion for store key {0} "
                             + "(triggered by HerdDB server DropIndex RPC, issue #509)",
                     k);
-            submitVectorStoreDeletion(k, removed);
+            submitVectorStoreDeletion(k, toDelete[0]);
         } else {
             LOGGER.log(Level.FINE,
-                    "dropIndexImmediate: store key {0} not tracked (already dropped or "
-                            + "never seen); no-op",
+                    "dropIndexImmediate: store key {0} not removed (already dropped, "
+                            + "never seen, or UUID mismatch — tailer will handle it); no-op",
                     k);
         }
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -23,6 +23,8 @@ package herddb.indexing;
 import com.google.protobuf.ByteString;
 import herddb.indexing.proto.DescribeIndexRequest;
 import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.indexing.proto.DropIndexRequest;
+import herddb.indexing.proto.DropIndexResponse;
 import herddb.indexing.proto.GetEngineStatsRequest;
 import herddb.indexing.proto.GetEngineStatsResponse;
 import herddb.indexing.proto.GetIndexStatusRequest;
@@ -610,6 +612,40 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             }
         } catch (RuntimeException e) {
             LOGGER.log(Level.SEVERE, "WaitForCheckpoint failed", e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    /**
+     * Issue #509: eager DROP cleanup trigger. The HerdDB server calls this
+     * RPC on DROP TABLE / DROP INDEX so the IS immediately begins background
+     * cleanup of the named index's ZK segment registry and file-server data,
+     * without waiting for the commit-log tailer to reach the matching
+     * {@code DROP_INDEX} log entry.
+     *
+     * <p>Delegates to {@link IndexingServiceEngine#dropIndexImmediate} which
+     * removes the store from the in-memory tracking maps and submits ZK + file
+     * cleanup to the background {@code checkpointExecutor}. The RPC returns as
+     * soon as the store has been removed from memory (before file deletion
+     * completes), so the caller does not block on large index cleanup.
+     */
+    @Override
+    public void dropIndex(DropIndexRequest request,
+                          StreamObserver<DropIndexResponse> responseObserver) {
+        String indexName = request.getIndex();
+        String table = request.getTable();
+        LOGGER.log(Level.INFO,
+                "DropIndex RPC: index={0} table={1} tablespace={2} (issue #509)",
+                new Object[]{indexName, table, request.getTablespace()});
+        try {
+            engine.dropIndexImmediate(table, indexName);
+            responseObserver.onNext(DropIndexResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "DropIndex RPC failed for index " + indexName, e);
             responseObserver.onError(Status.INTERNAL
                     .withDescription(e.getMessage())
                     .withCause(e)

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -637,11 +637,12 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                           StreamObserver<DropIndexResponse> responseObserver) {
         String indexName = request.getIndex();
         String table = request.getTable();
+        String droppedUuid = request.getDroppedIndexUuid();
         LOGGER.log(Level.INFO,
-                "DropIndex RPC: index={0} table={1} tablespace={2} (issue #509)",
-                new Object[]{indexName, table, request.getTablespace()});
+                "DropIndex RPC: index={0} table={1} tablespace={2} uuid={3} (issue #509)",
+                new Object[]{indexName, table, request.getTablespace(), droppedUuid});
         try {
-            engine.dropIndexImmediate(table, indexName);
+            engine.dropIndexImmediate(table, indexName, droppedUuid);
             responseObserver.onNext(DropIndexResponse.getDefaultInstance());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -327,6 +327,14 @@ message DropIndexRequest {
     string table = 2;
     // Index name.
     string index = 3;
+    // HerdDB catalog UUID of the specific index being dropped.  Used by the IS
+    // as a safety gate: if the in-memory store's UUID already differs from this
+    // value, the tailer has already processed both the DROP and a subsequent
+    // CREATE_INDEX for the same (table, index) name — the new store must not be
+    // removed.  Empty string means "unknown / pre-upgrade client" and the gate
+    // is skipped (idempotent fallback, safe because the IS-side UUID check only
+    // prevents false positives, never false negatives).
+    string dropped_index_uuid = 4;
 }
 
 // Intentionally empty: the IS begins cleanup asynchronously and returns as

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -41,6 +41,15 @@ service IndexingService {
 
     // Returns whether this instance is a shadow replica and its catch-up state.
     rpc GetShadowStatus (GetShadowStatusRequest) returns (GetShadowStatusResponse);
+
+    // Issue #509: eager DROP cleanup trigger. The HerdDB server calls this
+    // when DROP TABLE / DROP INDEX is executed so the IS immediately begins
+    // background cleanup of the ZK segment registry and file-server data for
+    // the named index, without waiting for the commit-log tailer to catch up.
+    // Best-effort from the caller's side: old IS pods that do not yet implement
+    // this RPC return UNIMPLEMENTED, which the client treats as a warning.
+    // The commit-log tailer path remains the authoritative cleanup fallback.
+    rpc DropIndex (DropIndexRequest) returns (DropIndexResponse);
 }
 
 message SearchRequest {
@@ -307,4 +316,20 @@ message GetShadowStatusResponse {
     // Operators compute the shadow data-staleness as
     // `now - loaded_entry_timestamp_ms`. 0 = unknown. Issue #423.
     int64 loaded_entry_timestamp_ms = 11;
+}
+
+// Issue #509: eagerly triggered DROP cleanup (see rpc DropIndex above).
+message DropIndexRequest {
+    // HerdDB tablespace UUID (same value as the IS's configured tablespace UUID).
+    string tablespace = 1;
+    // Table name — used together with index to compute the IS-internal store key
+    // without consulting the SchemaTracker (which lives on the tailer thread).
+    string table = 2;
+    // Index name.
+    string index = 3;
+}
+
+// Intentionally empty: the IS begins cleanup asynchronously and returns as
+// soon as the in-memory store has been removed from its tracking map.
+message DropIndexResponse {
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDropIndexImmediateTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDropIndexImmediateTest.java
@@ -239,8 +239,9 @@ public class IndexingServiceEngineDropIndexImmediateTest {
                 spy = spies.get(0);
             }
 
-            // Eager drop via RPC path (table + indexName computed by the gRPC handler).
-            engine.dropIndexImmediate("t1", "vidx");
+            // Eager drop via RPC path — pass the index UUID so the IS can gate
+            // the removal against concurrent DROP+CREATE cycles (issue #509 BLOCK fix).
+            engine.dropIndexImmediate("t1", "vidx", ix.uuid);
             engine.awaitPendingDeletionsForTest();
 
             // Store must have been closed.
@@ -311,14 +312,14 @@ public class IndexingServiceEngineDropIndexImmediateTest {
             engine.awaitPendingWorkForTest();
 
             // First eager drop.
-            engine.dropIndexImmediate("t2", "vidx2");
+            engine.dropIndexImmediate("t2", "vidx2", ix.uuid);
             engine.awaitPendingDeletionsForTest();
             int afterFirst = dsm.dropIndexCount.get();
             assertEquals("first dropIndexImmediate must call dsm.dropIndex once",
                     1, afterFirst);
 
             // Second eager drop — store is already gone.
-            engine.dropIndexImmediate("t2", "vidx2");
+            engine.dropIndexImmediate("t2", "vidx2", ix.uuid);
             engine.awaitPendingDeletionsForTest();
             assertEquals("second dropIndexImmediate must be a no-op",
                     afterFirst, dsm.dropIndexCount.get());
@@ -382,8 +383,8 @@ public class IndexingServiceEngineDropIndexImmediateTest {
                     LogEntryFactory.createIndex(ix, null));
             engine.awaitPendingWorkForTest();
 
-            // Eager drop via the new RPC path.
-            engine.dropIndexImmediate("t3", "vidx3");
+            // Eager drop via the new RPC path — pass the UUID.
+            engine.dropIndexImmediate("t3", "vidx3", ix.uuid);
             engine.awaitPendingDeletionsForTest();
             int afterEager = dsm.dropIndexCount.get();
             assertEquals("eager drop must call dsm.dropIndex once", 1, afterEager);
@@ -434,11 +435,124 @@ public class IndexingServiceEngineDropIndexImmediateTest {
             engine.start();
 
             // Call for an index that was never registered — must not throw.
-            engine.dropIndexImmediate("nonexistent_table", "nonexistent_index");
+            engine.dropIndexImmediate("nonexistent_table", "nonexistent_index", "any-uuid");
             engine.awaitPendingDeletionsForTest();
 
             assertEquals("dropIndexImmediate for unknown key must not call dsm.dropIndex",
                     0, dsm.dropIndexCount.get());
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * DROP+CREATE race regression test (issue #509 BLOCK fix).
+     *
+     * <p>Scenario: the IS tailer has already processed both the {@code DROP_INDEX}
+     * and a subsequent {@code CREATE_INDEX} for the same (table, indexName) — so
+     * the in-memory store now belongs to the new index (UUID_NEW ≠ UUID_OLD). A
+     * late-arriving {@code dropIndexImmediate} RPC carrying UUID_OLD must be a
+     * no-op: it must not remove or close the new store.
+     *
+     * <p>This test pins the correctness of the UUID gate in
+     * {@link IndexingServiceEngine#dropIndexImmediate}.
+     */
+    @Test
+    public void dropIndexImmediateDoesNotRemoveReplacedStoreOnDropCreateRace() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        MemoryDataStorageManager backing = new MemoryDataStorageManager();
+        CountingDsm dsm = new CountingDsm(backing);
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        List<CloseSpy> spies = new ArrayList<>();
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, configuration());
+        engine.setMetadataStorageManager(newMeta());
+        engine.setDataStorageManager(dsm);
+
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName,
+                                       dataDirectory, indexProperties) -> {
+            CloseSpy spy = new CloseSpy(
+                    indexName, tableName, engine.getTableSpaceUUID(), vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN, Long.MAX_VALUE);
+            try {
+                spy.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            synchronized (spies) {
+                spies.add(spy);
+            }
+            return spy;
+        });
+
+        engine.setWatermarkStore(new WatermarkStore() {
+            @Override
+            public WatermarkSnapshot load() {
+                return WatermarkSnapshot.START_OF_TIME;
+            }
+
+            @Override
+            public void save(WatermarkSnapshot snapshot) throws IOException {
+            }
+        });
+
+        Table table = buildTable("t_race");
+        // Two indexes with the same (table, name) but different UUIDs —
+        // simulating DROP + CREATE of the same index name.
+        Index ix1 = buildVectorIndex("vidx_race", "t_race");
+        Index ix2 = buildVectorIndex("vidx_race", "t_race"); // different UUID
+
+        try {
+            engine.start();
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+
+            // Tailer processes CREATE_INDEX for ix1 (UUID_OLD).
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(ix1, null));
+            engine.awaitPendingWorkForTest();
+
+            CloseSpy spyForIx1;
+            synchronized (spies) {
+                assertEquals("one store should have been created (ix1)", 1, spies.size());
+                spyForIx1 = spies.get(0);
+            }
+
+            // Tailer processes DROP_INDEX for ix1 — simulates the commit-log catching up.
+            engine.applyEntry(new LogSequenceNumber(1, 3),
+                    LogEntryFactory.dropIndex("vidx_race", null));
+            engine.awaitPendingWorkForTest();
+            engine.awaitPendingDeletionsForTest();
+
+            assertTrue("tailer DROP_INDEX must close spyForIx1", spyForIx1.wasClosed());
+
+            // Tailer processes CREATE_INDEX for ix2 (UUID_NEW — new index after recreate).
+            engine.applyEntry(new LogSequenceNumber(1, 4),
+                    LogEntryFactory.createIndex(ix2, null));
+            engine.awaitPendingWorkForTest();
+
+            CloseSpy spyForIx2;
+            synchronized (spies) {
+                assertEquals("second store should have been created (ix2)", 2, spies.size());
+                spyForIx2 = spies.get(1);
+            }
+
+            int dsmDropBeforeRpc = dsm.dropIndexCount.get();
+
+            // Late-arriving eager RPC for ix1 (UUID_OLD). The IS has already
+            // replaced the store with ix2 — this must be a UUID-gated no-op.
+            engine.dropIndexImmediate("t_race", "vidx_race", ix1.uuid);
+            engine.awaitPendingDeletionsForTest();
+
+            // The new store (ix2) must NOT have been closed or deleted.
+            assertTrue("late eager RPC with old UUID must NOT close the new store (ix2)",
+                    !spyForIx2.wasClosed());
+            assertEquals("late eager RPC with old UUID must NOT call dsm.dropIndex again",
+                    dsmDropBeforeRpc, dsm.dropIndexCount.get());
         } finally {
             engine.close();
         }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDropIndexImmediateTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineDropIndexImmediateTest.java
@@ -1,0 +1,446 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Table;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #509: unit tests for {@link IndexingServiceEngine#dropIndexImmediate}
+ * — the eager server-triggered cleanup path that removes a vector store from
+ * the IS's tracking maps and submits ZK + file cleanup without waiting for the
+ * commit-log tailer to reach the matching {@code DROP_INDEX} log entry.
+ *
+ * <p>Tests:
+ * <ol>
+ *   <li>Removes the store from {@code vectorStores}, submits deletion, and
+ *       dataStorageManager.dropIndex is called once (via
+ *       awaitPendingDeletionsForTest).</li>
+ *   <li>Idempotent: a second call for the same key is a harmless no-op (no
+ *       extra dropIndex call).</li>
+ *   <li>Tailer path after eager: a later {@code applyEntry(DROP_INDEX)} is a
+ *       no-op because the store is already gone (no double deletion).</li>
+ *   <li>Unknown key: calling {@code dropIndexImmediate} for an index that was
+ *       never created is a harmless no-op.</li>
+ * </ol>
+ */
+public class IndexingServiceEngineDropIndexImmediateTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private int savedMinLive;
+    private long savedDeferral;
+
+    @Before
+    public void saveGateState() {
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        savedDeferral = PersistentVectorStore.maxCheckpointDeferralMs;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreGateState() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+        PersistentVectorStore.maxCheckpointDeferralMs = savedDeferral;
+    }
+
+    private static final int DIM = 4;
+
+    private static Table buildTable(String name) {
+        int h = name.hashCode() & 0x7FFFFFFF;
+        return Table.builder()
+                .name(name)
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .tableId(h == 0 ? 1 : h)
+                .build();
+    }
+
+    private static Index buildVectorIndex(String name, String tableName) {
+        return Index.builder()
+                .name(name)
+                .table(tableName)
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    /**
+     * DSM wrapper that counts {@code dropIndex} calls (excluding the
+     * {@code _tmp_pkset_*} internal BLink drops that happen during checkpoint).
+     */
+    private static final class CountingDsm extends ForwardingDataStorageManager {
+        final AtomicInteger dropIndexCount = new AtomicInteger(0);
+        final List<String[]> dropIndexCalls = new ArrayList<>();
+
+        CountingDsm(DataStorageManager delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public synchronized void dropIndex(String tableSpace, String name)
+                throws DataStorageManagerException {
+            if (!name.contains("_tmp_pkset_")) {
+                dropIndexCount.incrementAndGet();
+                dropIndexCalls.add(new String[]{tableSpace, name});
+            }
+            super.dropIndex(tableSpace, name);
+        }
+    }
+
+    /** Close-tracking PersistentVectorStore subclass (same pattern as DropTableIndexCleanupTest). */
+    private static final class CloseSpy extends PersistentVectorStore {
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        CloseSpy(String indexName, String tableName, String tableSpaceUUID,
+                 String vectorColumnName, Path tmpDirectory,
+                 DataStorageManager dataStorageManager, MemoryManager memoryManager,
+                 int m, int beamWidth, float neighborOverflow, float alpha,
+                 boolean fusedPQ, long maxSegmentSize, int maxLiveGraphSize,
+                 long compactionIntervalMs, VectorSimilarityFunction similarityFunction,
+                 long maxVectorMemoryBytes) {
+            super(indexName, tableName, tableSpaceUUID, vectorColumnName,
+                    tmpDirectory, dataStorageManager, memoryManager,
+                    m, beamWidth, neighborOverflow, alpha, fusedPQ,
+                    maxSegmentSize, maxLiveGraphSize, compactionIntervalMs,
+                    similarityFunction, maxVectorMemoryBytes);
+        }
+
+        @Override
+        public void close() throws Exception {
+            closed.set(true);
+            super.close();
+        }
+
+        boolean wasClosed() {
+            return closed.get();
+        }
+    }
+
+    private IndexingServerConfiguration configuration() {
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        return new IndexingServerConfiguration(props);
+    }
+
+    private MemoryMetadataStorageManager newMeta() throws Exception {
+        MemoryMetadataStorageManager m = new MemoryMetadataStorageManager();
+        m.start();
+        m.ensureDefaultTableSpace("local", "local", 0, 1);
+        return m;
+    }
+
+    /**
+     * Normal eager-drop path: {@code dropIndexImmediate} removes the store,
+     * triggers deletion, the store is closed and local data erased.
+     */
+    @Test
+    public void dropIndexImmediateClosesStoreAndSubmitsDeletion() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        MemoryDataStorageManager backing = new MemoryDataStorageManager();
+        CountingDsm dsm = new CountingDsm(backing);
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        List<CloseSpy> spies = new ArrayList<>();
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, configuration());
+        engine.setMetadataStorageManager(newMeta());
+        engine.setDataStorageManager(dsm);
+
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName,
+                                       dataDirectory, indexProperties) -> {
+            CloseSpy spy = new CloseSpy(
+                    indexName, tableName, engine.getTableSpaceUUID(), vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN, Long.MAX_VALUE);
+            try {
+                spy.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            synchronized (spies) {
+                spies.add(spy);
+            }
+            return spy;
+        });
+
+        engine.setWatermarkStore(new WatermarkStore() {
+            @Override
+            public WatermarkSnapshot load() {
+                return WatermarkSnapshot.START_OF_TIME;
+            }
+
+            @Override
+            public void save(WatermarkSnapshot snapshot) throws IOException {
+            }
+        });
+
+        Table table = buildTable("t1");
+        Index ix = buildVectorIndex("vidx", "t1");
+
+        try {
+            engine.start();
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(ix, null));
+            engine.awaitPendingWorkForTest();
+
+            CloseSpy spy;
+            synchronized (spies) {
+                assertEquals("one vector store should have been created", 1, spies.size());
+                spy = spies.get(0);
+            }
+
+            // Eager drop via RPC path (table + indexName computed by the gRPC handler).
+            engine.dropIndexImmediate("t1", "vidx");
+            engine.awaitPendingDeletionsForTest();
+
+            // Store must have been closed.
+            assertTrue("dropIndexImmediate must close the vector store", spy.wasClosed());
+
+            // dataStorageManager.dropIndex must have been called exactly once.
+            assertEquals("dropIndexImmediate must call dsm.dropIndex exactly once",
+                    1, dsm.dropIndexCount.get());
+            assertEquals("dsm.dropIndex tableSpace must be the engine's tablespace UUID",
+                    engine.getTableSpaceUUID(), dsm.dropIndexCalls.get(0)[0]);
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Idempotency: calling {@code dropIndexImmediate} a second time for the same
+     * (table, index) pair is a no-op — no additional DSM drops.
+     */
+    @Test
+    public void dropIndexImmediateIsIdempotent() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        MemoryDataStorageManager backing = new MemoryDataStorageManager();
+        CountingDsm dsm = new CountingDsm(backing);
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, configuration());
+        engine.setMetadataStorageManager(newMeta());
+        engine.setDataStorageManager(dsm);
+
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName,
+                                       dataDirectory, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, engine.getTableSpaceUUID(), vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return pvs;
+        });
+
+        engine.setWatermarkStore(new WatermarkStore() {
+            @Override
+            public WatermarkSnapshot load() {
+                return WatermarkSnapshot.START_OF_TIME;
+            }
+
+            @Override
+            public void save(WatermarkSnapshot snapshot) throws IOException {
+            }
+        });
+
+        Table table = buildTable("t2");
+        Index ix = buildVectorIndex("vidx2", "t2");
+
+        try {
+            engine.start();
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(ix, null));
+            engine.awaitPendingWorkForTest();
+
+            // First eager drop.
+            engine.dropIndexImmediate("t2", "vidx2");
+            engine.awaitPendingDeletionsForTest();
+            int afterFirst = dsm.dropIndexCount.get();
+            assertEquals("first dropIndexImmediate must call dsm.dropIndex once",
+                    1, afterFirst);
+
+            // Second eager drop — store is already gone.
+            engine.dropIndexImmediate("t2", "vidx2");
+            engine.awaitPendingDeletionsForTest();
+            assertEquals("second dropIndexImmediate must be a no-op",
+                    afterFirst, dsm.dropIndexCount.get());
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Tailer path after eager drop: when the commit-log tailer later processes
+     * the {@code DROP_INDEX} log entry for an index that was already removed by
+     * {@code dropIndexImmediate}, the tailer must be a no-op (no double deletion).
+     */
+    @Test
+    public void tailerDropIndexAfterEagerDropIsNoOp() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        MemoryDataStorageManager backing = new MemoryDataStorageManager();
+        CountingDsm dsm = new CountingDsm(backing);
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, configuration());
+        engine.setMetadataStorageManager(newMeta());
+        engine.setDataStorageManager(dsm);
+
+        engine.setVectorStoreFactory((indexName, tableName, vectorColumnName,
+                                       dataDirectory, indexProperties) -> {
+            PersistentVectorStore pvs = new PersistentVectorStore(
+                    indexName, tableName, engine.getTableSpaceUUID(), vectorColumnName,
+                    dataDirectory, dsm, mm,
+                    16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                    Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN);
+            try {
+                pvs.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return pvs;
+        });
+
+        engine.setWatermarkStore(new WatermarkStore() {
+            @Override
+            public WatermarkSnapshot load() {
+                return WatermarkSnapshot.START_OF_TIME;
+            }
+
+            @Override
+            public void save(WatermarkSnapshot snapshot) throws IOException {
+            }
+        });
+
+        Table table = buildTable("t3");
+        Index ix = buildVectorIndex("vidx3", "t3");
+
+        try {
+            engine.start();
+            engine.applyEntry(new LogSequenceNumber(1, 1),
+                    LogEntryFactory.createTable(table, null));
+            engine.applyEntry(new LogSequenceNumber(1, 2),
+                    LogEntryFactory.createIndex(ix, null));
+            engine.awaitPendingWorkForTest();
+
+            // Eager drop via the new RPC path.
+            engine.dropIndexImmediate("t3", "vidx3");
+            engine.awaitPendingDeletionsForTest();
+            int afterEager = dsm.dropIndexCount.get();
+            assertEquals("eager drop must call dsm.dropIndex once", 1, afterEager);
+
+            // Now the tailer processes the DROP_INDEX log entry (simulating the
+            // commit-log catching up to the server's DROP_INDEX entry).
+            engine.applyEntry(new LogSequenceNumber(1, 999),
+                    LogEntryFactory.dropIndex("vidx3", null));
+            engine.awaitPendingWorkForTest();
+            engine.awaitPendingDeletionsForTest();
+
+            // The tailer must NOT have triggered another deletion.
+            assertEquals("tailer DROP_INDEX after eager drop must be a no-op",
+                    afterEager, dsm.dropIndexCount.get());
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Unknown-key path: calling {@code dropIndexImmediate} for an index that
+     * was never created (or was already removed) is a harmless no-op.
+     */
+    @Test
+    public void dropIndexImmediateForUnknownKeyIsNoOp() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        MemoryDataStorageManager backing = new MemoryDataStorageManager();
+        CountingDsm dsm = new CountingDsm(backing);
+
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir, configuration());
+        engine.setMetadataStorageManager(newMeta());
+        engine.setDataStorageManager(dsm);
+
+        engine.setWatermarkStore(new WatermarkStore() {
+            @Override
+            public WatermarkSnapshot load() {
+                return WatermarkSnapshot.START_OF_TIME;
+            }
+
+            @Override
+            public void save(WatermarkSnapshot snapshot) throws IOException {
+            }
+        });
+
+        try {
+            engine.start();
+
+            // Call for an index that was never registered — must not throw.
+            engine.dropIndexImmediate("nonexistent_table", "nonexistent_index");
+            engine.awaitPendingDeletionsForTest();
+
+            assertEquals("dropIndexImmediate for unknown key must not call dsm.dropIndex",
+                    0, dsm.dropIndexCount.get());
+        } finally {
+            engine.close();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceRebuildRemoteFileServerE2ETest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceRebuildRemoteFileServerE2ETest.java
@@ -178,6 +178,11 @@ public class MultiInstanceRebuildRemoteFileServerE2ETest {
         }
 
         @Override
+        public void dropIndex(String tablespace, String table, String indexName) {
+            // no-op in stub — eager cleanup not exercised by this test
+        }
+
+        @Override
         public void close() {
         }
     }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceRebuildRemoteFileServerE2ETest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/MultiInstanceRebuildRemoteFileServerE2ETest.java
@@ -178,7 +178,7 @@ public class MultiInstanceRebuildRemoteFileServerE2ETest {
         }
 
         @Override
-        public void dropIndex(String tablespace, String table, String indexName) {
+        public void dropIndex(String tablespace, String table, String indexName, String indexUuid) {
             // no-op in stub — eager cleanup not exercised by this test
         }
 


### PR DESCRIPTION
Fixes #509.

## Root cause

`DROP TABLE` / `DROP INDEX` writes `DROP_INDEX` log entries which the IS is
supposed to tail and use to clean up its ZK segment registry and file-server
data. However this relies entirely on the IS's commit-log tailer catching up
to those entries. On a DROP+recreate cycle where the IS is behind or was
recently restarted, stale segment ZK registrations survive and the optimizer
hits `Block not found` trying to merge incompletely-written segments from the
previous killed run.

## Changes

- **`indexing_service.proto`**: new `rpc DropIndex(DropIndexRequest) returns (DropIndexResponse)` — intentionally empty response since cleanup is background.
- **`RemoteVectorIndexService`**: new `void dropIndex(String, String, String)` method.
- **`VectorIndexManager.dropIndexData()`**: overridden to call `remoteService().dropIndex()` eagerly (best-effort, swallows IS failures so local catalog cleanup always runs). The commit-log tailer remains the authoritative fallback.
- **`IndexingServiceEngine.dropIndexImmediate(String table, String indexName)`**: removes the store from `vectorStores` / `vectorStoreIndexUuids` (thread-safe `ConcurrentHashMap.remove()`) and calls `submitVectorStoreDeletion()` which closes the store, sweeps ZK znodes via `dropAllRegistryEntries()`, and deletes file-server data in the background `checkpointExecutor`. The tailer's later `DROP_INDEX` entry finds `null` and is a no-op.
- **`IndexingServiceImpl.dropIndex()`**: gRPC handler delegating to the above.
- **`IndexingServiceClient.dropIndex()`**: iterates all IS channels and calls the RPC on each (best-effort; `UNIMPLEMENTED` from old IS pods is a warning, not an error).
- Existing mock stubs in test code updated to implement the new interface method.

## Tests

- **`VectorIndexManagerDropNotifiesRemoteServiceTest`** (herddb-core, plain): verifies `dropIndexData()` calls `RemoteVectorIndexService.dropIndex()` with correct args; null-supplier no-op path; IS-throws-RuntimeException is swallowed and local storage still cleaned.
- **`IndexingServiceEngineDropIndexImmediateTest`** (herddb-indexing-service, plain): verifies the engine removes the store, calls `dsm.dropIndex` once, is idempotent on second call, and that a subsequent tailer `DROP_INDEX` entry is a no-op after an eager drop.

🤖 Implemented by the `pr-worker` agent.