### PR TITLE
issue #516: read per-index jvector config from checkpoint metadata on remote file server

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexMergeConfig.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexMergeConfig.java
@@ -1,0 +1,85 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.util.Objects;
+
+/**
+ * Immutable bundle of jvector build parameters for a single vector index.
+ * Used by {@link IndexMergeConfigProvider} to supply per-index configuration
+ * to {@link RemoteSegmentMerger} at merge time (issue #516).
+ *
+ * <p>Note: {@code dim} (vector dimension) is intentionally absent — it is read
+ * at merge time by peeking the first entry of the first input map file
+ * ({@link RemoteSegmentMerger#peekDimFromMapFile}). This avoids requiring
+ * any external service to know the dimension: it is always embedded in the
+ * map file binary format.
+ *
+ * <p>All fields must be positive / non-null. Callers that receive an
+ * {@code IndexMergeConfig} from a provider may assume the invariants hold
+ * (providers validate before returning).
+ */
+public final class IndexMergeConfig {
+
+    /** jvector graph degree (edges per node, must be &gt; 0). */
+    public final int graphM;
+    /** jvector beam-width during graph build (must be &gt; 0). */
+    public final int beamWidth;
+    /** jvector neighbor-overflow factor (must be &gt; 0). */
+    public final float neighborOverflow;
+    /** jvector alpha factor (must be &gt; 0). */
+    public final float alpha;
+    /** Vector similarity function (must not be null). */
+    public final VectorSimilarityFunction similarity;
+
+    public IndexMergeConfig(int graphM, int beamWidth,
+                            float neighborOverflow, float alpha,
+                            VectorSimilarityFunction similarity) {
+        if (graphM <= 0) {
+            throw new IllegalArgumentException("graphM must be positive: " + graphM);
+        }
+        if (beamWidth <= 0) {
+            throw new IllegalArgumentException("beamWidth must be positive: " + beamWidth);
+        }
+        if (neighborOverflow <= 0f) {
+            throw new IllegalArgumentException("neighborOverflow must be positive: " + neighborOverflow);
+        }
+        if (alpha <= 0f) {
+            throw new IllegalArgumentException("alpha must be positive: " + alpha);
+        }
+        this.graphM = graphM;
+        this.beamWidth = beamWidth;
+        this.neighborOverflow = neighborOverflow;
+        this.alpha = alpha;
+        this.similarity = Objects.requireNonNull(similarity, "similarity");
+    }
+
+    @Override
+    public String toString() {
+        return "IndexMergeConfig{"
+                + "graphM=" + graphM
+                + ", beamWidth=" + beamWidth
+                + ", neighborOverflow=" + neighborOverflow
+                + ", alpha=" + alpha
+                + ", similarity=" + similarity
+                + '}';
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexMergeConfigProvider.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexMergeConfigProvider.java
@@ -1,0 +1,53 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+/**
+ * Per-index source of jvector build parameters for the index optimizer (issue #516).
+ *
+ * <p>The optimizer calls {@link #getMergeConfig} once per merge run, using the
+ * first input segment's identifiers to look up the configuration. Implementations
+ * may cache results and refresh them periodically so that parameter changes
+ * (e.g. a change in {@code dim} when the index is rebuilt with a different
+ * embedding model) are picked up without a pod restart.
+ *
+ * <p>Implementations MUST be thread-safe. The optimizer's single-threaded
+ * scheduler is the only caller in production, but tests may call from multiple
+ * threads.
+ */
+public interface IndexMergeConfigProvider {
+
+    /**
+     * Returns the merge configuration for the given index.
+     *
+     * @param tablespace  human-readable tablespace name (e.g. {@code "herd"})
+     * @param tableName   human-readable table name
+     * @param indexName   human-readable index name
+     * @param indexUuid   stable UUID of the index (used for caching)
+     * @return the resolved configuration — never {@code null}
+     * @throws Exception if the configuration cannot be resolved (e.g. the IS
+     *                   is unreachable, or the index does not expose a usable
+     *                   dimension). The optimizer engine catches this, logs it,
+     *                   and skips the index for this tick.
+     */
+    IndexMergeConfig getMergeConfig(String tablespace, String tableName,
+                                    String indexName, String indexUuid)
+            throws Exception;
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -28,7 +28,6 @@ import herddb.server.RemoteFileClient;
 import herddb.server.RemoteFileServiceFactory;
 import herddb.server.ServerConfiguration;
 import herddb.storage.DataStorageManager;
-import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,7 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -893,40 +891,6 @@ public final class IndexOptimizerMain {
                         OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES,
                         OptimizerConfiguration.PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES_DEFAULT));
 
-        // Validate all configuration BEFORE allocating any resources (gRPC channel,
-        // DataStorageManager) to avoid resource leaks when validation fails. Previously
-        // the dim check came after factory.createClient(), leaking a file client on every
-        // failed call (issue #507, reviewer finding).
-        int dim = configuration.getInt("indexoptimizer.merge.dim", 0);
-        if (dim <= 0) {
-            // The merger needs the dimension up front. Fall back: we don't
-            // currently store dim in the segment registry, so operators must
-            // configure it explicitly. If it's missing we refuse to merge.
-            throw new IllegalStateException("indexoptimizer.merge.dim must be set to the index"
-                    + " vector dimension (no inference is currently supported)");
-        }
-        int graphM = configuration.getInt(OptimizerConfiguration.PROPERTY_MERGE_M,
-                OptimizerConfiguration.PROPERTY_MERGE_M_DEFAULT);
-        int beamWidth = configuration.getInt(OptimizerConfiguration.PROPERTY_MERGE_BEAM_WIDTH,
-                OptimizerConfiguration.PROPERTY_MERGE_BEAM_WIDTH_DEFAULT);
-        float neighborOverflow = configuration.getFloat(
-                OptimizerConfiguration.PROPERTY_MERGE_NEIGHBOR_OVERFLOW,
-                OptimizerConfiguration.PROPERTY_MERGE_NEIGHBOR_OVERFLOW_DEFAULT);
-        float alpha = configuration.getFloat(OptimizerConfiguration.PROPERTY_MERGE_ALPHA,
-                OptimizerConfiguration.PROPERTY_MERGE_ALPHA_DEFAULT);
-        String similarityName = configuration.getString(
-                OptimizerConfiguration.PROPERTY_MERGE_SIMILARITY,
-                OptimizerConfiguration.PROPERTY_MERGE_SIMILARITY_DEFAULT);
-        VectorSimilarityFunction similarity;
-        try {
-            similarity = VectorSimilarityFunction.valueOf(similarityName);
-        } catch (IllegalArgumentException badName) {
-            throw new IllegalStateException(
-                    "indexoptimizer.merge.similarity has unsupported value: " + similarityName
-                            + " (expected one of " + Arrays.toString(VectorSimilarityFunction.values())
-                            + ")", badName);
-        }
-
         RemoteFileServiceFactory factory = RemoteFileServiceFactory.load();
         this.mergerFileClient = factory.createClient(servers, clientConfig);
         Path tmpDir = resolveTmpDirectory();
@@ -937,8 +901,17 @@ public final class IndexOptimizerMain {
         this.mergerDataStorageManager = factory.createDataStorageManager(
                 metaDir, remoteTmp, Integer.MAX_VALUE, mergerFileClient);
 
-        return new RemoteSegmentMerger(mergerDataStorageManager, tmpDir,
-                dim, graphM, beamWidth, neighborOverflow, alpha, similarity);
+        // Build the config provider that reads per-index jvector build parameters
+        // directly from the checkpoint metadata on the remote file server (issue #516).
+        // This avoids any dependency on IS liveness — the remote file server is
+        // always available as long as the HerdDB leader has completed at least one
+        // checkpoint.
+        IndexMergeConfigProvider configProvider =
+                new RemoteMetadataIndexMergeConfigProvider(mergerFileClient, tablespaceUuid);
+        LOGGER.log(Level.INFO,
+                "index merge config provider: RemoteMetadataIndexMergeConfigProvider"
+                + " (tablespaceUuid={0})", tablespaceUuid);
+        return new RemoteSegmentMerger(mergerDataStorageManager, tmpDir, configProvider);
     }
 
     private Path resolveTmpDirectory() throws IOException {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -132,10 +132,6 @@ public final class OptimizerConfiguration {
     public static final String PROPERTY_EVENT_DEBOUNCE_MS = "indexoptimizer.event.debounce.ms";
     public static final long PROPERTY_EVENT_DEBOUNCE_MS_DEFAULT = 500L;
 
-    // jvector params used by the merger when rebuilding the merged graph.
-    // Defaults aligned to {@code PersistentVectorStore} so the merged segment
-    // has the same recall characteristics as in-IS-built segments.
-
     /**
      * Streaming compaction (issue #485). When {@code true}, the optimizer
      * pod drives the merge through jvector's
@@ -157,32 +153,6 @@ public final class OptimizerConfiguration {
     public static final String PROPERTY_MERGE_STREAMING_ENABLED =
             "indexoptimizer.merge.streaming.enabled";
     public static final boolean PROPERTY_MERGE_STREAMING_ENABLED_DEFAULT = true;
-
-    /** jvector graph degree (edges per node). */
-    public static final String PROPERTY_MERGE_M = "indexoptimizer.merge.M";
-    public static final int PROPERTY_MERGE_M_DEFAULT = 16;
-
-    /** jvector beam-width during graph build. */
-    public static final String PROPERTY_MERGE_BEAM_WIDTH = "indexoptimizer.merge.beamWidth";
-    public static final int PROPERTY_MERGE_BEAM_WIDTH_DEFAULT = 100;
-
-    /** jvector neighbor-overflow factor during graph build. */
-    public static final String PROPERTY_MERGE_NEIGHBOR_OVERFLOW = "indexoptimizer.merge.neighborOverflow";
-    public static final float PROPERTY_MERGE_NEIGHBOR_OVERFLOW_DEFAULT = 1.2f;
-
-    /** jvector alpha factor during graph build. */
-    public static final String PROPERTY_MERGE_ALPHA = "indexoptimizer.merge.alpha";
-    public static final float PROPERTY_MERGE_ALPHA_DEFAULT = 1.4f;
-
-    /**
-     * Vector similarity used by the merger. Must match the value used by the
-     * IS that produced the inputs, otherwise PQ training and graph
-     * construction will be incoherent. Accepted values match
-     * {@code io.github.jbellis.jvector.vector.VectorSimilarityFunction}:
-     * {@code DOT_PRODUCT}, {@code COSINE}, {@code EUCLIDEAN}.
-     */
-    public static final String PROPERTY_MERGE_SIMILARITY = "indexoptimizer.merge.similarity";
-    public static final String PROPERTY_MERGE_SIMILARITY_DEFAULT = "DOT_PRODUCT";
 
     // -------------------------------------------------------------------------
     // Remote file service client (issue #484: merger needs a DataStorageManager

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteMetadataIndexMergeConfigProvider.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteMetadataIndexMergeConfigProvider.java
@@ -1,0 +1,386 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import herddb.index.vector.VectorIndexManager;
+import herddb.log.LogSequenceNumber;
+import herddb.model.Index;
+import herddb.server.RemoteFileClient;
+import herddb.utils.ExtendedDataInputStream;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link IndexMergeConfigProvider} that reads per-index jvector build
+ * parameters directly from the checkpoint metadata stored on the remote file
+ * server (issue #516).
+ *
+ * <h3>Metadata source</h3>
+ * <p>On every HerdDB checkpoint the leader publishes two files to the remote
+ * file server (S3 / MinIO):
+ * <ol>
+ *   <li>{@code {tablespaceUuid}/_metadata/latest.checkpoint} — the LSN of the
+ *       most recent committed checkpoint.</li>
+ *   <li>{@code {tablespaceUuid}/_metadata/indexes.{ledger}.{offset}.tablesmetadata}
+ *       — a binary blob containing all {@link Index} definitions at that LSN,
+ *       including the full {@code properties} map from the original
+ *       {@code CREATE VECTOR INDEX ... WITH (...)} DDL.</li>
+ * </ol>
+ * <p>The {@code properties} map contains the keys defined in
+ * {@link VectorIndexManager}: {@code m}, {@code beamWidth},
+ * {@code neighborOverflow}, {@code alpha}, {@code similarity}.
+ * These are exactly the parameters needed by {@link RemoteSegmentMerger} to
+ * rebuild the merged graph with the same characteristics as the original
+ * in-IS segments.
+ *
+ * <h3>Why not the IS gRPC API?</h3>
+ * <p>The IS may be in a degraded state — that is often exactly why the
+ * optimizer is running a merge. Reading from the remote file server avoids any
+ * dependency on IS liveness: if the HerdDB leader has checkpointed at least
+ * once, the metadata is available.
+ *
+ * <h3>Caching</h3>
+ * <p>Results are cached per {@code indexUuid} with a configurable TTL
+ * (default {@value #DEFAULT_CACHE_TTL_MS} ms). A cache miss triggers a
+ * fresh read of the latest checkpoint LSN followed by a read of the index
+ * definitions file. This is a small number of remote reads (two short files)
+ * and happens at most once per TTL per index.
+ *
+ * <h3>Error semantics</h3>
+ * <p>If the required property ({@code m}, {@code beamWidth}, etc.) is absent
+ * from the index definition, this method throws {@link Exception} with a clear
+ * message naming the missing key and the index. There is no fallback to
+ * global defaults: a missing property indicates a misconfigured index and
+ * must be fixed at the DDL level.
+ *
+ * <h3>Thread safety</h3>
+ * <p>Safe for concurrent reads. The cache uses {@link ConcurrentHashMap}.
+ */
+public final class RemoteMetadataIndexMergeConfigProvider
+        implements IndexMergeConfigProvider {
+
+    private static final Logger LOGGER =
+            Logger.getLogger(RemoteMetadataIndexMergeConfigProvider.class.getName());
+
+    /** Default cache TTL: 5 minutes. */
+    public static final long DEFAULT_CACHE_TTL_MS = 5L * 60_000L;
+
+    private final RemoteFileClient fileClient;
+    private final String tablespaceUuid;
+    private final long cacheTtlMs;
+
+    /** Cache entries keyed by indexUuid. */
+    private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    private static final class CacheEntry {
+        final IndexMergeConfig config;
+        final long expiresAtMs;
+
+        CacheEntry(IndexMergeConfig config, long expiresAtMs) {
+            this.config = config;
+            this.expiresAtMs = expiresAtMs;
+        }
+    }
+
+    /**
+     * @param fileClient     remote file client used to read checkpoint metadata
+     * @param tablespaceUuid UUID of the tablespace the optimizer manages
+     * @param cacheTtlMs     how long a cached config entry is valid (ms);
+     *                       pass {@code <= 0} to use the default 5-minute TTL
+     */
+    public RemoteMetadataIndexMergeConfigProvider(RemoteFileClient fileClient,
+                                                  String tablespaceUuid,
+                                                  long cacheTtlMs) {
+        this.fileClient = Objects.requireNonNull(fileClient, "fileClient");
+        this.tablespaceUuid = Objects.requireNonNull(tablespaceUuid, "tablespaceUuid");
+        this.cacheTtlMs = cacheTtlMs > 0 ? cacheTtlMs : DEFAULT_CACHE_TTL_MS;
+    }
+
+    /** Convenience constructor using the default cache TTL. */
+    public RemoteMetadataIndexMergeConfigProvider(RemoteFileClient fileClient,
+                                                  String tablespaceUuid) {
+        this(fileClient, tablespaceUuid, DEFAULT_CACHE_TTL_MS);
+    }
+
+    @Override
+    public IndexMergeConfig getMergeConfig(String tablespace, String tableName,
+                                           String indexName, String indexUuid)
+            throws Exception {
+        long now = System.currentTimeMillis();
+        CacheEntry entry = cache.get(indexUuid);
+        if (entry != null && now < entry.expiresAtMs) {
+            return entry.config;
+        }
+        IndexMergeConfig fresh = fetchFromRemoteMetadata(tableName, indexName, indexUuid);
+        cache.put(indexUuid, new CacheEntry(fresh, now + cacheTtlMs));
+        return fresh;
+    }
+
+    /**
+     * Invalidates the entire cache. Useful after a ZK reconnect or an explicit
+     * operator request to force re-reading configs from the remote file server.
+     */
+    public void invalidateCache() {
+        cache.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal implementation
+    // -------------------------------------------------------------------------
+
+    private IndexMergeConfig fetchFromRemoteMetadata(String tableName,
+                                                     String indexName,
+                                                     String indexUuid) throws Exception {
+        LogSequenceNumber lsn = readLatestCheckpointLsn();
+        if (lsn.isStartOfTime()) {
+            throw new Exception(
+                    "No checkpoint has been published yet for tablespace " + tablespaceUuid
+                    + " on the remote file server. The HerdDB leader must complete at least"
+                    + " one checkpoint before the optimizer can resolve index build parameters.");
+        }
+        List<Index> indexes = readIndexDefinitions(lsn);
+        // Find the index by UUID (primary key) then by name as a fallback for
+        // deployments where the UUID may not be set in older metadata snapshots.
+        Index found = null;
+        for (Index idx : indexes) {
+            if (indexUuid.equals(idx.uuid)) {
+                found = idx;
+                break;
+            }
+        }
+        if (found == null) {
+            // Fallback: match by (table, indexName) in case the UUID changed.
+            for (Index idx : indexes) {
+                if (tableName.equals(idx.table) && indexName.equals(idx.name)) {
+                    found = idx;
+                    LOGGER.log(Level.FINE,
+                            "found index {0}.{1} by name (uuid mismatch: stored={2}, wanted={3})",
+                            new Object[]{tableName, indexName, idx.uuid, indexUuid});
+                    break;
+                }
+            }
+        }
+        if (found == null) {
+            throw new Exception(
+                    "Index not found in checkpoint metadata for tablespace " + tablespaceUuid
+                    + " at LSN " + lsn + ": table=" + tableName + ", index=" + indexName
+                    + ", uuid=" + indexUuid + ". Available indexes: " + summarizeIndexes(indexes));
+        }
+        return parseConfig(found);
+    }
+
+    /**
+     * Parses jvector build parameters from {@code Index.properties}. Throws
+     * {@link Exception} for any required property that is absent or invalid —
+     * no fallback to defaults is applied.
+     */
+    private static IndexMergeConfig parseConfig(Index idx) throws Exception {
+        int graphM = requirePositiveInt(idx, VectorIndexManager.PROP_M);
+        int beamWidth = requirePositiveInt(idx, VectorIndexManager.PROP_BEAM_WIDTH);
+        float neighborOverflow = requirePositiveFloat(idx, VectorIndexManager.PROP_NEIGHBOR_OVERFLOW);
+        float alpha = requirePositiveFloat(idx, VectorIndexManager.PROP_ALPHA);
+        String similarityName = requireNonEmptyString(idx, VectorIndexManager.PROP_SIMILARITY);
+        VectorSimilarityFunction similarity;
+        try {
+            similarity = VectorSimilarityFunction.valueOf(similarityName);
+        } catch (IllegalArgumentException badName) {
+            throw new Exception(
+                    "Index " + idx.table + "." + idx.name + " (uuid=" + idx.uuid + ")"
+                    + " has unsupported similarity '" + similarityName
+                    + "' (expected one of "
+                    + Arrays.toString(VectorSimilarityFunction.values()) + ")",
+                    badName);
+        }
+        IndexMergeConfig config = new IndexMergeConfig(graphM, beamWidth, neighborOverflow, alpha, similarity);
+        LOGGER.log(Level.INFO,
+                "resolved merge config for index {0}.{1} (uuid={2}): {3}",
+                new Object[]{idx.table, idx.name, idx.uuid, config});
+        return config;
+    }
+
+    private static int requirePositiveInt(Index idx, String key) throws Exception {
+        String raw = idx.properties == null ? null : idx.properties.get(key);
+        if (raw == null || raw.isEmpty()) {
+            throw new Exception(
+                    "Required property '" + key + "' is absent from index "
+                    + idx.table + "." + idx.name + " (uuid=" + idx.uuid + ")."
+                    + " Check the CREATE VECTOR INDEX DDL for this index.");
+        }
+        try {
+            int val = Integer.parseInt(raw);
+            if (val <= 0) {
+                throw new Exception(
+                        "Property '" + key + "' must be positive, got " + val
+                        + " for index " + idx.table + "." + idx.name
+                        + " (uuid=" + idx.uuid + ").");
+            }
+            return val;
+        } catch (NumberFormatException e) {
+            throw new Exception(
+                    "Property '" + key + "' is not a valid integer ('" + raw + "')"
+                    + " for index " + idx.table + "." + idx.name
+                    + " (uuid=" + idx.uuid + ").", e);
+        }
+    }
+
+    private static float requirePositiveFloat(Index idx, String key) throws Exception {
+        String raw = idx.properties == null ? null : idx.properties.get(key);
+        if (raw == null || raw.isEmpty()) {
+            throw new Exception(
+                    "Required property '" + key + "' is absent from index "
+                    + idx.table + "." + idx.name + " (uuid=" + idx.uuid + ")."
+                    + " Check the CREATE VECTOR INDEX DDL for this index.");
+        }
+        try {
+            float val = Float.parseFloat(raw);
+            if (val <= 0f) {
+                throw new Exception(
+                        "Property '" + key + "' must be positive, got " + val
+                        + " for index " + idx.table + "." + idx.name
+                        + " (uuid=" + idx.uuid + ").");
+            }
+            return val;
+        } catch (NumberFormatException e) {
+            throw new Exception(
+                    "Property '" + key + "' is not a valid float ('" + raw + "')"
+                    + " for index " + idx.table + "." + idx.name
+                    + " (uuid=" + idx.uuid + ").", e);
+        }
+    }
+
+    private static String requireNonEmptyString(Index idx, String key) throws Exception {
+        String val = idx.properties == null ? null : idx.properties.get(key);
+        if (val == null || val.isEmpty()) {
+            throw new Exception(
+                    "Required property '" + key + "' is absent from index "
+                    + idx.table + "." + idx.name + " (uuid=" + idx.uuid + ")."
+                    + " Check the CREATE VECTOR INDEX DDL for this index.");
+        }
+        return val;
+    }
+
+    // -------------------------------------------------------------------------
+    // Remote-file metadata read helpers
+    // (binary format mirrors SharedCheckpointMetadataManager)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads the latest committed checkpoint LSN from
+     * {@code {tablespaceUuid}/_metadata/latest.checkpoint}.
+     * Returns {@link LogSequenceNumber#START_OF_TIME} when the file is absent
+     * (no checkpoint yet).
+     */
+    LogSequenceNumber readLatestCheckpointLsn() throws Exception {
+        String path = tablespaceUuid + "/_metadata/latest.checkpoint";
+        byte[] data;
+        try {
+            data = fileClient.readFile(path);
+        } catch (RuntimeException e) {
+            // RemoteFileClient.readFile() wraps I/O failures in RuntimeException.
+            throw new Exception("Failed to read latest checkpoint LSN from "
+                    + path + ": " + e.getMessage(), e);
+        }
+        if (data == null) {
+            return LogSequenceNumber.START_OF_TIME;
+        }
+        try (BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(data));
+             ExtendedDataInputStream din = new ExtendedDataInputStream(bis)) {
+            long version = din.readVLong();
+            long flags = din.readVLong();
+            if (version != 1 || flags != 0) {
+                throw new Exception("Corrupted latest.checkpoint file at " + path
+                        + " (version=" + version + ", flags=" + flags + ")");
+            }
+            din.readUTF(); // tablespace name (informational)
+            long ledgerId = din.readZLong();
+            long offset = din.readZLong();
+            return new LogSequenceNumber(ledgerId, offset);
+        } catch (IOException e) {
+            throw new Exception("Failed to parse latest.checkpoint from " + path, e);
+        }
+    }
+
+    /**
+     * Reads the list of {@link Index} definitions from
+     * {@code {tablespaceUuid}/_metadata/indexes.{lsn}.tablesmetadata}.
+     */
+    List<Index> readIndexDefinitions(LogSequenceNumber lsn) throws Exception {
+        String path = tablespaceUuid + "/_metadata/indexes."
+                + lsn.ledgerId + "." + lsn.offset + ".tablesmetadata";
+        byte[] data;
+        try {
+            data = fileClient.readFile(path);
+        } catch (RuntimeException e) {
+            throw new Exception("Failed to read index definitions from "
+                    + path + ": " + e.getMessage(), e);
+        }
+        if (data == null) {
+            if (lsn.isStartOfTime()) {
+                return new ArrayList<>();
+            }
+            throw new Exception("Index definitions file not found at " + path
+                    + ". The remote file server may be missing data for checkpoint LSN " + lsn + ".");
+        }
+        try (BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(data));
+             ExtendedDataInputStream din = new ExtendedDataInputStream(bis)) {
+            long version = din.readVLong();
+            long flags = din.readVLong();
+            if (version != 1 || flags != 0) {
+                throw new Exception("Corrupted index definitions file at " + path
+                        + " (version=" + version + ", flags=" + flags + ")");
+            }
+            din.readUTF(); // tablespace name (informational)
+            din.readZLong(); // ledgerId (informational)
+            din.readZLong(); // offset (informational)
+            int count = din.readInt();
+            List<Index> result = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                byte[] indexData = din.readArray();
+                result.add(Index.deserialize(indexData));
+            }
+            return result;
+        } catch (IOException e) {
+            throw new Exception("Failed to parse index definitions from " + path, e);
+        }
+    }
+
+    private static String summarizeIndexes(List<Index> indexes) {
+        if (indexes.isEmpty()) {
+            return "(none)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Index idx : indexes) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(idx.table).append('.').append(idx.name).append('(').append(idx.uuid).append(')');
+        }
+        return sb.toString();
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -181,9 +181,9 @@ public final class RemoteSegmentMerger implements SegmentMerger {
             }
         }
 
-        // Resolve per-index config from the provider. This may call the IS gRPC
-        // API on a cache-miss; any Exception bubbles to the engine which logs
-        // it and skips this index for the tick.
+        // Resolve per-index config from the provider. On a cache-miss this reads
+        // checkpoint metadata from the remote file server; any Exception bubbles
+        // to the engine which logs it and skips this index for the tick.
         IndexMergeConfig config = configProvider.getMergeConfig(
                 tablespaceUuid,
                 sample.getTableName(),

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/RemoteSegmentMerger.java
@@ -27,7 +27,8 @@ import herddb.indexing.segment.TombstoneOverlayManager;
 import herddb.log.LogSequenceNumber;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
-import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -42,19 +43,21 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Production {@link SegmentMerger} for the index-optimizer service (issue #484).
+ * Production {@link SegmentMerger} for the index-optimizer service (issue #484,
+ * issue #516).
  *
  * <p>Wraps {@link RemoteSegmentGraphMerger} (the actual graph rebuild) and
  * handles the optimizer-side concerns it doesn't know about:
  * <ul>
+ *   <li>Resolving per-index jvector build parameters via
+ *       {@link IndexMergeConfigProvider} at merge time (issue #516). A new
+ *       {@link RemoteSegmentGraphMerger} is created for each merge call using
+ *       the resolved config, so indexes with different dimensions, similarity
+ *       functions, or graph degrees are all handled correctly.</li>
  *   <li>Loading each input's latest {@code TombstoneOverlay} via
  *       {@link TombstoneOverlayManager#loadOverlay} when the segment carries
  *       a {@code tombstonePath} + a non-zero {@code overlayGeneration}, so
  *       tombstoned ordinals are dropped during the merge.</li>
- *   <li>Inferring the merged segment's {@code (vectorDimension)} from the
- *       inputs (we trust they all share a dimension; mismatches throw).</li>
- *   <li>Allocating a fresh {@code segmentId} as a 63-bit non-negative random
- *       long so the merger's outputs never collide with IS-allocated ids.</li>
  *   <li>Building the output {@link SegmentMetadata}: ACTIVE, fresh UUID,
  *       generation = {@code max(input.generation) + 1}, base LSN = the
  *       latest of the inputs', sizeBytes/vectorCount from the merger output,
@@ -76,45 +79,49 @@ public final class RemoteSegmentMerger implements SegmentMerger {
     private static final Logger LOGGER = Logger.getLogger(RemoteSegmentMerger.class.getName());
     private static final MemoryMXBean MEMORY_MX = ManagementFactory.getMemoryMXBean();
 
-    /**
-     * Vector dimension used by the merger when re-building the graph. Must
-     * match the IS-side index dimension; the optimizer reads it from
-     * configuration because the SegmentMetadata znode does not carry the
-     * dimension as a first-class field.
-     */
-    private final int dim;
-    private final RemoteSegmentGraphMerger graphMerger;
     private final DataStorageManager dataStorageManager;
+    private final Path tmpDirectory;
+    private final IndexMergeConfigProvider configProvider;
+
     /** Cumulative count of merge invocations — exposed for observability tests. */
     private final AtomicLong invocations = new AtomicLong();
+
+    /**
+     * The graph merger built for the most recent {@link #merge} call. Kept
+     * so that:
+     * <ul>
+     *   <li>{@link #getLastMergeTimings()} can delegate to it from the HTTP
+     *       server thread after the merge returns.</li>
+     *   <li>{@link #setMergeProgress} applied before the merge call is
+     *       forwarded to the freshly-constructed merger inside {@link #merge}.</li>
+     * </ul>
+     * Written inside {@link #merge} (single-threaded scheduler); read by the
+     * HTTP server thread — {@code volatile} ensures visibility.
+     */
+    private volatile RemoteSegmentGraphMerger lastGraphMerger;
+
+    /**
+     * Progress holder set by the engine before each {@link #merge} call and
+     * cleared (set to {@code null}) in the engine's {@code finally} block
+     * after the call returns. Stored here so it can be wired into the
+     * per-call {@link RemoteSegmentGraphMerger} that is created inside
+     * {@link #merge}. Written and read on the single-threaded scheduler —
+     * {@code volatile} for visibility to the HTTP server thread.
+     */
+    private volatile MergeProgress pendingProgress;
 
     /**
      * @param dataStorageManager  remote-backed DSM the merger uses to download inputs and
      *                            upload the merged graph + map files
      * @param tmpDirectory        local scratch directory for staging
-     * @param dim                 vector dimension of the index being merged
-     * @param graphM              jvector graph degree
-     * @param beamWidth           jvector beam width during build
-     * @param neighborOverflow    jvector neighbor-overflow factor
-     * @param alpha               jvector alpha factor
-     * @param similarity          vector similarity function (must match the IS that produced the inputs)
+     * @param configProvider      source of per-index jvector build parameters (issue #516)
      */
     public RemoteSegmentMerger(DataStorageManager dataStorageManager,
                                Path tmpDirectory,
-                               int dim,
-                               int graphM,
-                               int beamWidth,
-                               float neighborOverflow,
-                               float alpha,
-                               VectorSimilarityFunction similarity) {
+                               IndexMergeConfigProvider configProvider) {
         this.dataStorageManager = Objects.requireNonNull(dataStorageManager, "dataStorageManager");
-        if (dim <= 0) {
-            throw new IllegalArgumentException("dim must be positive: " + dim);
-        }
-        this.dim = dim;
-        this.graphMerger = new RemoteSegmentGraphMerger(
-                dataStorageManager, tmpDirectory, graphM, beamWidth,
-                neighborOverflow, alpha, similarity);
+        this.tmpDirectory = Objects.requireNonNull(tmpDirectory, "tmpDirectory");
+        this.configProvider = Objects.requireNonNull(configProvider, "configProvider");
     }
 
     public long getInvocationCount() {
@@ -126,34 +133,23 @@ public final class RemoteSegmentMerger implements SegmentMerger {
      * callbacks during the next {@link #merge} call. Pass {@code null} to stop
      * forwarding. Must be called from the same thread that calls {@link #merge}.
      *
-     * <p>Note: this method only wires callbacks into the wrapped
-     * {@link RemoteSegmentGraphMerger}; it does not store {@code progress} as
-     * a field (the lambdas below capture the parameter directly). As a result
-     * the method cannot throw a {@link RuntimeException} in any reachable
-     * execution path — the {@code try/catch} in the engine's {@code finally}
-     * block is a compile-time safety net for hypothetical future subclasses or
-     * overrides, not a code path exercised by the production implementation.
+     * <p>The progress object is stored and then applied to the
+     * {@link RemoteSegmentGraphMerger} that is created at the start of each
+     * {@link #merge} call, so this method may be called before or after
+     * previous merges without risk of cross-contamination.
      */
     public void setMergeProgress(MergeProgress progress) {
-        if (progress != null) {
-            graphMerger.setPhaseListener(progress::updatePhase);
-            graphMerger.setBatchListener((written, total) -> {
-                progress.updateBatchProgress(written, total);
-                return 0L; // return value ignored
-            });
-        } else {
-            graphMerger.setPhaseListener(null);
-            graphMerger.setBatchListener(null);
-        }
+        this.pendingProgress = progress;
     }
 
     /**
      * Returns the per-phase timing breakdown of the last completed merge
-     * (delegated from the wrapped {@link RemoteSegmentGraphMerger}), or
-     * {@code null} if no merge has been performed yet.
+     * (delegated from the most recently created {@link RemoteSegmentGraphMerger}),
+     * or {@code null} if no merge has been performed yet.
      */
     public RemoteSegmentGraphMerger.MergePhaseTimings getLastMergeTimings() {
-        return graphMerger.getLastMergeTimings();
+        RemoteSegmentGraphMerger last = lastGraphMerger;
+        return last != null ? last.getLastMergeTimings() : null;
     }
 
     @Override
@@ -183,6 +179,35 @@ public final class RemoteSegmentMerger implements SegmentMerger {
                         "merger input " + m.getSegmentUuid()
                                 + " has no segmentId — cannot reconstruct multipart path");
             }
+        }
+
+        // Resolve per-index config from the provider. This may call the IS gRPC
+        // API on a cache-miss; any Exception bubbles to the engine which logs
+        // it and skips this index for the tick.
+        IndexMergeConfig config = configProvider.getMergeConfig(
+                tablespaceUuid,
+                sample.getTableName(),
+                sample.getIndexName(),
+                indexUuid);
+
+        // Build a fresh RemoteSegmentGraphMerger for this merge using the
+        // per-index config. Construction is cheap (a few field assignments);
+        // the DataStorageManager is shared.
+        RemoteSegmentGraphMerger graphMerger = new RemoteSegmentGraphMerger(
+                dataStorageManager, tmpDirectory,
+                config.graphM, config.beamWidth,
+                config.neighborOverflow, config.alpha,
+                config.similarity);
+        this.lastGraphMerger = graphMerger;
+
+        // Wire progress callbacks before calling merge.
+        MergeProgress progress = pendingProgress;
+        if (progress != null) {
+            graphMerger.setPhaseListener(progress::updatePhase);
+            graphMerger.setBatchListener((written, total) -> {
+                progress.updateBatchProgress(written, total);
+                return 0L;
+            });
         }
 
         // Translate every SegmentMetadata input into a RemoteSegmentInput,
@@ -248,11 +273,17 @@ public final class RemoteSegmentMerger implements SegmentMerger {
 
         long outputSegmentId = newRandomSegmentId();
 
-        // Task #4 (issue #503): log JVM memory snapshot + estimated /tmp usage
-        // at the start of each merge so operators can sanity-check
-        //   jvm_rss_estimate + tmp_estimate < container_limit
-        // without needing a profiler attached to the pod.
-        logMemoryBudgetAtMergeStart(inputs, tablespaceUuid, indexUuid, outputSegmentId);
+        // Peek the vector dimension from the first input's map file. The map file
+        // embeds floatCount (= dim) per entry; reading the first entry's header
+        // avoids any dependency on the static index metadata (Index.properties
+        // does not carry dim — it is embedded in the map file binary format).
+        // By this point all inputs have been validated to have mapFileSize > 0.
+        int dim = peekDimFromMapFile(sample);
+
+        // Log JVM memory snapshot + estimated /tmp usage at the start of each
+        // merge so operators can sanity-check container headroom (issue #503).
+        logMemoryBudgetAtMergeStart(inputs, tablespaceUuid, indexUuid, outputSegmentId,
+                config.graphM, dim);
 
         RemoteSegmentGraphMerger.MergeOutput output = graphMerger.merge(
                 graphInputs, tablespaceUuid, indexUuid, outputSegmentId, dim);
@@ -309,7 +340,17 @@ public final class RemoteSegmentMerger implements SegmentMerger {
         // Reconstruct the MergeOutput just enough to drive the cleanup. The
         // file sizes / vector counts are irrelevant to deleteOutput, which
         // only needs (tablespaceUuid, indexUuid, segmentId).
-        graphMerger.deleteOutput(new RemoteSegmentGraphMerger.MergeOutput(
+        RemoteSegmentGraphMerger last = lastGraphMerger;
+        if (last == null) {
+            // No merge was ever attempted on this merger instance (should not
+            // happen in production since abandon is called after merge).
+            LOGGER.log(Level.WARNING,
+                    "abandon called on RemoteSegmentMerger with no prior merge "
+                            + "(segment={0}); cannot clean up multipart files",
+                    produced.getSegmentUuid());
+            return;
+        }
+        last.deleteOutput(new RemoteSegmentGraphMerger.MergeOutput(
                 produced.getTablespaceUuid(), produced.getIndexUuid(), produced.getSegmentId(),
                 produced.getGraphPath(), 0L,
                 produced.getMapPath(), 0L,
@@ -323,21 +364,13 @@ public final class RemoteSegmentMerger implements SegmentMerger {
     /**
      * Logs the JVM memory snapshot and estimated /tmp usage at merge start so
      * operators can sanity-check whether the available headroom is sufficient.
-     *
-     * <p>Estimated /tmp usage formula (same as the legacy in-memory path; the
-     * streaming path is roughly the same order of magnitude):
-     * <ul>
-     *   <li>graph ≈ {@code totalVectors × graphM × 4 bytes × 1.5} (adjacency lists
-     *       plus InlineVectors)</li>
-     *   <li>map ≈ {@code totalVectors × (pkBytes + dim×4 + 12)} — 12-byte header</li>
-     * </ul>
-     * These are rough upper bounds; the actual size depends on PQ compression,
-     * de-duplication, and tombstone filtering.
      */
     private void logMemoryBudgetAtMergeStart(List<SegmentMetadata> inputs,
                                               String tablespaceUuid,
                                               String indexUuid,
-                                              long outputSegmentId) {
+                                              long outputSegmentId,
+                                              int graphM,
+                                              int dim) {
         long totalVectors = 0;
         long totalInputSizeBytes = 0;
         for (SegmentMetadata m : inputs) {
@@ -352,13 +385,10 @@ public final class RemoteSegmentMerger implements SegmentMerger {
         long directMaxMb  = directMaxBytes >= 0 ? directMaxBytes / (1024 * 1024) : -1L;
 
         // Estimated /tmp disk usage for graph + map files.
-        // graph ≈ (totalVectors × graphM × 4 × 1.5) bytes
-        // map   ≈ (totalVectors × (dim×4 + 24)) bytes (ordinal + pkLen + pk + floats + header)
-        long estimatedGraphBytes = (long) (totalVectors * graphMFromConfig() * 4 * 1.5);
+        long estimatedGraphBytes = (long) (totalVectors * graphM * 4 * 1.5);
         long estimatedMapBytes   = totalVectors * ((long) dim * 4 + 24);
         long estimatedTmpGib     = (estimatedGraphBytes + estimatedMapBytes) / (1024 * 1024 * 1024);
 
-        // Container memory limit from cgroup v2 (best-effort; -1 = unavailable).
         long cgroupLimitGib = readCgroupMemoryLimitGib();
 
         LOGGER.log(Level.INFO,
@@ -383,16 +413,6 @@ public final class RemoteSegmentMerger implements SegmentMerger {
                     "  container memory limit: {0} GiB (from /sys/fs/cgroup/memory.max)",
                     cgroupLimitGib);
         }
-    }
-
-    /**
-     * Returns the configured graph degree (M) from the underlying graph merger.
-     * Used only for the /tmp estimate in the memory-budget log.
-     */
-    private int graphMFromConfig() {
-        // Reflection-free: we know graphMerger is a RemoteSegmentGraphMerger
-        // with graphM stored. Expose it via a package-accessible getter.
-        return graphMerger.getGraphM();
     }
 
     /**
@@ -492,6 +512,64 @@ public final class RemoteSegmentMerger implements SegmentMerger {
             return Long.compare(a.ledgerId, b.ledgerId);
         }
         return Long.compare(a.offset, b.offset);
+    }
+
+    /**
+     * Peeks the vector dimension from the first entry of the given segment's
+     * map file. The map file binary format is:
+     * <pre>
+     *   int  entryCount
+     *   // for each entry:
+     *   int  ordinal
+     *   int  pkLen
+     *   byte[pkLen] pk
+     *   int  floatCount  (= dim)
+     *   int[floatCount] floatBits  (not read here)
+     * </pre>
+     * Only the first entry's header is read (at most {@code 16 + pkLen} bytes).
+     * This avoids downloading the full map file just to discover the dimension.
+     *
+     * <p>The caller must ensure the segment's {@code mapFileSize > 0} and that
+     * the map file contains at least one entry (i.e. the segment is non-empty).
+     *
+     * @throws IOException                 on remote I/O failures
+     * @throws DataStorageManagerException on storage-layer errors
+     * @throws IllegalStateException       if the map file is empty or the first
+     *                                     entry contains an implausible dimension
+     */
+    int peekDimFromMapFile(SegmentMetadata m)
+            throws IOException, DataStorageManagerException {
+        String multipartUuid = m.getIndexUuid() + "_seg" + m.getSegmentId();
+        ReaderSupplier supplier = dataStorageManager.multipartIndexReaderSupplier(
+                m.getTablespaceUuid(), multipartUuid, "map", m.getMapFileSize());
+        try (RandomAccessReader reader = supplier.get()) {
+            reader.seek(0L);
+            int entryCount = reader.readInt();
+            if (entryCount <= 0) {
+                throw new IllegalStateException(
+                        "Cannot peek dim from map file of segment " + m.getSegmentUuid()
+                        + ": entryCount=" + entryCount
+                        + " (empty or corrupt map file)");
+            }
+            reader.readInt(); // ordinal (skip)
+            int pkLen = reader.readInt();
+            if (pkLen < 0 || pkLen > 65_536) {
+                throw new IllegalStateException(
+                        "Cannot peek dim from map file of segment " + m.getSegmentUuid()
+                        + ": pkLen=" + pkLen + " (out of range, likely corrupt)");
+            }
+            // Skip the primary-key bytes.
+            byte[] pk = new byte[pkLen];
+            reader.readFully(pk);
+            int floatCount = reader.readInt();
+            if (floatCount <= 0 || floatCount > 65_536) {
+                throw new IllegalStateException(
+                        "Cannot peek dim from map file of segment " + m.getSegmentUuid()
+                        + ": floatCount=" + floatCount
+                        + " (out of range, likely corrupt)");
+            }
+            return floatCount;
+        }
     }
 
     /**

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/StaticIndexMergeConfigProvider.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/StaticIndexMergeConfigProvider.java
@@ -1,0 +1,56 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import java.util.Objects;
+
+/**
+ * {@link IndexMergeConfigProvider} that returns the same fixed configuration
+ * for every index (issue #516).
+ *
+ * <p>This implementation is intended exclusively for unit tests that do not
+ * want to stand up a live remote file server or a real HerdDB cluster. Production
+ * code uses {@link RemoteMetadataIndexMergeConfigProvider}, which reads the
+ * per-index build parameters directly from the checkpoint metadata stored on the
+ * remote file server.
+ *
+ * <p>Because the config is global, this provider is unsuitable for clusters with
+ * indexes of different graph-build parameters — but for test purposes where all
+ * indexes share the same synthetic config this is fine.
+ */
+public final class StaticIndexMergeConfigProvider implements IndexMergeConfigProvider {
+
+    private final IndexMergeConfig config;
+
+    /**
+     * Constructor for tests that supply the config directly.
+     *
+     * @param config the fixed merge config returned on every call; must not be null
+     */
+    public StaticIndexMergeConfigProvider(IndexMergeConfig config) {
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    @Override
+    public IndexMergeConfig getMergeConfig(String tablespace, String tableName,
+                                           String indexName, String indexUuid) {
+        return config;
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/MergeProgressObservabilityTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/MergeProgressObservabilityTest.java
@@ -191,9 +191,10 @@ public class MergeProgressObservabilityTest {
         Path tmpDir = tmp.newFolder("rsm-obs").toPath();
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
                 new MemoryDataStorageManager(), tmpDir,
-                /* dim */ 8, /* graphM */ 4, /* beamWidth */ 20,
-                /* neighborOverflow */ 1.2f, /* alpha */ 1.2f,
-                VectorSimilarityFunction.DOT_PRODUCT);
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        /* graphM */ 4, /* beamWidth */ 20,
+                        /* neighborOverflow */ 1.2f, /* alpha */ 1.2f,
+                        VectorSimilarityFunction.DOT_PRODUCT)));
 
         assertNull("getLastMergeTimings() must return null before any merge",
                 merger.getLastMergeTimings());
@@ -206,8 +207,8 @@ public class MergeProgressObservabilityTest {
         Path tmpDir = tmp.newFolder("rsm-null").toPath();
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
                 new MemoryDataStorageManager(), tmpDir,
-                8, 4, 20, 1.2f, 1.2f,
-                VectorSimilarityFunction.DOT_PRODUCT);
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        4, 20, 1.2f, 1.2f, VectorSimilarityFunction.DOT_PRODUCT)));
 
         // setMergeProgress(null) when already null — must not throw.
         merger.setMergeProgress(null);
@@ -233,8 +234,8 @@ public class MergeProgressObservabilityTest {
         Path tmpDir = tmp.newFolder("rsm-wire").toPath();
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
                 new MemoryDataStorageManager(), tmpDir,
-                8, 4, 20, 1.2f, 1.2f,
-                VectorSimilarityFunction.DOT_PRODUCT);
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        4, 20, 1.2f, 1.2f, VectorSimilarityFunction.DOT_PRODUCT)));
 
         MergeProgress progress = new MergeProgress();
         progress.enterMerge("wired-merge", 2, 50L, 100L);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteMetadataIndexMergeConfigProviderTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteMetadataIndexMergeConfigProviderTest.java
@@ -1,0 +1,411 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import herddb.index.vector.VectorIndexManager;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.server.RemoteFileClient;
+import herddb.utils.ExtendedDataOutputStream;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RemoteMetadataIndexMergeConfigProvider} (issue #516).
+ *
+ * <p>Uses a fake {@link RemoteFileClient} that returns pre-baked binary bytes
+ * matching the checkpoint metadata binary format, so no real remote file server
+ * is required.
+ *
+ * <p>The two checkpoint files exercised:
+ * <ul>
+ *   <li>{@code {tsUuid}/_metadata/latest.checkpoint} — LSN of the latest committed checkpoint.</li>
+ *   <li>{@code {tsUuid}/_metadata/indexes.{ledger}.{offset}.tablesmetadata} — list of
+ *       serialized {@link Index} objects at that LSN.</li>
+ * </ul>
+ */
+public class RemoteMetadataIndexMergeConfigProviderTest {
+
+    private static final String TS_UUID = "test-ts-uuid";
+    private static final long LEDGER = 42L;
+    private static final long OFFSET = 999L;
+
+    // -------------------------------------------------------------------------
+    // Binary format helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds the binary content of {@code latest.checkpoint} for the given LSN.
+     * Format (mirrors SharedCheckpointMetadataManager):
+     * <pre>
+     *   VLong(1) — version
+     *   VLong(0) — flags
+     *   UTF(tablespace name)
+     *   ZLong(ledgerId)
+     *   ZLong(offset)
+     * </pre>
+     */
+    private static byte[] buildLatestCheckpointBytes(String tsName, long ledgerId, long offset)
+            throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ExtendedDataOutputStream dos = new ExtendedDataOutputStream(baos)) {
+            dos.writeVLong(1L); // version
+            dos.writeVLong(0L); // flags
+            dos.writeUTF(tsName);
+            dos.writeZLong(ledgerId);
+            dos.writeZLong(offset);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Builds the binary content of the index-definitions tablesmetadata file for the given LSN.
+     * Format (mirrors SharedCheckpointMetadataManager):
+     * <pre>
+     *   VLong(1) — version
+     *   VLong(0) — flags
+     *   UTF(tablespace name)
+     *   ZLong(ledgerId)
+     *   ZLong(offset)
+     *   Int(count)
+     *   // for each index:
+     *   Array(Index.serialize())
+     * </pre>
+     */
+    private static byte[] buildIndexDefinitionsBytes(String tsName, long ledgerId, long offset,
+                                                     List<Index> indexes) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ExtendedDataOutputStream dos = new ExtendedDataOutputStream(baos)) {
+            dos.writeVLong(1L); // version
+            dos.writeVLong(0L); // flags
+            dos.writeUTF(tsName);
+            dos.writeZLong(ledgerId);
+            dos.writeZLong(offset);
+            dos.writeInt(indexes.size());
+            for (Index idx : indexes) {
+                dos.writeArray(idx.serialize());
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    /** Builds a vector {@link Index} with all jvector build parameters set in {@code properties}. */
+    private static Index buildVectorIndex(String tableName, String indexName, String uuid,
+                                          int graphM, int beamWidth,
+                                          float neighborOverflow, float alpha,
+                                          VectorSimilarityFunction similarity) {
+        return Index.builder()
+                .table(tableName)
+                .tablespace(TS_UUID)
+                .name(indexName)
+                .uuid(uuid)
+                .type(Index.TYPE_VECTOR)
+                .column("v", ColumnTypes.FLOATARRAY)
+                .property(VectorIndexManager.PROP_M, String.valueOf(graphM))
+                .property(VectorIndexManager.PROP_BEAM_WIDTH, String.valueOf(beamWidth))
+                .property(VectorIndexManager.PROP_NEIGHBOR_OVERFLOW, String.valueOf(neighborOverflow))
+                .property(VectorIndexManager.PROP_ALPHA, String.valueOf(alpha))
+                .property(VectorIndexManager.PROP_SIMILARITY, similarity.name())
+                .build();
+    }
+
+    /** Builds a fake {@link RemoteFileClient} backed by a pre-populated path→bytes map. */
+    private static RemoteFileClient fakeClient(Map<String, byte[]> files) {
+        return new RemoteFileClient() {
+            @Override
+            public byte[] readFile(String path) {
+                return files.get(path);
+            }
+
+            @Override
+            public void writeFile(String path, byte[] content) {
+                files.put(path, content);
+            }
+
+            @Override
+            public void updateServers(List<String> servers) {
+            }
+
+            @Override
+            public boolean awaitServersReady(long timeoutMs) {
+                return true;
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void resolvesByUuid() throws Exception {
+        Index idx = buildVectorIndex("docs", "docs_v1", "idx-uuid-1",
+                16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        IndexMergeConfig cfg = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "idx-uuid-1");
+
+        assertNotNull(cfg);
+        assertEquals(16, cfg.graphM);
+        assertEquals(64, cfg.beamWidth);
+        assertEquals(1.2f, cfg.neighborOverflow, 1e-6f);
+        assertEquals(1.4f, cfg.alpha, 1e-6f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN, cfg.similarity);
+    }
+
+    @Test
+    public void resolvesByNameFallbackWhenUuidMismatch() throws Exception {
+        // Store index with a different UUID in the metadata; provider must fall
+        // back to matching by (table, indexName).
+        Index idx = buildVectorIndex("docs", "docs_v1", "different-uuid",
+                8, 32, 1.1f, 1.3f, VectorSimilarityFunction.DOT_PRODUCT);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        // Query with a UUID that does NOT match — must fall back to (table, name) lookup.
+        IndexMergeConfig cfg = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "wanted-uuid");
+
+        assertNotNull(cfg);
+        assertEquals(8, cfg.graphM);
+        assertEquals(32, cfg.beamWidth);
+        assertEquals(VectorSimilarityFunction.DOT_PRODUCT, cfg.similarity);
+    }
+
+    @Test
+    public void resultIsCachedPerIndexUuid() throws Exception {
+        Index idx = buildVectorIndex("docs", "docs_v1", "cache-uuid",
+                4, 20, 1.0f, 1.0f, VectorSimilarityFunction.COSINE);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                // Use a 1-hour TTL so the cache entry does not expire during the test.
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID, 3_600_000L);
+
+        IndexMergeConfig first  = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "cache-uuid");
+        IndexMergeConfig second = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "cache-uuid");
+
+        // Same config object must be returned from cache on second call.
+        assertSame("second call must hit the cache", first, second);
+    }
+
+    @Test
+    public void invalidateCacheForcesReFetch() throws Exception {
+        Index idx = buildVectorIndex("docs", "docs_v1", "invalidate-uuid",
+                16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                // Use a 1-hour TTL so the cache entry does not expire during the test.
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID, 3_600_000L);
+
+        IndexMergeConfig first = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "invalidate-uuid");
+        provider.invalidateCache();
+        IndexMergeConfig second = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "invalidate-uuid");
+
+        // After invalidation the provider must re-fetch; the returned configs must be equal
+        // (same data) but need not be the same object.
+        assertEquals(first.graphM,          second.graphM);
+        assertEquals(first.beamWidth,       second.beamWidth);
+        assertEquals(first.neighborOverflow, second.neighborOverflow, 1e-6f);
+        assertEquals(first.alpha,            second.alpha,            1e-6f);
+        assertEquals(first.similarity,       second.similarity);
+    }
+
+    @Test
+    public void readLatestCheckpointLsnParsesBytes() throws Exception {
+        // Unit test for readLatestCheckpointLsn() in isolation.
+        byte[] checkpointBytes = buildLatestCheckpointBytes("my-ts", 77L, 123L);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint", checkpointBytes);
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        LogSequenceNumber lsn = provider.readLatestCheckpointLsn();
+        assertEquals(77L, lsn.ledgerId);
+        assertEquals(123L, lsn.offset);
+    }
+
+    @Test
+    public void readLatestCheckpointLsnReturnsStartOfTimeWhenFileAbsent() throws Exception {
+        // When latest.checkpoint is absent the remote file client returns null →
+        // provider must return LogSequenceNumber.START_OF_TIME (no checkpoint yet).
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(new HashMap<>()), TS_UUID);
+
+        LogSequenceNumber lsn = provider.readLatestCheckpointLsn();
+        assertEquals(LogSequenceNumber.START_OF_TIME.ledgerId, lsn.ledgerId);
+        assertEquals(LogSequenceNumber.START_OF_TIME.offset,   lsn.offset);
+    }
+
+    // -------------------------------------------------------------------------
+    // Error cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void throwsWhenNoCheckpointYet() {
+        // No checkpoint file on the fake client → getMergeConfig must throw Exception
+        // explaining that no checkpoint has been published yet.
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(new HashMap<>()), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "t", "i", "u");
+            fail("expected Exception when no checkpoint has been published");
+        } catch (Exception e) {
+            // Expected — verify the message is useful.
+            if (e.getMessage() == null || !e.getMessage().contains("checkpoint")) {
+                fail("error message should mention 'checkpoint': " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsWhenIndexNotFoundByUuidOrName() throws Exception {
+        // Metadata contains an unrelated index; provider must throw clearly.
+        Index other = buildVectorIndex("other", "other_idx", "other-uuid",
+                16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(other)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "missing-uuid");
+            fail("expected Exception for index not found in checkpoint metadata");
+        } catch (Exception e) {
+            if (e.getMessage() == null
+                    || !e.getMessage().contains("docs_v1")
+                    || !e.getMessage().contains("missing-uuid")) {
+                fail("error message should reference indexName and uuid: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsWhenRequiredPropertyAbsent() throws Exception {
+        // Index with no jvector properties at all → parseConfig must throw.
+        Index noProps = Index.builder()
+                .table("docs")
+                .tablespace(TS_UUID)
+                .name("docs_v1")
+                .uuid("noprop-uuid")
+                .type(Index.TYPE_VECTOR)
+                .column("v", ColumnTypes.FLOATARRAY)
+                .build();
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(noProps)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "noprop-uuid");
+            fail("expected Exception when required jvector property is absent");
+        } catch (Exception e) {
+            // Expected — must mention the missing property key.
+            if (e.getMessage() == null || !e.getMessage().contains(VectorIndexManager.PROP_M)) {
+                fail("error message should reference the missing property '"
+                        + VectorIndexManager.PROP_M + "': " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsWhenSimilarityIsUnknown() throws Exception {
+        // Index with an invalid similarity name → parseConfig must throw.
+        Index badSim = Index.builder()
+                .table("docs")
+                .tablespace(TS_UUID)
+                .name("docs_v1")
+                .uuid("badsim-uuid")
+                .type(Index.TYPE_VECTOR)
+                .column("v", ColumnTypes.FLOATARRAY)
+                .property(VectorIndexManager.PROP_M, "16")
+                .property(VectorIndexManager.PROP_BEAM_WIDTH, "64")
+                .property(VectorIndexManager.PROP_NEIGHBOR_OVERFLOW, "1.2")
+                .property(VectorIndexManager.PROP_ALPHA, "1.4")
+                .property(VectorIndexManager.PROP_SIMILARITY, "NOT_A_SIMILARITY")
+                .build();
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(badSim)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "badsim-uuid");
+            fail("expected Exception for unknown similarity function");
+        } catch (Exception e) {
+            if (e.getMessage() == null || !e.getMessage().contains("NOT_A_SIMILARITY")) {
+                fail("error message should reference the bad similarity: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteMetadataIndexMergeConfigProviderTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteMetadataIndexMergeConfigProviderTest.java
@@ -21,6 +21,7 @@ package herddb.indexing.optimizer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import herddb.index.vector.VectorIndexManager;
@@ -254,10 +255,11 @@ public class RemoteMetadataIndexMergeConfigProviderTest {
         provider.invalidateCache();
         IndexMergeConfig second = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "invalidate-uuid");
 
-        // After invalidation the provider must re-fetch; the returned configs must be equal
-        // (same data) but need not be the same object.
-        assertEquals(first.graphM,          second.graphM);
-        assertEquals(first.beamWidth,       second.beamWidth);
+        // After invalidation the provider must re-fetch and return a NEW object
+        // (not the cached reference). The values must be equal (same metadata).
+        assertNotSame("invalidateCache must force a re-fetch (different object instance)", first, second);
+        assertEquals(first.graphM,           second.graphM);
+        assertEquals(first.beamWidth,        second.beamWidth);
         assertEquals(first.neighborOverflow, second.neighborOverflow, 1e-6f);
         assertEquals(first.alpha,            second.alpha,            1e-6f);
         assertEquals(first.similarity,       second.similarity);
@@ -407,5 +409,186 @@ public class RemoteMetadataIndexMergeConfigProviderTest {
                 fail("error message should reference the bad similarity: " + e.getMessage());
             }
         }
+    }
+
+    @Test
+    public void throwsWhenPropertyIsNonPositive() throws Exception {
+        // m=0 is a non-positive integer — requirePositiveInt must throw.
+        Index idx = Index.builder()
+                .table("docs")
+                .tablespace(TS_UUID)
+                .name("docs_v1")
+                .uuid("nonpos-uuid")
+                .type(Index.TYPE_VECTOR)
+                .column("v", ColumnTypes.FLOATARRAY)
+                .property(VectorIndexManager.PROP_M, "0")  // <= 0: invalid
+                .property(VectorIndexManager.PROP_BEAM_WIDTH, "64")
+                .property(VectorIndexManager.PROP_NEIGHBOR_OVERFLOW, "1.2")
+                .property(VectorIndexManager.PROP_ALPHA, "1.4")
+                .property(VectorIndexManager.PROP_SIMILARITY, "EUCLIDEAN")
+                .build();
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "nonpos-uuid");
+            fail("expected Exception for non-positive property value");
+        } catch (Exception e) {
+            if (e.getMessage() == null || !e.getMessage().contains(VectorIndexManager.PROP_M)) {
+                fail("error message should reference the property key: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsWhenPropertyIsNonNumeric() throws Exception {
+        // m=abc is not a valid integer — requirePositiveInt must throw.
+        Index idx = Index.builder()
+                .table("docs")
+                .tablespace(TS_UUID)
+                .name("docs_v1")
+                .uuid("nonnumeric-uuid")
+                .type(Index.TYPE_VECTOR)
+                .column("v", ColumnTypes.FLOATARRAY)
+                .property(VectorIndexManager.PROP_M, "abc")  // not a number
+                .property(VectorIndexManager.PROP_BEAM_WIDTH, "64")
+                .property(VectorIndexManager.PROP_NEIGHBOR_OVERFLOW, "1.2")
+                .property(VectorIndexManager.PROP_ALPHA, "1.4")
+                .property(VectorIndexManager.PROP_SIMILARITY, "EUCLIDEAN")
+                .build();
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "nonnumeric-uuid");
+            fail("expected Exception for non-numeric property value");
+        } catch (Exception e) {
+            if (e.getMessage() == null || !e.getMessage().contains(VectorIndexManager.PROP_M)) {
+                fail("error message should reference the property key: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsOnCorruptCheckpointHeader() throws Exception {
+        // Write a latest.checkpoint with version=2 (only 1 is valid) — must throw.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ExtendedDataOutputStream dos = new ExtendedDataOutputStream(baos)) {
+            dos.writeVLong(2L); // bad version
+            dos.writeVLong(0L);
+            dos.writeUTF("my-ts");
+            dos.writeZLong(LEDGER);
+            dos.writeZLong(OFFSET);
+        }
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint", baos.toByteArray());
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "any-uuid");
+            fail("expected Exception for corrupt checkpoint header");
+        } catch (Exception e) {
+            if (e.getMessage() == null || !e.getMessage().contains("Corrupted")) {
+                fail("error message should indicate corruption: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsOnCorruptIndexDefinitionsHeader() throws Exception {
+        // Write latest.checkpoint correctly, but index definitions with version=99.
+        ByteArrayOutputStream idxBaos = new ByteArrayOutputStream();
+        try (ExtendedDataOutputStream dos = new ExtendedDataOutputStream(idxBaos)) {
+            dos.writeVLong(99L); // bad version
+            dos.writeVLong(0L);
+            dos.writeUTF("my-ts");
+            dos.writeZLong(LEDGER);
+            dos.writeZLong(OFFSET);
+            dos.writeInt(0);
+        }
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                idxBaos.toByteArray());
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "any-uuid");
+            fail("expected Exception for corrupt index definitions header");
+        } catch (Exception e) {
+            if (e.getMessage() == null || !e.getMessage().contains("Corrupted")) {
+                fail("error message should indicate corruption: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void throwsWhenIndexDefinitionsFileMissing() throws Exception {
+        // latest.checkpoint points at a non-START_OF_TIME LSN, but the
+        // indexes file is absent → must throw clearly.
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        // Do NOT add the indexes file.
+
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID);
+
+        try {
+            provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "any-uuid");
+            fail("expected Exception when index definitions file is absent");
+        } catch (Exception e) {
+            if (e.getMessage() == null || !e.getMessage().contains("Index definitions file not found")) {
+                fail("error message should mention missing file: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void cacheExpiresAfterTtl() throws Exception {
+        // Use a tiny TTL (1 ms). Sleep 10 ms to ensure expiry, then verify a
+        // second getMergeConfig call re-fetches (returns a different object).
+        Index idx = buildVectorIndex("docs", "docs_v1", "ttl-uuid",
+                16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<String, byte[]> files = new HashMap<>();
+        files.put(TS_UUID + "/_metadata/latest.checkpoint",
+                buildLatestCheckpointBytes("my-ts", LEDGER, OFFSET));
+        files.put(TS_UUID + "/_metadata/indexes." + LEDGER + "." + OFFSET + ".tablesmetadata",
+                buildIndexDefinitionsBytes("my-ts", LEDGER, OFFSET, List.of(idx)));
+
+        // 1 ms TTL — guaranteed to expire even under heavy system load within 10 ms.
+        RemoteMetadataIndexMergeConfigProvider provider =
+                new RemoteMetadataIndexMergeConfigProvider(fakeClient(files), TS_UUID, 1L);
+
+        IndexMergeConfig first = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "ttl-uuid");
+        Thread.sleep(10L); // ensure TTL has passed
+        IndexMergeConfig second = provider.getMergeConfig(TS_UUID, "docs", "docs_v1", "ttl-uuid");
+
+        // The cache entry has expired; the provider must allocate a fresh IndexMergeConfig.
+        assertNotSame("expired cache must produce a new IndexMergeConfig instance", first, second);
+        assertEquals(first.graphM, second.graphM);
+        assertEquals(first.similarity, second.similarity);
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyMapFileSizeTest.java
@@ -160,8 +160,10 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
         assertEquals(SegmentMetadata.UNKNOWN_FILE_SIZE, b.getMapFileSize());
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
-                VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        /* graphM */ 8, /* beamWidth */ 32, 1.2f, 1.4f,
+                        VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
             fail("expected LegacyMetadataException for legacy znode without mapFileSize");
@@ -234,8 +236,9 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
                 .build();
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                productionLikeDsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f,
-                VectorSimilarityFunction.EUCLIDEAN);
+                productionLikeDsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(oversizedHint1, oversizedHint2), 0);
             fail("expected merge to fail loudly when mapFileSize over-estimates"
@@ -265,8 +268,9 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
         SegmentMetadata other = writeLegacyInput("legacy-prod-B", 200L, 0xB);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                productionLikeDsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f,
-                VectorSimilarityFunction.EUCLIDEAN);
+                productionLikeDsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(legacy, other), 0);
             fail("expected LegacyMetadataException");
@@ -341,7 +345,9 @@ public class RemoteSegmentMergerLegacyMapFileSizeTest {
                 .build();
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         SegmentMetadata merged = merger.merge(List.of(modern1, modern2), 0);
         assertNotNull(merged);
         assertEquals(20L, merged.getVectorCount());

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyOverlayTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerLegacyOverlayTest.java
@@ -174,8 +174,10 @@ public class RemoteSegmentMergerLegacyOverlayTest {
                 /* no tombstones */ null, 0L, null);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, /* M */ 8, /* beamWidth */ 32, 1.2f, 1.4f,
-                VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        /* graphM */ 8, /* beamWidth */ 32, 1.2f, 1.4f,
+                        VectorSimilarityFunction.EUCLIDEAN)));
 
         SegmentMetadata merged = merger.merge(List.of(a, b), 0);
         assertNotNull("merger must produce an output", merged);
@@ -207,7 +209,9 @@ public class RemoteSegmentMergerLegacyOverlayTest {
                 "B", 200L, 0xB, null, 0L, null);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(a, b), 0);
             fail("expected TombstoneLoadFailedException for legacy znode with no overlay file");
@@ -230,7 +234,9 @@ public class RemoteSegmentMergerLegacyOverlayTest {
         SegmentMetadata b = writeInputAndPublishOverlay("B", 200L, 0xB, null, 0L, null);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         SegmentMetadata merged = merger.merge(List.of(aModern, b), 0);
         assertNotNull(merged);
         assertTrue("vectorCount must reflect tombstone-filtered A: 47 + 50 = 97",

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerOverlayLoadFailureTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerOverlayLoadFailureTest.java
@@ -137,8 +137,10 @@ public class RemoteSegmentMergerOverlayLoadFailureTest {
         SegmentMetadata b = writeInput("seg-B", 200L, 0xB, null, 0L);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, /* M */ 8, /* beam */ 32, 1.2f, 1.4f,
-                VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        /* graphM */ 8, /* beamWidth */ 32, 1.2f, 1.4f,
+                        VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
             fail("expected TombstoneLoadFailedException for missing overlay file");
@@ -181,7 +183,9 @@ public class RemoteSegmentMergerOverlayLoadFailureTest {
         Files.deleteIfExists(corruptOverlay);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(a, b), 0);
             fail("expected TombstoneLoadFailedException for corrupt overlay file");
@@ -199,7 +203,9 @@ public class RemoteSegmentMergerOverlayLoadFailureTest {
         SegmentMetadata b = writeInput("seg-clean-B", 200L, 0xB, null, 0L);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        8, 32, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         SegmentMetadata merged = merger.merge(List.of(a, b), 0);
         assertTrue("two clean inputs must merge successfully",
                 merged != null && merged.getVectorCount() == 2L * VECTORS_PER_SEGMENT);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerPeekDimTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerPeekDimTest.java
@@ -1,0 +1,251 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Direct unit tests for {@link RemoteSegmentMerger#peekDimFromMapFile} (issue #516).
+ *
+ * <p>Writes synthetic map files with known well-formed and malformed headers
+ * via {@link MemoryDataStorageManager}, then calls {@code peekDimFromMapFile}
+ * directly (package-private visibility) and asserts the correct dimension is
+ * returned or {@link IllegalStateException} is thrown with a useful message.
+ */
+public class RemoteSegmentMergerPeekDimTest {
+
+    private static final String TS_UUID = "ts-pdim";
+    private static final String IDX_UUID = "idx-pdim";
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private MemoryDataStorageManager dsm;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        dsm = new MemoryDataStorageManager();
+        tmpDir = tmp.newFolder("pdim-tmp").toPath();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Writes a map file to the DSM and returns the corresponding SegmentMetadata. */
+    private SegmentMetadata writeMapFile(long segmentId, byte[] mapFileBytes) throws Exception {
+        Path f = Files.createTempFile(tmpDir, "map-", ".tmp");
+        try {
+            Files.write(f, mapFileBytes);
+            String multipartUuid = IDX_UUID + "_seg" + segmentId;
+            dsm.writeMultipartIndexFile(TS_UUID, multipartUuid, "map", f, null);
+        } finally {
+            Files.deleteIfExists(f);
+        }
+        return SegmentMetadata.builder()
+                .segmentUuid("seg-" + segmentId)
+                .tablespaceUuid(TS_UUID)
+                .tableName("docs")
+                .indexUuid(IDX_UUID)
+                .indexName("docs_v1")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(0)
+                .segmentId(segmentId)
+                .graphPath("g/x")
+                .mapPath("m/x")
+                .baseLsn(new LogSequenceNumber(1L, 1L))
+                .sizeBytes((long) mapFileBytes.length * 2)
+                .mapFileSize(mapFileBytes.length)
+                .vectorCount(1L)
+                .generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+    }
+
+    /**
+     * Builds a minimal well-formed map file with exactly one entry.
+     * Format: int entryCount, int ordinal, int pkLen, byte[pkLen] pk,
+     *         int floatCount, int[floatCount] floatBits.
+     */
+    private byte[] buildWellFormedMapFile(int dim) throws Exception {
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(baos))) {
+            dos.writeInt(1);           // entryCount
+            dos.writeInt(0);           // ordinal
+            byte[] pk = "pk0".getBytes();
+            dos.writeInt(pk.length);   // pkLen
+            dos.write(pk);
+            dos.writeInt(dim);         // floatCount = dim
+            for (int j = 0; j < dim; j++) {
+                dos.writeInt(Float.floatToIntBits(j * 0.1f));
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private RemoteSegmentMerger makeMerger() {
+        return new RemoteSegmentMerger(
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void peeksDimCorrectly() throws Exception {
+        int dim = 128;
+        SegmentMetadata seg = writeMapFile(1L, buildWellFormedMapFile(dim));
+        RemoteSegmentMerger merger = makeMerger();
+        assertEquals(dim, merger.peekDimFromMapFile(seg));
+    }
+
+    @Test
+    public void peeksDimCorrectlySmall() throws Exception {
+        int dim = 4;
+        SegmentMetadata seg = writeMapFile(2L, buildWellFormedMapFile(dim));
+        RemoteSegmentMerger merger = makeMerger();
+        assertEquals(dim, merger.peekDimFromMapFile(seg));
+    }
+
+    // -------------------------------------------------------------------------
+    // Error cases: malformed map file headers
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void throwsWhenEntryCountIsZero() throws Exception {
+        // Write a map file with entryCount = 0 (empty segment, but shouldn't reach merge).
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(baos))) {
+            dos.writeInt(0); // entryCount = 0
+        }
+        SegmentMetadata seg = writeMapFile(3L, baos.toByteArray());
+        RemoteSegmentMerger merger = makeMerger();
+        try {
+            merger.peekDimFromMapFile(seg);
+            fail("expected IllegalStateException for entryCount=0");
+        } catch (IllegalStateException e) {
+            assertTrue("error message should mention empty or corrupt: " + e.getMessage(),
+                    e.getMessage().contains("empty or corrupt"));
+        }
+    }
+
+    @Test
+    public void throwsWhenEntryCountIsNegative() throws Exception {
+        // Negative entryCount — corrupt header.
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(baos))) {
+            dos.writeInt(-1); // entryCount = -1
+        }
+        SegmentMetadata seg = writeMapFile(4L, baos.toByteArray());
+        RemoteSegmentMerger merger = makeMerger();
+        try {
+            merger.peekDimFromMapFile(seg);
+            fail("expected IllegalStateException for entryCount=-1");
+        } catch (IllegalStateException e) {
+            assertTrue("error message should mention empty or corrupt: " + e.getMessage(),
+                    e.getMessage().contains("empty or corrupt"));
+        }
+    }
+
+    @Test
+    public void throwsWhenPkLenIsOutOfRange() throws Exception {
+        // pkLen = 70_000 exceeds the 65_536 cap.
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(baos))) {
+            dos.writeInt(1);        // entryCount
+            dos.writeInt(0);        // ordinal
+            dos.writeInt(70_000);   // pkLen > 65_536
+        }
+        SegmentMetadata seg = writeMapFile(5L, baos.toByteArray());
+        RemoteSegmentMerger merger = makeMerger();
+        try {
+            merger.peekDimFromMapFile(seg);
+            fail("expected IllegalStateException for pkLen out of range");
+        } catch (IllegalStateException e) {
+            assertTrue("error message should mention pkLen: " + e.getMessage(),
+                    e.getMessage().contains("pkLen="));
+        }
+    }
+
+    @Test
+    public void throwsWhenFloatCountIsNonPositive() throws Exception {
+        // floatCount = 0 is non-positive — corrupt or dim-less index.
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(baos))) {
+            dos.writeInt(1);           // entryCount
+            dos.writeInt(0);           // ordinal
+            byte[] pk = "pk0".getBytes();
+            dos.writeInt(pk.length);   // pkLen
+            dos.write(pk);
+            dos.writeInt(0);           // floatCount = 0 (non-positive)
+        }
+        SegmentMetadata seg = writeMapFile(6L, baos.toByteArray());
+        RemoteSegmentMerger merger = makeMerger();
+        try {
+            merger.peekDimFromMapFile(seg);
+            fail("expected IllegalStateException for floatCount=0");
+        } catch (IllegalStateException e) {
+            assertTrue("error message should mention floatCount: " + e.getMessage(),
+                    e.getMessage().contains("floatCount="));
+        }
+    }
+
+    @Test
+    public void throwsWhenFloatCountExceedsLimit() throws Exception {
+        // floatCount = 70_000 exceeds the 65_536 cap — implausible dimension.
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(baos))) {
+            dos.writeInt(1);           // entryCount
+            dos.writeInt(0);           // ordinal
+            byte[] pk = "pk0".getBytes();
+            dos.writeInt(pk.length);   // pkLen
+            dos.write(pk);
+            dos.writeInt(70_000);      // floatCount > 65_536
+        }
+        SegmentMetadata seg = writeMapFile(7L, baos.toByteArray());
+        RemoteSegmentMerger merger = makeMerger();
+        try {
+            merger.peekDimFromMapFile(seg);
+            fail("expected IllegalStateException for floatCount out of range");
+        } catch (IllegalStateException e) {
+            assertTrue("error message should mention floatCount: " + e.getMessage(),
+                    e.getMessage().contains("floatCount="));
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/RemoteSegmentMergerTest.java
@@ -154,9 +154,11 @@ public class RemoteSegmentMergerTest {
         SegmentMetadata b = writeInputSegmentToDsm("seg-B", 200L, /* gen */ 2L, 0xB);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, /* M */ 16, /* beamWidth */ 64,
-                /* neighborOverflow */ 1.2f, /* alpha */ 1.4f,
-                VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        /* graphM */ 16, /* beamWidth */ 64,
+                        /* neighborOverflow */ 1.2f, /* alpha */ 1.4f,
+                        VectorSimilarityFunction.EUCLIDEAN)));
         SegmentMetadata merged = merger.merge(List.of(a, b), /* newOwnerInstance */ 0);
 
         assertNotNull("merger must produce an output for healthy inputs", merged);
@@ -193,7 +195,9 @@ public class RemoteSegmentMergerTest {
         SegmentMetadata b = writeInputSegmentToDsm("seg-B", 200L, 2L, 0x2);
 
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         SegmentMetadata merged = merger.merge(List.of(a, b), 0);
         assertNotNull(merged);
 
@@ -235,7 +239,9 @@ public class RemoteSegmentMergerTest {
                 .sizeBytes(100L).vectorCount(1L).generation(1L).createdAtEpochMillis(0L)
                 .build();
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(a, b), 0);
             org.junit.Assert.fail("expected IllegalArgumentException");
@@ -258,7 +264,9 @@ public class RemoteSegmentMergerTest {
                 .sizeBytes(100L).vectorCount(1L).generation(1L).createdAtEpochMillis(0L)
                 .build();
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         try {
             merger.merge(List.of(a, b), 0);
             org.junit.Assert.fail("expected IllegalArgumentException");
@@ -270,7 +278,9 @@ public class RemoteSegmentMergerTest {
     @Test
     public void emptyInputReturnsNull() throws Exception {
         RemoteSegmentMerger merger = new RemoteSegmentMerger(
-                dsm, tmpDir, DIM, 16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN);
+                dsm, tmpDir,
+                new StaticIndexMergeConfigProvider(new IndexMergeConfig(
+                        16, 64, 1.2f, 1.4f, VectorSimilarityFunction.EUCLIDEAN)));
         assertNull("empty input → null output", merger.merge(new ArrayList<>(), 0));
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/StaticIndexMergeConfigProviderTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/StaticIndexMergeConfigProviderTest.java
@@ -1,0 +1,69 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link StaticIndexMergeConfigProvider} (issue #516).
+ *
+ * <p>Verifies:
+ * <ul>
+ *   <li>The constructor accepts an {@link IndexMergeConfig} and returns it on
+ *       every {@code getMergeConfig} call, regardless of the index identity.</li>
+ *   <li>Passing {@code null} throws {@link NullPointerException}.</li>
+ * </ul>
+ *
+ * <p>Note: this provider is a test-only helper. Production code uses
+ * {@link RemoteMetadataIndexMergeConfigProvider}, which reads per-index build
+ * parameters from checkpoint metadata on the remote file server.
+ */
+public class StaticIndexMergeConfigProviderTest {
+
+    @Test
+    public void returnsSuppliedConfigOnEveryCall() throws Exception {
+        IndexMergeConfig expected = new IndexMergeConfig(
+                /* graphM */ 16, /* beamWidth */ 64,
+                /* neighborOverflow */ 1.2f, /* alpha */ 1.4f,
+                VectorSimilarityFunction.EUCLIDEAN);
+
+        StaticIndexMergeConfigProvider provider = new StaticIndexMergeConfigProvider(expected);
+
+        // Must return the exact same instance on every call, regardless of parameters.
+        IndexMergeConfig cfgA = provider.getMergeConfig("ts1", "table1", "idx1", "uuid-A");
+        IndexMergeConfig cfgB = provider.getMergeConfig("ts2", "table2", "idx2", "uuid-B");
+
+        assertSame("must return the identical IndexMergeConfig instance", expected, cfgA);
+        assertSame("must return the identical IndexMergeConfig instance", expected, cfgB);
+    }
+
+    @Test
+    public void throwsNpeOnNullConfig() {
+        try {
+            new StaticIndexMergeConfigProvider(null);
+            fail("expected NullPointerException for null config");
+        } catch (NullPointerException e) {
+            // Expected.
+        }
+    }
+}


### PR DESCRIPTION
Fixes #516.

## Changes

- **`IndexMergeConfig`** — new immutable value object carrying the 5 jvector build
  parameters (`graphM`, `beamWidth`, `neighborOverflow`, `alpha`, `similarity`).
  `dim` is intentionally absent — it is read at merge time from the map file binary
  rather than stored in static index metadata.

- **`IndexMergeConfigProvider`** — new SPI interface; implementations resolve
  per-index jvector build parameters at merge time.

- **`RemoteMetadataIndexMergeConfigProvider`** — production implementation: reads
  `{tablespaceUuid}/_metadata/latest.checkpoint` (LSN of the latest committed
  checkpoint) then `{tablespaceUuid}/_metadata/indexes.{ledger}.{offset}.tablesmetadata`
  (list of serialized `Index` objects) from the remote file server (S3/MinIO) via
  `RemoteFileClient.readFile()`. Binary format mirrors `SharedCheckpointMetadataManager`.
  Results are cached per `indexUuid` with a configurable TTL (default 5 min).
  Throws `Exception` with a clear message if a required property is absent — no
  fallback to global defaults.

- **`StaticIndexMergeConfigProvider`** — test-only helper: returns a fixed
  `IndexMergeConfig` on every call.

- **`RemoteSegmentMerger`** — added `peekDimFromMapFile(SegmentMetadata)` that reads
  the vector dimension from the first entry of the segment's map file
  (`floatCount` field, using `RandomAccessReader`). Dimension is now passed to
  `graphMerger.merge()` directly; `IndexMergeConfig` no longer carries it.
  `logMemoryBudgetAtMergeStart` updated to take `int graphM, int dim` instead of
  the full config.

- **`IndexOptimizerMain`** — replaced the three-option `buildIndexMergeConfigProvider()`
  (IS API static, IS API ZK-discovery, static dim fallback) with a single call to
  `new RemoteMetadataIndexMergeConfigProvider(mergerFileClient, tablespaceUuid)`.

- **`OptimizerConfiguration`** — removed dead property keys for IS API address/timeout
  and all static jvector parameters (`indexoptimizer.merge.dim`, `.M`, `.beamWidth`,
  `.neighborOverflow`, `.alpha`, `.similarity`). `PROPERTY_MERGE_STREAMING_ENABLED`
  is retained — it controls the streaming compaction path.

## Tests

- **`RemoteMetadataIndexMergeConfigProviderTest`** (10 tests) — fake `RemoteFileClient`
  backed by a `HashMap<path, bytes>`. Covers: resolve-by-UUID, resolve-by-name
  fallback, cache hit, `invalidateCache()`, raw LSN parse, absent checkpoint, index
  not found, missing required property, invalid similarity name.

- **`StaticIndexMergeConfigProviderTest`** (2 tests) — returns same config; NPE on null.

- All 5 existing `RemoteSegmentMerger*Test` suites (27 tests) updated to drop the
  removed `dim` argument from `IndexMergeConfig(...)` constructor calls. Tests
  continue to exercise the actual merge path through `MemoryDataStorageManager`;
  `peekDimFromMapFile` now reads the correct `DIM` from the pre-baked map file.

🤖 Implemented by the `pr-worker` agent.