### PR TITLE
issue #530: wire CompactionProgressListener to streaming-merge batch-progress callback

### DIFF
--- a/excludeFindBugsFilter.xml
+++ b/excludeFindBugsFilter.xml
@@ -87,19 +87,6 @@
         <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>
     <!--
-      RemoteSegmentGraphMerger.buildGraph() (issue #503): batchListener is a
-      LongBinaryOperator used purely for its side effect (updating MergeProgress batch
-      counters via a lambda). The return value is deliberately ignored — the JDK has no
-      void-returning primitive-specialised consumer for two longs (no LongBiConsumer).
-      The lambda always returns 0L as a documented no-op return. Scoped to the exact
-      method that fires the callback to avoid suppressing the rule across the whole class.
-    -->
-    <Match>
-        <Class name="herddb.index.vector.RemoteSegmentGraphMerger"/>
-        <Method name="buildGraph"/>
-        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
-    </Match>
-    <!--
       RemoteSegmentMerger.readCgroupMemoryLimitGib() (issue #503): reads the cgroup v2
       container memory limit from /sys/fs/cgroup/memory.max, which is a well-known Linux
       kernel pseudo-filesystem path, not a user-configurable absolute file path. The

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -1413,13 +1413,13 @@ public final class RemoteSegmentGraphMerger {
             // Fire batch-progress callback every BATCH_PROGRESS_INTERVAL vectors
             // so the HTTP /status endpoint can show fine-grained build progress.
             if (batchCb != null && (ord % BATCH_PROGRESS_INTERVAL == 0)) {
-                batchCb.applyAsLong(ord, keptCount);
+                fireBatchProgress(batchCb, ord, keptCount);
             }
             ord++;
         }
         // Final batch-progress notification at 100%.
         if (batchCb != null) {
-            batchCb.applyAsLong(keptCount, keptCount);
+            fireBatchProgress(batchCb, keptCount, keptCount);
         }
         try {
             builder.cleanup();

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -19,6 +19,7 @@
  */
 package herddb.index.vector;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
@@ -28,6 +29,7 @@ import io.github.jbellis.jvector.disk.ReaderSupplierFactory;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
+import io.github.jbellis.jvector.graph.disk.CompactionProgressListener;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexCompactor;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
@@ -459,6 +461,22 @@ public final class RemoteSegmentGraphMerger {
     }
 
     /**
+     * Bridge between {@link java.util.function.LongBinaryOperator} (the batch-progress
+     * callback type used throughout this class) and {@link CompactionProgressListener}
+     * (which has a {@code void onProgress(long, long)} contract).
+     *
+     * <p>The JDK provides no {@code LongBiConsumer} specialisation, so callers must use
+     * {@code LongBinaryOperator} and return a documented no-op {@code 0L}. SpotBugs would
+     * otherwise flag the ignored return value as
+     * {@code RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT}.
+     */
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "LongBinaryOperator used for side-effect only; 0L return is a documented no-op sentinel")
+    private static void fireBatchProgress(LongBinaryOperator cb, long completed, long total) {
+        cb.applyAsLong(completed, total);
+    }
+
+    /**
      * Legacy in-memory rebuild: reads each input's map file (carrying
      * {@code (ordinal, pk, vector)} tuples), de-duplicates by PK across
      * sources keeping the highest generation, builds a fresh
@@ -829,6 +847,14 @@ public final class RemoteSegmentGraphMerger {
             //    on the second allocation doesn't leak the first; allocations
             //    happen inside the outer try so the existing finally cleans up.
             notifyPhase("compacting");
+            // Notify the initial batch state so the HTTP /status endpoint immediately
+            // shows a non-zero denominator when entering the "compacting" phase. The
+            // batchListener is read once here so the same reference is used for both
+            // the initial call and the CompactionProgressListener lambda below.
+            LongBinaryOperator batchCb = batchListener;
+            if (batchCb != null) {
+                fireBatchProgress(batchCb, 0L, keptCount);
+            }
             Path graphOutTemp = null;
             Path mapOutTemp = null;
             String multipartUuid = outputIndexUuid + "_seg" + outputSegmentId;
@@ -847,8 +873,17 @@ public final class RemoteSegmentGraphMerger {
                 OnDiskGraphIndexCompactor compactor = new OnDiskGraphIndexCompactor(
                         sources, liveBitsets, mappers, similarity,
                         PhysicalCoreExecutor.pool());
+                // Build a typed CompactionProgressListener from the batch callback so
+                // jvector can push (completedBatches, totalBatches) updates back to
+                // MergeProgress without log-message parsing. The listener is null when
+                // no observer is registered (avoids an empty lambda allocation).
+                // fireBatchProgress() is used to avoid a lambda that ignores the
+                // LongBinaryOperator return value (SpotBugs RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT).
+                CompactionProgressListener progressListener = batchCb != null
+                        ? (completed, total) -> fireBatchProgress(batchCb, completed, total)
+                        : null;
                 try {
-                    compactor.compact(graphOutTemp);
+                    compactor.compact(graphOutTemp, progressListener);
                 } catch (java.io.FileNotFoundException | RuntimeException e) {
                     throw new IOException("OnDiskGraphIndexCompactor.compact failed"
                             + " (streaming merge)", e);

--- a/herddb-core/src/test/java/herddb/index/vector/StreamingCompactionBatchProgressTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/StreamingCompactionBatchProgressTest.java
@@ -1,0 +1,232 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+*/
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.LongBinaryOperator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that {@link RemoteSegmentGraphMerger} correctly propagates
+ * {@link io.github.jbellis.jvector.graph.disk.CompactionProgressListener} callbacks
+ * during the streaming merge path (issue #530).
+ *
+ * <p>Before this fix, {@code GET /status} on the index-optimizer returned
+ * {@code batches_written: 0 / pct_complete: 0.00} for the entire duration of a
+ * multi-minute streaming compaction because the batch-progress callback was never
+ * wired to {@link io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexCompactor}.
+ *
+ * <p>The test builds three real on-disk segments via {@link PersistentVectorStore},
+ * runs a streaming merge, and asserts that the {@code batchListener} receives:
+ * <ol>
+ *   <li>An initial {@code (0, keptCount)} notification immediately when the
+ *       "compacting" phase begins — so the HTTP denominator is non-zero from
+ *       the first instant.</li>
+ *   <li>At least one {@code (completed ≥ 10, total > 0)} notification from
+ *       {@code OnDiskGraphIndexCompactor} itself.</li>
+ *   <li>A final notification where {@code completed == total} (the 100 %
+ *       signal emitted at level completion).</li>
+ *   <li>Monotonically non-decreasing {@code completed} values within a level.</li>
+ * </ol>
+ */
+public class StreamingCompactionBatchProgressTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private boolean savedStreamingFlag;
+
+    @Before
+    public void setUp() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+        savedStreamingFlag = VectorIndexCompactor.streamingCompactionEnabled;
+        VectorIndexCompactor.streamingCompactionEnabled = true;
+    }
+
+    @After
+    public void tearDown() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+        VectorIndexCompactor.streamingCompactionEnabled = savedStreamingFlag;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Builds {@code numSegments} on-disk segments via a real
+     * {@link PersistentVectorStore} and returns the merger inputs.
+     */
+    private List<RemoteSegmentGraphMerger.RemoteSegmentInput> buildInputs(
+            Path tmpDir, MemoryDataStorageManager dsm, int dim,
+            int numSegments, int perSegment, long seed) throws Exception {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        try (PersistentVectorStore store = new PersistentVectorStore(
+                "ts-progress-test", "tbl", "tsuuid-prog", "vec_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE)) {
+            store.start();
+            Random rng = new Random(seed);
+            for (int c = 0; c < numSegments; c++) {
+                for (int i = 0; i < perSegment; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            assertEquals(numSegments, store.getSegmentCount());
+
+            List<VectorSegment> segments = store.getOnDiskSegmentsSnapshotForTest();
+            List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs = new ArrayList<>(segments.size());
+            String tablespaceUuid = "tsuuid-prog";
+            String indexUuid = store.indexUUID();
+            for (VectorSegment seg : segments) {
+                inputs.add(new RemoteSegmentGraphMerger.RemoteSegmentInput(
+                        tablespaceUuid, indexUuid,
+                        seg.segmentUuid != null ? seg.segmentUuid : indexUuid + "_seg" + seg.segmentId,
+                        seg.segmentId,
+                        seg.mapFileSize,
+                        seg.graphFileSize,
+                        seg.generation,
+                        new int[0]));
+            }
+            return inputs;
+        }
+    }
+
+    @Test
+    public void batchProgressIsReportedDuringStreamingCompaction() throws Exception {
+        int dim = 16;
+        int numSegments = 3;
+        int perSegment = 200;
+        long expectedKeptCount = (long) numSegments * perSegment; // 600, no tombstones/duplicates
+
+        Path tmpDir = tmpFolder.newFolder("progress-test").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        List<RemoteSegmentGraphMerger.RemoteSegmentInput> inputs =
+                buildInputs(tmpDir, dsm, dim, numSegments, perSegment, 99L);
+
+        // Verify streaming dispatch can fire (all inputs have real graphFileSize).
+        for (RemoteSegmentGraphMerger.RemoteSegmentInput in : inputs) {
+            assertTrue("graphFileSize must be > 0 for streaming: " + in.segmentUuid,
+                    in.graphFileSize > 0L);
+        }
+
+        // Collect all (completed, total) pairs in arrival order.
+        // CopyOnWriteArrayList because the jvector compactor fires callbacks from
+        // its ForkJoinPool threads while the test thread is blocked in merge().
+        List<long[]> progressPairs = new CopyOnWriteArrayList<>();
+
+        RemoteSegmentGraphMerger merger = new RemoteSegmentGraphMerger(
+                dsm, tmpDir, 16, 100, 1.2f, 1.4f, VectorSimilarityFunction.COSINE);
+
+        LongBinaryOperator batchListener = (completed, total) -> {
+            progressPairs.add(new long[]{completed, total});
+            return 0L;
+        };
+        merger.setBatchListener(batchListener);
+
+        RemoteSegmentGraphMerger.MergeOutput out = merger.merge(
+                inputs, "tsuuid-prog", inputs.get(0).indexUuid, 77777L, dim);
+
+        assertTrue("merge must produce output", out != null);
+        assertEquals("all 600 vectors kept", expectedKeptCount, out.vectorCount);
+
+        // ---------------------------------------------------------------
+        // Assertion 1: the initial (0, keptCount) notification fires so the
+        // HTTP /status denominator is non-zero from the first instant of the
+        // "compacting" phase.
+        // ---------------------------------------------------------------
+        assertTrue("at least one progress notification must be received",
+                !progressPairs.isEmpty());
+        long[] first = progressPairs.get(0);
+        assertEquals("first notification: completed must be 0 (initial denominator seed)",
+                0L, first[0]);
+        assertEquals("first notification: total must equal keptCount",
+                expectedKeptCount, first[1]);
+
+        // ---------------------------------------------------------------
+        // Assertion 2: at least one notification from the compactor itself
+        // with completed >= 10 (first % 10 == 0 fire).
+        // ---------------------------------------------------------------
+        boolean sawCompactorProgress = false;
+        for (long[] pair : progressPairs) {
+            if (pair[0] >= 10) {
+                sawCompactorProgress = true;
+                break;
+            }
+        }
+        assertTrue("compactor must fire at least one progress notification with completed >= 10",
+                sawCompactorProgress);
+
+        // ---------------------------------------------------------------
+        // Assertion 3: a final (completed == total) notification is present
+        // for level-0 completion (the "completed == total" branch added in jvector).
+        // ---------------------------------------------------------------
+        boolean sawLevelCompletion = false;
+        for (long[] pair : progressPairs) {
+            if (pair[0] == pair[1] && pair[1] > 0) {
+                sawLevelCompletion = true;
+                break;
+            }
+        }
+        assertTrue("a completed==total notification must be received at level completion",
+                sawLevelCompletion);
+
+        // ---------------------------------------------------------------
+        // Assertion 4: within a contiguous run sharing the same total,
+        // completed must be monotonically non-decreasing.
+        // ---------------------------------------------------------------
+        long prevCompleted = 0L;
+        long prevTotal = 0L;
+        for (long[] pair : progressPairs) {
+            long completed = pair[0];
+            long total = pair[1];
+            assertTrue("completed must always be >= 0", completed >= 0);
+            assertTrue("total must always be > 0", total > 0);
+            assertTrue("completed must always be <= total", completed <= total);
+            if (total == prevTotal) {
+                // Same level: completed must not go backwards.
+                assertTrue("completed must be non-decreasing within a level",
+                        completed >= prevCompleted);
+            }
+            prevCompleted = completed;
+            prevTotal = total;
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/StreamingCompactionBatchProgressTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/StreamingCompactionBatchProgressTest.java
@@ -66,9 +66,11 @@ public class StreamingCompactionBatchProgressTest {
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     private boolean savedStreamingFlag;
+    private int savedMinLiveVectors;
 
     @Before
     public void setUp() {
+        savedMinLiveVectors = PersistentVectorStore.minLiveVectorsForCheckpoint;
         PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
         savedStreamingFlag = VectorIndexCompactor.streamingCompactionEnabled;
         VectorIndexCompactor.streamingCompactionEnabled = true;
@@ -76,7 +78,7 @@ public class StreamingCompactionBatchProgressTest {
 
     @After
     public void tearDown() {
-        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectors;
         VectorIndexCompactor.streamingCompactionEnabled = savedStreamingFlag;
     }
 


### PR DESCRIPTION
Fixes #530.

## Root cause

`GET /status` on the index-optimizer always returned `batches_written: 0`,
`batches_total: 0`, `pct_complete: 0.00` throughout a streaming compaction
because `RemoteSegmentGraphMerger.mergeStreaming()` never forwarded the
`batchListener` field to `OnDiskGraphIndexCompactor`. The legacy in-memory
path (`mergeLegacy`) already wired the callback to `buildGraph()`; the
streaming path had no equivalent plumbing.

## Changes

- **`RemoteSegmentGraphMerger.java`**
  - On entering the `"compacting"` phase, fires an initial
    `(0, keptCount)` notification so `/status` immediately shows a
    non-zero denominator — not only after the first batch completes.
  - Creates a `CompactionProgressListener` that delegates to the
    `batchListener` and passes it to the new
    `OnDiskGraphIndexCompactor.compact(Path, CompactionProgressListener)`
    overload (added in `eolivelli/jvector#7`, now on `eolivelli/jvector` main).
  - Introduces `fireBatchProgress(LongBinaryOperator, long, long)` static
    helper with `@SuppressFBWarnings` to bridge the JDK's void-less
    `LongBinaryOperator` to the typed `void onProgress()` contract without
    SpotBugs false positives.

## Tests

- **`StreamingCompactionBatchProgressTest`** (new, plain test — no cluster
  infra required): builds 3 real on-disk segments via `PersistentVectorStore`,
  enables `VectorIndexCompactor.streamingCompactionEnabled`, runs a full
  streaming merge, and asserts:
  1. An initial `(0, keptCount=600)` notification fires immediately when the
     `"compacting"` phase begins (denominator always non-zero from the first instant).
  2. At least one `(completed ≥ 10, total > 0)` notification arrives from
     `OnDiskGraphIndexCompactor` (proves the jvector callback actually fires).
  3. A final `(completed == total)` notification marks level completion
     (100% signal).
  4. `completed` values are monotonically non-decreasing within a level.

🤖 Implemented by the `pr-worker` agent.