### PR TITLE
issue #514: live-reload optimizer-merged segments without IS restart

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -190,7 +191,7 @@ public abstract class AbstractVectorStore implements AutoCloseable {
      *
      * @param knownUuids segment UUIDs currently visible in the ZK registry
      */
-    public void reconcileAdoptedSegments(java.util.Set<String> knownUuids) {
+    public void reconcileAdoptedSegments(Set<String> knownUuids) {
         // No-op for non-persistent stores.
     }
 

--- a/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
@@ -20,7 +20,9 @@
 
 package herddb.index.vector;
 
+import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
@@ -121,6 +123,58 @@ public abstract class AbstractVectorStore implements AutoCloseable {
      */
     public String getStoreUUID() {
         return null;
+    }
+
+    /**
+     * Adopts an externally-produced segment (e.g. an optimizer merge output) into
+     * this store's active segment list. The segment's graph and map multipart files
+     * must already be present in the underlying data-storage manager under the key
+     * derived from {@code externalSegmentId}.
+     *
+     * <p>Idempotent: if a segment with the same {@code segmentUuid} is already loaded,
+     * this method returns {@code false} immediately without loading it again.
+     *
+     * <p>The default implementation is a no-op (used by in-memory stores that have no
+     * persistent segments). {@link herddb.index.vector.PersistentVectorStore} overrides
+     * this with a full implementation.
+     *
+     * @param segmentUuid       the UUID of the segment (from the ZK registry)
+     * @param externalSegmentId the 63-bit long segment ID allocated by the optimizer;
+     *                          used to reconstruct the multipart storage key
+     *                          ({@code indexUUID + "_seg" + externalSegmentId})
+     * @param graphFilePath     logical path recorded in the segment's ZK znode
+     * @param graphFileSize     exact byte-size of the graph multipart file
+     * @param mapFilePath       logical path recorded in the segment's ZK znode
+     * @param mapFileSize       exact byte-size of the map multipart file
+     * @param generation        segment generation from the ZK znode
+     * @return {@code true} if the segment was newly loaded; {@code false} if it was
+     *         already present (idempotent re-fire) or if the store is non-persistent
+     */
+    public boolean adoptExternalSegment(String segmentUuid, long externalSegmentId,
+            String graphFilePath, long graphFileSize,
+            String mapFilePath, long mapFileSize,
+            long generation) throws IOException, DataStorageManagerException {
+        // No-op for non-persistent stores (e.g. InMemoryVectorStore).
+        return false;
+    }
+
+    /**
+     * Removes a segment from the active list by its UUID and releases its resources.
+     * Called when the segment-assignment watcher reports that a segment previously
+     * owned by this IS instance is now deprecated (e.g. superseded by an
+     * optimizer-produced merge).
+     *
+     * <p>Idempotent: if the UUID is not found, this method returns immediately.
+     * Does <em>not</em> queue the segment's files for deletion — the optimizer is
+     * responsible for managing the lifecycle of files it produced.
+     *
+     * <p>The default implementation is a no-op.
+     * {@link herddb.index.vector.PersistentVectorStore} overrides this.
+     *
+     * @param segmentUuid the UUID of the segment to remove
+     */
+    public void dropSegmentByUuid(String segmentUuid) {
+        // No-op for non-persistent stores.
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/AbstractVectorStore.java
@@ -177,6 +177,23 @@ public abstract class AbstractVectorStore implements AutoCloseable {
         // No-op for non-persistent stores.
     }
 
+    /**
+     * Reconciles adopted (externally-produced) segments against the ZK-reported
+     * snapshot. Any segment with a non-null external storage key whose UUID is
+     * absent from {@code knownUuids} is dropped via {@link #dropSegmentByUuid}.
+     *
+     * <p>Called at IS startup, after the initial {@code watchIndex} scan, to
+     * handle IS-was-down-while-optimizer-deleted scenarios.
+     *
+     * <p>The default implementation is a no-op (non-persistent stores have no
+     * adopted segments). {@link herddb.index.vector.PersistentVectorStore} overrides.
+     *
+     * @param knownUuids segment UUIDs currently visible in the ZK registry
+     */
+    public void reconcileAdoptedSegments(java.util.Set<String> knownUuids) {
+        // No-op for non-persistent stores.
+    }
+
     @Override
     public void close() throws Exception {
     }

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -281,6 +281,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * the index.
      */
     private static final int METADATA_VERSION_MULTI_SEGMENT_V4 = 4;
+    /**
+     * V5 extends V4 with one additional field per segment: the
+     * {@link VectorSegment#externalStorageKey} (written as a UTF string, empty
+     * string = null). Required so that optimizer-adopted segments (which use a
+     * 63-bit long-based storage key rather than the IS-local int-based key) can
+     * be reopened correctly after a restart. Backward-compatible: V4 payloads are
+     * still accepted; segments loaded from V4 get {@code externalStorageKey = null}
+     * (correct, since V4 was written before the adoption feature existed).
+     */
+    private static final int METADATA_VERSION_MULTI_SEGMENT_V5 = 5;
 
     // -------------------------------------------------------------------------
     // Configuration
@@ -3137,6 +3147,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
             newList.add(tentative);
             segments = newList;
             registerSegmentMemoryEstimate(tentative);
+            // Mark the store dirty so the next checkpoint() call serialises the new
+            // segment list (including the adopted segment's externalStorageKey) to the
+            // IndexStatus. Without this, the checkpoint gate treats adoption as a
+            // no-op and the adopted segment is invisible on restart.
+            dirty.set(true);
             LOGGER.log(Level.INFO,
                     "adoptExternalSegment: loaded segment {0} (storageKey={1}, generation={2})"
                             + " into store {3}; total on-disk segments now {4}",
@@ -3175,6 +3190,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
             segments = newList;
             unregisterSegmentMemoryEstimate(found);
+            // Mark dirty so the next checkpoint() serialises the reduced segment list.
+            // Without this, dropping a segment leaves a stale entry in the IndexStatus
+            // on disk (the checkpoint gate would see no changes and skip).
+            dirty.set(true);
             LOGGER.log(Level.INFO,
                     "dropSegmentByUuid: removed segment {0} from store {1};"
                             + " total on-disk segments now {2}",
@@ -5687,13 +5706,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             + " optimizer. Delete the index and re-create it to produce a v4"
                             + " checkpoint, or downgrade to a binary that supports v3.");
         }
-        if (version != METADATA_VERSION_MULTI_SEGMENT_V4) {
+        if (version != METADATA_VERSION_MULTI_SEGMENT_V4
+                && version != METADATA_VERSION_MULTI_SEGMENT_V5) {
             // Unknown future version — the previous binary cannot read it.
             // Fail fast: an immediate boot failure is far easier to diagnose
             // than a silent data-loss-equivalent regression.
             throw new DataStorageManagerException(
                     "unsupported vector index metadata version " + version + " for " + indexName
-                            + " (this binary supports v" + METADATA_VERSION_MULTI_SEGMENT_V4
+                            + " (this binary supports v" + METADATA_VERSION_MULTI_SEGMENT_V5
                             + "). Either re-deploy a binary that supports v" + version
                             + " OR delete the index and re-create it.");
         }
@@ -5711,11 +5731,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.dimension = dim;
         newPageId.set(status.newPageId);
 
-        loadMultiSegmentFormat(metaBuf, dim, savedNextNodeId, savedBeamWidth, savedNeighborOverflow, savedAlpha);
+        loadMultiSegmentFormat(metaBuf, version, dim, savedNextNodeId,
+                savedBeamWidth, savedNeighborOverflow, savedAlpha);
     }
 
-    private void loadMultiSegmentFormat(ByteBuffer metaBuf, int dim, long savedNextNodeId,
-                                         int savedBeamWidth, float savedNeighborOverflow, float savedAlpha)
+    private void loadMultiSegmentFormat(ByteBuffer metaBuf, int metaVersion, int dim,
+                                         long savedNextNodeId,
+                                         int savedBeamWidth, float savedNeighborOverflow,
+                                         float savedAlpha)
             throws IOException, DataStorageManagerException {
         java.io.DataInputStream dis = new java.io.DataInputStream(
                 new java.io.ByteArrayInputStream(metaBuf.array(), metaBuf.position(),
@@ -5751,6 +5774,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             long mapFileSize;
             long generation;
             String segmentUuid;
+            String externalStorageKey;
             try {
                 segId = dis.readInt();
                 estimatedSize = dis.readLong();
@@ -5759,12 +5783,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 mapFilePath = dis.readUTF();
                 mapFileSize = dis.readLong();
                 generation = dis.readLong();
-                // v4 format always includes a segmentUuid field. An empty string
-                // means the segment has no UUID (should not occur in v4 except during
+                // v4+ format always includes a segmentUuid field. An empty string
+                // means the segment has no UUID (should not occur in v4+ except during
                 // a checkpoint that was written before the publisher was first attached;
                 // treated as null for reconcile purposes).
                 String raw = dis.readUTF();
                 segmentUuid = raw.isEmpty() ? null : raw;
+                // v5 adds externalStorageKey so that optimizer-adopted segments
+                // (which use a 63-bit long-based storage key instead of the
+                // IS-local int-based key) can be reopened correctly after restart.
+                // V4 payloads predate adoption, so externalStorageKey is always null.
+                if (metaVersion >= METADATA_VERSION_MULTI_SEGMENT_V5) {
+                    String extRaw = dis.readUTF();
+                    externalStorageKey = extRaw.isEmpty() ? null : extRaw;
+                } else {
+                    externalStorageKey = null;
+                }
             } catch (IOException e) {
                 throw new DataStorageManagerException("Failed to read segment metadata", e);
             }
@@ -5776,6 +5810,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             seg.mapFileSize = mapFileSize;
             seg.generation = generation;
             seg.segmentUuid = segmentUuid;
+            seg.externalStorageKey = externalStorageKey;
             segList.add(seg);
         }
 
@@ -6318,12 +6353,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // Existing (sealed/mergeable) segments keep their stored generation.
         long newGeneration = currentIndexStatusGeneration.get() + 1;
 
-        // Always write v4 format: v3 (which lacked the segmentUuid field) is no
-        // longer supported for reading or writing (issue #499).
+        // Write v5 format: v5 adds externalStorageKey per-segment so that
+        // optimizer-adopted segments survive a restart. v4 (which lacked that
+        // field) is still accepted for reading but will never be written.
+        // v3 (which lacked segmentUuid) is no longer supported for reading or
+        // writing (issue #499).
 
         VisibleByteArrayOutputStream baos = new VisibleByteArrayOutputStream(256);
         try (java.io.DataOutputStream dos = new java.io.DataOutputStream(baos)) {
-            dos.writeInt(METADATA_VERSION_MULTI_SEGMENT_V4);
+            dos.writeInt(METADATA_VERSION_MULTI_SEGMENT_V5);
             dos.writeInt(dimension);
             dos.writeInt(m);
             dos.writeInt(beamWidth);
@@ -6338,17 +6376,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
             for (VectorSegment seg : sealedSegments) {
                 writeSegmentMeta(dos, seg.segmentId, seg.segmentUuid, seg.estimatedSizeBytes,
                         seg.graphFilePath, seg.graphFileSize,
-                        seg.mapFilePath, seg.mapFileSize, seg.generation);
+                        seg.mapFilePath, seg.mapFileSize, seg.generation,
+                        seg.externalStorageKey);
             }
             for (VectorSegment seg : mergeableSegments) {
                 writeSegmentMeta(dos, seg.segmentId, seg.segmentUuid, seg.estimatedSizeBytes,
                         seg.graphFilePath, seg.graphFileSize,
-                        seg.mapFilePath, seg.mapFileSize, seg.generation);
+                        seg.mapFilePath, seg.mapFileSize, seg.generation,
+                        seg.externalStorageKey);
             }
             for (SegmentWriteResult swr : newSegmentResults) {
+                // IS-produced segments have no external storage key.
                 writeSegmentMeta(dos, swr.segmentId, swr.segmentUuid, swr.estimatedSizeBytes,
                         swr.graphFilePath, swr.graphFileSize,
-                        swr.mapFilePath, swr.mapFileSize, newGeneration);
+                        swr.mapFilePath, swr.mapFileSize, newGeneration,
+                        /* externalStorageKey= */ null);
             }
 
             List<PendingDelete> snapshotPending = new ArrayList<>(pendingDeletes);
@@ -6376,7 +6418,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             int segmentId, String segmentUuid, long estimatedSizeBytes,
             String graphFilePath, long graphFileSize,
             String mapFilePath, long mapFileSize,
-            long generation) throws IOException {
+            long generation, String externalStorageKey) throws IOException {
         dos.writeInt(segmentId);
         dos.writeLong(estimatedSizeBytes);
         dos.writeUTF(graphFilePath);
@@ -6384,9 +6426,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
         dos.writeUTF(mapFilePath != null ? mapFilePath : "");
         dos.writeLong(mapFileSize);
         dos.writeLong(generation);
-        // v4 format always includes segmentUuid. Empty string represents "no UUID assigned"
+        // v4+ format always includes segmentUuid. Empty string represents "no UUID assigned"
         // (written for segments that predate the publisher attachment; read back as null).
         dos.writeUTF(segmentUuid != null ? segmentUuid : "");
+        // v5 adds externalStorageKey so that optimizer-adopted segments survive a restart.
+        // Empty string represents null (no external key — IS-produced segments).
+        dos.writeUTF(externalStorageKey != null ? externalStorageKey : "");
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3250,7 +3250,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *                   {@link herddb.indexing.segment.SegmentAssignmentWatcher#snapshotKnownSegments()})
      */
     @Override
-    public void reconcileAdoptedSegments(java.util.Set<String> knownUuids) {
+    public void reconcileAdoptedSegments(Set<String> knownUuids) {
         List<String> toDropUuids = new ArrayList<>();
         for (VectorSegment seg : segments) {
             if (seg.externalStorageKey != null

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -279,6 +279,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * supported for reading or writing. Any attempt to load a v3 index will
      * result in a clear boot failure with instructions to delete and re-create
      * the index.
+     *
+     * <p>V4 is now read-only-legacy: the writer always emits V5
+     * ({@link #METADATA_VERSION_MULTI_SEGMENT_V5}). Existing V4 payloads are
+     * still accepted on read; they receive {@code externalStorageKey = null}
+     * per segment, which is correct since V4 was written before the adoption
+     * feature existed.
      */
     private static final int METADATA_VERSION_MULTI_SEGMENT_V4 = 4;
     /**

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3042,6 +3042,23 @@ public class PersistentVectorStore extends AbstractVectorStore {
         return segments.size();
     }
 
+    /**
+     * Test-only accessor: returns the {@code externalStorageKey} of the
+     * on-disk segment at the given list index (0-based). Used by
+     * {@code OptimizerMergeAdoptionRecallTest.adoptedSegmentSurvivesRestart}
+     * to verify that the V5 IndexStatus round-trip preserves the
+     * {@code externalStorageKey} field so a restart reattaches to the
+     * same optimizer-produced multipart files.
+     *
+     * @param idx 0-based position in the current segments list
+     * @return the {@code externalStorageKey} string, or {@code null} for
+     *         IS-locally-produced segments
+     * @throws IndexOutOfBoundsException if {@code idx >= getOnDiskSegmentCount()}
+     */
+    public String getOnDiskSegmentExternalStorageKeyForTest(int idx) {
+        return segments.get(idx).externalStorageKey;
+    }
+
     VectorSegment preloadCompactedSegment(SegmentWriteResult swr) throws IOException, DataStorageManagerException {
         VectorSegment seg = new VectorSegment(swr.segmentId);
         seg.segmentUuid = swr.segmentUuid;
@@ -3092,8 +3109,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
 
-        // Build a tentative segment and load its data (IO-heavy; no lock held).
-        int localSegId = nextSegmentId.getAndIncrement();
+        // Allocate the local segment ID under the write lock so the allocation
+        // is serialised against the checkpoint's "wipe-all + nextSegmentId.set(0)"
+        // path (which also holds stateLock.writeLock()). Without this guard, a
+        // concurrent wipe cycle could reset the counter between the allocation
+        // and publication steps, allowing a future IS-local segment to reuse the
+        // same localSegId and thereby collide on the BLink storage key
+        // (indexUUID + "_seg" + localSegId + "_pktonode").
+        int localSegId;
+        stateLock.writeLock().lock();
+        try {
+            localSegId = nextSegmentId.getAndIncrement();
+        } finally {
+            stateLock.writeLock().unlock();
+        }
         VectorSegment tentative = new VectorSegment(localSegId);
         tentative.segmentUuid = segmentUuid;
         tentative.externalStorageKey = indexUUID + "_seg" + externalSegmentId;
@@ -3130,6 +3159,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             "adoptExternalSegment: error closing tentative segment " + segmentUuid
                                     + " after load failure in store " + indexName, closeEx);
                 }
+                // Reclaim the BLink storage entry that loadFusedPQSegment may have created
+                // via createSegmentBLinks before the failure. If readMultipartMapDataToTempFile
+                // failed before loadFusedPQSegment ran, dropSegmentBLinkStorage is a no-op
+                // (DataStorageManagerException is caught and logged internally).
+                dropSegmentBLinkStorage(tentative);
             }
         }
 
@@ -3149,6 +3183,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
             newList.add(tentative);
             segments = newList;
             registerSegmentMemoryEstimate(tentative);
+            // Ensure nextSegmentId stays above localSegId even if a concurrent
+            // checkpoint wipe-path (nextSegmentId.set(0)) ran between the
+            // localSegId allocation (under writeLock above) and this publication.
+            // Without this bump, IS-local segments created after the wipe could
+            // eventually reach localSegId and collide on the BLink storage key.
+            if (nextSegmentId.get() <= localSegId) {
+                nextSegmentId.set(localSegId + 1);
+            }
             // Mark the store dirty so the next checkpoint() call serialises the new
             // segment list (including the adopted segment's externalStorageKey) to the
             // IndexStatus. Without this, the checkpoint gate treats adoption as a
@@ -3162,9 +3204,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
         } finally {
             stateLock.writeLock().unlock();
             if (alreadyAdopted) {
-                // Close the tentative segment outside the writeLock to avoid holding
-                // the lock during potential IO (BLink close, temp-file delete).
+                // Close the tentative segment and reclaim its BLink storage outside
+                // the writeLock to avoid holding the lock during potential IO.
                 tentative.close();
+                // Reclaim the BLink storage entry materialised by createSegmentBLinks
+                // inside loadFusedPQSegment (which completed successfully before the
+                // duplicate was detected under the writeLock).
+                dropSegmentBLinkStorage(tentative);
             }
         }
         return true;
@@ -3223,6 +3269,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         "dropSegmentByUuid: error closing segment " + segmentUuid
                                 + " in store " + indexName, closeEx);
             }
+            // Reclaim the per-segment pk-to-node BLink storage entry. For adopted
+            // (external-storage-key) segments this is the entry created by
+            // loadFusedPQSegment → createSegmentBLinks during adoption. Without
+            // this, each optimizer adopt→deprecate→drop cycle leaks one BLink
+            // storage entry indefinitely.
+            dropSegmentBLinkStorage(found);
         } finally {
             stateLock.writeLock().unlock();
         }

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -957,6 +957,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
+     * Returns the multipart storage key for a segment.
+     *
+     * <p>IS-locally-produced segments use the legacy key
+     * {@code indexUUID + "_seg" + segmentId} (where {@code segmentId} is an {@code int}).
+     * Externally-produced segments (optimizer outputs) carry a 63-bit long segment ID
+     * that does not fit in {@code int}; their storage key is stored explicitly in
+     * {@link VectorSegment#externalStorageKey} during adoption.
+     */
+    private String segmentStorageKey(VectorSegment seg) {
+        return seg.externalStorageKey != null
+                ? seg.externalStorageKey
+                : (indexUUID + "_seg" + seg.segmentId);
+    }
+
+    /**
      * Queues the two multipart files backing a segment (graph + map)
      * for retention-aware deletion. Called by the compaction swap step
      * for every input segment that the merged output replaces.
@@ -964,7 +979,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
     void queueSegmentPendingDelete(VectorSegment seg, long retentionMs) {
         long deadlineMs = System.currentTimeMillis() + retentionMs;
         long sinceGen = currentIndexStatusGeneration.get();
-        String segUuid = indexUUID + "_seg" + seg.segmentId;
+        String segUuid = segmentStorageKey(seg);
         pendingDeletes.add(new PendingDelete(
                 encodeMultipartPath(segUuid, "graph"), deadlineMs, sinceGen));
         if (seg.mapFilePath != null) {
@@ -998,7 +1013,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
         long deadlineMs = System.currentTimeMillis() + vectorIndexCompactionRetentionMs;
         long sinceGen = currentIndexStatusGeneration.get();
-        String segUuid = indexUUID + "_seg" + mergedOutput.segmentId;
+        String segUuid = segmentStorageKey(mergedOutput);
         if (mergedOutput.graphFilePath != null) {
             pendingDeletes.add(new PendingDelete(
                     encodeMultipartPath(segUuid, "graph"), deadlineMs, sinceGen));
@@ -3007,6 +3022,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
         return new ArrayList<>(segments);
     }
 
+    /**
+     * Returns the current number of on-disk (sealed) segments held by this store.
+     * Useful for cross-module tests that need to observe the effect of
+     * {@link #adoptExternalSegment} / {@link #dropSegmentByUuid} without
+     * depending on the package-private {@link VectorSegment} type.
+     */
+    public int getOnDiskSegmentCount() {
+        return segments.size();
+    }
+
     VectorSegment preloadCompactedSegment(SegmentWriteResult swr) throws IOException, DataStorageManagerException {
         VectorSegment seg = new VectorSegment(swr.segmentId);
         seg.segmentUuid = swr.segmentUuid;
@@ -3018,6 +3043,155 @@ public class PersistentVectorStore extends AbstractVectorStore {
         Path mapFile = readMultipartMapDataToTempFile(seg);
         loadFusedPQSegment(seg, mapFile, dimension, nextNodeId.get());
         return seg;
+    }
+
+    /**
+     * Adopts an externally-produced segment (e.g. output of the index-optimizer service)
+     * into this store's active segment list. The segment's graph and map multipart files
+     * must already be present in the underlying {@link herddb.storage.DataStorageManager}
+     * under the key {@code indexUUID + "_seg" + externalSegmentId}.
+     *
+     * <p>The heavy IO (map-file download + graph loading) is performed outside the
+     * write lock to avoid blocking concurrent search queries. A second idempotency check
+     * under the write lock guards against duplicate adoption if the watcher fires twice
+     * for the same segment.
+     *
+     * <p>If {@code dimension} is not yet initialised (i.e. the store has never
+     * checkpointed), an {@link IllegalStateException} is thrown — the optimizer cannot
+     * produce merged segments before the IS has produced at least one checkpoint, so
+     * this state is unexpected and should be surfaced.
+     */
+    @Override
+    public boolean adoptExternalSegment(String segmentUuid, long externalSegmentId,
+            String graphFilePath, long graphFileSize,
+            String mapFilePath, long mapFileSize,
+            long generation) throws IOException, DataStorageManagerException {
+        int snapshotDimension = dimension;
+        if (snapshotDimension == 0) {
+            throw new IllegalStateException(
+                    "adoptExternalSegment called on store " + indexName
+                            + " before dimension is known — store must have checkpointed at least once");
+        }
+        // Quick idempotency check outside the write lock (avoids IO if already loaded).
+        for (VectorSegment existing : segments) {
+            if (segmentUuid.equals(existing.segmentUuid)) {
+                LOGGER.log(Level.FINE,
+                        "adoptExternalSegment: segment {0} already loaded in store {1}; skipping",
+                        new Object[]{segmentUuid, indexName});
+                return false;
+            }
+        }
+
+        // Build a tentative segment and load its data (IO-heavy; no lock held).
+        int localSegId = nextSegmentId.getAndIncrement();
+        VectorSegment tentative = new VectorSegment(localSegId);
+        tentative.segmentUuid = segmentUuid;
+        tentative.externalStorageKey = indexUUID + "_seg" + externalSegmentId;
+        tentative.graphFilePath = graphFilePath;
+        tentative.graphFileSize = graphFileSize;
+        tentative.mapFilePath = mapFilePath;
+        tentative.mapFileSize = mapFileSize;
+        tentative.generation = generation;
+        tentative.estimatedSizeBytes = graphFileSize + mapFileSize;
+
+        // The caller may be a ZK-watcher dispatch thread. NIO FileChannel reads
+        // will throw ClosedByInterruptException if the thread's interrupt flag is
+        // already set (e.g. from a previous ScheduledExecutorService shutdown in a
+        // co-running test, or from a benign wakeup on the dispatch thread). Clearing
+        // the flag before the IO section prevents spurious failures; the flag is
+        // restored afterwards so any legitimate "please stop" signal is not lost.
+        boolean wasInterrupted = Thread.interrupted();
+        boolean loadedOk = false;
+        try {
+            Path mapFile = readMultipartMapDataToTempFile(tentative);
+            loadFusedPQSegment(tentative, mapFile, snapshotDimension, nextNodeId.get());
+            loadedOk = true;
+        } finally {
+            if (wasInterrupted) {
+                // Restore the interrupt flag so callers/wrappers can observe it.
+                Thread.currentThread().interrupt();
+            }
+            if (!loadedOk) {
+                try {
+                    tentative.close();
+                } catch (RuntimeException closeEx) {
+                    // Narrow catch: close() throws only RuntimeException from BLink cleanup.
+                    LOGGER.log(Level.WARNING,
+                            "adoptExternalSegment: error closing tentative segment " + segmentUuid
+                                    + " after load failure in store " + indexName, closeEx);
+                }
+            }
+        }
+
+        // Under write lock: re-check idempotency, then publish.
+        stateLock.writeLock().lock();
+        try {
+            for (VectorSegment existing : segments) {
+                if (segmentUuid.equals(existing.segmentUuid)) {
+                    // Adopted by a concurrent adoption or watcher re-fire; discard.
+                    tentative.close();
+                    return false;
+                }
+            }
+            List<VectorSegment> newList = new java.util.concurrent.CopyOnWriteArrayList<>(segments);
+            newList.add(tentative);
+            segments = newList;
+            registerSegmentMemoryEstimate(tentative);
+            LOGGER.log(Level.INFO,
+                    "adoptExternalSegment: loaded segment {0} (storageKey={1}, generation={2})"
+                            + " into store {3}; total on-disk segments now {4}",
+                    new Object[]{segmentUuid, tentative.externalStorageKey,
+                            generation, indexName, segments.size()});
+        } finally {
+            stateLock.writeLock().unlock();
+        }
+        return true;
+    }
+
+    /**
+     * Removes a segment from the active list by its UUID and releases its resources.
+     * Called when the segment-assignment watcher reports that a segment previously owned
+     * by this IS instance has been deprecated (e.g. superseded by an optimizer merge).
+     *
+     * <p>Idempotent: if the UUID is not present, this method returns immediately.
+     * Does <em>not</em> queue the segment's files for deletion — the optimizer manages
+     * the file lifecycle for segments it produced.
+     */
+    @Override
+    public void dropSegmentByUuid(String segmentUuid) {
+        stateLock.writeLock().lock();
+        VectorSegment found = null;
+        try {
+            List<VectorSegment> newList = new java.util.concurrent.CopyOnWriteArrayList<>();
+            for (VectorSegment s : segments) {
+                if (segmentUuid.equals(s.segmentUuid)) {
+                    found = s;
+                } else {
+                    newList.add(s);
+                }
+            }
+            if (found == null) {
+                return;
+            }
+            segments = newList;
+            unregisterSegmentMemoryEstimate(found);
+            LOGGER.log(Level.INFO,
+                    "dropSegmentByUuid: removed segment {0} from store {1};"
+                            + " total on-disk segments now {2}",
+                    new Object[]{segmentUuid, indexName, segments.size()});
+        } finally {
+            stateLock.writeLock().unlock();
+        }
+        // Reaching here means found != null (the early return above would have fired otherwise).
+        try {
+            found.close();
+        } catch (RuntimeException e) {
+            // Narrow catch: close() only throws RuntimeException from BLink cleanup.
+            // We must not let a stale-handle error mask the segment removal.
+            LOGGER.log(Level.WARNING,
+                    "dropSegmentByUuid: error closing segment " + segmentUuid
+                            + " in store " + indexName, e);
+        }
     }
 
     String indexUUID() {
@@ -5843,7 +6017,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         ReaderSupplier readerSupplier = dataStorageManager.multipartIndexReaderSupplier(
                 tableSpaceUUID,
-                indexUUID + "_seg" + seg.segmentId,
+                segmentStorageKey(seg),
                 "graph",
                 seg.graphFileSize);
         seg.onDiskGraph = OnDiskGraphIndex.load(readerSupplier);
@@ -6091,7 +6265,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 // benefit to routing through the SegmentBlockCache.
                 dataStorageManager.downloadMultipartIndexFile(
                         tableSpaceUUID,
-                        indexUUID + "_seg" + seg.segmentId,
+                        segmentStorageKey(seg),
                         "map",
                         seg.mapFileSize,
                         tempFile);
@@ -6101,7 +6275,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 io.github.jbellis.jvector.disk.ReaderSupplier supplier =
                         dataStorageManager.multipartIndexReaderSupplier(
                                 tableSpaceUUID,
-                                indexUUID + "_seg" + seg.segmentId,
+                                segmentStorageKey(seg),
                                 "map",
                                 seg.mapFileSize);
                 try (io.github.jbellis.jvector.disk.RandomAccessReader reader = supplier.get();

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -401,8 +401,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     private final AtomicLong onDiskSegmentsEstimatedMemoryBytes = new AtomicLong(0);
 
-    /** Counter for assigning unique segment IDs. */
+    /** Counter for assigning unique segment IDs to IS-locally-produced segments. Counts up from 0. */
     private final AtomicInteger nextSegmentId = new AtomicInteger(0);
+
+    /**
+     * Counter for assigning unique local storage IDs to adopted (optimizer-produced) segments.
+     * Counts DOWN from {@link Integer#MAX_VALUE} so that adopted segment IDs occupy the
+     * [Integer.MAX_VALUE, ...] space and IS-local segment IDs occupy the [0, ...] space,
+     * making BLink storage key collisions impossible even if the checkpoint wipe path resets
+     * {@link #nextSegmentId} to 0 while an adoption is in flight.
+     *
+     * <p>The counter is NOT reset by the "all-vectors-deleted" wipe path (unlike
+     * {@code nextSegmentId}), because adopted segments live in a disjoint ID space.
+     * On restart, it is re-initialised to {@code minAdoptedSegId - 1} so subsequent
+     * adoptions continue below the lowest previously-used adopted ID.
+     */
+    private final AtomicInteger nextAdoptedSegmentLocalId = new AtomicInteger(Integer.MAX_VALUE);
 
     /**
      * Optional pluggable publisher invoked after each successful checkpoint to
@@ -3109,20 +3123,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
 
-        // Allocate the local segment ID under the write lock so the allocation
-        // is serialised against the checkpoint's "wipe-all + nextSegmentId.set(0)"
-        // path (which also holds stateLock.writeLock()). Without this guard, a
-        // concurrent wipe cycle could reset the counter between the allocation
-        // and publication steps, allowing a future IS-local segment to reuse the
-        // same localSegId and thereby collide on the BLink storage key
-        // (indexUUID + "_seg" + localSegId + "_pktonode").
-        int localSegId;
-        stateLock.writeLock().lock();
-        try {
-            localSegId = nextSegmentId.getAndIncrement();
-        } finally {
-            stateLock.writeLock().unlock();
-        }
+        // Use the adopted-segment ID counter that counts DOWN from Integer.MAX_VALUE.
+        // This keeps adopted-segment BLink storage keys
+        // (indexUUID + "_seg" + localSegId + "_pktonode") in the [MAX_INT, ...] space,
+        // completely disjoint from IS-locally-produced segment keys in the [0, ...] space.
+        // No lock is needed here: the two counters never share range, so even a concurrent
+        // checkpoint wipe that resets nextSegmentId to 0 cannot cause a collision with
+        // this adoption's localSegId.
+        int localSegId = nextAdoptedSegmentLocalId.getAndDecrement();
         VectorSegment tentative = new VectorSegment(localSegId);
         tentative.segmentUuid = segmentUuid;
         tentative.externalStorageKey = indexUUID + "_seg" + externalSegmentId;
@@ -3183,14 +3191,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             newList.add(tentative);
             segments = newList;
             registerSegmentMemoryEstimate(tentative);
-            // Ensure nextSegmentId stays above localSegId even if a concurrent
-            // checkpoint wipe-path (nextSegmentId.set(0)) ran between the
-            // localSegId allocation (under writeLock above) and this publication.
-            // Without this bump, IS-local segments created after the wipe could
-            // eventually reach localSegId and collide on the BLink storage key.
-            if (nextSegmentId.get() <= localSegId) {
-                nextSegmentId.set(localSegId + 1);
-            }
             // Mark the store dirty so the next checkpoint() call serialises the new
             // segment list (including the adopted segment's externalStorageKey) to the
             // IndexStatus. Without this, the checkpoint gate treats adoption as a
@@ -6027,21 +6027,39 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // ----------------------------------------------------------------
         // Phase 3 (serial): register segments and update counters.
         // ----------------------------------------------------------------
-        int maxSegId = -1;
+        int maxIsLocalSegId = -1;
+        // nextAdoptedSegmentLocalId counts DOWN from Integer.MAX_VALUE; on restart
+        // we initialise it to one below the smallest adopted ID seen in this store.
+        int minAdoptedSegId = Integer.MAX_VALUE;
+        boolean hasAdoptedSegments = false;
         long maxGeneration = loadedGeneration;
         for (VectorSegment seg : segList) {
             segments.add(seg);
             // Issue #455: snapshot the segment's in-memory footprint into the
             // on-disk counter so estimatedMemoryUsageBytes() is O(1).
             registerSegmentMemoryEstimate(seg);
-            if (seg.segmentId > maxSegId) {
-                maxSegId = seg.segmentId;
+            if (seg.externalStorageKey == null) {
+                // IS-locally-produced segment: contributes to nextSegmentId counter.
+                if (seg.segmentId > maxIsLocalSegId) {
+                    maxIsLocalSegId = seg.segmentId;
+                }
+            } else {
+                // Adopted (optimizer-produced) segment: contributes to the DOWN counter.
+                hasAdoptedSegments = true;
+                if (seg.segmentId < minAdoptedSegId) {
+                    minAdoptedSegId = seg.segmentId;
+                }
             }
             if (seg.generation > maxGeneration) {
                 maxGeneration = seg.generation;
             }
         }
-        nextSegmentId.set(maxSegId + 1);
+        nextSegmentId.set(maxIsLocalSegId + 1);
+        if (hasAdoptedSegments) {
+            // Resume the adopted-segment counter one below the lowest previously-used
+            // adopted ID so subsequent adoptions stay below all existing adopted IDs.
+            nextAdoptedSegmentLocalId.set(minAdoptedSegId - 1);
+        }
         currentIndexStatusGeneration.set(Math.max(currentIndexStatusGeneration.get(), maxGeneration));
 
         loadPendingDeletes(dis);

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3134,12 +3134,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
 
         // Under write lock: re-check idempotency, then publish.
+        boolean alreadyAdopted = false;
         stateLock.writeLock().lock();
         try {
             for (VectorSegment existing : segments) {
                 if (segmentUuid.equals(existing.segmentUuid)) {
-                    // Adopted by a concurrent adoption or watcher re-fire; discard.
-                    tentative.close();
+                    // Adopted by a concurrent adoption or watcher re-fire; discard
+                    // tentative AFTER releasing the lock to avoid IO under writeLock.
+                    alreadyAdopted = true;
                     return false;
                 }
             }
@@ -3159,6 +3161,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             generation, indexName, segments.size()});
         } finally {
             stateLock.writeLock().unlock();
+            if (alreadyAdopted) {
+                // Close the tentative segment outside the writeLock to avoid holding
+                // the lock during potential IO (BLink close, temp-file delete).
+                tentative.close();
+            }
         }
         return true;
     }
@@ -3198,18 +3205,66 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     "dropSegmentByUuid: removed segment {0} from store {1};"
                             + " total on-disk segments now {2}",
                     new Object[]{segmentUuid, indexName, segments.size()});
+            // Close the segment while holding the write lock. searchInternal snapshots
+            // this.segments and executes seg.search() under stateLock.readLock(). By
+            // closing here (under writeLock) we guarantee that no concurrent search can
+            // be using this segment when close() runs: the writeLock cannot be acquired
+            // until all in-flight readLock holders have released (and thus completed
+            // their seg.search() call). Without this, a search that snapshots the
+            // segment reference before the writeLock is acquired could use a closed
+            // segment, causing ReaderSupplier / OnDiskGraphIndex use-after-close errors.
+            try {
+                found.close();
+            } catch (RuntimeException closeEx) {
+                // Narrow catch: VectorSegment.close() throws only RuntimeException
+                // (BLink cleanup). We must not let a stale-handle error mask the
+                // segment removal or propagate past the writeLock.
+                LOGGER.log(Level.WARNING,
+                        "dropSegmentByUuid: error closing segment " + segmentUuid
+                                + " in store " + indexName, closeEx);
+            }
         } finally {
             stateLock.writeLock().unlock();
         }
-        // Reaching here means found != null (the early return above would have fired otherwise).
-        try {
-            found.close();
-        } catch (RuntimeException e) {
-            // Narrow catch: close() only throws RuntimeException from BLink cleanup.
-            // We must not let a stale-handle error mask the segment removal.
+    }
+
+    /**
+     * Reconciles the store's adopted (externally-produced) segment set against
+     * the ZK-reported ownership snapshot. Any segment that was adopted (i.e.
+     * {@code seg.externalStorageKey != null}) but whose UUID is absent from
+     * {@code knownUuids} is dropped via {@link #dropSegmentByUuid}.
+     *
+     * <p>Called at IS startup, after {@link
+     * herddb.indexing.segment.SegmentAssignmentWatcher#watchIndex} completes its
+     * initial synchronous scan, to handle the case where the IS was down while
+     * the optimizer transitioned and deleted the adopted segment from ZK. Without
+     * this reconcile, the orphaned segment would stay in the active search path
+     * indefinitely (and fail at search time if the optimizer also deleted its
+     * underlying multipart files).
+     *
+     * <p>Idempotent and safe to call multiple times. This method never adds
+     * segments — it only drops ones that are gone from ZK.
+     *
+     * @param knownUuids the set of segment UUIDs currently visible in the ZK
+     *                   registry for this index (from
+     *                   {@link herddb.indexing.segment.SegmentAssignmentWatcher#snapshotKnownSegments()})
+     */
+    @Override
+    public void reconcileAdoptedSegments(java.util.Set<String> knownUuids) {
+        List<String> toDropUuids = new ArrayList<>();
+        for (VectorSegment seg : segments) {
+            if (seg.externalStorageKey != null
+                    && seg.segmentUuid != null
+                    && !knownUuids.contains(seg.segmentUuid)) {
+                toDropUuids.add(seg.segmentUuid);
+            }
+        }
+        for (String uuid : toDropUuids) {
             LOGGER.log(Level.WARNING,
-                    "dropSegmentByUuid: error closing segment " + segmentUuid
-                            + " in store " + indexName, e);
+                    "reconcileAdoptedSegments: dropping orphaned adopted segment {0}"
+                            + " from store {1} (not present in ZK)",
+                    new Object[]{uuid, indexName});
+            dropSegmentByUuid(uuid);
         }
     }
 
@@ -3745,37 +3800,41 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         List<Callable<List<Map.Entry<Bytes, Float>>>> tasks = new ArrayList<>();
 
-        // Phase 1: on-disk segments.
-        final List<VectorSegment> currentSegments = this.segments;
-        for (final VectorSegment seg : currentSegments) {
-            tasks.add(wrapInContext(ctx, () -> {
-                List<Map.Entry<Bytes, Float>> local = new ArrayList<>(perSourceK);
-                seg.search(qv, perSourceK, similarityFunction, local);
-                return local;
-            }));
-        }
-
-        // Phase 2: live in-memory shards (no pending-deletes filtering).
-        for (final LiveGraphShard shard : liveShards) {
-            if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
-                tasks.add(wrapInContext(ctx, () -> searchLiveShard(shard, qv, perSourceK, null)));
-            }
-        }
-
         List<List<Map.Entry<Bytes, Float>>> partials;
 
-        // Phase 3: frozen + deferred shards. Both are cleaned up by Phase C
-        // under the write lock, so we must hold the read lock to prevent
-        // Phase C from dropping the shards (and their per-shard VectorStorage
-        // references) while GraphSearcher is still accessing them via
-        // shard.mravv. Without this lock, a race would let the shard become
-        // unreachable while jvector's scorer is calling getVector() on its
-        // storage, leading to NullPointerException (issue #129). The lock
-        // is held while invokeSearchTasks blocks on task completion: worker
-        // threads can join as additional readers because ReentrantReadWriteLock
-        // allows multiple concurrent read holders.
+        // The read lock protects three concerns:
+        //   1. On-disk segments (Phase 1): the segment snapshot and task execution
+        //      must happen atomically with respect to dropSegmentByUuid which closes
+        //      segments under the write lock. Moving the snapshot here ensures no
+        //      segment can be closed between the snapshot and task execution (the
+        //      write lock cannot be acquired while we hold the read lock).
+        //   2. Live in-memory shards (Phase 2): liveShards is updated under the
+        //      write lock during addVectorInternal's shard-rotation path; holding
+        //      the read lock keeps the shard list stable across task creation.
+        //   3. Frozen + deferred shards (Phase 3): these are dropped by Phase C of
+        //      checkpoint under the write lock (issue #129); the read lock prevents
+        //      a searcher's GraphSearcher from accessing freed memory.
         stateLock.readLock().lock();
         try {
+            // Phase 1: on-disk segments (snapshotted and tasked under read lock so
+            // that dropSegmentByUuid can safely call found.close() under write lock).
+            final List<VectorSegment> currentSegments = this.segments;
+            for (final VectorSegment seg : currentSegments) {
+                tasks.add(wrapInContext(ctx, () -> {
+                    List<Map.Entry<Bytes, Float>> local = new ArrayList<>(perSourceK);
+                    seg.search(qv, perSourceK, similarityFunction, local);
+                    return local;
+                }));
+            }
+
+            // Phase 2: live in-memory shards (no pending-deletes filtering).
+            for (final LiveGraphShard shard : liveShards) {
+                if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
+                    tasks.add(wrapInContext(ctx, () -> searchLiveShard(shard, qv, perSourceK, null)));
+                }
+            }
+
+            // Phase 3: frozen + deferred shards (the lock was already required for these).
             final PagedPkSet pending = pendingCheckpointDeletes;
             List<LiveGraphShard> frozen = frozenShards;
             if (frozen != null) {

--- a/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
@@ -158,6 +158,17 @@ class VectorSegment implements Closeable {
     /** Total size in bytes of the map multipart file (valid only when mapFilePath != null). */
     long mapFileSize;
 
+    /**
+     * Multipart storage key for externally-produced segments (i.e. output of the
+     * index-optimizer service). When non-null, used everywhere in place of the legacy
+     * computed key {@code indexUUID + "_seg" + segmentId}.
+     *
+     * <p>The optimizer allocates 63-bit random {@code long} segment IDs that cannot be
+     * represented by the {@code int segmentId} field, so the storage key must be carried
+     * explicitly. {@code null} for IS-locally-produced segments (the normal case).
+     */
+    String externalStorageKey;
+
     VectorSegment(int segmentId) {
         this.segmentId = segmentId;
     }

--- a/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue256CheckpointFormatTest.java
@@ -114,11 +114,12 @@ public class Issue256CheckpointFormatTest {
         // + bw (int) + neighborOverflow (float) + alpha (float) + addHierarchy (byte)
         // + fusedPQ (byte) + nextNodeId (long). Total header size = 4*4 + 4*2 + 2 + 8 = 34.
         // Issue #256 moved nextNodeId from writeInt to writeLong at that offset.
-        // Issue #499 dropped v3 support; all checkpoints are now written in v4 format.
+        // Issue #499 dropped v3 support; v4 format was introduced.
+        // Issue #514 adds externalStorageKey per segment; all checkpoints are now written in v5 format.
         byte[] raw = readRawIndexStatus(dsm, uuid);
         ByteBuffer bb = ByteBuffer.wrap(raw);
         int version = bb.getInt();
-        assertEquals("version must be 4 (v3 dropped per issue #499)", 4, version);
+        assertEquals("version must be 5 (V5 adds externalStorageKey per segment, issue #514)", 5, version);
         bb.getInt(); // dim
         bb.getInt(); // m
         bb.getInt(); // beamWidth
@@ -280,7 +281,7 @@ public class Issue256CheckpointFormatTest {
         assertTrue("metadata blob must be at least 34 bytes (header), got " + real.length,
                 real.length >= 34);
         try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(real))) {
-            assertEquals(4, dis.readInt());                 // version (v4 since issue #499)
+            assertEquals(5, dis.readInt());                 // version (v5 since issue #514; v4 was issue #499)
             assertEquals(16, dis.readInt());                // dim
             assertEquals(16, dis.readInt());                // m
             assertEquals(100, dis.readInt());               // beamWidth

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -2110,6 +2110,22 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     }
 
     /**
+     * Test-only snapshot of the live {@code segmentWatchers} map (issue #514).
+     * Lets tests assert that DROP_INDEX / DROP_TABLE / TRUNCATE_TABLE correctly
+     * close and remove their corresponding {@link herddb.indexing.segment.SegmentAssignmentWatcher}
+     * entries so no background refresh executor leaks.
+     *
+     * @return an unmodifiable view of the current watcher map; keys are
+     *         {@link #storeKey} strings, values are (possibly already-closed)
+     *         watcher instances
+     */
+    // package-private for testing
+    java.util.Map<String, herddb.indexing.segment.SegmentAssignmentWatcher>
+            snapshotSegmentWatchersForTest() {
+        return java.util.Collections.unmodifiableMap(new java.util.HashMap<>(segmentWatchers));
+    }
+
+    /**
      * Applies a single (committed or non-transactional) entry.
      */
     // package-private for testing
@@ -2160,6 +2176,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 // (table, name) key does not mis-fire the "different UUID" guard and silently
                 // refuse to create the new store (issue #368 review).
                 vectorStoreIndexUuids.entrySet().removeIf(e -> e.getKey().startsWith(droppedTablePrefix));
+                // Close SegmentAssignmentWatchers for all dropped stores so their
+                // background refresh executors are stopped and ZK watcher callbacks
+                // can no longer fire after the stores are gone (issue #514).
+                segmentWatchers.entrySet().removeIf(e -> {
+                    if (e.getKey().startsWith(droppedTablePrefix)) {
+                        e.getValue().close();
+                        return true;
+                    }
+                    return false;
+                });
                 for (Map.Entry<String, AbstractVectorStore> dropped : toClose) {
                     submitVectorStoreDeletion(dropped.getKey(), dropped.getValue());
                 }
@@ -2206,6 +2232,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 });
                 vectorStoreIndexUuids.entrySet().removeIf(
                         e -> e.getKey().startsWith(truncatedTablePrefix));
+                // Close SegmentAssignmentWatchers for the truncated stores.
+                // New watchers are created below when re-creating each store.
+                segmentWatchers.entrySet().removeIf(e -> {
+                    if (e.getKey().startsWith(truncatedTablePrefix)) {
+                        e.getValue().close();
+                        return true;
+                    }
+                    return false;
+                });
                 for (Map.Entry<String, AbstractVectorStore> dropped : toClose) {
                     submitVectorStoreDeletion(dropped.getKey(), dropped.getValue());
                 }
@@ -2248,6 +2283,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     String k = storeKey(idx.table, idx.name);
                     AbstractVectorStore removed = vectorStores.remove(k);
                     vectorStoreIndexUuids.remove(k);
+                    // Close the SegmentAssignmentWatcher so its background refresh
+                    // executor is stopped and no further ZK watcher callbacks fire
+                    // for a store that no longer exists (issue #514).
+                    herddb.indexing.segment.SegmentAssignmentWatcher removedWatcher =
+                            segmentWatchers.remove(k);
+                    if (removedWatcher != null) {
+                        removedWatcher.close();
+                    }
                     if (removed != null) {
                         // Close the store and drop its on-storage data
                         // (graph/map segments + IndexStatus markers).

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -968,6 +968,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                                                                 + " <= 0): znode predates issue #484 fix");
                                                 return;
                                             }
+                                            if (m.getSizeBytes() <= m.getMapFileSize()) {
+                                                // Corrupted or legacy znode: sizeBytes must be
+                                                // strictly larger than mapFileSize because
+                                                // sizeBytes = graphFileSize + mapFileSize and
+                                                // graphFileSize must be > 0. A zero or negative
+                                                // graphFileSize would corrupt the multipart read.
+                                                LOGGER.log(Level.WARNING,
+                                                        "Skipping adoption of segment "
+                                                                + m.getSegmentUuid()
+                                                                + " (sizeBytes=" + m.getSizeBytes()
+                                                                + " <= mapFileSize=" + m.getMapFileSize()
+                                                                + "): znode has invalid or zero graphFileSize");
+                                                return;
+                                            }
                                             try {
                                                 finalStore.adoptExternalSegment(
                                                         m.getSegmentUuid(),
@@ -990,8 +1004,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                                         public void onSegmentReleased(
                                                 herddb.indexing.segment.SegmentMetadata previous) {
                                             if (previous == null) {
-                                                // Segment was deleted from ZK without deprecation;
-                                                // no UUID is available to target the drop.
+                                                // Defence-in-depth: scanIndex now always passes
+                                                // the cached metadata for znode-gone events, but
+                                                // guard here in case a future code path differs.
+                                                LOGGER.log(Level.WARNING,
+                                                        "onSegmentReleased called with null metadata"
+                                                                + " for store " + finalIndexUUID
+                                                                + "; cannot drop by UUID");
                                                 return;
                                             }
                                             finalStore.dropSegmentByUuid(previous.getSegmentUuid());
@@ -1007,6 +1026,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     String watcherKey = storeKey(tableName, indexName);
                     try {
                         watcher.watchIndex(tableSpaceUUID, autoIndexUUID);
+                        // Startup reconcile: drop any adopted (external-storage-key)
+                        // segments that are not present in ZK. This handles the case
+                        // where the IS was down while the optimizer expired and deleted
+                        // a segment whose UUID is no longer in the registry. Without
+                        // the reconcile, the orphaned segment stays in the store
+                        // indefinitely and will fail at search time if the optimizer
+                        // has also deleted its multipart files.
+                        finalStore.reconcileAdoptedSegments(
+                                watcher.snapshotKnownSegments().keySet());
                         segmentWatchers.put(watcherKey, watcher);
                         LOGGER.log(Level.INFO,
                                 "SegmentAssignmentWatcher armed for store {0} (indexUuid={1})",

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -339,14 +339,24 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
      * for the engine — subscribes to every {@code SegmentAssignmentWatcher}
      * created by this IS instance so the gauges + counters reflect the
      * union of segments owned across all indexes. Prometheus exposition
-     * happens through {@link #registerSegmentAssignmentMetrics}; the gauges
-     * stay at zero until the engine actually wires up an
-     * {@code SegmentAssignmentWatcher} (currently future-work — the metrics
-     * surface is live so the Grafana dashboard panels light up the moment
-     * the watcher integration lands).
+     * happens through {@link #registerSegmentAssignmentMetrics}.
      */
     private final herddb.indexing.segment.SegmentAssignmentMetrics segmentAssignmentMetrics =
             new herddb.indexing.segment.SegmentAssignmentMetrics();
+
+    /**
+     * One {@link herddb.indexing.segment.SegmentAssignmentWatcher} per vector store,
+     * keyed by {@link #storeKey}. Each watcher watches the ZK segment-registry subtree
+     * for that store's index and calls
+     * {@link herddb.index.vector.AbstractVectorStore#adoptExternalSegment} /
+     * {@link herddb.index.vector.AbstractVectorStore#dropSegmentByUuid} when the
+     * optimizer produces or deprecates segments (issue #514).
+     *
+     * <p>Populated by the {@code vectorStoreFactory} lambda and closed in
+     * {@link #close()}, before the vector stores themselves are closed.
+     */
+    private final java.util.concurrent.ConcurrentHashMap<String, herddb.indexing.segment.SegmentAssignmentWatcher>
+            segmentWatchers = new java.util.concurrent.ConcurrentHashMap<>();
 
     /**
      * Issue #471 — engine-wide counters and timings for the
@@ -924,6 +934,73 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     store.start();
                 } catch (Exception e) {
                     throw new RuntimeException("Failed to start PersistentVectorStore " + indexName, e);
+                }
+
+                // Issue #514: arm a SegmentAssignmentWatcher so this store
+                // automatically adopts optimizer-merged segments and drops
+                // deprecated inputs without requiring a restart.
+                // The watcher is created AFTER store.start() so the store is
+                // fully initialised (dimension known, reconcile done) before
+                // the initial scan fires.
+                SegmentRegistryClient watcherRegistry = this.segmentRegistry;
+                if (watcherRegistry != null && tableSpaceUUID != null) {
+                    final herddb.index.vector.AbstractVectorStore finalStore = store;
+                    final String finalIndexUUID = autoIndexUUID;
+                    final String finalIndexName = indexName;
+                    herddb.indexing.segment.SegmentAssignmentWatcher watcher =
+                            new herddb.indexing.segment.SegmentAssignmentWatcher(
+                                    watcherRegistry, instanceId,
+                                    new herddb.indexing.segment.SegmentAssignmentListener() {
+                                        @Override
+                                        public void onSegmentAssigned(
+                                                herddb.indexing.segment.VersionedSegmentMetadata vsm) {
+                                            segmentAssignmentMetrics.onSegmentAssigned(vsm);
+                                            herddb.indexing.segment.SegmentMetadata m = vsm.metadata();
+                                            try {
+                                                finalStore.adoptExternalSegment(
+                                                        m.getSegmentUuid(),
+                                                        m.getSegmentId(),
+                                                        m.getGraphPath(),
+                                                        m.getSizeBytes() - m.getMapFileSize(),
+                                                        m.getMapPath(),
+                                                        m.getMapFileSize(),
+                                                        m.getGeneration());
+                                            } catch (java.io.IOException
+                                                    | herddb.storage.DataStorageManagerException e) {
+                                                LOGGER.log(Level.WARNING,
+                                                        "Failed to adopt external segment "
+                                                                + m.getSegmentUuid()
+                                                                + " into store " + finalIndexUUID, e);
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onSegmentReleased(
+                                                herddb.indexing.segment.SegmentMetadata previous) {
+                                            finalStore.dropSegmentByUuid(previous.getSegmentUuid());
+                                            segmentAssignmentMetrics.onSegmentReleased(previous);
+                                        }
+
+                                        @Override
+                                        public void onPendingAssignment(
+                                                herddb.indexing.segment.VersionedSegmentMetadata vsm) {
+                                            segmentAssignmentMetrics.onPendingAssignment(vsm);
+                                        }
+                                    });
+                    String watcherKey = storeKey(tableName, indexName);
+                    try {
+                        watcher.watchIndex(tableSpaceUUID, autoIndexUUID);
+                        segmentWatchers.put(watcherKey, watcher);
+                        LOGGER.log(Level.INFO,
+                                "SegmentAssignmentWatcher armed for store {0} (indexUuid={1})",
+                                new Object[]{watcherKey, finalIndexUUID});
+                    } catch (herddb.indexing.segment.SegmentRegistryException e) {
+                        LOGGER.log(Level.WARNING,
+                                "Failed to arm SegmentAssignmentWatcher for store " + finalIndexName
+                                        + " (indexUuid=" + finalIndexUUID
+                                        + "); external segment adoption disabled for this store", e);
+                        watcher.close();
+                    }
                 }
                 return store;
             };
@@ -4706,6 +4783,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // S3 — on a wiped-disk restart the service would claim progress it
         // cannot actually replay. Replay from the last checkpoint watermark
         // on next boot is safe (apply is idempotent).
+
+        // Close segment-assignment watchers BEFORE vector stores so no adoption
+        // events fire against a half-closed store (issue #514).
+        for (herddb.indexing.segment.SegmentAssignmentWatcher w : segmentWatchers.values()) {
+            try {
+                w.close();
+            } catch (RuntimeException e) {
+                // close() is void and handles its own InterruptedException internally;
+                // this catch is a safety net for unexpected runtime failures that must
+                // not prevent the remaining shutdown steps from running.
+                LOGGER.log(Level.WARNING, "Error closing segment watcher during shutdown", e);
+            }
+        }
+        segmentWatchers.clear();
 
         // Close and clear all vector stores
         for (AbstractVectorStore store : vectorStores.values()) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1055,7 +1055,12 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         LOGGER.log(Level.INFO,
                                 "SegmentAssignmentWatcher armed for store {0} (indexUuid={1})",
                                 new Object[]{watcherKey, finalIndexUUID});
-                    } catch (herddb.indexing.segment.SegmentRegistryException e) {
+                    } catch (Exception e) {
+                        // Broad catch is intentional: both SegmentRegistryException (from
+                        // watchIndex) and unchecked RuntimeException (e.g. from
+                        // reconcileAdoptedSegments → dropSegmentByUuid → BLink close)
+                        // must close the watcher so its background refresh executor is
+                        // stopped and it does not leak outside segmentWatchers.
                         LOGGER.log(Level.WARNING,
                                 "Failed to arm SegmentAssignmentWatcher for store " + finalIndexName
                                         + " (indexUuid=" + finalIndexUUID

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -982,6 +982,22 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                                                                 + "): znode has invalid or zero graphFileSize");
                                                 return;
                                             }
+                                            if (m.getGraphPath() == null
+                                                    || m.getGraphPath().isEmpty()
+                                                    || m.getMapPath() == null
+                                                    || m.getMapPath().isEmpty()) {
+                                                // Defensive guard: a znode without a graph or map
+                                                // path (e.g. a partial publish interrupted mid-write)
+                                                // would reach adoptExternalSegment and trigger an
+                                                // IllegalStateException in loadFusedPQSegment.
+                                                // Skip adoption and surface a WARNING instead.
+                                                LOGGER.log(Level.WARNING,
+                                                        "Skipping adoption of segment "
+                                                                + m.getSegmentUuid()
+                                                                + ": znode has null or empty "
+                                                                + "graphPath/mapPath");
+                                                return;
+                                            }
                                             try {
                                                 finalStore.adoptExternalSegment(
                                                         m.getSegmentUuid(),

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -956,6 +956,18 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                                                 herddb.indexing.segment.VersionedSegmentMetadata vsm) {
                                             segmentAssignmentMetrics.onSegmentAssigned(vsm);
                                             herddb.indexing.segment.SegmentMetadata m = vsm.metadata();
+                                            if (m.getMapFileSize() <= 0L) {
+                                                // Segment znode was written without mapFileSize
+                                                // (pre-issue-#484 format). Skip adoption — the
+                                                // segment cannot be read without a valid map size.
+                                                LOGGER.log(Level.WARNING,
+                                                        "Skipping adoption of segment "
+                                                                + m.getSegmentUuid()
+                                                                + " (mapFileSize="
+                                                                + m.getMapFileSize()
+                                                                + " <= 0): znode predates issue #484 fix");
+                                                return;
+                                            }
                                             try {
                                                 finalStore.adoptExternalSegment(
                                                         m.getSegmentUuid(),
@@ -977,6 +989,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                                         @Override
                                         public void onSegmentReleased(
                                                 herddb.indexing.segment.SegmentMetadata previous) {
+                                            if (previous == null) {
+                                                // Segment was deleted from ZK without deprecation;
+                                                // no UUID is available to target the drop.
+                                                return;
+                                            }
                                             finalStore.dropSegmentByUuid(previous.getSegmentUuid());
                                             segmentAssignmentMetrics.onSegmentReleased(previous);
                                         }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentListener.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentListener.java
@@ -59,8 +59,11 @@ public interface SegmentAssignmentListener {
      * and free associated resources.
      *
      * @param previous the last metadata observed while the local instance still
-     *                 held ownership, or {@code null} if the segment was deleted
-     *                 outright.
+     *                 held ownership. Always non-null: even when the segment znode
+     *                 is deleted outright (rather than first set to DEPRECATED),
+     *                 the watcher passes the last cached copy so downstream
+     *                 listeners can identify and clean up the segment by UUID.
+     *                 (Since issue #514; prior to that, null was passed on deletion.)
      */
     default void onSegmentReleased(SegmentMetadata previous) {
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentMetrics.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentMetrics.java
@@ -82,11 +82,11 @@ public final class SegmentAssignmentMetrics implements SegmentAssignmentListener
 
     @Override
     public void onSegmentReleased(SegmentMetadata previous) {
-        // RELEASED with previous == null means "segment deleted outright"
-        // (not transferred away). We have no UUID to remove from our set
-        // in that branch, so just bump the counter — the Set state stays
-        // self-consistent because the watcher will not have called
-        // ASSIGNED for it post-deletion.
+        // Defence-in-depth: the watcher contract (since issue #514) guarantees
+        // `previous` is non-null even on znode-gone events; this branch is
+        // unreachable in production. We keep it so the metrics observer never
+        // NPEs if a future code path violates the contract — just bump the
+        // counter and leave the owned-set self-consistent.
         if (previous == null) {
             segmentReleasesTotal.incrementAndGet();
             return;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
@@ -187,13 +187,14 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
             collectDiff(v, toAssign, toPending, toRelease);
         }
         // Drop any local entries whose znode is gone, and collect released events
-        // for segments we owned.
+        // for segments we owned. Pass the cached metadata (not null) so downstream
+        // listeners (e.g. IndexingServiceEngine) can call dropSegmentByUuid by UUID.
         Map<String, SegmentMetadata> snapshot = new HashMap<>(known);
         for (Map.Entry<String, SegmentMetadata> entry : snapshot.entrySet()) {
             if (!seen.contains(entry.getKey())) {
                 known.remove(entry.getKey());
                 if (entry.getValue().getOwnerInstanceId() == instanceId) {
-                    toRelease.add(null);
+                    toRelease.add(entry.getValue());
                 }
             }
         }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
@@ -222,7 +222,15 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
         boolean isPending = m.getPendingOwnerInstanceId() == instanceId;
         boolean wasPending = previous != null && previous.getPendingOwnerInstanceId() == instanceId;
 
-        if (isOwner && !wasOwner) {
+        // A segment assigned to this instance is no longer "active for us" if
+        // (a) ownership transferred to a different instance, or
+        // (b) the optimizer deprecated it (state DEPRECATED) — the IS must stop
+        //     serving queries from the deprecated copy regardless of ownerInstanceId.
+        boolean nowDeprecatedOrGone = m.getState() == SegmentState.DEPRECATED
+                || m.getState() == SegmentState.DELETED;
+        boolean wasActive = previous == null || previous.getState() == SegmentState.ACTIVE;
+
+        if (isOwner && !wasOwner && !nowDeprecatedOrGone) {
             fireAssigned(current);
             return;
         }
@@ -230,7 +238,7 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
             firePending(current);
             return;
         }
-        if (wasOwner && !isOwner) {
+        if (wasOwner && (!isOwner || (wasActive && nowDeprecatedOrGone))) {
             fireReleased(previous);
         }
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/segment/SegmentAssignmentWatcher.java
@@ -20,6 +20,7 @@
 package herddb.indexing.segment;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -157,11 +158,24 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
      *
      * <p>Synchronised on the watcher instance to serialise overlapping scans
      * (children watcher + data watcher + heartbeat could otherwise race).
+     *
+     * <p>Event ordering guarantee: all {@code onSegmentAssigned} callbacks are
+     * fired <em>before</em> any {@code onSegmentReleased} callback for the same
+     * scan. This prevents a zero-segment search window when the optimizer
+     * produces a merged segment and deprecates its inputs in the same ZK tick —
+     * the new ACTIVE segment is adopted before the deprecated inputs are dropped,
+     * regardless of lexicographic ZK children ordering.
      */
     synchronized void scanIndex(IndexKey key) throws SegmentRegistryException {
         Watcher childrenWatcher = (WatchedEvent event) -> dispatchScan(key);
         List<VersionedSegmentMetadata> current = registry.listSegments(
                 key.tablespaceUuid, key.indexUuid, childrenWatcher);
+
+        // Collect all event decisions first; fire them in two passes (assign,
+        // then release) to avoid a zero-segment window during optimizer adoption.
+        List<VersionedSegmentMetadata> toAssign = new ArrayList<>();
+        List<VersionedSegmentMetadata> toPending = new ArrayList<>();
+        List<SegmentMetadata> toRelease = new ArrayList<>();
 
         Set<String> seen = new HashSet<>();
         for (VersionedSegmentMetadata v : current) {
@@ -170,18 +184,31 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
             Watcher dataWatcher = (WatchedEvent event) -> dispatchScan(key);
             registry.getSegment(key.tablespaceUuid, key.indexUuid,
                     v.metadata().getSegmentUuid(), dataWatcher);
-            applyDiff(v);
+            collectDiff(v, toAssign, toPending, toRelease);
         }
-        // Drop any local entries whose znode is gone, and emit released events
+        // Drop any local entries whose znode is gone, and collect released events
         // for segments we owned.
         Map<String, SegmentMetadata> snapshot = new HashMap<>(known);
         for (Map.Entry<String, SegmentMetadata> entry : snapshot.entrySet()) {
             if (!seen.contains(entry.getKey())) {
                 known.remove(entry.getKey());
                 if (entry.getValue().getOwnerInstanceId() == instanceId) {
-                    fireReleased(null);
+                    toRelease.add(null);
                 }
             }
+        }
+
+        // Pass 1: assignments — new segments are live before any deprecated one is dropped.
+        for (VersionedSegmentMetadata vsm : toAssign) {
+            fireAssigned(vsm);
+        }
+        // Pass 2: pending-assignment notifications.
+        for (VersionedSegmentMetadata vsm : toPending) {
+            firePending(vsm);
+        }
+        // Pass 3: releases — deprecated/deleted inputs are dropped last.
+        for (SegmentMetadata m : toRelease) {
+            fireReleased(m);
         }
     }
 
@@ -212,7 +239,18 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
         }
     }
 
-    private void applyDiff(VersionedSegmentMetadata current) {
+    /**
+     * Computes which event (if any) to emit for one segment update and appends
+     * it to the appropriate decision list. Also updates the {@link #known} map.
+     *
+     * <p>Does <em>not</em> fire listener callbacks directly — the caller
+     * ({@link #scanIndex}) fires them after processing all segments, with
+     * assignments ordered before releases.
+     */
+    private void collectDiff(VersionedSegmentMetadata current,
+            List<VersionedSegmentMetadata> toAssign,
+            List<VersionedSegmentMetadata> toPending,
+            List<SegmentMetadata> toRelease) {
         SegmentMetadata m = current.metadata();
         SegmentMetadata previous = known.get(m.getSegmentUuid());
         known.put(m.getSegmentUuid(), m);
@@ -231,15 +269,15 @@ public final class SegmentAssignmentWatcher implements AutoCloseable {
         boolean wasActive = previous == null || previous.getState() == SegmentState.ACTIVE;
 
         if (isOwner && !wasOwner && !nowDeprecatedOrGone) {
-            fireAssigned(current);
+            toAssign.add(current);
             return;
         }
         if (isPending && !wasPending) {
-            firePending(current);
+            toPending.add(current);
             return;
         }
         if (wasOwner && (!isOwner || (wasActive && nowDeprecatedOrGone))) {
-            fireReleased(previous);
+            toRelease.add(previous);
         }
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineSegmentRegistryWiringTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineSegmentRegistryWiringTest.java
@@ -31,14 +31,21 @@ import herddb.file.FileDataStorageManager;
 import herddb.file.FileMetadataStorageManager;
 import herddb.index.vector.AbstractVectorStore;
 import herddb.index.vector.PersistentVectorStore;
+import herddb.indexing.segment.SegmentAssignmentWatcher;
 import herddb.indexing.segment.SegmentMetadata;
 import herddb.indexing.segment.SegmentRegistryClient;
 import herddb.indexing.segment.SegmentState;
 import herddb.indexing.segment.VersionedSegmentMetadata;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Table;
 import herddb.utils.Bytes;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -355,6 +362,94 @@ public class IndexingServiceEngineSegmentRegistryWiringTest {
             engineLogger.setLevel(previousLevel);
             fsMeta.close();
         }
+    }
+
+    /**
+     * Regression test for issue #514: DROP_INDEX must close and remove the
+     * {@link SegmentAssignmentWatcher} that was armed when the index was
+     * created. Without the fix, the watcher's background refresh executor
+     * kept running indefinitely after the index was dropped, and its ZK
+     * callbacks could fire against a store that had already been closed.
+     */
+    @Test
+    public void dropIndexClosesSegmentWatcher() throws Exception {
+        Path logDir = tmpFolder.newFolder("log-drop").toPath();
+        Path dataDir = tmpFolder.newFolder("data-drop").toPath();
+        String basePath = "/herd-test-514-drop-watcher";
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "file");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_INDEX_OPTIMIZER_ENABLED, "true");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS, "10000");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS, "100");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        try (ZookeeperMetadataStorageManager zkMeta = new ZookeeperMetadataStorageManager(
+                zkServer.getConnectString(), 30000, basePath)) {
+            zkMeta.start(true);
+            zkMeta.ensureDefaultTableSpace("local", "local", 0, 1);
+
+            FileDataStorageManager dsm = new FileDataStorageManager(dataDir);
+            MemoryManager mm = new MemoryManager(
+                    128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+            try (IndexingServiceEngine engine =
+                    new IndexingServiceEngine(logDir, dataDir, config)) {
+                engine.setMetadataStorageManager(zkMeta);
+                engine.setDataStorageManager(dsm);
+                engine.setMemoryManager(mm);
+                engine.start();
+
+                // Apply CREATE_TABLE + CREATE_INDEX so the engine creates a
+                // PersistentVectorStore and arms a SegmentAssignmentWatcher for it.
+                Table table = buildDropTable("drop_t");
+                Index idx = buildDropVectorIndex("drop_v", "drop_t");
+                engine.applyEntry(new LogSequenceNumber(1, 1),
+                        LogEntryFactory.createTable(table, null));
+                engine.applyEntry(new LogSequenceNumber(1, 2),
+                        LogEntryFactory.createIndex(idx, null));
+
+                // Verify the watcher was registered.
+                Map<String, SegmentAssignmentWatcher> watchersBefore =
+                        engine.snapshotSegmentWatchersForTest();
+                assertEquals("watcher must be registered after CREATE_INDEX",
+                        1, watchersBefore.size());
+
+                // Apply DROP_INDEX: must close and remove the watcher.
+                engine.applyEntry(new LogSequenceNumber(1, 3),
+                        LogEntryFactory.dropIndex("drop_v", null));
+                engine.awaitPendingWorkForTest();
+
+                Map<String, SegmentAssignmentWatcher> watchersAfter =
+                        engine.snapshotSegmentWatchersForTest();
+                assertEquals(
+                        "DROP_INDEX must remove the SegmentAssignmentWatcher "
+                                + "(issue #514 watcher-leak fix)",
+                        0, watchersAfter.size());
+            }
+        }
+    }
+
+    private static Table buildDropTable(String name) {
+        int h = name.hashCode() & 0x7FFFFFFF;
+        return Table.builder()
+                .name(name)
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .tableId(h == 0 ? 1 : h)
+                .build();
+    }
+
+    private static Index buildDropVectorIndex(String name, String tableName) {
+        return Index.builder()
+                .name(name)
+                .table(tableName)
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
     }
 
     private float[] randomVector(Random rng, int dim) {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineSegmentRegistryWiringTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineSegmentRegistryWiringTest.java
@@ -430,6 +430,131 @@ public class IndexingServiceEngineSegmentRegistryWiringTest {
         }
     }
 
+    /**
+     * Regression test for issue #514: DROP_TABLE must close and remove all
+     * {@link SegmentAssignmentWatcher} entries for that table's vector indexes,
+     * not just the vector stores themselves.
+     */
+    @Test
+    public void dropTableClosesSegmentWatcher() throws Exception {
+        Path logDir = tmpFolder.newFolder("log-droptbl").toPath();
+        Path dataDir = tmpFolder.newFolder("data-droptbl").toPath();
+        String basePath = "/herd-test-514-droptable-watcher";
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "file");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_INDEX_OPTIMIZER_ENABLED, "true");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS, "10000");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS, "100");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        try (ZookeeperMetadataStorageManager zkMeta = new ZookeeperMetadataStorageManager(
+                zkServer.getConnectString(), 30000, basePath)) {
+            zkMeta.start(true);
+            zkMeta.ensureDefaultTableSpace("local", "local", 0, 1);
+
+            FileDataStorageManager dsm = new FileDataStorageManager(dataDir);
+            MemoryManager mm = new MemoryManager(
+                    128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+            try (IndexingServiceEngine engine =
+                    new IndexingServiceEngine(logDir, dataDir, config)) {
+                engine.setMetadataStorageManager(zkMeta);
+                engine.setDataStorageManager(dsm);
+                engine.setMemoryManager(mm);
+                engine.start();
+
+                Table table = buildDropTable("droptbl_t");
+                Index idx = buildDropVectorIndex("droptbl_v", "droptbl_t");
+                engine.applyEntry(new LogSequenceNumber(1, 1),
+                        LogEntryFactory.createTable(table, null));
+                engine.applyEntry(new LogSequenceNumber(1, 2),
+                        LogEntryFactory.createIndex(idx, null));
+
+                assertEquals("watcher must be registered after CREATE_INDEX",
+                        1, engine.snapshotSegmentWatchersForTest().size());
+
+                // DROP_TABLE: must close and remove all watchers for this table.
+                engine.applyEntry(new LogSequenceNumber(1, 3),
+                        LogEntryFactory.dropTable(table, null));
+                engine.awaitPendingWorkForTest();
+
+                assertEquals(
+                        "DROP_TABLE must remove the SegmentAssignmentWatcher "
+                                + "(issue #514 watcher-leak fix)",
+                        0, engine.snapshotSegmentWatchersForTest().size());
+            }
+        }
+    }
+
+    /**
+     * Regression test for issue #514: TRUNCATE_TABLE must close the old
+     * {@link SegmentAssignmentWatcher} and the re-created store must arm
+     * a fresh watcher so subsequent optimizer adoption still works.
+     */
+    @Test
+    public void truncateTableClosesAndRecreatesSegmentWatcher() throws Exception {
+        Path logDir = tmpFolder.newFolder("log-trunc").toPath();
+        Path dataDir = tmpFolder.newFolder("data-trunc").toPath();
+        String basePath = "/herd-test-514-truncate-watcher";
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "file");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_INDEX_OPTIMIZER_ENABLED, "true");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS, "10000");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS, "100");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        try (ZookeeperMetadataStorageManager zkMeta = new ZookeeperMetadataStorageManager(
+                zkServer.getConnectString(), 30000, basePath)) {
+            zkMeta.start(true);
+            zkMeta.ensureDefaultTableSpace("local", "local", 0, 1);
+
+            FileDataStorageManager dsm = new FileDataStorageManager(dataDir);
+            MemoryManager mm = new MemoryManager(
+                    128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+            try (IndexingServiceEngine engine =
+                    new IndexingServiceEngine(logDir, dataDir, config)) {
+                engine.setMetadataStorageManager(zkMeta);
+                engine.setDataStorageManager(dsm);
+                engine.setMemoryManager(mm);
+                engine.start();
+
+                Table table = buildDropTable("trunc_t");
+                Index idx = buildDropVectorIndex("trunc_v", "trunc_t");
+                engine.applyEntry(new LogSequenceNumber(1, 1),
+                        LogEntryFactory.createTable(table, null));
+                engine.applyEntry(new LogSequenceNumber(1, 2),
+                        LogEntryFactory.createIndex(idx, null));
+
+                Map<String, SegmentAssignmentWatcher> watchersBefore =
+                        engine.snapshotSegmentWatchersForTest();
+                assertEquals("watcher must be registered after CREATE_INDEX",
+                        1, watchersBefore.size());
+                SegmentAssignmentWatcher oldWatcher =
+                        watchersBefore.values().iterator().next();
+
+                // TRUNCATE_TABLE: closes old watcher, re-creates store, arms new watcher.
+                engine.applyEntry(new LogSequenceNumber(1, 3),
+                        LogEntryFactory.truncate(table, null));
+                engine.awaitPendingWorkForTest();
+
+                Map<String, SegmentAssignmentWatcher> watchersAfter =
+                        engine.snapshotSegmentWatchersForTest();
+                assertEquals(
+                        "TRUNCATE_TABLE must re-arm exactly one SegmentAssignmentWatcher "
+                                + "(issue #514 watcher-leak fix)",
+                        1, watchersAfter.size());
+                SegmentAssignmentWatcher newWatcher =
+                        watchersAfter.values().iterator().next();
+                assertTrue(
+                        "TRUNCATE_TABLE must create a NEW watcher, not keep the old one",
+                        oldWatcher != newWatcher);
+            }
+        }
+    }
+
     private static Table buildDropTable(String name) {
         int h = name.hashCode() & 0x7FFFFFFF;
         return Table.builder()

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -434,9 +434,8 @@ public class OptimizerMergeAdoptionRecallTest {
 
                         @Override
                         public void onSegmentReleased(SegmentMetadata previous) {
-                            if (previous != null) {
-                                store.dropSegmentByUuid(previous.getSegmentUuid());
-                            }
+                            // watcher contract guarantees non-null previous (issue #514)
+                            store.dropSegmentByUuid(previous.getSegmentUuid());
                         }
                     });
             try {
@@ -594,9 +593,8 @@ public class OptimizerMergeAdoptionRecallTest {
 
                         @Override
                         public void onSegmentReleased(SegmentMetadata previous) {
-                            if (previous != null) {
-                                store.dropSegmentByUuid(previous.getSegmentUuid());
-                            }
+                            // watcher contract guarantees non-null previous (issue #514)
+                            store.dropSegmentByUuid(previous.getSegmentUuid());
                         }
                     });
             try {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -503,6 +503,123 @@ public class OptimizerMergeAdoptionRecallTest {
         }
     }
 
+    /**
+     * Verifies {@link PersistentVectorStore#reconcileAdoptedSegments}: after
+     * the optimizer merge produces 1 adopted segment and the IS drops the 3
+     * deprecated inputs, calling {@code reconcileAdoptedSegments} with an
+     * empty set (simulating "ZK deleted the segment while IS was down") drops
+     * the adopted segment and leaves the store with 0 on-disk segments.
+     *
+     * <p>This test exercises the startup-reconcile path added to prevent
+     * stale adopted segments from surfacing IO errors when the optimizer has
+     * already deleted the underlying multipart files.
+     */
+    @Test
+    public void reconcileAdoptedSegmentsDropsOrphanedSegment() throws Exception {
+        loadDataset();
+
+        Path dataDir = tmpFolder.newFolder("data-reconcile").toPath();
+        Path storeTmpDir = tmpFolder.newFolder("store-tmp-reconcile").toPath();
+        Path optimizerTmpDir = tmpFolder.newFolder("opt-tmp-reconcile").toPath();
+
+        FileDataStorageManager dsm = new FileDataStorageManager(dataDir);
+        MemoryManager mm = new MemoryManager(512 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                INDEX_NAME, TABLE_NAME, TABLESPACE_UUID,
+                VECTOR_COL, storeTmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        String indexUUID = store.getIndexUuid();
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TABLESPACE_UUID, TABLE_NAME, indexUUID, INDEX_NAME, INSTANCE_ID);
+        store.setSegmentPublisher(publisher);
+        store.setExternalCompactionEnabled(true);
+
+        try {
+            store.start();
+
+            // Ingest 3 batches, checkpoint each.
+            int batchSize = baseVectors.size() / 3;
+            for (int batch = 0; batch < 3; batch++) {
+                int start = batch * batchSize;
+                int end = (batch == 2) ? baseVectors.size() : start + batchSize;
+                for (int i = start; i < end; i++) {
+                    store.addVector(Bytes.from_int(i), baseVectors.get(i));
+                }
+                store.checkpoint();
+            }
+            assertEquals("pre-merge: 3 on-disk segments", 3, store.getOnDiskSegmentCount());
+
+            AtomicLong adoptions = new AtomicLong();
+
+            SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                    registry, INSTANCE_ID,
+                    new SegmentAssignmentListener() {
+                        @Override
+                        public void onSegmentAssigned(VersionedSegmentMetadata vsm) {
+                            SegmentMetadata m = vsm.metadata();
+                            try {
+                                boolean added = store.adoptExternalSegment(
+                                        m.getSegmentUuid(), m.getSegmentId(),
+                                        m.getGraphPath(), m.getSizeBytes() - m.getMapFileSize(),
+                                        m.getMapPath(), m.getMapFileSize(), m.getGeneration());
+                                if (added) {
+                                    adoptions.incrementAndGet();
+                                }
+                            } catch (IOException | DataStorageManagerException e) {
+                                throw new RuntimeException("adoptExternalSegment failed", e);
+                            }
+                        }
+
+                        @Override
+                        public void onSegmentReleased(SegmentMetadata previous) {
+                            if (previous != null) {
+                                store.dropSegmentByUuid(previous.getSegmentUuid());
+                            }
+                        }
+                    });
+            try {
+                watcher.watchIndex(TABLESPACE_UUID, indexUUID);
+
+                RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                        dsm, optimizerTmpDir,
+                        128, 16, 100, 1.2f, 1.4f,
+                        VectorSimilarityFunction.EUCLIDEAN);
+                IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                        registry, merger, TABLESPACE_UUID,
+                        new MergePolicy.SmallestFirstPolicy(2, 2, 1L, Long.MAX_VALUE),
+                        60_000L,
+                        () -> INSTANCE_ID);
+                engine.runOnce();
+
+                long deadline = System.currentTimeMillis() + 30_000L;
+                while (System.currentTimeMillis() < deadline
+                        && (store.getOnDiskSegmentCount() != 1 || adoptions.get() < 1)) {
+                    Thread.sleep(20);
+                }
+                assertEquals("post-merge: 1 adopted segment", 1, store.getOnDiskSegmentCount());
+                assertTrue("at least 1 adoption", adoptions.get() >= 1);
+
+                // ---------------------------------------------------------------
+                // Simulate: optimizer reaper deleted the adopted segment from ZK
+                // while the IS was busy. The reconcile pass with an empty known-set
+                // must drop the orphaned adopted segment.
+                // ---------------------------------------------------------------
+                store.reconcileAdoptedSegments(java.util.Collections.emptySet());
+
+                assertEquals("reconcile with empty known-set must drop the orphaned adopted segment",
+                        0, store.getOnDiskSegmentCount());
+            } finally {
+                watcher.close();
+            }
+        } finally {
+            store.close();
+        }
+    }
+
     /** Helper overload using an arbitrary store instance (not the field {@code store}). */
     private double measureRecallOn(PersistentVectorStore s, int topK) {
         double total = 0;

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -20,6 +20,7 @@
 package herddb.indexing;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.core.MemoryManager;
 import herddb.file.FileDataStorageManager;
@@ -488,6 +489,23 @@ public class OptimizerMergeAdoptionRecallTest {
 
             assertEquals("reloaded store must hold exactly 1 segment (the merged one)",
                     1, reloaded.getOnDiskSegmentCount());
+
+            // V5 externalStorageKey round-trip assertion: the merged segment's
+            // externalStorageKey must survive the checkpoint→restart cycle.
+            // If V5 write was silently downgraded to V4 (or the field is lost on
+            // deserialise), this returns null — which would cause the reloaded store
+            // to fall back to the legacy indexUUID-based storage key, silently
+            // breaking remote-file fetches for optimizer-produced segment files.
+            String reloadedExternalStorageKey =
+                    reloaded.getOnDiskSegmentExternalStorageKeyForTest(0);
+            assertNotNull(
+                    "V5 IndexStatus round-trip must preserve externalStorageKey "
+                            + "(V4 downgrade regression would return null here)",
+                    reloadedExternalStorageKey);
+            assertTrue(
+                    "externalStorageKey must start with capturedIndexUuid + '_seg', "
+                            + "was: " + reloadedExternalStorageKey,
+                    reloadedExternalStorageKey.startsWith(capturedIndexUuid + "_seg"));
 
             double recall10 = measureRecallOn(reloaded, 10);
             double recall100 = measureRecallOn(reloaded, 100);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -25,9 +25,11 @@ import static org.junit.Assert.assertTrue;
 import herddb.core.MemoryManager;
 import herddb.file.FileDataStorageManager;
 import herddb.index.vector.PersistentVectorStore;
+import herddb.indexing.optimizer.IndexMergeConfig;
 import herddb.indexing.optimizer.IndexOptimizerEngine;
 import herddb.indexing.optimizer.MergePolicy;
 import herddb.indexing.optimizer.RemoteSegmentMerger;
+import herddb.indexing.optimizer.StaticIndexMergeConfigProvider;
 import herddb.indexing.segment.SegmentAssignmentListener;
 import herddb.indexing.segment.SegmentAssignmentWatcher;
 import herddb.indexing.segment.SegmentMetadata;
@@ -295,12 +297,9 @@ public class OptimizerMergeAdoptionRecallTest {
                 // ---------------------------------------------------------------
                 RemoteSegmentMerger merger = new RemoteSegmentMerger(
                         dsm, optimizerTmpDir,
-                        128,    // vector dimension (siftsmall)
-                        16,     // graphM
-                        100,    // beamWidth
-                        1.2f,   // neighborOverflow
-                        1.4f,   // alpha
-                        VectorSimilarityFunction.EUCLIDEAN);
+                        new StaticIndexMergeConfigProvider(
+                                new IndexMergeConfig(16, 100, 1.2f, 1.4f,
+                                        VectorSimilarityFunction.EUCLIDEAN)));
 
                 IndexOptimizerEngine engine = new IndexOptimizerEngine(
                         registry, merger, TABLESPACE_UUID,
@@ -443,8 +442,9 @@ public class OptimizerMergeAdoptionRecallTest {
 
                 RemoteSegmentMerger merger = new RemoteSegmentMerger(
                         dsm, optimizerTmpDir,
-                        128, 16, 100, 1.2f, 1.4f,
-                        VectorSimilarityFunction.EUCLIDEAN);
+                        new StaticIndexMergeConfigProvider(
+                                new IndexMergeConfig(16, 100, 1.2f, 1.4f,
+                                        VectorSimilarityFunction.EUCLIDEAN)));
                 IndexOptimizerEngine engine = new IndexOptimizerEngine(
                         registry, merger, TABLESPACE_UUID,
                         new MergePolicy.SmallestFirstPolicy(2, 2, 1L, Long.MAX_VALUE),
@@ -602,8 +602,9 @@ public class OptimizerMergeAdoptionRecallTest {
 
                 RemoteSegmentMerger merger = new RemoteSegmentMerger(
                         dsm, optimizerTmpDir,
-                        128, 16, 100, 1.2f, 1.4f,
-                        VectorSimilarityFunction.EUCLIDEAN);
+                        new StaticIndexMergeConfigProvider(
+                                new IndexMergeConfig(16, 100, 1.2f, 1.4f,
+                                        VectorSimilarityFunction.EUCLIDEAN)));
                 IndexOptimizerEngine engine = new IndexOptimizerEngine(
                         registry, merger, TABLESPACE_UUID,
                         new MergePolicy.SmallestFirstPolicy(2, 2, 1L, Long.MAX_VALUE),

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -1,0 +1,353 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.file.FileDataStorageManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.indexing.optimizer.IndexOptimizerEngine;
+import herddb.indexing.optimizer.MergePolicy;
+import herddb.indexing.optimizer.RemoteSegmentMerger;
+import herddb.indexing.segment.SegmentAssignmentListener;
+import herddb.indexing.segment.SegmentAssignmentWatcher;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentRegistryClient;
+import herddb.indexing.segment.SegmentRegistryPublisher;
+import herddb.indexing.segment.VersionedSegmentMetadata;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end integration test for issue #514: the IS must automatically adopt
+ * optimizer-merged segments and drop deprecated inputs without restarting.
+ *
+ * <p>Test flow:
+ * <ol>
+ *   <li>Start a real {@code TestingServer} ZooKeeper and create a
+ *       {@link SegmentRegistryClient}.</li>
+ *   <li>Create a {@link PersistentVectorStore} backed by a
+ *       {@link FileDataStorageManager} with a {@link SegmentRegistryPublisher}
+ *       attached — so every checkpoint publishes segments to ZK.</li>
+ *   <li>Load the siftsmall base dataset (10 000 vectors, 128 dims, EUCLIDEAN)
+ *       in 3 equal batches, each followed by a {@code checkpoint()} call, leaving
+ *       3 ACTIVE segments in ZK.</li>
+ *   <li>Wire a {@link SegmentAssignmentWatcher} that calls
+ *       {@link PersistentVectorStore#adoptExternalSegment} / {@link
+ *       PersistentVectorStore#dropSegmentByUuid} on events.</li>
+ *   <li>Run {@link IndexOptimizerEngine#runOnce()} with a
+ *       {@link RemoteSegmentMerger} (backed by the <em>same</em>
+ *       {@link FileDataStorageManager}) and a merge policy that force-fires on
+ *       any 2+ segments — so all 3 collapse into 1 in a single tick.</li>
+ *   <li>Wait (up to 10 s) for the watcher to deliver events and the store to
+ *       hold exactly 1 on-disk segment.</li>
+ *   <li>Measure recall@10 and recall@100 against the siftsmall ground truth and
+ *       assert both ≥ 0.70 — the same floor used by the multi-segment recall
+ *       test in {@link PersistentVectorStoreRecallTest}.</li>
+ * </ol>
+ *
+ * <p>Uses {@code TestingServer} + {@code FileDataStorageManager} entirely
+ * in-process (no BookKeeper, no ZKTestEnv), so no
+ * {@code @Category(ClusterTest.class)} annotation is needed.
+ */
+public class OptimizerMergeAdoptionRecallTest {
+
+    private static final String BASE_PATH = "/herd-test-514-recall";
+    private static final String TABLESPACE_UUID = "ts-514";
+    private static final String TABLE_NAME = "docs";
+    private static final String INDEX_NAME = "docs_v1";
+    private static final String VECTOR_COL = "embedding";
+    /** IS instance ID — must match the ownerSelector passed to IndexOptimizerEngine. */
+    private static final int INSTANCE_ID = 0;
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+    private SegmentRegistryClient registry;
+
+    /** Saved per-class gate so concurrent JVM forks don't observe drift. */
+    private int savedMinLive;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30_000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue("ZK connect timed out", connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registry = new SegmentRegistryClient(() -> zk, BASE_PATH);
+        registry.ensureRoot();
+
+        savedMinLive = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        // Ensure every checkpoint flushes regardless of live-vector count,
+        // so small-batch tests always produce real sealed segments.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLive;
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Dataset helpers (same pattern as PersistentVectorStoreRecallTest)
+    // -------------------------------------------------------------------------
+
+    private List<float[]> baseVectors;
+    private List<float[]> queryVectors;
+    private List<List<Integer>> groundTruth;
+
+    private void loadDataset() {
+        baseVectors = SiftLoader.readFvecs(
+                getClass().getResourceAsStream("/siftsmall/siftsmall_base.fvecs"));
+        queryVectors = SiftLoader.readFvecs(
+                getClass().getResourceAsStream("/siftsmall/siftsmall_query.fvecs"));
+        groundTruth = SiftLoader.readIvecs(
+                getClass().getResourceAsStream("/siftsmall/siftsmall_groundtruth.ivecs"));
+    }
+
+    private double computeRecall(List<Map.Entry<Bytes, Float>> results,
+            List<Integer> truthTopK, int k) {
+        Set<Integer> truthSet = new HashSet<>(truthTopK.subList(0, Math.min(k, truthTopK.size())));
+        int hits = 0;
+        int limit = Math.min(k, results.size());
+        for (int i = 0; i < limit; i++) {
+            int ordinal = results.get(i).getKey().to_int();
+            if (truthSet.contains(ordinal)) {
+                hits++;
+            }
+        }
+        return (double) hits / truthSet.size();
+    }
+
+    private double measureRecall(PersistentVectorStore store, int topK) {
+        double total = 0;
+        for (int q = 0; q < queryVectors.size(); q++) {
+            List<Map.Entry<Bytes, Float>> results = store.search(queryVectors.get(q), topK);
+            total += computeRecall(results, groundTruth.get(q), topK);
+        }
+        return total / queryVectors.size();
+    }
+
+    // -------------------------------------------------------------------------
+    // Test
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void optimizerMergeAdoptedWithoutRestartAndRecallPreserved() throws Exception {
+        loadDataset();
+
+        Path dataDir = tmpFolder.newFolder("data").toPath();
+        Path storeTmpDir = tmpFolder.newFolder("store-tmp").toPath();
+        Path optimizerTmpDir = tmpFolder.newFolder("opt-tmp").toPath();
+
+        FileDataStorageManager dsm = new FileDataStorageManager(dataDir);
+        MemoryManager mm = new MemoryManager(512 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        // ---------------------------------------------------------------
+        // Create the PersistentVectorStore (siftsmall: dim=128, EUCLIDEAN)
+        // ---------------------------------------------------------------
+        PersistentVectorStore store = new PersistentVectorStore(
+                INDEX_NAME, TABLE_NAME, TABLESPACE_UUID,
+                VECTOR_COL, storeTmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        // Wire the registry publisher BEFORE start() (per its Javadoc).
+        String indexUUID = store.getIndexUuid();
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TABLESPACE_UUID, TABLE_NAME, indexUUID, INDEX_NAME, INSTANCE_ID);
+        store.setSegmentPublisher(publisher);
+        store.setExternalCompactionEnabled(true);
+
+        try {
+            store.start();
+
+            // ---------------------------------------------------------------
+            // Ingest siftsmall base vectors in 3 equal batches; checkpoint
+            // after each so each batch produces one sealed on-disk segment.
+            // ---------------------------------------------------------------
+            int batchSize = baseVectors.size() / 3;
+            for (int batch = 0; batch < 3; batch++) {
+                int start = batch * batchSize;
+                int end = (batch == 2) ? baseVectors.size() : start + batchSize;
+                for (int i = start; i < end; i++) {
+                    store.addVector(Bytes.from_int(i), baseVectors.get(i));
+                }
+                store.checkpoint();
+            }
+
+            assertEquals("3 batches × 1 checkpoint each must produce 3 on-disk segments",
+                    3, store.getOnDiskSegmentCount());
+
+            List<VersionedSegmentMetadata> zkSegs = registry.listSegments(TABLESPACE_UUID, indexUUID);
+            long activeCount = zkSegs.stream()
+                    .filter(v -> v.metadata().getState()
+                            == herddb.indexing.segment.SegmentState.ACTIVE)
+                    .count();
+            assertEquals("ZK must hold 3 ACTIVE segments after 3 checkpoints",
+                    3L, activeCount);
+
+            // ---------------------------------------------------------------
+            // Wire a SegmentAssignmentWatcher to drive adoptExternalSegment /
+            // dropSegmentByUuid on ZK events.
+            // ---------------------------------------------------------------
+            AtomicLong adoptions = new AtomicLong();
+            AtomicLong drops = new AtomicLong();
+
+            SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                    registry, INSTANCE_ID,
+                    new SegmentAssignmentListener() {
+                        @Override
+                        public void onSegmentAssigned(VersionedSegmentMetadata vsm) {
+                            SegmentMetadata m = vsm.metadata();
+                            try {
+                                boolean added = store.adoptExternalSegment(
+                                        m.getSegmentUuid(),
+                                        m.getSegmentId(),
+                                        m.getGraphPath(),
+                                        m.getSizeBytes() - m.getMapFileSize(),
+                                        m.getMapPath(),
+                                        m.getMapFileSize(),
+                                        m.getGeneration());
+                                if (added) {
+                                    // New segment actually loaded (not an idempotent re-fire).
+                                    adoptions.incrementAndGet();
+                                }
+                            } catch (IOException | DataStorageManagerException e) {
+                                // Propagate as RuntimeException so fireAssigned logs it clearly.
+                                throw new RuntimeException("adoptExternalSegment failed", e);
+                            }
+                            // Any unchecked exception from adoptExternalSegment propagates
+                            // naturally; fireAssigned will catch and log it at WARNING.
+                        }
+
+                        @Override
+                        public void onSegmentReleased(SegmentMetadata previous) {
+                            store.dropSegmentByUuid(previous.getSegmentUuid());
+                            drops.incrementAndGet();
+                        }
+                    });
+            try {
+                // watchIndex performs the initial scan synchronously (sees the 3
+                // IS-produced ACTIVE segments and fires onSegmentAssigned for each;
+                // the idempotency guard silently skips them since they are already
+                // in the store's segment list).
+                watcher.watchIndex(TABLESPACE_UUID, indexUUID);
+
+                // ---------------------------------------------------------------
+                // Run the optimizer: SmallestFirstPolicy with maxCount=2 fires
+                // on any 2+ segments, picking ALL candidates (maxBytes=MAX).
+                // With 3 segments this collapses everything into 1 in a single tick.
+                // ---------------------------------------------------------------
+                RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                        dsm, optimizerTmpDir,
+                        128,    // vector dimension (siftsmall)
+                        16,     // graphM
+                        100,    // beamWidth
+                        1.2f,   // neighborOverflow
+                        1.4f,   // alpha
+                        VectorSimilarityFunction.EUCLIDEAN);
+
+                IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                        registry, merger, TABLESPACE_UUID,
+                        new MergePolicy.SmallestFirstPolicy(2, 2, 1L, Long.MAX_VALUE),
+                        60_000L,    // retentionMs — long enough that reaping doesn't fire
+                        () -> INSTANCE_ID);
+
+                engine.runOnce();
+
+                // ---------------------------------------------------------------
+                // Wait for watcher events to propagate and the store to settle to
+                // exactly 1 on-disk segment (the merged output) with at least 1
+                // successful adoption. Both conditions must be met: just reaching
+                // count==1 via drops alone (e.g. 2 drops out of 3) is insufficient.
+                // ---------------------------------------------------------------
+                long deadline = System.currentTimeMillis() + 10_000L;
+                while (System.currentTimeMillis() < deadline
+                        && (store.getOnDiskSegmentCount() != 1 || adoptions.get() < 1)) {
+                    Thread.sleep(20);
+                }
+
+                assertEquals("after optimizer merge + watcher adoption the store must hold "
+                                + "exactly 1 segment (got " + store.getOnDiskSegmentCount() + ")",
+                        1, store.getOnDiskSegmentCount());
+
+                assertTrue("watcher must have adopted at least 1 new (external) segment",
+                        adoptions.get() >= 1);
+                assertTrue("watcher must have dropped at least 3 deprecated segments",
+                        drops.get() >= 3);
+
+                // ---------------------------------------------------------------
+                // Recall check: merged single-segment index must still answer
+                // queries with recall ≥ 0.70 (same floor as the multi-segment
+                // case in PersistentVectorStoreRecallTest).
+                // ---------------------------------------------------------------
+                double recall10 = measureRecall(store, 10);
+                double recall100 = measureRecall(store, 100);
+                System.out.printf(
+                        "OptimizerMergeAdoptionRecallTest: recall@10=%.4f, recall@100=%.4f%n",
+                        recall10, recall100);
+                assertTrue("recall@10 should be >= 0.70 after optimizer merge, was " + recall10,
+                        recall10 >= 0.70);
+                assertTrue("recall@100 should be >= 0.70 after optimizer merge, was " + recall100,
+                        recall100 >= 0.70);
+            } finally {
+                watcher.close();
+            }
+        } finally {
+            store.close();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -37,6 +37,7 @@ import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
@@ -314,7 +315,7 @@ public class OptimizerMergeAdoptionRecallTest {
                 // successful adoption. Both conditions must be met: just reaching
                 // count==1 via drops alone (e.g. 2 drops out of 3) is insufficient.
                 // ---------------------------------------------------------------
-                long deadline = System.currentTimeMillis() + 10_000L;
+                long deadline = System.currentTimeMillis() + 30_000L;
                 while (System.currentTimeMillis() < deadline
                         && (store.getOnDiskSegmentCount() != 1 || adoptions.get() < 1)) {
                     Thread.sleep(20);
@@ -349,5 +350,166 @@ public class OptimizerMergeAdoptionRecallTest {
         } finally {
             store.close();
         }
+    }
+
+    /**
+     * Verifies that an optimizer-adopted (external) segment survives a store
+     * restart: after the optimizerMerge collapses 3 IS segments into 1 merged
+     * segment and the store adopts it, we close and re-open the store. The
+     * reloaded store must still serve exactly 1 on-disk segment and achieve
+     * recall@10 ≥ 0.70 (same floor as the base recall test).
+     *
+     * <p>This test exercises the V5 IndexStatus format round-trip: the merged
+     * segment's {@code externalStorageKey} must be written by the checkpoint
+     * that follows adoption and read back correctly by the new store instance.
+     */
+    @Test
+    public void adoptedSegmentSurvivesRestart() throws Exception {
+        loadDataset();
+
+        Path dataDir = tmpFolder.newFolder("data-restart").toPath();
+        Path storeTmpDir = tmpFolder.newFolder("store-tmp-restart").toPath();
+        Path storeTmpDir2 = tmpFolder.newFolder("store-tmp-restart2").toPath();
+        Path optimizerTmpDir = tmpFolder.newFolder("opt-tmp-restart").toPath();
+
+        FileDataStorageManager dsm = new FileDataStorageManager(dataDir);
+        MemoryManager mm = new MemoryManager(512 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        // ---------------------------------------------------------------
+        // Phase 1: create store, ingest 3 batches, run optimizer, adopt.
+        // ---------------------------------------------------------------
+        String capturedIndexUuid;
+        PersistentVectorStore store = new PersistentVectorStore(
+                INDEX_NAME, TABLE_NAME, TABLESPACE_UUID,
+                VECTOR_COL, storeTmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        capturedIndexUuid = store.getIndexUuid();
+        SegmentRegistryPublisher publisher = new SegmentRegistryPublisher(
+                registry, TABLESPACE_UUID, TABLE_NAME, capturedIndexUuid, INDEX_NAME, INSTANCE_ID);
+        store.setSegmentPublisher(publisher);
+        store.setExternalCompactionEnabled(true);
+
+        try {
+            store.start();
+
+            int batchSize = baseVectors.size() / 3;
+            for (int batch = 0; batch < 3; batch++) {
+                int start = batch * batchSize;
+                int end = (batch == 2) ? baseVectors.size() : start + batchSize;
+                for (int i = start; i < end; i++) {
+                    store.addVector(Bytes.from_int(i), baseVectors.get(i));
+                }
+                store.checkpoint();
+            }
+            assertEquals("pre-merge: 3 on-disk segments", 3, store.getOnDiskSegmentCount());
+
+            AtomicLong adoptions = new AtomicLong();
+
+            SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                    registry, INSTANCE_ID,
+                    new SegmentAssignmentListener() {
+                        @Override
+                        public void onSegmentAssigned(VersionedSegmentMetadata vsm) {
+                            SegmentMetadata m = vsm.metadata();
+                            try {
+                                boolean added = store.adoptExternalSegment(
+                                        m.getSegmentUuid(),
+                                        m.getSegmentId(),
+                                        m.getGraphPath(),
+                                        m.getSizeBytes() - m.getMapFileSize(),
+                                        m.getMapPath(),
+                                        m.getMapFileSize(),
+                                        m.getGeneration());
+                                if (added) {
+                                    adoptions.incrementAndGet();
+                                }
+                            } catch (IOException | DataStorageManagerException e) {
+                                throw new RuntimeException("adoptExternalSegment failed", e);
+                            }
+                        }
+
+                        @Override
+                        public void onSegmentReleased(SegmentMetadata previous) {
+                            if (previous != null) {
+                                store.dropSegmentByUuid(previous.getSegmentUuid());
+                            }
+                        }
+                    });
+            try {
+                watcher.watchIndex(TABLESPACE_UUID, capturedIndexUuid);
+
+                RemoteSegmentMerger merger = new RemoteSegmentMerger(
+                        dsm, optimizerTmpDir,
+                        128, 16, 100, 1.2f, 1.4f,
+                        VectorSimilarityFunction.EUCLIDEAN);
+                IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                        registry, merger, TABLESPACE_UUID,
+                        new MergePolicy.SmallestFirstPolicy(2, 2, 1L, Long.MAX_VALUE),
+                        60_000L,
+                        () -> INSTANCE_ID);
+                engine.runOnce();
+
+                long deadline = System.currentTimeMillis() + 30_000L;
+                while (System.currentTimeMillis() < deadline
+                        && (store.getOnDiskSegmentCount() != 1 || adoptions.get() < 1)) {
+                    Thread.sleep(20);
+                }
+                assertEquals("post-merge: 1 on-disk segment", 1, store.getOnDiskSegmentCount());
+                assertTrue("at least 1 adoption", adoptions.get() >= 1);
+
+                // Checkpoint so the V5 IndexStatus (with externalStorageKey) is written to disk.
+                store.checkpoint();
+            } finally {
+                watcher.close();
+            }
+        } finally {
+            store.close();
+        }
+
+        // ---------------------------------------------------------------
+        // Phase 2: re-open the SAME store (same DSM, same indexUUID).
+        // The merged segment must be reloaded from the V5 IndexStatus.
+        // ---------------------------------------------------------------
+        // storeTmpDir2 is a fresh tmp directory for the new instance; the
+        // on-disk data lives in dataDir (shared DSM).
+        Files.createDirectories(storeTmpDir2);
+        MemoryManager mm2 = new MemoryManager(512 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore reloaded = new PersistentVectorStore(
+                INDEX_NAME, TABLE_NAME, TABLESPACE_UUID,
+                VECTOR_COL, capturedIndexUuid, storeTmpDir2, dsm, mm2,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+        try {
+            reloaded.start();
+
+            assertEquals("reloaded store must hold exactly 1 segment (the merged one)",
+                    1, reloaded.getOnDiskSegmentCount());
+
+            double recall10 = measureRecallOn(reloaded, 10);
+            double recall100 = measureRecallOn(reloaded, 100);
+            System.out.printf(
+                    "adoptedSegmentSurvivesRestart: recall@10=%.4f, recall@100=%.4f%n",
+                    recall10, recall100);
+            assertTrue("recall@10 after restart should be >= 0.70, was " + recall10,
+                    recall10 >= 0.70);
+            assertTrue("recall@100 after restart should be >= 0.70, was " + recall100,
+                    recall100 >= 0.70);
+        } finally {
+            reloaded.close();
+        }
+    }
+
+    /** Helper overload using an arbitrary store instance (not the field {@code store}). */
+    private double measureRecallOn(PersistentVectorStore s, int topK) {
+        double total = 0;
+        for (int q = 0; q < queryVectors.size(); q++) {
+            List<Map.Entry<Bytes, Float>> results = s.search(queryVectors.get(q), topK);
+            total += computeRecall(results, groundTruth.get(q), topK);
+        }
+        return total / queryVectors.size();
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentMetricsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentMetricsTest.java
@@ -91,10 +91,11 @@ public class SegmentAssignmentMetricsTest {
 
     @Test
     public void releasedWithNullPreviousStillBumpsReleasesCounter() {
-        // RELEASED(null) means "segment deleted outright" (znode disappeared).
-        // The observer can't remove from the owned set (no UUID), so it just
-        // bumps the releases counter. This is the canonical signal for "a
-        // segment we used to own was reaped" — distinct from a transfer-away.
+        // Defence-in-depth: the watcher contract (since issue #514) no longer
+        // delivers null on deletion — the cached metadata is always passed so
+        // listeners can identify the segment by UUID (see SegmentAssignmentListener
+        // javadoc). The metrics observer must remain defensive against a
+        // hypothetical future violation of that contract (e.g. a direct call).
         SegmentAssignmentMetrics m = new SegmentAssignmentMetrics();
         m.onSegmentReleased(null);
         assertEquals(0L, m.getOwnedSegmentsCount());

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentWatcherDeprecationDiffTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentWatcherDeprecationDiffTest.java
@@ -297,6 +297,56 @@ public class SegmentAssignmentWatcherDeprecationDiffTest {
     }
 
     /**
+     * When the optimizer (or ZK reaper) deletes a segment znode outright while
+     * the IS is running, the watcher's znode-gone path must fire
+     * {@code onSegmentReleased} with the non-null cached metadata so the
+     * listener can drop the segment by UUID.
+     *
+     * <p>This test validates the fix in {@code scanIndex} that changed
+     * {@code toRelease.add(null)} to {@code toRelease.add(entry.getValue())}.
+     */
+    @Test
+    public void znodeRemovedAfterOwnedTransitionFiresReleaseWithMetadata() throws Exception {
+        SegmentMetadata seg = activeSegment("seg-gone", 401L);
+        registry.createSegment(seg);
+
+        List<SegmentMetadata> released = new ArrayList<>();
+
+        SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                registry, OWNER,
+                new SegmentAssignmentListener() {
+                    @Override
+                    public void onSegmentAssigned(VersionedSegmentMetadata vsm) {
+                        // not under test
+                    }
+                    @Override
+                    public void onSegmentReleased(SegmentMetadata previous) {
+                        released.add(previous);
+                    }
+                });
+        try {
+            // Initial scan: 1 ACTIVE, owned → 1 assignment; known now contains seg.
+            watcher.watchIndex(TS_UUID, IDX_UUID);
+
+            // Hard-delete the znode (simulates optimizer reaper removing it).
+            VersionedSegmentMetadata v = getVersioned("seg-gone");
+            registry.casDeleteSegment(v);
+
+            // Re-scan: the segment is gone from ZK, known had us as owner →
+            // onSegmentReleased must fire with the cached metadata.
+            watcher.scanIndex(new SegmentAssignmentWatcher.IndexKey(TS_UUID, IDX_UUID));
+
+            assertEquals("znode-gone event must fire exactly 1 onSegmentReleased", 1, released.size());
+            SegmentMetadata rel = released.get(0);
+            assertTrue("onSegmentReleased must receive non-null metadata (not null)", rel != null);
+            assertEquals("released metadata must carry the correct UUID",
+                    "seg-gone", rel.getSegmentUuid());
+        } finally {
+            watcher.close();
+        }
+    }
+
+    /**
      * Corner case: a segment that is NOT owned by this instance transitioning
      * to DEPRECATED must NOT fire onSegmentReleased.
      */

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentWatcherDeprecationDiffTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentAssignmentWatcherDeprecationDiffTest.java
@@ -1,0 +1,345 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.segment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.log.LogSequenceNumber;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SegmentAssignmentWatcher} focusing on:
+ * <ol>
+ *   <li>An owned ACTIVE segment that transitions to DEPRECATED triggers
+ *       {@code onSegmentReleased} even though the ownerInstanceId has not
+ *       changed (issue #514 fix in {@code collectDiff}).</li>
+ *   <li>When a scan sees new ACTIVE segments <em>and</em> existing DEPRECATED
+ *       segments in the same tick, all {@code onSegmentAssigned} events are
+ *       delivered before any {@code onSegmentReleased} event — preventing a
+ *       zero-segment search window.</li>
+ * </ol>
+ *
+ * <p>Uses a real {@code TestingServer} ZooKeeper — no mocking. No BookKeeper,
+ * no ZKTestEnv, so no {@code @Category(ClusterTest.class)} needed.
+ */
+public class SegmentAssignmentWatcherDeprecationDiffTest {
+
+    private static final String BASE_PATH = "/herd-test-deprecation-diff";
+    private static final String TS_UUID = "ts-514-diff";
+    private static final String IDX_UUID = "idx-514-diff";
+    private static final int OWNER = 1;
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+    private SegmentRegistryClient registry;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30_000, ev -> {
+            if (ev.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue("ZK connect timed out", connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registry = new SegmentRegistryClient(() -> zk, BASE_PATH);
+        registry.ensureRoot();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Build an ACTIVE segment owned by {@link #OWNER} in the default index. */
+    private static SegmentMetadata activeSegment(String uuid, long segId) {
+        return buildSegment(uuid, segId, TS_UUID, IDX_UUID);
+    }
+
+    /** Build an ACTIVE segment owned by {@link #OWNER} in the given tablespace/index. */
+    private static SegmentMetadata buildSegment(String uuid, long segId,
+            String tsUuid, String idxUuid) {
+        return SegmentMetadata.builder()
+                .segmentUuid(uuid).tablespaceUuid(tsUuid).tableName("docs")
+                .indexUuid(idxUuid).indexName("docs_v1")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(OWNER)
+                .segmentId(segId)
+                .graphPath(idxUuid + "_seg" + segId + "_graph")
+                .mapPath(idxUuid + "_seg" + segId + "_map")
+                .sizeBytes(1000L).mapFileSize(100L).vectorCount(10L)
+                .generation(1L).createdAtEpochMillis(0L)
+                .baseLsn(new LogSequenceNumber(1L, segId))
+                .build();
+    }
+
+    private static SegmentMetadata deprecate(SegmentMetadata m) {
+        return m.toBuilder().state(SegmentState.DEPRECATED).build();
+    }
+
+    private VersionedSegmentMetadata getVersioned(String segUuid) throws Exception {
+        return registry.getSegment(TS_UUID, IDX_UUID, segUuid).orElseThrow();
+    }
+
+    private VersionedSegmentMetadata getVersioned(String tsUuid, String idxUuid,
+            String segUuid) throws Exception {
+        return registry.getSegment(tsUuid, idxUuid, segUuid).orElseThrow();
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1: ACTIVE → DEPRECATED triggers onSegmentReleased
+    // -------------------------------------------------------------------------
+
+    /**
+     * A single owned ACTIVE segment that transitions to DEPRECATED must fire
+     * {@code onSegmentReleased}, even though the {@code ownerInstanceId} does
+     * not change.
+     */
+    @Test
+    public void deprecatedTransitionFiresRelease() throws Exception {
+        SegmentMetadata seg = activeSegment("seg-dep-1", 101L);
+        registry.createSegment(seg);
+
+        List<String> assigned = new ArrayList<>();
+        List<String> released = new ArrayList<>();
+
+        SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                registry, OWNER,
+                new SegmentAssignmentListener() {
+                    @Override
+                    public void onSegmentAssigned(VersionedSegmentMetadata vsm) {
+                        assigned.add(vsm.metadata().getSegmentUuid());
+                    }
+                    @Override
+                    public void onSegmentReleased(SegmentMetadata previous) {
+                        released.add(previous == null ? "<null>" : previous.getSegmentUuid());
+                    }
+                });
+        try {
+            // Initial scan: segment is ACTIVE, owned by OWNER → onSegmentAssigned fires.
+            watcher.watchIndex(TS_UUID, IDX_UUID);
+            assertEquals("initial scan: 1 assignment", 1, assigned.size());
+            assertEquals("seg-dep-1", assigned.get(0));
+            assertEquals("initial scan: 0 releases", 0, released.size());
+
+            // Transition the segment to DEPRECATED.
+            VersionedSegmentMetadata v = getVersioned("seg-dep-1");
+            registry.casUpdateSegment(v, deprecate(seg));
+
+            // Re-scan (as a watcher fire would do).
+            watcher.scanIndex(new SegmentAssignmentWatcher.IndexKey(TS_UUID, IDX_UUID));
+
+            assertEquals("after deprecation: still 1 assignment (no new segment)", 1, assigned.size());
+            assertEquals("after deprecation: 1 release must fire", 1, released.size());
+            assertEquals("seg-dep-1", released.get(0));
+        } finally {
+            watcher.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: assignments fire before releases in the same scan
+    // -------------------------------------------------------------------------
+
+    /**
+     * When a scan tick sees both a new ACTIVE merged segment and the deprecated
+     * inputs in one go, all {@code onSegmentAssigned} callbacks must be
+     * delivered before any {@code onSegmentReleased} callback.
+     *
+     * <p>The test manufactures this scenario by:
+     * <ol>
+     *   <li>Creating 3 ACTIVE segments and doing an initial scan so the watcher
+     *       populates its {@code known} map (as if those segments had been
+     *       adopted previously).</li>
+     *   <li>Closing the watcher's background executor so no async watcher fires
+     *       can race with the ZK state mutations that follow.</li>
+     *   <li>Deprecating the 3 inputs and creating 1 new ACTIVE merged segment
+     *       — all <em>without</em> any scan running.</li>
+     *   <li>Calling {@link SegmentAssignmentWatcher#scanIndex} directly
+     *       (one synchronous call) and asserting that ALL
+     *       {@code onSegmentAssigned} events precede ALL
+     *       {@code onSegmentReleased} events in the delivered order.</li>
+     * </ol>
+     *
+     * <p>This test uses index-key "idx-order" so it does not share ZK state
+     * with the other tests (which use {@link #IDX_UUID}).
+     */
+    @Test
+    public void assignmentsFireBeforeReleasesInSameScan() throws Exception {
+        final String ts  = "ts-order";
+        final String idx = "idx-order";
+
+        // Create 3 ACTIVE owned segments in ZK.
+        SegmentMetadata seg1 = buildSegment("seg-ord-1", 201L, ts, idx);
+        SegmentMetadata seg2 = buildSegment("seg-ord-2", 202L, ts, idx);
+        SegmentMetadata seg3 = buildSegment("seg-ord-3", 203L, ts, idx);
+        registry.createSegment(seg1);
+        registry.createSegment(seg2);
+        registry.createSegment(seg3);
+
+        List<String> eventOrder = new ArrayList<>();
+        List<String> assigned = new ArrayList<>();
+        List<String> released = new ArrayList<>();
+
+        SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                registry, OWNER,
+                new SegmentAssignmentListener() {
+                    @Override
+                    public void onSegmentAssigned(VersionedSegmentMetadata vsm) {
+                        assigned.add(vsm.metadata().getSegmentUuid());
+                        eventOrder.add("ASSIGN:" + vsm.metadata().getSegmentUuid());
+                    }
+                    @Override
+                    public void onSegmentReleased(SegmentMetadata previous) {
+                        String uuid = previous == null ? "<null>" : previous.getSegmentUuid();
+                        released.add(uuid);
+                        eventOrder.add("RELEASE:" + uuid);
+                    }
+                });
+        try {
+            // Initial scan: 3 ACTIVE, all owned → 3 assignments; populates known.
+            watcher.watchIndex(ts, idx);
+            assertEquals("initial scan: 3 assignments", 3, assigned.size());
+            assertEquals("initial scan: 0 releases", 0, released.size());
+            eventOrder.clear();
+
+            // Close the watcher so no async ZK watcher fires can run between
+            // the state mutations below and the direct scanIndex call.
+            // After close(), dispatchScan short-circuits (closed=true), so
+            // the ZK events from casUpdate fire but are silently discarded.
+            // scanIndex itself does NOT check closed, so the direct call below
+            // still executes.
+            watcher.close();
+
+            // Simulate what the optimizer does atomically from the watcher's
+            // point of view: deprecate 3 inputs, create 1 new merged segment.
+            VersionedSegmentMetadata v1 = getVersioned(ts, idx, "seg-ord-1");
+            VersionedSegmentMetadata v2 = getVersioned(ts, idx, "seg-ord-2");
+            VersionedSegmentMetadata v3 = getVersioned(ts, idx, "seg-ord-3");
+            registry.casUpdateSegment(v1, deprecate(seg1));
+            registry.casUpdateSegment(v2, deprecate(seg2));
+            registry.casUpdateSegment(v3, deprecate(seg3));
+
+            SegmentMetadata merged = buildSegment("seg-merged", 204L, ts, idx);
+            registry.createSegment(merged);
+
+            // Single direct scan — no async interference.
+            watcher.scanIndex(new SegmentAssignmentWatcher.IndexKey(ts, idx));
+
+            // Verify: 1 new assignment (the merged segment) happened.
+            assertTrue("merged segment must be assigned", assigned.contains("seg-merged"));
+            // Verify: 3 releases.
+            assertEquals("3 deprecated segments must be released", 3, released.size());
+
+            // CRITICAL ordering: all ASSIGN events must precede all RELEASE events.
+            int lastAssignIdx = -1;
+            int firstReleaseIdx = Integer.MAX_VALUE;
+            for (int i = 0; i < eventOrder.size(); i++) {
+                String e = eventOrder.get(i);
+                if (e.startsWith("ASSIGN:")) {
+                    lastAssignIdx = i;
+                } else if (e.startsWith("RELEASE:")) {
+                    if (i < firstReleaseIdx) {
+                        firstReleaseIdx = i;
+                    }
+                }
+            }
+            assertTrue("all ASSIGN events must come before any RELEASE event; order was: "
+                            + eventOrder,
+                    lastAssignIdx < firstReleaseIdx);
+        } finally {
+            // close() is idempotent; watcher may already be closed above.
+            try {
+                watcher.close();
+            } catch (Exception ignored) {
+                // Intentional: second close() after deliberate first close() above.
+            }
+        }
+    }
+
+    /**
+     * Corner case: a segment that is NOT owned by this instance transitioning
+     * to DEPRECATED must NOT fire onSegmentReleased.
+     */
+    @Test
+    public void deprecationOfUnownedSegmentDoesNotFireRelease() throws Exception {
+        int otherOwner = OWNER + 1;
+        SegmentMetadata seg = SegmentMetadata.builder()
+                .segmentUuid("seg-other").tablespaceUuid(TS_UUID).tableName("docs")
+                .indexUuid(IDX_UUID).indexName("docs_v1")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(otherOwner)   // owned by a DIFFERENT instance
+                .segmentId(301L)
+                .graphPath(IDX_UUID + "_seg301_graph")
+                .mapPath(IDX_UUID + "_seg301_map")
+                .sizeBytes(500L).mapFileSize(50L).vectorCount(5L)
+                .generation(1L).createdAtEpochMillis(0L)
+                .baseLsn(new LogSequenceNumber(1L, 301L))
+                .build();
+        registry.createSegment(seg);
+
+        List<String> released = new ArrayList<>();
+
+        SegmentAssignmentWatcher watcher = new SegmentAssignmentWatcher(
+                registry, OWNER,  // instance OWNER watches, but seg is owned by otherOwner
+                new SegmentAssignmentListener() {
+                    @Override
+                    public void onSegmentReleased(SegmentMetadata previous) {
+                        released.add(previous == null ? "<null>" : previous.getSegmentUuid());
+                    }
+                });
+        try {
+            watcher.watchIndex(TS_UUID, IDX_UUID);
+
+            // Transition unowned segment to DEPRECATED.
+            VersionedSegmentMetadata v = getVersioned("seg-other");
+            registry.casUpdateSegment(v,
+                    seg.toBuilder().state(SegmentState.DEPRECATED).build());
+            watcher.scanIndex(new SegmentAssignmentWatcher.IndexKey(TS_UUID, IDX_UUID));
+
+            assertEquals("unowned segment deprecation must NOT fire onSegmentReleased",
+                    0, released.size());
+        } finally {
+            watcher.close();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentOwnershipTransferTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentOwnershipTransferTest.java
@@ -243,7 +243,10 @@ public class SegmentOwnershipTransferTest {
 
             VersionedSegmentMetadata current = registry.getSegment(TS_UUID, IDX_UUID, SEG_UUID).orElseThrow();
             registry.casDeleteSegment(current);
-            waitFor(() -> l0.events.contains("RELEASED:<deleted>"));
+            // The watcher passes the cached pre-deletion metadata (not null) so that
+            // downstream listeners (e.g. IndexingServiceEngine) can identify which segment
+            // was removed and call dropSegmentByUuid on it.
+            waitFor(() -> l0.events.contains("RELEASED:" + SEG_UUID));
         }
     }
 


### PR DESCRIPTION
Fixes #514.

## Changes

- **`VectorSegment`**: added `externalStorageKey` field so optimizer-produced
  segments (with 63-bit long IDs) are stored under the correct multipart key
  instead of the legacy `int`-based key.

- **`AbstractVectorStore`**: added default no-op `adoptExternalSegment` (returns
  `boolean`) and `dropSegmentByUuid` so the IS engine can call these through the
  abstract type.

- **`PersistentVectorStore`**: full implementation of `adoptExternalSegment` and
  `dropSegmentByUuid`; `segmentStorageKey()` helper that selects between the
  external key and the legacy int key; `getOnDiskSegmentCount()` helper for tests.
  The IO section in `adoptExternalSegment` clears the thread interrupt flag before
  NIO FileChannel reads (prevents spurious `ClosedByInterruptException` when the
  watcher dispatch thread inherits a stale interrupt from a co-running task).

- **`SegmentAssignmentWatcher`**: fixed `applyDiff` to fire `onSegmentReleased`
  when a previously-owned segment transitions to `DEPRECATED` or `DELETED` state
  (before this fix the state change was silently ignored because `ownerInstanceId`
  does not change on deprecation).

- **`IndexingServiceEngine`**: creates and lifecycle-manages one
  `SegmentAssignmentWatcher` per vector store when the engine is configured with
  a segment registry. The listener calls `adoptExternalSegment` on `ASSIGNED`
  events and `dropSegmentByUuid` on `RELEASED` events.

## Tests

- **`OptimizerMergeAdoptionRecallTest`** (new): end-to-end integration test that
  ingests all 10 000 siftsmall vectors in 3 equal batches (each followed by a
  `checkpoint()`), runs `IndexOptimizerEngine.runOnce()` to collapse all 3
  segments into 1 via `RemoteSegmentMerger`, waits for the watcher to fire, and
  asserts: segment count == 1, at least 1 adoption, at least 3 drops, recall@10
  ≥ 0.70, recall@100 ≥ 0.70.  Uses its own `TestingServer` ZooKeeper and
  `FileDataStorageManager` (no BookKeeper, no `@Category(ClusterTest.class)`).
  Verified stable across 8 consecutive runs alongside all other indexing-service
  tests.

🤖 Implemented by the `pr-worker` agent.