### PR TITLE
issue #524: k-way single-pass merge in AggressivePolicy

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -399,8 +399,19 @@ public final class IndexOptimizerMain {
         // Issue #484: aggressive policy by default. Segments at or above
         // targetMaxBytes are graduated; everything else is mergeable as long
         // as ≥2 sub-target segments exist — there's no minCount/minBytes gate.
+        // Issue #524: k-way mode (kwayMax >= 2) collapses all sub-target
+        // segments into one merge round per cycle, bypassing perCycleMaxBytes.
+        // Set indexoptimizer.merge.kway.max=0 to revert to the legacy byte-cap
+        // behaviour (serial 2-way merges bounded by perCycleMaxBytes).
+        int kwayMax = configuration.getInt(
+                OptimizerConfiguration.PROPERTY_MERGE_KWAY_MAX,
+                OptimizerConfiguration.PROPERTY_MERGE_KWAY_MAX_DEFAULT);
         MergePolicy policy = new MergePolicy.AggressivePolicy(
-                targetMaxBytes, perCycleMaxBytes, maxCount);
+                targetMaxBytes, perCycleMaxBytes, maxCount, kwayMax);
+        LOGGER.log(Level.INFO,
+                "merge policy: AggressivePolicy(targetMaxBytes={0}, perCycleMaxBytes={1},"
+                        + " maxCount={2}, kwayMax={3})",
+                new Object[]{targetMaxBytes, perCycleMaxBytes, maxCount, kwayMax});
 
         // Resolve the merger (SPI override → preconfigured → RemoteSegmentMerger
         // → NoopMerger) and the DataStorageManager that drives it (only when

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -399,10 +399,10 @@ public final class IndexOptimizerMain {
         // Issue #484: aggressive policy by default. Segments at or above
         // targetMaxBytes are graduated; everything else is mergeable as long
         // as ≥2 sub-target segments exist — there's no minCount/minBytes gate.
-        // Issue #524: k-way mode (kwayMax >= 2) collapses all sub-target
-        // segments into one merge round per cycle, bypassing perCycleMaxBytes.
-        // Set indexoptimizer.merge.kway.max=0 to revert to the legacy byte-cap
-        // behaviour (serial 2-way merges bounded by perCycleMaxBytes).
+        // Issue #524: k-way mode — set indexoptimizer.merge.kway.max >= 2 (e.g. 8)
+        // to enable k-way single-pass merges that bypass perCycleMaxBytes and
+        // collapse all sub-target segments into one round. Default 0 keeps the
+        // legacy byte-cap behaviour (serial merge rounds bounded by perCycleMaxBytes).
         int kwayMax = configuration.getInt(
                 OptimizerConfiguration.PROPERTY_MERGE_KWAY_MAX,
                 OptimizerConfiguration.PROPERTY_MERGE_KWAY_MAX_DEFAULT);

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergePolicy.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergePolicy.java
@@ -207,9 +207,15 @@ public interface MergePolicy {
                 // ignoring perCycleMaxBytes. This merges all sub-target segments in one
                 // pass (O(N) work) instead of sequential 2-way rounds (O(N²) work).
                 int limit = Math.min(kwayMax, maxCount);
-                List<VersionedSegmentMetadata> picked = mergeable.size() <= limit
-                        ? new ArrayList<>(mergeable)
-                        : new ArrayList<>(mergeable.subList(0, limit));
+                // subList(0, n) works for both n == size and n < size; the returned
+                // view is then copied into a fresh ArrayList to avoid holding a
+                // reference to the sorted intermediate list.
+                List<VersionedSegmentMetadata> picked =
+                        new ArrayList<>(mergeable.subList(0, Math.min(limit, mergeable.size())));
+                // Invariant: mergeable.size() >= 2 (checked above) and limit >= 2
+                // (constructor enforces kwayMax >= 2 and maxCount >= 2), so
+                // picked.size() >= 2 is always true here. The guard is kept as a
+                // defensive belt-and-suspenders check.
                 return picked.size() >= 2 ? picked : new ArrayList<>();
             }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergePolicy.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/MergePolicy.java
@@ -108,18 +108,46 @@ public interface MergePolicy {
      * optimizer to leave small graphs un-merged for hours under sustained
      * load, which is precisely the failure mode this policy fixes.
      *
-     * <p>Selection: smallest-first; the picked set is capped at
-     * {@code perCycleMaxBytes} of input data per cycle (write-amplification
-     * budget) and at {@code maxCount} segments. The 2-segment minimum
-     * always overrides those caps so a cycle with two segments whose sum
-     * exceeds the byte cap still proceeds.
+     * <p>Selection (k-way mode, issue #524): when {@code kwayMax >= 2}, the
+     * policy picks up to {@code min(kwayMax, maxCount, candidates.size())}
+     * segments in a single cycle, smallest-first, <em>ignoring</em>
+     * {@code perCycleMaxBytes}. This collapses N sub-target segments into
+     * one merge round instead of the O(N) rounds that the byte-cap forces,
+     * cutting cumulative vector-processing work from O(N²) to O(N).
+     *
+     * <p>Selection (legacy mode, {@code kwayMax == 0}): smallest-first; the
+     * picked set is capped at {@code perCycleMaxBytes} of input data per
+     * cycle (write-amplification budget) and at {@code maxCount} segments.
+     * The 2-segment minimum always overrides the byte cap so a cycle with
+     * two segments whose sum exceeds the cap still proceeds.
      */
     final class AggressivePolicy implements MergePolicy {
         private final long targetMaxBytes;
         private final long perCycleMaxBytes;
         private final int maxCount;
+        /**
+         * K-way max (issue #524). When {@code >= 2}: pick up to this many
+         * candidates per cycle, bypassing {@code perCycleMaxBytes}. When
+         * {@code 0}: legacy byte-cap behaviour.
+         */
+        private final int kwayMax;
 
+        /**
+         * Backward-compatible 3-arg constructor: uses legacy {@code perCycleMaxBytes}
+         * candidate selection ({@code kwayMax = 0}).
+         */
         public AggressivePolicy(long targetMaxBytes, long perCycleMaxBytes, int maxCount) {
+            this(targetMaxBytes, perCycleMaxBytes, maxCount, /* kwayMax */ 0);
+        }
+
+        /**
+         * Full constructor adding k-way candidate selection (issue #524).
+         *
+         * @param kwayMax  max inputs per merge cycle in k-way mode (0 = legacy byte-cap
+         *                 mode; must be 0 or {@code >= 2})
+         */
+        public AggressivePolicy(long targetMaxBytes, long perCycleMaxBytes, int maxCount,
+                                int kwayMax) {
             if (targetMaxBytes <= 0L) {
                 throw new IllegalArgumentException("targetMaxBytes must be positive: " + targetMaxBytes);
             }
@@ -129,9 +157,13 @@ public interface MergePolicy {
             if (maxCount < 2) {
                 throw new IllegalArgumentException("maxCount must be >= 2: " + maxCount);
             }
+            if (kwayMax != 0 && kwayMax < 2) {
+                throw new IllegalArgumentException("kwayMax must be 0 (disabled) or >= 2: " + kwayMax);
+            }
             this.targetMaxBytes = targetMaxBytes;
             this.perCycleMaxBytes = perCycleMaxBytes;
             this.maxCount = maxCount;
+            this.kwayMax = kwayMax;
         }
 
         public long getTargetMaxBytes() {
@@ -144,6 +176,11 @@ public interface MergePolicy {
 
         public int getMaxCount() {
             return maxCount;
+        }
+
+        /** Returns the configured k-way max (0 = legacy byte-cap mode). */
+        public int getKwayMax() {
+            return kwayMax;
         }
 
         @Override
@@ -165,6 +202,18 @@ public interface MergePolicy {
             }
             mergeable.sort(Comparator.comparingLong(v -> v.metadata().getSizeBytes()));
 
+            if (kwayMax >= 2) {
+                // K-way mode (issue #524): pick up to min(kwayMax, maxCount) candidates,
+                // ignoring perCycleMaxBytes. This merges all sub-target segments in one
+                // pass (O(N) work) instead of sequential 2-way rounds (O(N²) work).
+                int limit = Math.min(kwayMax, maxCount);
+                List<VersionedSegmentMetadata> picked = mergeable.size() <= limit
+                        ? new ArrayList<>(mergeable)
+                        : new ArrayList<>(mergeable.subList(0, limit));
+                return picked.size() >= 2 ? picked : new ArrayList<>();
+            }
+
+            // Legacy byte-cap mode: respect perCycleMaxBytes.
             List<VersionedSegmentMetadata> picked = new ArrayList<>();
             long pickedBytes = 0L;
             for (VersionedSegmentMetadata v : mergeable) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -201,6 +201,29 @@ public final class OptimizerConfiguration {
             "indexoptimizer.remote.file.client.max.inflight.write.bytes";
     public static final long PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES_DEFAULT = 256L * 1024L * 1024L;
 
+    // -------------------------------------------------------------------------
+    // K-way single-pass merge (issue #524)
+    // -------------------------------------------------------------------------
+
+    /**
+     * K-way merge max (issue #524). When {@code >= 2}, the
+     * {@link MergePolicy.AggressivePolicy} picks up to this many sub-target
+     * segments per cycle and merges them in a single pass, bypassing the
+     * {@code perCycleMaxBytes} cap. This collapses N segments into one merge
+     * round instead of the O(N) rounds that the byte-cap forces, cutting
+     * cumulative vector-processing work from O(N²) to O(N).
+     *
+     * <p>Default {@code 8} — sized for the gist1m / 8-initial-segments workload
+     * that motivated the issue. For tablespaces with more initial segments, raise
+     * this value. Set to {@code 0} to revert to the legacy byte-cap behavior
+     * ({@code perCycleMaxBytes} re-applies).
+     *
+     * <p>The hard ceiling {@code optimizer.merge.max.count} (default 200) is
+     * always respected regardless of this setting.
+     */
+    public static final String PROPERTY_MERGE_KWAY_MAX = "indexoptimizer.merge.kway.max";
+    public static final int PROPERTY_MERGE_KWAY_MAX_DEFAULT = 8;
+
     private final Properties properties;
 
     public OptimizerConfiguration(Properties properties) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -222,7 +222,14 @@ public final class OptimizerConfiguration {
      * always respected regardless of this setting.
      */
     public static final String PROPERTY_MERGE_KWAY_MAX = "indexoptimizer.merge.kway.max";
-    public static final int PROPERTY_MERGE_KWAY_MAX_DEFAULT = 8;
+    /**
+     * Default is {@code 0} (disabled = legacy byte-cap mode) so that existing
+     * deployments are not silently affected by the larger per-cycle input footprint
+     * that k-way implies. Operators opt in by setting this to {@code >= 2}
+     * (e.g. {@code 8} for the gist1m workload) once they have verified the
+     * optimizer pod has enough heap and local disk for the fan-in.
+     */
+    public static final int PROPERTY_MERGE_KWAY_MAX_DEFAULT = 0;
 
     private final Properties properties;
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -213,22 +213,19 @@ public final class OptimizerConfiguration {
      * round instead of the O(N) rounds that the byte-cap forces, cutting
      * cumulative vector-processing work from O(N²) to O(N).
      *
-     * <p>Default {@code 8} — sized for the gist1m / 8-initial-segments workload
-     * that motivated the issue. For tablespaces with more initial segments, raise
-     * this value. Set to {@code 0} to revert to the legacy byte-cap behavior
+     * <p>Default {@code 0} (disabled = legacy byte-cap mode): existing deployments
+     * are not silently affected by the larger per-cycle input footprint that k-way
+     * implies. Operators opt in by setting this to {@code >= 2} (recommended
+     * {@code 8} for the gist1m / 8-initial-segments workload that motivated the
+     * issue; raise further for tablespaces with more initial segments) once they
+     * have verified the optimizer pod has sufficient heap and local disk for the
+     * fan-in. Set back to {@code 0} to revert to legacy byte-cap behaviour
      * ({@code perCycleMaxBytes} re-applies).
      *
      * <p>The hard ceiling {@code optimizer.merge.max.count} (default 200) is
      * always respected regardless of this setting.
      */
     public static final String PROPERTY_MERGE_KWAY_MAX = "indexoptimizer.merge.kway.max";
-    /**
-     * Default is {@code 0} (disabled = legacy byte-cap mode) so that existing
-     * deployments are not silently affected by the larger per-cycle input footprint
-     * that k-way implies. Operators opt in by setting this to {@code >= 2}
-     * (e.g. {@code 8} for the gist1m workload) once they have verified the
-     * optimizer pod has enough heap and local disk for the fan-in.
-     */
     public static final int PROPERTY_MERGE_KWAY_MAX_DEFAULT = 0;
 
     private final Properties properties;

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/AggressivePolicyKwayTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/AggressivePolicyKwayTest.java
@@ -216,4 +216,57 @@ public class AggressivePolicyKwayTest {
         List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(4));
         assertEquals("kwayMax=2 picks exactly 2 (smallest)", 2, picked.size());
     }
+
+    // -------------------------------------------------------------------------
+    // Additional edge cases (requested by pr-reviewer)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Zero-size sub-target segments are still included in k-way picks.
+     * The legacy byte-cap path clamps size to {@code Math.max(0, sizeBytes)};
+     * k-way must not silently drop zero-size candidates or trip on them.
+     */
+    @Test
+    public void kwayHandlesZeroSizeSegments() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, 1L, 100, 8);
+        List<VersionedSegmentMetadata> all = new ArrayList<>();
+        all.add(seg("zero1", 0L));
+        all.add(seg("zero2", 0L));
+        all.add(seg("small", 50L));
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(all);
+        assertEquals("zero-size sub-target segments must still be picked in k-way mode",
+                3, picked.size());
+    }
+
+    /**
+     * When {@code mergeable.size() == maxCount < kwayMax}, the policy picks
+     * exactly {@code maxCount} candidates — the limit is {@code min(kwayMax, maxCount)}.
+     */
+    @Test
+    public void kwayMaxAboveMaxCountWithExactlyMaxCountCandidates() {
+        // kwayMax=20, maxCount=5, exactly 5 sub-target candidates → pick all 5
+        // (limited by maxCount, not kwayMax).
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, 1L, /* maxCount */ 5, /* kwayMax */ 20);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(5));
+        assertEquals("when candidates.size() == maxCount < kwayMax, pick all maxCount",
+                5, picked.size());
+    }
+
+    /**
+     * When more candidates exist than {@code maxCount}, exactly {@code maxCount}
+     * are picked even though {@code kwayMax > maxCount}.
+     */
+    @Test
+    public void kwayMaxAboveMaxCountWithMoreCandidatesThanMaxCount() {
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, 1L, /* maxCount */ 5, /* kwayMax */ 20);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(10));
+        assertEquals("maxCount must cap the result even when kwayMax is higher", 5, picked.size());
+        // Verify smallest-first ordering.
+        for (int i = 0; i < picked.size(); i++) {
+            assertEquals("must pick smallest maxCount segments",
+                    "s" + (i + 1), picked.get(i).metadata().getSegmentUuid());
+        }
+    }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/AggressivePolicyKwayTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/AggressivePolicyKwayTest.java
@@ -1,0 +1,219 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentState;
+import herddb.indexing.segment.VersionedSegmentMetadata;
+import herddb.log.LogSequenceNumber;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MergePolicy.AggressivePolicy} k-way mode (issue #524).
+ *
+ * <p>Verifies that when {@code kwayMax >= 2} the policy:
+ * <ul>
+ *   <li>picks all mergeable candidates when their count is {@code <= kwayMax}
+ *       regardless of the {@code perCycleMaxBytes} cap;</li>
+ *   <li>picks exactly the smallest {@code kwayMax} candidates when more exist;</li>
+ *   <li>still respects the {@code maxCount} hard ceiling;</li>
+ *   <li>falls back to the legacy byte-cap behaviour when {@code kwayMax == 0}.</li>
+ * </ul>
+ */
+public class AggressivePolicyKwayTest {
+
+    private static final String TS = "ts";
+    private static final String IDX = "idx";
+
+    private VersionedSegmentMetadata seg(String uuid, long sizeBytes) {
+        SegmentMetadata m = SegmentMetadata.builder()
+                .segmentUuid(uuid)
+                .tablespaceUuid(TS).tableName("t").indexUuid(IDX).indexName("i")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(0)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(sizeBytes).vectorCount(1L).generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+        return new VersionedSegmentMetadata(m, /* zkVersion */ 0);
+    }
+
+    /** Makes a list of N segments with distinct 1-byte sizes (s1=1, s2=2, …). */
+    private List<VersionedSegmentMetadata> makeSegments(int n) {
+        List<VersionedSegmentMetadata> list = new ArrayList<>();
+        for (int i = 1; i <= n; i++) {
+            list.add(seg("s" + i, i));
+        }
+        return list;
+    }
+
+    // -------------------------------------------------------------------------
+    // k-way mode: ignores perCycleMaxBytes
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void kwayPicksAllWhenCandidatesLeqKwayMax() {
+        // 4 candidates, kwayMax=4, perCycleMaxBytes=1 (far below total) →
+        // k-way ignores the byte cap and picks all 4.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes */ 10_000L,
+                /* perCycleMaxBytes */ 1L,       // would block legacy mode after 1st candidate
+                /* maxCount */ 100,
+                /* kwayMax */ 4);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(4));
+        assertEquals("k-way must pick all 4 candidates regardless of perCycleMaxBytes",
+                4, picked.size());
+    }
+
+    @Test
+    public void kwayPicksSmallestKWhenCandidatesExceedKwayMax() {
+        // 8 candidates, kwayMax=4 → pick the 4 smallest.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, 1L, 100, 4);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(8));
+        assertEquals("k-way must pick exactly kwayMax=4 when more candidates exist",
+                4, picked.size());
+        // Verify smallest-first ordering.
+        for (int i = 0; i < picked.size(); i++) {
+            assertEquals("must pick smallest k (s1..s4)",
+                    "s" + (i + 1), picked.get(i).metadata().getSegmentUuid());
+        }
+    }
+
+    @Test
+    public void kwayPicks8InOnePassForGist1mScenario() {
+        // Simulates the gist1m / 8-initial-segment scenario from the issue.
+        // With legacy byte-cap of 1 GiB and 8 segments of ~400 MB each, the
+        // old policy could only pick 2-3 per cycle. K-way picks all 8 at once.
+        long segmentBytes = 400L * 1024L * 1024L;   // 400 MiB each
+        long perCycleMax  = 1L * 1024L * 1024L * 1024L; // 1 GiB (old default)
+        List<VersionedSegmentMetadata> segments = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            segments.add(seg("seg" + i, segmentBytes + i)); // slightly different sizes
+        }
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes */ 8L * 1024L * 1024L * 1024L, // 8 GiB target
+                perCycleMax,
+                /* maxCount */ 200,
+                /* kwayMax */ 8);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(segments);
+        assertEquals("k-way=8 must pick all 8 segments in one pass", 8, picked.size());
+    }
+
+    @Test
+    public void kwayMaxCountHardCeilingIsStillRespected() {
+        // kwayMax=20 but maxCount=5 → maxCount wins.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, 1L, /* maxCount */ 5, /* kwayMax */ 20);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(10));
+        assertEquals("maxCount must cap the picked set even in k-way mode", 5, picked.size());
+    }
+
+    @Test
+    public void kwayWithExactlyTwoCandidatesStillFires() {
+        // Minimum viable merge: 2 candidates, kwayMax=8 → pick both.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, 1L, 100, 8);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(2));
+        assertEquals(2, picked.size());
+    }
+
+    @Test
+    public void kwayGraduatedSegmentsAreExcluded() {
+        // 3 sub-target + 2 graduated; kwayMax=8 → picks the 3 sub-target only.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes */ 100L, 1L, 100, 8);
+        List<VersionedSegmentMetadata> all = new ArrayList<>();
+        all.add(seg("small1", 10L));
+        all.add(seg("small2", 20L));
+        all.add(seg("small3", 30L));
+        all.add(seg("graduated1", 100L)); // exactly at target → graduated
+        all.add(seg("graduated2", 500L));
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(all);
+        assertEquals("only sub-target segments are picked in k-way mode", 3, picked.size());
+        for (VersionedSegmentMetadata v : picked) {
+            assertEquals("all picked must be sub-target",
+                    true, v.metadata().getSizeBytes() < 100L);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // kwayMax == 0: legacy byte-cap behaviour is preserved
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void kwayZeroFallsBackToPerCycleBytesLogic() {
+        // Same 3-segment, tight-byte-cap scenario as AggressivePolicyTest —
+        // kwayMax=0 must reproduce the original perCycleMaxBytes-capped result.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L,
+                /* perCycleMaxBytes */ 250L,
+                100,
+                /* kwayMax */ 0);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(
+                List.of(seg("s1", 100L), seg("s2", 100L), seg("s3", 100L)));
+        assertEquals("kwayMax=0 must respect perCycleMaxBytes (picks 2, not 3)", 2, picked.size());
+    }
+
+    @Test
+    public void kwayZeroPicksAllWhenBudgetAllows() {
+        // kwayMax=0 with unlimited budget → same as before (picks all).
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, Long.MAX_VALUE, 100, 0);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(8));
+        assertEquals(8, picked.size());
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void kwayMaxOneIsRejected() {
+        try {
+            new MergePolicy.AggressivePolicy(1_000L, 1_000L, 2, 1);
+            fail("kwayMax=1 must throw IllegalArgumentException");
+        } catch (IllegalArgumentException ok) {
+            // expected
+        }
+    }
+
+    @Test
+    public void kwayMaxNegativeIsRejected() {
+        try {
+            new MergePolicy.AggressivePolicy(1_000L, 1_000L, 2, -1);
+            fail("kwayMax=-1 must throw IllegalArgumentException");
+        } catch (IllegalArgumentException ok) {
+            // expected
+        }
+    }
+
+    @Test
+    public void kwayMaxTwoIsAccepted() {
+        // Minimum valid k-way value.
+        MergePolicy policy = new MergePolicy.AggressivePolicy(10_000L, 1L, 100, 2);
+        List<VersionedSegmentMetadata> picked = policy.pickMergeCandidates(makeSegments(4));
+        assertEquals("kwayMax=2 picks exactly 2 (smallest)", 2, picked.size());
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEngineKwayMergeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEngineKwayMergeTest.java
@@ -21,6 +21,7 @@ package herddb.indexing.optimizer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.indexing.segment.OwnershipTransfer;
 import herddb.indexing.segment.SegmentMetadata;
 import herddb.indexing.segment.SegmentRegistryClient;
 import herddb.indexing.segment.SegmentState;
@@ -31,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
@@ -118,16 +120,27 @@ public class IndexOptimizerEngineKwayMergeTest {
      * Thin wrapper that delegates to {@link InMemorySegmentMerger} and records
      * the input count of each {@link #merge} call. We use delegation instead of
      * subclassing because {@link InMemorySegmentMerger} is {@code final}.
+     *
+     * <p>An optional {@link #mergeHook} {@code Runnable} is invoked at the
+     * start of each {@link #merge} call (before the delegate), allowing tests
+     * to inject concurrent registry mutations (e.g. deprecating an input) that
+     * simulate drift in the pick→revalidate window.
      */
     private static final class TrackingMerger implements SegmentMerger {
         private final InMemorySegmentMerger delegate = new InMemorySegmentMerger();
         private final AtomicInteger invocations = new AtomicInteger(0);
         private final AtomicInteger lastInputCount = new AtomicInteger(0);
+        /** Hook invoked at the start of each merge call. {@code null} = no-op. */
+        volatile Runnable mergeHook;
 
         @Override
         public SegmentMetadata merge(List<SegmentMetadata> inputs, int newOwnerInstance) {
             invocations.incrementAndGet();
             lastInputCount.set(inputs.size());
+            Runnable hook = mergeHook;
+            if (hook != null) {
+                hook.run();
+            }
             return delegate.merge(inputs, newOwnerInstance);
         }
 
@@ -141,18 +154,18 @@ public class IndexOptimizerEngineKwayMergeTest {
     }
 
     /**
-     * The core k-way test: 8 sub-target segments are merged into 1 in a single
-     * optimizer tick. The merger is called exactly once with all 8 inputs, not
-     * 7 times with 2 inputs each.
+     * Verifies that the policy passes all 8 candidates to the merger in a single
+     * call when {@code kwayMax=8}, rather than requiring 7 sequential 2-way rounds.
      *
-     * <p>This reproduces the gist1m / 8-initial-segments scenario from the issue.
-     * With the legacy byte-cap policy (perCycleMaxBytes=1 GiB, segments ~400 MiB
-     * each), only 2-3 segments were picked per cycle, forcing 7 sequential rounds.
-     * K-way picks all 8 in one shot.
+     * <p>The segments are sized to simulate the gist1m workload (400 MiB each) so
+     * that the legacy {@code perCycleMaxBytes=1 GiB} cap would have limited picks
+     * to 2 per cycle. The merger here is {@link InMemorySegmentMerger} — it does
+     * not exercise real graph I/O or peak heap/disk behaviour; it proves only the
+     * policy-to-engine contract (all 8 inputs passed in one call).
      */
     @Test
     public void eightSegmentsMergedInOneTickWithKway8() throws Exception {
-        long segBytes = 400L * 1024L * 1024L; // 400 MiB each — realistic for gist1m shards
+        long segBytes = 400L * 1024L * 1024L; // 400 MiB each — matches gist1m shard size
         for (int i = 0; i < 8; i++) {
             registry.createSegment(seg("seg-" + i, segBytes + i /* distinct sizes */));
         }
@@ -255,5 +268,69 @@ public class IndexOptimizerEngineKwayMergeTest {
         assertEquals("merger called once", 1, trackingMerger.getInvocations());
         assertEquals("legacy mode: perCycleMaxBytes caps at 2 inputs",
                 2, trackingMerger.getLastInputCount());
+    }
+
+    /**
+     * Drift-abort: one of the 8 candidates is externally deprecated (simulating
+     * an ownership change or another optimizer pod racing) DURING the merge call,
+     * i.e. between pick-candidates and the pre-publish revalidation. The engine
+     * must detect the drift in {@code revalidateInputsStillActive}, abort the
+     * publish, increment {@code mergeAbortsRevalidateFailedTotal}, and leave no
+     * orphan ACTIVE output.
+     *
+     * <p>This verifies that k-way's larger fan-in does not weaken the revalidation
+     * safety net — a drift in any one of the 8 inputs still causes an abort.
+     */
+    @Test
+    public void kwayAbortsMergeWhenInputDriftsDuringMerge() throws Exception {
+        for (int i = 0; i < 8; i++) {
+            registry.createSegment(seg("seg-" + i, 100L + i));
+        }
+
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                10_000L, 1L, 200, 8);
+
+        // Capture the first input UUID the merger receives so we can deprecate it.
+        AtomicReference<String> firstInputUuid = new AtomicReference<>();
+        TrackingMerger trackingMerger = new TrackingMerger();
+        trackingMerger.mergeHook = () -> {
+            // Deprecate "seg-0" while the merge is running (before revalidation).
+            try {
+                VersionedSegmentMetadata seg0 =
+                        registry.getSegment(TS_UUID, IDX_UUID, "seg-0").orElseThrow();
+                firstInputUuid.set(seg0.metadata().getSegmentUuid());
+                // Initiate an ownership transfer on seg-0, which changes its state to
+                // TRANSFERRING — enough to fail the ACTIVE+version check in revalidate.
+                OwnershipTransfer.initiate(registry, seg0, /* newOwner */ 1);
+            } catch (Exception e) {
+                throw new RuntimeException("drift hook failed: " + e, e);
+            }
+        };
+
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                registry, trackingMerger, TS_UUID, policy,
+                60_000L, () -> 0, fakeClock::get);
+
+        engine.runOnce();
+
+        // Merger was still called (the drift happens inside merge(), before revalidate).
+        assertEquals("merger invoked once", 1, trackingMerger.getInvocations());
+        assertEquals("all 8 inputs passed to merger", 8, trackingMerger.getLastInputCount());
+
+        // Revalidation detected the drift → publish aborted.
+        assertEquals("merge aborted due to input drift",
+                1L, engine.getMergeAbortsRevalidateFailedTotal());
+        assertEquals("no output published", 0L, engine.getSegmentsMerged());
+
+        // No ACTIVE output segment must exist — only the 7 still-ACTIVE inputs
+        // (seg-1..seg-7) and the one TRANSFERRING segment (seg-0).
+        List<VersionedSegmentMetadata> all = registry.listSegments(TS_UUID, IDX_UUID);
+        long activeCount = all.stream()
+                .filter(v -> v.metadata().getState() == SegmentState.ACTIVE).count();
+        long transferringCount = all.stream()
+                .filter(v -> v.metadata().getState() == SegmentState.TRANSFERRING).count();
+        assertEquals("7 inputs remain ACTIVE (seg-1..seg-7)", 7L, activeCount);
+        assertEquals("seg-0 is TRANSFERRING (drifted)", 1L, transferringCount);
+        assertEquals("no other znodes created (output must be abandoned)", 8L, all.size());
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEngineKwayMergeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEngineKwayMergeTest.java
@@ -1,0 +1,259 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.indexing.segment.SegmentMetadata;
+import herddb.indexing.segment.SegmentRegistryClient;
+import herddb.indexing.segment.SegmentState;
+import herddb.indexing.segment.VersionedSegmentMetadata;
+import herddb.log.LogSequenceNumber;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end engine tests for the k-way single-pass merge feature (issue #524).
+ *
+ * <p>Uses a real ZooKeeper registry (via Curator {@code TestingServer}) and a
+ * {@link SegmentMerger} delegate backed by {@link InMemorySegmentMerger} that
+ * also records the input count per call. Verifies:
+ * <ul>
+ *   <li>8 ACTIVE sub-target segments are collapsed to a single output in ONE
+ *       tick with {@code kwayMax=8}, and the merger is called exactly once
+ *       with all 8 inputs. Without k-way, the same scenario requires 7
+ *       rounds of 2-way merges (cumulative O(N²) work).</li>
+ *   <li>The output segment is ACTIVE; all 8 inputs are DEPRECATED.</li>
+ *   <li>With {@code kwayMax=4} and 8 candidates, exactly 4 are merged per
+ *       tick (the smallest 4), leaving 4 ACTIVE.</li>
+ *   <li>With {@code kwayMax=0} (legacy mode) and a tight byte cap, the engine
+ *       falls back to picking only 2 inputs per tick.</li>
+ * </ul>
+ */
+public class IndexOptimizerEngineKwayMergeTest {
+
+    private static final String BASE_PATH = "/herd-test-kway";
+    private static final String TS_UUID = "ts-kway";
+    private static final String IDX_UUID = "idx-kway";
+
+    private TestingServer zkServer;
+    private ZooKeeper zk;
+    private SegmentRegistryClient registry;
+    private AtomicLong fakeClock;
+
+    @Before
+    public void setUp() throws Exception {
+        zkServer = new TestingServer(true);
+        CountDownLatch connected = new CountDownLatch(1);
+        zk = new ZooKeeper(zkServer.getConnectString(), 30000, event -> {
+            if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                connected.countDown();
+            }
+        });
+        assertTrue("ZK connect timed out", connected.await(30, TimeUnit.SECONDS));
+        zk.create(BASE_PATH, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        registry = new SegmentRegistryClient(() -> zk, BASE_PATH);
+        registry.ensureRoot();
+        fakeClock = new AtomicLong(0L);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (zk != null) {
+            zk.close();
+        }
+        if (zkServer != null) {
+            zkServer.close();
+        }
+    }
+
+    private SegmentMetadata seg(String uuid, long sizeBytes) {
+        return SegmentMetadata.builder()
+                .segmentUuid(uuid)
+                .tablespaceUuid(TS_UUID)
+                .tableName("docs")
+                .indexUuid(IDX_UUID)
+                .indexName("docs_v1")
+                .state(SegmentState.ACTIVE)
+                .ownerInstanceId(0)
+                .graphPath("g/" + uuid)
+                .mapPath("m/" + uuid)
+                .baseLsn(new LogSequenceNumber(1L, 100L))
+                .sizeBytes(sizeBytes)
+                .vectorCount(sizeBytes / 100L)
+                .generation(1L)
+                .createdAtEpochMillis(0L)
+                .build();
+    }
+
+    /**
+     * Thin wrapper that delegates to {@link InMemorySegmentMerger} and records
+     * the input count of each {@link #merge} call. We use delegation instead of
+     * subclassing because {@link InMemorySegmentMerger} is {@code final}.
+     */
+    private static final class TrackingMerger implements SegmentMerger {
+        private final InMemorySegmentMerger delegate = new InMemorySegmentMerger();
+        private final AtomicInteger invocations = new AtomicInteger(0);
+        private final AtomicInteger lastInputCount = new AtomicInteger(0);
+
+        @Override
+        public SegmentMetadata merge(List<SegmentMetadata> inputs, int newOwnerInstance) {
+            invocations.incrementAndGet();
+            lastInputCount.set(inputs.size());
+            return delegate.merge(inputs, newOwnerInstance);
+        }
+
+        int getInvocations() {
+            return invocations.get();
+        }
+
+        int getLastInputCount() {
+            return lastInputCount.get();
+        }
+    }
+
+    /**
+     * The core k-way test: 8 sub-target segments are merged into 1 in a single
+     * optimizer tick. The merger is called exactly once with all 8 inputs, not
+     * 7 times with 2 inputs each.
+     *
+     * <p>This reproduces the gist1m / 8-initial-segments scenario from the issue.
+     * With the legacy byte-cap policy (perCycleMaxBytes=1 GiB, segments ~400 MiB
+     * each), only 2-3 segments were picked per cycle, forcing 7 sequential rounds.
+     * K-way picks all 8 in one shot.
+     */
+    @Test
+    public void eightSegmentsMergedInOneTickWithKway8() throws Exception {
+        long segBytes = 400L * 1024L * 1024L; // 400 MiB each — realistic for gist1m shards
+        for (int i = 0; i < 8; i++) {
+            registry.createSegment(seg("seg-" + i, segBytes + i /* distinct sizes */));
+        }
+
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes   */ 8L * 1024L * 1024L * 1024L,  // 8 GiB — nothing graduated
+                /* perCycleMaxBytes */ 1L * 1024L * 1024L * 1024L,  // 1 GiB — would cap to 2 in legacy
+                /* maxCount         */ 200,
+                /* kwayMax          */ 8);
+
+        TrackingMerger trackingMerger = new TrackingMerger();
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                registry, trackingMerger, TS_UUID, policy,
+                /* retentionMs */ 60_000L, () -> 0, fakeClock::get);
+
+        engine.runOnce();
+
+        assertEquals("merger must be invoked exactly once (k-way single-pass)",
+                1, trackingMerger.getInvocations());
+        assertEquals("all 8 segments must be merged in one call",
+                8, trackingMerger.getLastInputCount());
+
+        // Registry state: 1 ACTIVE output + 8 DEPRECATED inputs.
+        List<VersionedSegmentMetadata> all = registry.listSegments(TS_UUID, IDX_UUID);
+        assertEquals("registry must contain 9 znodes after merge (8 deprecated + 1 active)",
+                9, all.size());
+        long active = all.stream()
+                .filter(v -> v.metadata().getState() == SegmentState.ACTIVE).count();
+        long deprecated = all.stream()
+                .filter(v -> v.metadata().getState() == SegmentState.DEPRECATED).count();
+        assertEquals("exactly 1 ACTIVE output", 1, active);
+        assertEquals("all 8 inputs deprecated", 8, deprecated);
+
+        assertEquals(1L, engine.getSegmentsMerged());
+        assertEquals(8L, engine.getSegmentsDeprecated());
+    }
+
+    /**
+     * With {@code kwayMax=4} and 8 available candidates, the policy picks the 4
+     * smallest. After one tick, 4 are merged into 1 and 4 remain ACTIVE.
+     */
+    @Test
+    public void kwayMax4MergesSmallest4Of8() throws Exception {
+        for (int i = 1; i <= 8; i++) {
+            registry.createSegment(seg("seg-" + i, 100L * i)); // 100, 200, …, 800 bytes
+        }
+
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes   */ 10_000L,
+                /* perCycleMaxBytes */ 1L,       // irrelevant in k-way mode
+                /* maxCount         */ 200,
+                /* kwayMax          */ 4);
+
+        TrackingMerger trackingMerger = new TrackingMerger();
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                registry, trackingMerger, TS_UUID, policy,
+                60_000L, () -> 0, fakeClock::get);
+
+        engine.runOnce();
+
+        assertEquals("merger called once", 1, trackingMerger.getInvocations());
+        assertEquals("exactly 4 inputs merged (kwayMax=4)", 4, trackingMerger.getLastInputCount());
+
+        List<VersionedSegmentMetadata> all = registry.listSegments(TS_UUID, IDX_UUID);
+        long active = all.stream()
+                .filter(v -> v.metadata().getState() == SegmentState.ACTIVE).count();
+        long deprecated = all.stream()
+                .filter(v -> v.metadata().getState() == SegmentState.DEPRECATED).count();
+        // 1 merged output + 4 remaining un-merged ACTIVE = 5 ACTIVE; 4 deprecated
+        assertEquals("1 merged output + 4 un-merged = 5 ACTIVE", 5, active);
+        assertEquals("4 smallest inputs deprecated", 4, deprecated);
+    }
+
+    /**
+     * With {@code kwayMax=0} (legacy mode) and a tight byte cap, the engine
+     * falls back to the old behaviour: only 2 segments per tick because the
+     * byte budget is exhausted after the mandatory first pair.
+     */
+    @Test
+    public void kwayMax0FallsBackToLegacyByteCap() throws Exception {
+        // 4 segments of 100 bytes each; perCycleMaxBytes=250 → only 2 fit
+        // (100+100=200 < 250, but 100+100+100=300 > 250).
+        for (int i = 0; i < 4; i++) {
+            registry.createSegment(seg("seg-" + i, 100L));
+        }
+
+        MergePolicy policy = new MergePolicy.AggressivePolicy(
+                /* targetMaxBytes   */ 10_000L,
+                /* perCycleMaxBytes */ 250L,
+                /* maxCount         */ 200,
+                /* kwayMax          */ 0);   // legacy mode
+
+        TrackingMerger trackingMerger = new TrackingMerger();
+        IndexOptimizerEngine engine = new IndexOptimizerEngine(
+                registry, trackingMerger, TS_UUID, policy,
+                60_000L, () -> 0, fakeClock::get);
+
+        engine.runOnce();
+
+        assertEquals("merger called once", 1, trackingMerger.getInvocations());
+        assertEquals("legacy mode: perCycleMaxBytes caps at 2 inputs",
+                2, trackingMerger.getLastInputCount());
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEngineKwayMergeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerEngineKwayMergeTest.java
@@ -134,7 +134,7 @@ public class IndexOptimizerEngineKwayMergeTest {
         volatile Runnable mergeHook;
 
         @Override
-        public SegmentMetadata merge(List<SegmentMetadata> inputs, int newOwnerInstance) {
+        public SegmentMetadata merge(List<SegmentMetadata> inputs, int newOwnerInstance) throws Exception {
             invocations.incrementAndGet();
             lastInputCount.set(inputs.size());
             Runnable hook = mergeHook;
@@ -142,6 +142,11 @@ public class IndexOptimizerEngineKwayMergeTest {
                 hook.run();
             }
             return delegate.merge(inputs, newOwnerInstance);
+        }
+
+        @Override
+        public void abandon(SegmentMetadata produced) {
+            delegate.abandon(produced);
         }
 
         int getInvocations() {
@@ -332,5 +337,8 @@ public class IndexOptimizerEngineKwayMergeTest {
         assertEquals("7 inputs remain ACTIVE (seg-1..seg-7)", 7L, activeCount);
         assertEquals("seg-0 is TRANSFERRING (drifted)", 1L, transferringCount);
         assertEquals("no other znodes created (output must be abandoned)", 8L, all.size());
+
+        // Verify the hook captured "seg-0" (round-trip check on the UUID).
+        assertEquals("drift hook captured seg-0's UUID", "seg-0", firstInputUuid.get());
     }
 }

--- a/herddb-services/src/main/resources/conf/indexoptimizer.properties
+++ b/herddb-services/src/main/resources/conf/indexoptimizer.properties
@@ -47,15 +47,20 @@ indexoptimizer.merge.max.count=200
 indexoptimizer.merge.min.bytes=268435456
 
 # Per-run cap on input segment bytes.
+# NOTE: this setting is only honoured when indexoptimizer.merge.kway.max=0
+# (legacy byte-cap mode). When kway.max >= 2 (k-way mode), the byte cap is
+# bypassed and kway.max governs candidate selection instead.
 indexoptimizer.merge.max.bytes=1073741824
 
 # K-way single-pass merge (issue #524).
 # When >= 2, the merge policy picks up to this many sub-target segments per
 # cycle and merges them in one pass, bypassing indexoptimizer.merge.max.bytes.
 # This collapses N segments into one merge round (O(N) work) instead of
-# sequential 2-way rounds (O(N^2) work). Set to 0 for legacy byte-cap behaviour.
-# Default: 8
-#indexoptimizer.merge.kway.max=8
+# sequential 2-way rounds (O(N^2) work).
+# DEFAULT 0 (disabled, legacy byte-cap mode): opt in explicitly once you have
+# verified the optimizer pod has sufficient heap and local disk for the fan-in.
+# Recommended value when enabling: 8 (sized for the gist1m / 8-segment workload).
+#indexoptimizer.merge.kway.max=0
 
 # Retention window for DEPRECATED segments before transitioning to DELETED.
 indexoptimizer.retention.ms=600000

--- a/herddb-services/src/main/resources/conf/indexoptimizer.properties
+++ b/herddb-services/src/main/resources/conf/indexoptimizer.properties
@@ -49,5 +49,13 @@ indexoptimizer.merge.min.bytes=268435456
 # Per-run cap on input segment bytes.
 indexoptimizer.merge.max.bytes=1073741824
 
+# K-way single-pass merge (issue #524).
+# When >= 2, the merge policy picks up to this many sub-target segments per
+# cycle and merges them in one pass, bypassing indexoptimizer.merge.max.bytes.
+# This collapses N segments into one merge round (O(N) work) instead of
+# sequential 2-way rounds (O(N^2) work). Set to 0 for legacy byte-cap behaviour.
+# Default: 8
+#indexoptimizer.merge.kway.max=8
+
 # Retention window for DEPRECATED segments before transitioning to DELETED.
 indexoptimizer.retention.ms=600000


### PR DESCRIPTION
Fixes #524.

## Changes

- **`MergePolicy.AggressivePolicy`**: added `kwayMax` int field and a 4-arg constructor. When `kwayMax >= 2`, `pickMergeCandidates` picks up to `min(kwayMax, maxCount, candidates.size())` sub-target segments per cycle, smallest-first, **ignoring `perCycleMaxBytes`**. This collapses N segments into one merge round (O(N) work) instead of the O(N) sequential rounds the byte-cap forced (O(N²) cumulative work). The 3-arg constructor delegates with `kwayMax=0`, preserving the existing byte-cap behaviour for all callers that have not opted in.
- **`OptimizerConfiguration`**: new constant `PROPERTY_MERGE_KWAY_MAX = "indexoptimizer.merge.kway.max"` with default `0` (opt-in/disabled). Operators enable k-way by setting `indexoptimizer.merge.kway.max=8` (or any value ≥ 2) once they have verified the optimizer pod has sufficient heap and local disk for the fan-in.
- **`IndexOptimizerMain`**: reads `kwayMax` from config and passes it to `AggressivePolicy`; logs the resolved policy parameters at startup.
- **`indexoptimizer.properties`**: documents the new `kway.max` key (default 0); adds a banner above `merge.max.bytes` explaining it is inert when `kway.max ≥ 2`.

Proposal 2 (concurrent merges of disjoint segment sets) is intentionally deferred. `RemoteSegmentMerger` stores per-call volatile state (`lastGraphMerger`, `pendingProgress`) as instance fields and is not thread-safe. True concurrent graph merges require a pool of merger instances with separate `tmpDirectory` sub-spaces — a larger change tracked separately.

## Tests

- **`AggressivePolicyKwayTest`** (14 cases): verifies k-way candidate selection when candidates ≤ kwayMax; selects the smallest k when more exist; ignores `perCycleMaxBytes` in k-way mode; still respects `maxCount`; excludes graduated segments; handles zero-size sub-target segments; covers `kwayMax > maxCount` boundary (exactly maxCount candidates, and more-than-maxCount candidates); rejects invalid `kwayMax` values (1, −1). Also verifies `kwayMax=0` falls back to the legacy byte-cap logic.
- **`IndexOptimizerEngineKwayMergeTest`** (4 cases): end-to-end ZK-registry tests:
  - `eightSegmentsMergedInOneTickWithKway8`: 8 sub-target segments (simulated gist1m 400 MiB/segment sizes) → single merge call with all 8 inputs in one tick; 8 inputs DEPRECATED, 1 output ACTIVE. Uses `InMemorySegmentMerger` (does not exercise real graph I/O — proves the policy-to-engine contract only).
  - `kwayMax4MergesSmallest4Of8`: 8 candidates, kwayMax=4 → smallest 4 merged, 4 remain ACTIVE.
  - `kwayMax0FallsBackToLegacyByteCap`: kwayMax=0, tight byte cap → only 2 inputs per cycle.
  - `kwayAbortsMergeWhenInputDriftsDuringMerge`: drift injected via `OwnershipTransfer.initiate` on one of 8 inputs during the merge call; verifies `mergeAbortsRevalidateFailedTotal` increments to 1, no ACTIVE output is published, and only 8 znodes exist (no leaked output).

## Hammer suites

This change is exclusively in `herddb-indexing-service` — it modifies how the **out-of-process index-optimizer** selects merge candidates from the ZooKeeper registry. The change does not touch `herddb-core`, the BLink index, checkpoint pipeline, or transaction isolation. The hammer suites (`DirectMultipleConcurrentUpdatesSuite*`, `BLinkConcurrentSearchInsertTest`, `LazyValueCacheConcurrentUpdatesSuite*`) exercise the in-process compaction path and BLink node-locking — those code paths are not affected by this PR. Running them would not provide additional regression coverage for the optimizer-policy change.

All 45 changed/related tests green locally. Pre-PR validation (checkstyle, Apache RAT, SpotBugs) also green.

🤖 Implemented by the `pr-worker` agent.