### PR TITLE
issue #523: fix acquireInflightWriteBytes deadlock for payloads > cap

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -376,10 +376,12 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         // deadlock on acquireUninterruptibly.
         int toAcquire = Math.min(bytes, writePermits);
         if (bytes > writePermits) {
-            LOGGER.log(Level.WARNING,
+            // Payload exceeds the cap. We will hold up to writePermits permits at
+            // a time; smaller concurrent writes can interleave between chunks.
+            logPreservingInterrupt(Level.WARNING,
                     "remote file client write payload ({0} bytes) exceeds inflight-write cap "
-                            + "({1} bytes); acquiring full budget ({1} bytes) for the duration "
-                            + "of this write — consider raising "
+                            + "({1} bytes); will hold up to {1} permits at a time during "
+                            + "this write — consider raising "
                             + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
                     new Object[]{bytes, writePermits});
         }
@@ -389,27 +391,13 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         }
         // Slow path: acquire in chunks of blockSize so smaller concurrent
         // writes can interleave. Warn before blocking starts.
-        //
-        // Save/restore the interrupt flag around every LOGGER.log() call.
-        // Some I/O streams that back the log handler (e.g. a pipe that Maven
-        // Surefire uses to capture test output) silently consume the flag when
-        // the calling thread is interrupted. If we leave the flag cleared before
-        // calling acquireUninterruptibly, the AQS will not call selfInterrupt()
-        // on return and the caller's interrupt status will be lost.
-        boolean interruptedBeforeBlock = Thread.interrupted();
-        try {
-            LOGGER.log(Level.WARNING,
-                    "remote file client inflight-write reservation blocked "
-                            + "(requested={0} bytes, available={1}/{2}); waiting — consider raising "
-                            + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES
-                            + " or reducing concurrent compaction/page-write load",
-                    new Object[]{toAcquire, inflightWriteBytes.availablePermits(),
-                            maxInflightWriteBytes});
-        } finally {
-            if (interruptedBeforeBlock) {
-                Thread.currentThread().interrupt();
-            }
-        }
+        logPreservingInterrupt(Level.WARNING,
+                "remote file client inflight-write reservation blocked "
+                        + "(requested={0} bytes, available={1}/{2}); waiting — consider raising "
+                        + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES
+                        + " or reducing concurrent compaction/page-write load",
+                new Object[]{toAcquire, inflightWriteBytes.availablePermits(),
+                        maxInflightWriteBytes});
         long startNanos = System.nanoTime();
         int acquired = 0;
         while (acquired < toAcquire) {
@@ -419,28 +407,39 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         }
         long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
         if (elapsedMs >= PERMIT_ACQUIRE_WARN_THRESHOLD_MS) {
-            // Also preserve interrupt around the post-unblock log: acquireUninterruptibly
-            // calls selfInterrupt() when the thread was interrupted during the wait, and
-            // logging afterwards must not silently consume that restored flag.
-            boolean interruptedAfterBlock = Thread.interrupted();
-            try {
-                LOGGER.log(Level.WARNING,
-                        "remote file client inflight-write reservation unblocked after {0}ms "
-                                + "(requested={1} bytes, available={2}/{3}); consider raising "
-                                + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
-                        new Object[]{elapsedMs, toAcquire, inflightWriteBytes.availablePermits(),
-                                maxInflightWriteBytes});
-            } finally {
-                if (interruptedAfterBlock) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+            logPreservingInterrupt(Level.WARNING,
+                    "remote file client inflight-write reservation unblocked after {0}ms "
+                            + "(requested={1} bytes, available={2}/{3}); consider raising "
+                            + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                    new Object[]{elapsedMs, toAcquire, inflightWriteBytes.availablePermits(),
+                            maxInflightWriteBytes});
         }
         return toAcquire;
     }
 
     private void releaseInflightWriteBytes(int bytes) {
         inflightWriteBytes.release(bytes);
+    }
+
+    /**
+     * Emits a log record at the given level while preserving the calling
+     * thread's interrupt status.
+     *
+     * <p>Some I/O streams that back the log handler (e.g. a pipe that Maven
+     * Surefire uses to capture test output) silently consume the interrupt
+     * flag. Callers that need interrupt-sensitive semantics around
+     * {@link java.util.concurrent.Semaphore#acquireUninterruptibly} must
+     * use this wrapper so that the flag survives the log call.
+     */
+    private static void logPreservingInterrupt(Level level, String msg, Object[] params) {
+        boolean interrupted = Thread.interrupted();
+        try {
+            LOGGER.log(level, msg, params);
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /**

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -126,7 +126,17 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     public static final int DEFAULT_BLOCK_SIZE = 4 * 1024 * 1024;
     /** Default cap on in-flight read bytes: 256 MiB (issue #246). */
     public static final long DEFAULT_CLIENT_MAX_INFLIGHT_READ_BYTES = 256L * 1024 * 1024;
-    /** Default cap on in-flight write bytes: 256 MiB (issue #468). */
+    /**
+     * Default cap on in-flight write bytes: 256 MiB (issue #468).
+     *
+     * <p>This value intentionally keeps back-pressure active. Payloads that
+     * exceed the cap (e.g. a large serialised open-transactions blob written
+     * during a checkpoint — issue #523) are handled without deadlocking by
+     * {@link #acquireInflightWriteBytes}: the acquisition is capped to
+     * {@code writePermits} and performed in {@link #blockSize}-sized chunks
+     * so that the full semaphore capacity is never requested in a single
+     * {@code acquireUninterruptibly} call.
+     */
     public static final long DEFAULT_CLIENT_MAX_INFLIGHT_WRITE_BYTES = 256L * 1024 * 1024;
     /**
      * Emit a WARNING log line if acquiring the in-flight reservation
@@ -165,6 +175,8 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     private final long maxInflightReadBytes;
     private final Semaphore inflightReadBytes;
     private final long maxInflightWriteBytes;
+    /** Semaphore capacity for writes: {@code min(maxInflightWriteBytes, Integer.MAX_VALUE)}. */
+    private final int writePermits;
     private final Semaphore inflightWriteBytes;
     private final ScheduledExecutorService retryScheduler;
     private final Supplier<String> oidcTokenSupplier;
@@ -232,10 +244,10 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                     + ") so a single full-block write is always admissible");
         }
         this.maxInflightWriteBytes = configuredMaxInflightWriteBytes;
-        int writePermits = maxInflightWriteBytes > Integer.MAX_VALUE
+        this.writePermits = maxInflightWriteBytes > Integer.MAX_VALUE
                 ? Integer.MAX_VALUE
                 : (int) maxInflightWriteBytes;
-        this.inflightWriteBytes = new Semaphore(writePermits);
+        this.inflightWriteBytes = new Semaphore(this.writePermits);
         this.retryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
             FastThreadLocalThread t = new FastThreadLocalThread(r, "remote-file-retry");
             t.setDaemon(true);
@@ -330,25 +342,101 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         inflightReadBytes.release(bytes);
     }
 
-    private void acquireInflightWriteBytes(int bytes) {
+    /**
+     * Acquires permits from the in-flight write-bytes semaphore and returns
+     * the number of permits actually taken (which may be less than
+     * {@code bytes} when the payload exceeds the configured cap — see below).
+     *
+     * <h3>Deadlock prevention (issue #523)</h3>
+     * <p>{@link java.util.concurrent.Semaphore#acquireUninterruptibly(int)}
+     * blocks forever when the requested count exceeds the semaphore's total
+     * capacity. Large single-shot writes (e.g. the serialised
+     * open-transactions blob written during a checkpoint) can exceed the
+     * 256 MiB default. To avoid the permanent block:
+     * <ol>
+     *   <li>The requested permits are capped to {@link #writePermits} (the
+     *       semaphore's initial capacity): {@code toAcquire = min(bytes, writePermits)}.
+     *   <li>On the slow path the acquisition is done in chunks of
+     *       {@link #blockSize} so that smaller concurrent writes can
+     *       interleave between chunks.
+     *   <li>A WARNING is logged when the payload exceeds the cap (so
+     *       operators can tune {@link #CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES})
+     *       and a separate WARNING is logged before blocking begins
+     *       (previously the warning only fired after unblocking).
+     * </ol>
+     *
+     * @return the number of permits actually acquired; always
+     *         {@code min(bytes, writePermits)} and always &gt; 0.
+     */
+    private int acquireInflightWriteBytes(int bytes) {
         if (bytes <= 0) {
             throw new IllegalArgumentException("bytes must be > 0, got " + bytes);
         }
-        if (inflightWriteBytes.tryAcquire(bytes)) {
-            return;
-        }
-        long startNanos = System.nanoTime();
-        inflightWriteBytes.acquireUninterruptibly(bytes);
-        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-        if (elapsedMs >= PERMIT_ACQUIRE_WARN_THRESHOLD_MS) {
+        // Cap to semaphore capacity — requesting more than writePermits would
+        // deadlock on acquireUninterruptibly.
+        int toAcquire = Math.min(bytes, writePermits);
+        if (bytes > writePermits) {
             LOGGER.log(Level.WARNING,
-                    "remote file client inflight-write reservation blocked for {0}ms "
-                            + "(requested={1} bytes, available={2}/{3}); consider raising "
+                    "remote file client write payload ({0} bytes) exceeds inflight-write cap "
+                            + "({1} bytes); acquiring full budget ({1} bytes) for the duration "
+                            + "of this write — consider raising "
+                            + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                    new Object[]{bytes, writePermits});
+        }
+        // Fast path: all permits available right now.
+        if (inflightWriteBytes.tryAcquire(toAcquire)) {
+            return toAcquire;
+        }
+        // Slow path: acquire in chunks of blockSize so smaller concurrent
+        // writes can interleave. Warn before blocking starts.
+        //
+        // Save/restore the interrupt flag around every LOGGER.log() call.
+        // Some I/O streams that back the log handler (e.g. a pipe that Maven
+        // Surefire uses to capture test output) silently consume the flag when
+        // the calling thread is interrupted. If we leave the flag cleared before
+        // calling acquireUninterruptibly, the AQS will not call selfInterrupt()
+        // on return and the caller's interrupt status will be lost.
+        boolean interruptedBeforeBlock = Thread.interrupted();
+        try {
+            LOGGER.log(Level.WARNING,
+                    "remote file client inflight-write reservation blocked "
+                            + "(requested={0} bytes, available={1}/{2}); waiting — consider raising "
                             + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES
                             + " or reducing concurrent compaction/page-write load",
-                    new Object[]{elapsedMs, bytes, inflightWriteBytes.availablePermits(),
+                    new Object[]{toAcquire, inflightWriteBytes.availablePermits(),
                             maxInflightWriteBytes});
+        } finally {
+            if (interruptedBeforeBlock) {
+                Thread.currentThread().interrupt();
+            }
         }
+        long startNanos = System.nanoTime();
+        int acquired = 0;
+        while (acquired < toAcquire) {
+            int chunk = Math.min(toAcquire - acquired, blockSize);
+            inflightWriteBytes.acquireUninterruptibly(chunk);
+            acquired += chunk;
+        }
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        if (elapsedMs >= PERMIT_ACQUIRE_WARN_THRESHOLD_MS) {
+            // Also preserve interrupt around the post-unblock log: acquireUninterruptibly
+            // calls selfInterrupt() when the thread was interrupted during the wait, and
+            // logging afterwards must not silently consume that restored flag.
+            boolean interruptedAfterBlock = Thread.interrupted();
+            try {
+                LOGGER.log(Level.WARNING,
+                        "remote file client inflight-write reservation unblocked after {0}ms "
+                                + "(requested={1} bytes, available={2}/{3}); consider raising "
+                                + CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES,
+                        new Object[]{elapsedMs, toAcquire, inflightWriteBytes.availablePermits(),
+                                maxInflightWriteBytes});
+            } finally {
+                if (interruptedAfterBlock) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        return toAcquire;
     }
 
     private void releaseInflightWriteBytes(int bytes) {
@@ -356,26 +444,34 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     /**
-     * Acquires {@code bytes} from the in-flight write-bytes budget and
-     * returns an idempotent {@link Runnable} that releases the same number
-     * of permits exactly once. Callers wire the runnable into the
-     * {@code whenComplete} hook of the future returned by
-     * {@code sendRequest}, and into every synchronous failure branch (e.g.
-     * {@code writeChannelForBlock} throwing) so the reservation is always
-     * returned. Empty payloads ({@code bytes == 0}) skip both the acquire
-     * and the release — {@link #writeAsMultipart} legitimately uses
+     * Acquires permits from the in-flight write-bytes budget via
+     * {@link #acquireInflightWriteBytes} and returns an idempotent
+     * {@link Runnable} that releases the same number of permits exactly once.
+     *
+     * <p>Callers wire the runnable into the {@code whenComplete} hook of the
+     * future returned by {@code sendRequest}, and into every synchronous
+     * failure branch (e.g. {@code writeChannelForBlock} throwing) so the
+     * reservation is always returned.
+     *
+     * <p>Empty payloads ({@code bytes == 0}) skip both the acquire and the
+     * release — {@link #writeAsMultipart} legitimately uses
      * {@code Unpooled.EMPTY_BUFFER} to materialise an empty file marker
      * and would otherwise be rejected by {@link #acquireInflightWriteBytes}.
+     *
+     * <p>When {@code bytes > writePermits} the returned runnable releases
+     * only {@code writePermits} permits (the amount actually acquired),
+     * never {@code bytes}, so the semaphore is never over-inflated.
      */
     private Runnable reserveInflightWriteBytes(int bytes) {
         if (bytes <= 0) {
             return () -> { };
         }
-        acquireInflightWriteBytes(bytes);
+        // acquired may be < bytes when the payload exceeds the cap.
+        int acquired = acquireInflightWriteBytes(bytes);
         AtomicBoolean released = new AtomicBoolean(false);
         return () -> {
             if (released.compareAndSet(false, true)) {
-                releaseInflightWriteBytes(bytes);
+                releaseInflightWriteBytes(acquired);
             }
         };
     }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
@@ -1296,6 +1296,9 @@ public class RemoteFileServiceClientByteBufTest {
                 try {
                     tuned.writeFile("test/permits/write/chunked-slow-path.bin", payload);
                 } catch (Throwable t) {
+                    // Catch Throwable so AssertionError or any other Error
+                    // still surfaces via writeError instead of being silently
+                    // swallowed by the daemon thread (per CLAUDE.md guidance).
                     writeError.set(t);
                 } finally {
                     writeDone.countDown();
@@ -1368,6 +1371,9 @@ public class RemoteFileServiceClientByteBufTest {
                 try {
                     tuned.writeFile("test/permits/write/nondivisible-slow-path.bin", payload);
                 } catch (Throwable t) {
+                    // Catch Throwable so AssertionError or any other Error
+                    // still surfaces via writeError instead of being silently
+                    // swallowed by the daemon thread (per CLAUDE.md guidance).
                     writeError.set(t);
                 } finally {
                     writeDone.countDown();

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
@@ -1254,4 +1254,146 @@ public class RemoteFileServiceClientByteBufTest {
                     cap, tuned.availableInflightWriteBytes());
         }
     }
+
+    /**
+     * Exercises the slow-path chunked-acquisition while-loop in
+     * {@code acquireInflightWriteBytes}: reflectively drains the write-byte
+     * semaphore to 0 so that {@code tryAcquire(toAcquire)} fails and the
+     * loop runs. The semaphore is then restored by the main thread while the
+     * oversized writer is parked, verifying that each chunk wakes up and the
+     * full loop completes correctly.
+     *
+     * <p>Config: {@code cap = 2 × blockSize} (two loop iterations), payload
+     * {@code = 3 × blockSize} ({@code toAcquire = cap}). The slow-path loop
+     * must execute both iterations ({@code blockSize} + {@code blockSize}
+     * permits), and the budget must be fully restored afterwards.
+     */
+    @Test(timeout = 30_000)
+    public void testInflightWriteBytes_oversizedWriteSlowPathChunkedLoop() throws Exception {
+        int blockSize = 4096;
+        long cap = 2L * blockSize; // 2 chunks so both loop iterations run
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, blockSize);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, cap);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            // Reflectively drain the write-byte semaphore so tryAcquire fails
+            // and the chunked slow path is entered.
+            Field semField = RemoteFileServiceClient.class.getDeclaredField("inflightWriteBytes");
+            semField.setAccessible(true);
+            Semaphore writeSem = (Semaphore) semField.get(tuned);
+            int drained = writeSem.drainPermits();
+            assertEquals("drained exactly cap permits", (int) cap, drained);
+
+            // Launch an oversized write (3× cap → toAcquire = cap) on a
+            // background thread. It will park inside acquireUninterruptibly
+            // for each chunk until the main thread restores the permits.
+            byte[] payload = new byte[blockSize * 3];
+            Arrays.fill(payload, (byte) 0xEF);
+            AtomicReference<Throwable> writeError = new AtomicReference<>();
+            CountDownLatch writeDone = new CountDownLatch(1);
+            Thread writer = new Thread(() -> {
+                try {
+                    tuned.writeFile("test/permits/write/chunked-slow-path.bin", payload);
+                } catch (Throwable t) {
+                    writeError.set(t);
+                } finally {
+                    writeDone.countDown();
+                }
+            }, "oversized-slow-path-writer");
+            writer.setDaemon(true);
+            writer.start();
+
+            // Wait for the writer to park on the first chunk.
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (writer.getState() != Thread.State.WAITING
+                    && writer.getState() != Thread.State.TIMED_WAITING) {
+                if (System.nanoTime() > deadline) {
+                    writeSem.release(drained); // unblock writer before failing
+                    fail("writer did not enter WAITING state within 10 s; state="
+                            + writer.getState() + ", error=" + writeError.get());
+                }
+                Thread.sleep(5);
+            }
+
+            // Restore all drained permits — the chunked loop will consume
+            // them (blockSize at a time) and complete.
+            writeSem.release(drained);
+
+            assertTrue("oversized slow-path write completed within timeout",
+                    writeDone.await(20, TimeUnit.SECONDS));
+            assertNull("oversized slow-path write must not throw", writeError.get());
+            assertEquals("budget restored to cap after chunked slow-path write",
+                    cap, tuned.availableInflightWriteBytes());
+        }
+    }
+
+    /**
+     * Exercises the partial-last-chunk case of the slow-path loop: when
+     * {@code toAcquire} is not a multiple of {@code blockSize}, the final
+     * {@code Math.min(toAcquire - acquired, blockSize)} call produces a
+     * chunk smaller than {@code blockSize}. This test verifies that the
+     * arithmetic is correct and that no permits are leaked.
+     *
+     * <p>Config: {@code cap = blockSize + 100} (not a multiple of
+     * {@code blockSize}), payload {@code = 2 × blockSize} ({@code toAcquire
+     * = blockSize + 100}). Loop iteration breakdown:
+     * <ul>
+     *   <li>Chunk 1: {@code blockSize} permits.</li>
+     *   <li>Chunk 2: {@code 100} permits (partial last chunk).</li>
+     * </ul>
+     * The semaphore is drained to force the slow path.
+     */
+    @Test(timeout = 30_000)
+    public void testInflightWriteBytes_oversizedWriteNonDivisibleCapSlowPath() throws Exception {
+        int blockSize = 4096;
+        long cap = blockSize + 100L; // non-divisible: last chunk = 100 bytes
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, blockSize);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, cap);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            // Drain to force the chunked slow path.
+            Field semField = RemoteFileServiceClient.class.getDeclaredField("inflightWriteBytes");
+            semField.setAccessible(true);
+            Semaphore writeSem = (Semaphore) semField.get(tuned);
+            int drained = writeSem.drainPermits();
+            assertEquals("drained exactly cap permits", (int) cap, drained);
+
+            byte[] payload = new byte[blockSize * 2]; // > cap → toAcquire = cap
+            Arrays.fill(payload, (byte) 0x12);
+            AtomicReference<Throwable> writeError = new AtomicReference<>();
+            CountDownLatch writeDone = new CountDownLatch(1);
+            Thread writer = new Thread(() -> {
+                try {
+                    tuned.writeFile("test/permits/write/nondivisible-slow-path.bin", payload);
+                } catch (Throwable t) {
+                    writeError.set(t);
+                } finally {
+                    writeDone.countDown();
+                }
+            }, "nondivisible-slow-path-writer");
+            writer.setDaemon(true);
+            writer.start();
+
+            // Wait for the writer to park, then restore all permits.
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (writer.getState() != Thread.State.WAITING
+                    && writer.getState() != Thread.State.TIMED_WAITING) {
+                if (System.nanoTime() > deadline) {
+                    writeSem.release(drained);
+                    fail("writer did not enter WAITING state within 10 s; state="
+                            + writer.getState() + ", error=" + writeError.get());
+                }
+                Thread.sleep(5);
+            }
+            writeSem.release(drained);
+
+            assertTrue("non-divisible slow-path write completed within timeout",
+                    writeDone.await(20, TimeUnit.SECONDS));
+            assertNull("non-divisible slow-path write must not throw", writeError.get());
+            assertEquals("budget restored to exactly cap (partial last chunk must not leak)",
+                    cap, tuned.availableInflightWriteBytes());
+        }
+    }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientByteBufTest.java
@@ -1184,4 +1184,74 @@ public class RemoteFileServiceClientByteBufTest {
                 client.maxInflightWriteBytes(),
                 client.availableInflightWriteBytes());
     }
+
+    // -----------------------------------------------------------------
+    // Issue #523 — oversized single-shot write (payload > cap) must not
+    // deadlock and must restore the budget exactly.
+    // -----------------------------------------------------------------
+
+    /**
+     * Regression test for issue #523: a single {@code writeFile} whose
+     * payload exceeds the configured inflight-write cap used to block
+     * forever on {@code Semaphore.acquireUninterruptibly(bytes)} because a
+     * semaphore can never grant more permits than its initial count.
+     *
+     * <p>The fix caps the acquisition to {@code min(bytes, writePermits)} and
+     * acquires on the slow path in {@link RemoteFileServiceClient#blockSize}-
+     * sized chunks. This test uses a cap equal to exactly one block (4 MiB)
+     * and a payload of two blocks (8 MiB); before the fix the test would hang
+     * until the 30-second {@code @Test(timeout)} fires.
+     */
+    @Test(timeout = 30_000)
+    public void testInflightWriteBytes_oversizedWriteDoesNotDeadlock() throws Exception {
+        int blockSize = RemoteFileServiceClient.DEFAULT_BLOCK_SIZE;
+        long cap = blockSize; // 1 block = 4 MiB cap
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, blockSize);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, cap);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            // 2× cap — with the old code this would deadlock:
+            // acquireUninterruptibly(2*cap) on a semaphore with cap permits.
+            byte[] payload = new byte[blockSize * 2];
+            Arrays.fill(payload, (byte) 0xAB);
+            tuned.writeFile("test/permits/write/oversized-nodead.bin", payload);
+            assertEquals("budget restored to cap (not to raw bytes) after oversized write",
+                    cap, tuned.availableInflightWriteBytes());
+        }
+    }
+
+    /**
+     * After an oversized {@code writeFile} (payload &gt; cap) completes, the
+     * inflight-write budget must be restored to exactly {@code cap} — not to
+     * the raw payload size. Before the fix, {@code reserveInflightWriteBytes}
+     * released {@code bytes} permits (the raw argument) rather than the number
+     * actually acquired ({@code min(bytes, writePermits)}), which would have
+     * over-inflated the semaphore and made subsequent reads of
+     * {@link RemoteFileServiceClient#availableInflightWriteBytes()} return a
+     * value larger than the configured cap.
+     */
+    @Test(timeout = 30_000)
+    public void testInflightWriteBytes_oversizedWriteReleasesExactAcquired() throws Exception {
+        int blockSize = RemoteFileServiceClient.DEFAULT_BLOCK_SIZE;
+        long cap = blockSize; // 1 block = 4 MiB cap
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_BLOCK_SIZE, blockSize);
+        cfg.put(RemoteFileServiceClient.CONFIG_CLIENT_MAX_INFLIGHT_WRITE_BYTES, cap);
+        try (RemoteFileServiceClient tuned = new RemoteFileServiceClient(
+                Arrays.asList("localhost:" + server.getPort()), cfg)) {
+            assertEquals("budget starts at cap", cap, tuned.availableInflightWriteBytes());
+            // Write 3× cap to amplify any over-inflation: if release used raw
+            // bytes instead of acquired, available would jump to 3*cap after
+            // the first call and 6*cap after the second.
+            byte[] payload = new byte[blockSize * 3];
+            Arrays.fill(payload, (byte) 0xCD);
+            tuned.writeFile("test/permits/write/oversized-release1.bin", payload);
+            assertEquals("budget must equal cap after first oversized write (not 3*cap)",
+                    cap, tuned.availableInflightWriteBytes());
+            tuned.writeFile("test/permits/write/oversized-release2.bin", payload);
+            assertEquals("budget must equal cap after second oversized write (not 6*cap)",
+                    cap, tuned.availableInflightWriteBytes());
+        }
+    }
 }


### PR DESCRIPTION
Fixes #523.

## Root cause

`Semaphore.acquireUninterruptibly(N)` blocks forever when `N` exceeds the semaphore's total capacity. With the 256 MiB default and a serialised open-transactions blob that can exceed 256 MiB during a large checkpoint, the server's activator thread deadlocks permanently.

## Changes

- **`RemoteFileServiceClient.java`**
  - Add `private final int writePermits` field storing `min(maxInflightWriteBytes, Integer.MAX_VALUE)` — the semaphore's actual capacity.
  - `acquireInflightWriteBytes` now returns `int` (permits actually acquired = `min(bytes, writePermits)`). On the slow path, acquires in `blockSize`-sized chunks so smaller concurrent writes can interleave — no single `acquireUninterruptibly` call ever requests more permits than the semaphore holds.
  - Warn when payload exceeds the cap (single WARNING, before blocking).
  - Preserve the thread interrupt flag around all `LOGGER.log()` calls: some I/O streams backing the log handler (e.g. a Surefire pipe) silently consume the flag, which would cause `acquireUninterruptibly` to skip its `selfInterrupt()` call and lose the caller's interrupt status.
  - `reserveInflightWriteBytes` releases only the `acquired` count, never the raw `bytes` argument — prevents semaphore over-inflation when the payload exceeds the cap.

## Tests

- `testInflightWriteBytes_oversizedWriteDoesNotDeadlock` — configures cap = 1 block (4 MiB), writes 2 blocks (8 MiB); before the fix this hung forever until the 30-second `@Test(timeout)` fired.
- `testInflightWriteBytes_oversizedWriteReleasesExactAcquired` — writes 3× cap twice and asserts `availableInflightWriteBytes() == cap` each time; before the fix the release would have used the raw `bytes` argument, over-inflating the semaphore to 3× cap after the first write.

🤖 Implemented by the `pr-worker` agent.