### PR TITLE
issue #535: defer dropSegmentByUuid close past in-flight compaction

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -499,6 +499,40 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /** Serialises compaction cycles. One run at a time. */
     private final ReentrantLock compactionLock = new ReentrantLock();
 
+    /**
+     * Segments removed from {@link #segments} by {@link #dropSegmentByUuid}
+     * (typically fired by the optimizer-watcher's
+     * {@code onSegmentReleased} callback) that are awaiting
+     * {@link VectorSegment#close()} + BLink-storage drop (issue #535).
+     *
+     * <p>The close cannot run synchronously inside {@code dropSegmentByUuid}
+     * because a concurrent {@link #runCompactionCycle} may hold live
+     * references to the same {@code VectorSegment} object via its
+     * candidate snapshot (taken at the start of the cycle without a
+     * read-lock). Closing the segment while the cycle's snapshot still
+     * references it nulls out {@code seg.onDiskGraph}, causing
+     * {@link VectorIndexCompactor#rebuildSegmentStreaming} to throw
+     * {@code CompactionException(CORRUPTION, "candidate segment N has no
+     * on-disk graph")} on the next iteration of the candidate list — the
+     * exact production symptom of issue #535.
+     *
+     * <p>The deque is drained at two points (both guarded by
+     * {@link #compactionLock} so the drainer can never run alongside a
+     * cycle that might still be using the queued segments):
+     * <ul>
+     *   <li>Opportunistically at the end of {@code dropSegmentByUuid}
+     *       via {@link #drainPendingSegmentClosesOpportunistically} —
+     *       fast path when no compaction is active.</li>
+     *   <li>In {@link #runCompactionCycle}'s finally block, AFTER the
+     *       cycle's snapshot is no longer being iterated, but BEFORE
+     *       {@code compactionLock} is released — guarantees the
+     *       drop+close pair is observable to the next cycle as a single
+     *       atomic step.</li>
+     * </ul>
+     */
+    private final java.util.concurrent.ConcurrentLinkedDeque<VectorSegment>
+            pendingSegmentCloses = new java.util.concurrent.ConcurrentLinkedDeque<>();
+
     /** Background thread driving {@link #runCompactionCycle(long)}. */
     private volatile Thread vectorIndexCompactionThread;
     private final Object vectorIndexCompactionWakeup = new Object();
@@ -1264,6 +1298,36 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * For testing. */
     public void setPhaseCPostDeletesApplyHookForTest(Runnable hook) {
         this.phaseCPostDeletesApplyHook = hook;
+    }
+
+    /**
+     * Test hook (issue #535) fired inside {@link #runCompactionCycle} AFTER
+     * the {@code candidates} list has been built by
+     * {@link VectorIndexCompactor#chooseSegmentsToMerge} and BEFORE
+     * {@link VectorIndexCompactor#rebuildSegment} is called. Lets a test
+     * deterministically inject a concurrent mutation (e.g. a
+     * {@link #dropSegmentByUuid} that closes one of the candidate
+     * {@code VectorSegment} objects) while the cycle is holding live
+     * references to those candidates — reproducing the race that surfaces
+     * as {@code "candidate segment N has no on-disk graph"} on production
+     * deployments where the optimizer-driven {@link
+     * herddb.indexing.segment.SegmentAssignmentWatcher} fires
+     * {@code onSegmentReleased} concurrently with an IS-local fallback
+     * compaction.
+     *
+     * <p>Hook runs under {@link #compactionLock} but NOT under
+     * {@link #stateLock}, so it can safely call any operation that takes
+     * the state writeLock.
+     */
+    private volatile Runnable compactionPostCandidateSelectionHookForTests;
+
+    /**
+     * Sets the test hook fired between candidate selection and
+     * {@code rebuildSegment} in {@link #runCompactionCycle}.
+     * For testing only (issue #535 reproducer).
+     */
+    public void setCompactionPostCandidateSelectionHookForTest(Runnable hook) {
+        this.compactionPostCandidateSelectionHookForTests = hook;
     }
 
     // -------------------------------------------------------------------------
@@ -2292,6 +2356,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 long vectorsWritten = 0;
                 long vectorsFiltered = 0;
                 VectorIndexCompactor.RebuildResult rebuild = null;
+                // Issue #535 — test hook: fires AFTER candidates + authority are
+                // built but BEFORE rebuildSegment iterates the candidates'
+                // onDiskGraph references. Lets a reproducer test simulate the
+                // race where a concurrent dropSegmentByUuid (from the optimizer
+                // watcher) closes a candidate VectorSegment under our feet.
+                Runnable postCandSelHook = compactionPostCandidateSelectionHookForTests;
+                if (postCandSelHook != null) {
+                    postCandSelHook.run();
+                }
                 try {
                     rebuild = VectorIndexCompactor.rebuildSegment(this, candidates, authority);
                     if (rebuild == null) {
@@ -2420,6 +2493,13 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         } finally {
             compactionActive.set(0);
+            // Issue #535: drain segments queued for close by any concurrent
+            // dropSegmentByUuid that landed during this cycle. Doing this
+            // BEFORE releasing compactionLock guarantees the close cannot
+            // race with this cycle's iteration of candidates (the snapshot
+            // is fully consumed by now), and that the next cycle to acquire
+            // compactionLock starts from an empty queue.
+            drainPendingSegmentClosesUnderCompactionLock();
             compactionLock.unlock();
             // Belt-and-suspenders notify (issue #370): all normal and checked-exception
             // exit paths call notifySegmentCountMonitor() explicitly above for immediate
@@ -3233,8 +3313,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     @Override
     public void dropSegmentByUuid(String segmentUuid) {
-        stateLock.writeLock().lock();
         VectorSegment found = null;
+        stateLock.writeLock().lock();
         try {
             List<VectorSegment> newList = new java.util.concurrent.CopyOnWriteArrayList<>();
             for (VectorSegment s : segments) {
@@ -3257,33 +3337,44 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     "dropSegmentByUuid: removed segment {0} from store {1};"
                             + " total on-disk segments now {2}",
                     new Object[]{segmentUuid, indexName, segments.size()});
-            // Close the segment while holding the write lock. searchInternal snapshots
-            // this.segments and executes seg.search() under stateLock.readLock(). By
-            // closing here (under writeLock) we guarantee that no concurrent search can
-            // be using this segment when close() runs: the writeLock cannot be acquired
-            // until all in-flight readLock holders have released (and thus completed
-            // their seg.search() call). Without this, a search that snapshots the
-            // segment reference before the writeLock is acquired could use a closed
-            // segment, causing ReaderSupplier / OnDiskGraphIndex use-after-close errors.
-            try {
-                found.close();
-            } catch (RuntimeException closeEx) {
-                // Narrow catch: VectorSegment.close() throws only RuntimeException
-                // (BLink cleanup). We must not let a stale-handle error mask the
-                // segment removal or propagate past the writeLock.
-                LOGGER.log(Level.WARNING,
-                        "dropSegmentByUuid: error closing segment " + segmentUuid
-                                + " in store " + indexName, closeEx);
-            }
-            // Reclaim the per-segment pk-to-node BLink storage entry. For adopted
-            // (external-storage-key) segments this is the entry created by
-            // loadFusedPQSegment → createSegmentBLinks during adoption. Without
-            // this, each optimizer adopt→deprecate→drop cycle leaks one BLink
-            // storage entry indefinitely.
-            dropSegmentBLinkStorage(found);
+            // Issue #535: do NOT close `found` synchronously here. A concurrent
+            // runCompactionCycle may have snapshotted `segments` (volatile read,
+            // no readLock) at the start of the cycle and may still hold a live
+            // reference to `found` via its `candidates` list. Closing `found`
+            // immediately would null out `found.onDiskGraph` (the only place that
+            // field is ever written to null — see {@link VectorSegment#close})
+            // and the cycle's next iteration of `candidates` in
+            // {@link VectorIndexCompactor#rebuildSegmentStreaming} (line ~780)
+            // would throw {@code CompactionException(CORRUPTION,
+            // "candidate segment N has no on-disk graph (streaming compaction)")},
+            // matching the exact failure observed during the bigann-100M k3s
+            // benchmark (issue #535).
+            //
+            // Instead, queue `found` for deferred close. The drainer is guarded
+            // by {@link #compactionLock} so it cannot run while a cycle is in
+            // progress — i.e. close happens AFTER any in-flight cycle has
+            // released its references. The two drain points are
+            // {@link #drainPendingSegmentClosesOpportunistically} (called below,
+            // OUTSIDE the writeLock, fast path) and
+            // {@link #runCompactionCycle}'s finally block.
+            //
+            // Search safety: searchInternal snapshots `this.segments` under
+            // stateLock.readLock() and uses the VectorSegment objects under the
+            // same readLock. The writeLock above guarantees no readLock holder
+            // overlaps the segment-list mutation, so any concurrent searcher
+            // either (a) finishes before we publish `newList` (writeLock waits
+            // for outstanding readLock holders) or (b) starts after we publish
+            // `newList` and never sees `found`. Either way, no search will
+            // dereference `found.onDiskGraph` after we drain.
+            pendingSegmentCloses.add(found);
         } finally {
             stateLock.writeLock().unlock();
         }
+        // Outside the writeLock: try to drain immediately if no compaction is
+        // running. If a cycle IS running, its finally block will drain when it
+        // releases compactionLock, so the segment resources are released as
+        // soon as it is safe to do so. See {@link #pendingSegmentCloses}.
+        drainPendingSegmentClosesOpportunistically();
     }
 
     /**
@@ -3576,6 +3667,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
         if (latch != null) {
             latch.countDown();
             this.checkpointPhaseComplete = null;
+        }
+        // Issue #535: drain any segments queued for close by a deferred
+        // dropSegmentByUuid that landed after the compaction thread exited.
+        // After the join above, no new cycle can start, so no contention
+        // for compactionLock — but we still take it for invariant clarity.
+        compactionLock.lock();
+        try {
+            drainPendingSegmentClosesUnderCompactionLock();
+        } finally {
+            compactionLock.unlock();
         }
         // Issue #455: drop every segment's contribution from the on-disk
         // memory counter before closing them, so the counter goes back to 0
@@ -6594,6 +6695,85 @@ public class PersistentVectorStore extends AbstractVectorStore {
         } catch (DataStorageManagerException e) {
             LOGGER.log(Level.WARNING, "Failed to drop BLink storage for segment " + seg.segmentId
                     + " of vector store " + indexName, e);
+        }
+    }
+
+    /**
+     * Issue #535: drains every queued {@link VectorSegment} in
+     * {@link #pendingSegmentCloses}, closing each one and dropping its
+     * BLink storage entry. Caller MUST hold {@link #compactionLock} so
+     * the close cannot race with a {@link #runCompactionCycle} that has
+     * already snapshotted {@code this.segments} and would dereference
+     * {@code seg.onDiskGraph} on the (now-closed) segment.
+     *
+     * <p>Idempotent and safe to call repeatedly: drains until the queue
+     * is empty and {@link VectorSegment#close()} is itself idempotent
+     * (its {@code if (odg != null)} guard).
+     */
+    private void drainPendingSegmentClosesUnderCompactionLock() {
+        // Sanity-check the lock invariant (assertions are no-ops in production).
+        assert compactionLock.isHeldByCurrentThread()
+                : "drainPendingSegmentClosesUnderCompactionLock requires compactionLock";
+        VectorSegment seg;
+        while ((seg = pendingSegmentCloses.pollFirst()) != null) {
+            try {
+                seg.close();
+            } catch (RuntimeException closeEx) {
+                // Narrow catch: VectorSegment.close() throws only
+                // RuntimeException (BLink cleanup). Logging-and-continue is
+                // the correct behaviour — the segment's bookkeeping must
+                // not block the drain of subsequent segments.
+                LOGGER.log(Level.WARNING,
+                        "drainPendingSegmentCloses: error closing segment "
+                                + seg.segmentId + " in store " + indexName, closeEx);
+            }
+            dropSegmentBLinkStorage(seg);
+        }
+    }
+
+    /**
+     * Issue #535: opportunistic drain — runs only if {@link #compactionLock}
+     * is currently free AND not already held by the current thread.
+     * Called from {@link #dropSegmentByUuid} immediately after the
+     * writeLock release, so a "drop while no compaction is running" path
+     * closes synchronously (preserving the original behaviour for the
+     * common case where the watcher fires while the IS is idle). When
+     * compaction IS running, this is a no-op and the cycle's own finally
+     * block drains the queue when it completes.
+     *
+     * <p>The {@code isHeldByCurrentThread} guard is critical because
+     * {@link java.util.concurrent.locks.ReentrantLock} returns {@code true}
+     * from {@code tryLock} when the calling thread already holds it
+     * (re-entrance). Without the guard, a {@code dropSegmentByUuid} call
+     * fired from inside a {@link #runCompactionCycle}-driven code path
+     * (e.g., a test hook, or any future caller that runs on the
+     * compaction thread itself) would acquire the lock re-entrantly and
+     * close the segment immediately — reintroducing the very race this
+     * fix is meant to eliminate.
+     */
+    private void drainPendingSegmentClosesOpportunistically() {
+        if (pendingSegmentCloses.isEmpty()) {
+            return;
+        }
+        if (compactionLock.isHeldByCurrentThread()) {
+            // The current thread is already inside a compaction cycle (or
+            // some other code path that took compactionLock). Reentering
+            // the lock here would let the drain run alongside that cycle's
+            // own snapshot iteration. Skip — the cycle's finally block
+            // drains the queue before releasing compactionLock.
+            return;
+        }
+        if (!compactionLock.tryLock()) {
+            // Another thread is running a compaction. Its finally block
+            // drains pendingSegmentCloses before releasing compactionLock,
+            // so the queue is guaranteed to be empty by the time the next
+            // caller observes the lock as free.
+            return;
+        }
+        try {
+            drainPendingSegmentClosesUnderCompactionLock();
+        } finally {
+            compactionLock.unlock();
         }
     }
 

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -76,6 +76,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -516,7 +517,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * on-disk graph")} on the next iteration of the candidate list — the
      * exact production symptom of issue #535.
      *
-     * <p>The deque is drained at two points (both guarded by
+     * <p>The deque is drained at three points (all guarded by
      * {@link #compactionLock} so the drainer can never run alongside a
      * cycle that might still be using the queued segments):
      * <ul>
@@ -528,10 +529,27 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *       {@code compactionLock} is released — guarantees the
      *       drop+close pair is observable to the next cycle as a single
      *       atomic step.</li>
+     *   <li>In {@link #close} after the compaction thread has been
+     *       joined, so a queued segment is never leaked at shutdown.</li>
      * </ul>
+     *
+     * <p><b>Known residual race (issue #537):</b> the drain holds
+     * {@code compactionLock} but NOT {@link #stateLock}'s writeLock, so
+     * it does not serialize with concurrent {@code searchInternal}
+     * callers. The drain is safe in the common case because
+     * {@code dropSegmentByUuid} removes the segment from
+     * {@code this.segments} under the writeLock (which waits for all
+     * in-flight {@code searchInternal} readLock holders), so the next
+     * search snapshot won't see the queued segment. However, when
+     * {@code atomicSwapCompactionResult}'s Stage-3 publish races with
+     * {@code dropSegmentByUuid} as described in issue #537, the
+     * just-dropped segment can be re-published into {@code this.segments}
+     * by the Stage-3 writeLock window; the drain then closes a segment
+     * that is observable to new searches. That residual race is tracked
+     * separately and not addressed by this field.
      */
-    private final java.util.concurrent.ConcurrentLinkedDeque<VectorSegment>
-            pendingSegmentCloses = new java.util.concurrent.ConcurrentLinkedDeque<>();
+    private final ConcurrentLinkedDeque<VectorSegment>
+            pendingSegmentCloses = new ConcurrentLinkedDeque<>();
 
     /** Background thread driving {@link #runCompactionCycle(long)}. */
     private volatile Thread vectorIndexCompactionThread;
@@ -2738,6 +2756,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // checkpointLock is the outermost serialiser of segments mutations,
             // so the volatile read of `this.segments` is stable for the
             // duration of this method.
+            //
+            // KNOWN RACE (issue #537): dropSegmentByUuid does NOT take
+            // checkpointLock; it only takes stateLock.writeLock(). So a
+            // drop landing between this read of `current` and Stage 3's
+            // writeLock-protected publish can:
+            //   - remove a NON-INPUT segment from `this.segments`, and
+            //   - leave it queued in pendingSegmentCloses;
+            // then Stage 3 publishes `newSegments` built from `current`
+            // (which still has the dropped segment) and re-inserts it
+            // into `this.segments`. The cycle's finally then closes the
+            // re-published segment, leaving it visible to subsequent
+            // searches / compactions with onDiskGraph == null. Tracked
+            // separately; outside the scope of issue #535.
             List<VectorSegment> current = this.segments;
             // Canonical pre-sizing: HashSet rounds up to the next power of two,
             // so we want capacity = ceil(size / loadFactor). 0.75f is the
@@ -3313,68 +3344,76 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     @Override
     public void dropSegmentByUuid(String segmentUuid) {
-        VectorSegment found = null;
-        stateLock.writeLock().lock();
         try {
-            List<VectorSegment> newList = new java.util.concurrent.CopyOnWriteArrayList<>();
-            for (VectorSegment s : segments) {
-                if (segmentUuid.equals(s.segmentUuid)) {
-                    found = s;
-                } else {
-                    newList.add(s);
+            VectorSegment found = null;
+            stateLock.writeLock().lock();
+            try {
+                List<VectorSegment> newList = new java.util.concurrent.CopyOnWriteArrayList<>();
+                for (VectorSegment s : segments) {
+                    if (segmentUuid.equals(s.segmentUuid)) {
+                        found = s;
+                    } else {
+                        newList.add(s);
+                    }
                 }
+                if (found == null) {
+                    return;
+                }
+                segments = newList;
+                // Mark dirty so the next checkpoint() serialises the reduced segment list.
+                // Without this, dropping a segment leaves a stale entry in the IndexStatus
+                // on disk (the checkpoint gate would see no changes and skip).
+                dirty.set(true);
+                LOGGER.log(Level.INFO,
+                        "dropSegmentByUuid: removed segment {0} from store {1};"
+                                + " total on-disk segments now {2}",
+                        new Object[]{segmentUuid, indexName, segments.size()});
+                // Issue #535: do NOT close `found` synchronously here. A concurrent
+                // runCompactionCycle may have snapshotted `segments` (volatile read,
+                // no readLock) at the start of the cycle and may still hold a live
+                // reference to `found` via its `candidates` list. Closing `found`
+                // immediately would null out `found.onDiskGraph` (the only place that
+                // field is ever written to null — see {@link VectorSegment#close})
+                // and the cycle's next iteration of `candidates` in
+                // {@link VectorIndexCompactor#rebuildSegmentStreaming} (line ~780)
+                // would throw {@code CompactionException(CORRUPTION,
+                // "candidate segment N has no on-disk graph (streaming compaction)")},
+                // matching the exact failure observed during the bigann-100M k3s
+                // benchmark (issue #535).
+                //
+                // Instead, queue `found` for deferred close. The drainer is guarded
+                // by {@link #compactionLock} so it cannot run while a cycle is in
+                // progress — i.e. close happens AFTER any in-flight cycle has
+                // released its references. The drain also calls
+                // {@code unregisterSegmentMemoryEstimate} on `found` (review item:
+                // counter and actual heap must release in lockstep — releasing the
+                // counter here would create a window where the counter is low but
+                // the segment's BLink pages / pkData arrays are still resident).
+                //
+                // Search safety: searchInternal snapshots `this.segments` under
+                // stateLock.readLock() and uses the VectorSegment objects under the
+                // same readLock. The writeLock above guarantees no readLock holder
+                // overlaps the segment-list mutation, so any concurrent searcher
+                // either (a) finishes before we publish `newList` (writeLock waits
+                // for outstanding readLock holders) or (b) starts after we publish
+                // `newList` and never sees `found`. Either way, no search will
+                // dereference `found.onDiskGraph` after we drain (modulo issue
+                // #537's Stage-1-snapshot-then-republish residual race).
+                pendingSegmentCloses.add(found);
+            } finally {
+                stateLock.writeLock().unlock();
             }
-            if (found == null) {
-                return;
-            }
-            segments = newList;
-            unregisterSegmentMemoryEstimate(found);
-            // Mark dirty so the next checkpoint() serialises the reduced segment list.
-            // Without this, dropping a segment leaves a stale entry in the IndexStatus
-            // on disk (the checkpoint gate would see no changes and skip).
-            dirty.set(true);
-            LOGGER.log(Level.INFO,
-                    "dropSegmentByUuid: removed segment {0} from store {1};"
-                            + " total on-disk segments now {2}",
-                    new Object[]{segmentUuid, indexName, segments.size()});
-            // Issue #535: do NOT close `found` synchronously here. A concurrent
-            // runCompactionCycle may have snapshotted `segments` (volatile read,
-            // no readLock) at the start of the cycle and may still hold a live
-            // reference to `found` via its `candidates` list. Closing `found`
-            // immediately would null out `found.onDiskGraph` (the only place that
-            // field is ever written to null — see {@link VectorSegment#close})
-            // and the cycle's next iteration of `candidates` in
-            // {@link VectorIndexCompactor#rebuildSegmentStreaming} (line ~780)
-            // would throw {@code CompactionException(CORRUPTION,
-            // "candidate segment N has no on-disk graph (streaming compaction)")},
-            // matching the exact failure observed during the bigann-100M k3s
-            // benchmark (issue #535).
-            //
-            // Instead, queue `found` for deferred close. The drainer is guarded
-            // by {@link #compactionLock} so it cannot run while a cycle is in
-            // progress — i.e. close happens AFTER any in-flight cycle has
-            // released its references. The two drain points are
-            // {@link #drainPendingSegmentClosesOpportunistically} (called below,
-            // OUTSIDE the writeLock, fast path) and
-            // {@link #runCompactionCycle}'s finally block.
-            //
-            // Search safety: searchInternal snapshots `this.segments` under
-            // stateLock.readLock() and uses the VectorSegment objects under the
-            // same readLock. The writeLock above guarantees no readLock holder
-            // overlaps the segment-list mutation, so any concurrent searcher
-            // either (a) finishes before we publish `newList` (writeLock waits
-            // for outstanding readLock holders) or (b) starts after we publish
-            // `newList` and never sees `found`. Either way, no search will
-            // dereference `found.onDiskGraph` after we drain.
-            pendingSegmentCloses.add(found);
         } finally {
-            stateLock.writeLock().unlock();
+            // Issue #535 / pr-reviewer follow-up: drain in finally so the queue
+            // is also drained when `found == null` (a no-op lookup that follows
+            // an earlier successful drop), AND when an exception inside the
+            // writeLock body unwinds. Without this, a previous drop's queued
+            // close could be stranded until the next compaction cycle runs.
+            //
+            // The drain is outside the writeLock to keep the writeLock window
+            // tight and avoid lock-order inversion against compactionLock.
+            drainPendingSegmentClosesOpportunistically();
         }
-        // Outside the writeLock: try to drain immediately if no compaction is
-        // running. If a cycle IS running, its finally block will drain when it
-        // releases compactionLock, so the segment resources are released as
-        // soon as it is safe to do so. See {@link #pendingSegmentCloses}.
-        drainPendingSegmentClosesOpportunistically();
     }
 
     /**
@@ -3672,11 +3711,31 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // dropSegmentByUuid that landed after the compaction thread exited.
         // After the join above, no new cycle can start, so no contention
         // for compactionLock — but we still take it for invariant clarity.
-        compactionLock.lock();
+        //
+        // tryLock with a 30s budget guards against the (pathological) case
+        // where the compaction thread hung mid-cycle and was not actually
+        // released by the earlier vct.join(10000) — without the timeout
+        // close() would block here indefinitely. On timeout we log SEVERE
+        // and continue; any queued segments will leak their BLink storage
+        // entries (acceptable at shutdown — the process is going away).
+        boolean drainLockHeld = false;
         try {
-            drainPendingSegmentClosesUnderCompactionLock();
-        } finally {
-            compactionLock.unlock();
+            drainLockHeld = compactionLock.tryLock(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (drainLockHeld) {
+            try {
+                drainPendingSegmentClosesUnderCompactionLock();
+            } finally {
+                compactionLock.unlock();
+            }
+        } else {
+            LOGGER.log(Level.SEVERE,
+                    "vector store {0}: compactionLock not released within 30s"
+                            + " during close() — {1} segments queued for deferred"
+                            + " close will leak their BLink storage entries",
+                    new Object[]{indexName, pendingSegmentCloses.size()});
         }
         // Issue #455: drop every segment's contribution from the on-disk
         // memory counter before closing them, so the counter goes back to 0
@@ -3963,10 +4022,34 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         // The read lock protects three concerns:
         //   1. On-disk segments (Phase 1): the segment snapshot and task execution
-        //      must happen atomically with respect to dropSegmentByUuid which closes
-        //      segments under the write lock. Moving the snapshot here ensures no
-        //      segment can be closed between the snapshot and task execution (the
-        //      write lock cannot be acquired while we hold the read lock).
+        //      must happen atomically with respect to dropSegmentByUuid, which
+        //      removes a segment from `this.segments` under the write lock. The
+        //      write lock cannot be acquired while we hold the read lock, so a
+        //      search that enters here and snapshots `this.segments` is guaranteed
+        //      to observe a consistent list — by the time the writeLock is
+        //      acquired by a concurrent drop, this search has already completed
+        //      and released the read lock.
+        //
+        //      Post-issue-#535: dropSegmentByUuid NO LONGER closes the segment
+        //      synchronously under the writeLock. The close is deferred to
+        //      drainPendingSegmentClosesUnderCompactionLock (drained either
+        //      opportunistically after the dropSegmentByUuid writeLock release
+        //      or in runCompactionCycle's finally). The drain holds
+        //      compactionLock but NOT stateLock.writeLock — and crucially, the
+        //      drain operates only on segments that are NO LONGER in
+        //      this.segments (they were removed BEFORE being queued). So a
+        //      search that snapshotted this.segments AFTER the writeLock-protected
+        //      removal cannot reference a queued segment; a search that
+        //      snapshotted BEFORE the removal already completed (the writeLock
+        //      waited for the readLock to release). Either way the drain's
+        //      seg.close() is invisible to in-flight searches.
+        //
+        //      RESIDUAL RACE (issue #537): atomicSwapCompactionResult's Stage-3
+        //      writeLock window can re-publish a just-dropped segment into
+        //      this.segments. In that narrow window a new search starting AFTER
+        //      Stage 3 and BEFORE the cycle's finally-drain CAN observe the
+        //      queued segment and then race the drain's close. Tracked
+        //      separately; not addressed by issue #535's fix.
         //   2. Live in-memory shards (Phase 2): liveShards is updated under the
         //      write lock during addVectorInternal's shard-rotation path; holding
         //      the read lock keeps the shard list stable across task creation.
@@ -3976,7 +4059,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
         stateLock.readLock().lock();
         try {
             // Phase 1: on-disk segments (snapshotted and tasked under read lock so
-            // that dropSegmentByUuid can safely call found.close() under write lock).
+            // that dropSegmentByUuid's writeLock-protected removal cannot land
+            // between the snapshot and task execution — see invariant above).
             final List<VectorSegment> currentSegments = this.segments;
             for (final VectorSegment seg : currentSegments) {
                 tasks.add(wrapInContext(ctx, () -> {
@@ -6700,15 +6784,26 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     /**
      * Issue #535: drains every queued {@link VectorSegment} in
-     * {@link #pendingSegmentCloses}, closing each one and dropping its
-     * BLink storage entry. Caller MUST hold {@link #compactionLock} so
-     * the close cannot race with a {@link #runCompactionCycle} that has
-     * already snapshotted {@code this.segments} and would dereference
-     * {@code seg.onDiskGraph} on the (now-closed) segment.
+     * {@link #pendingSegmentCloses}, closing each one, dropping its
+     * BLink storage entry, and unregistering its memory estimate.
+     * Caller MUST hold {@link #compactionLock} so the close cannot race
+     * with a {@link #runCompactionCycle} that has already snapshotted
+     * {@code this.segments} and would dereference {@code seg.onDiskGraph}
+     * on the (now-closed) segment.
      *
-     * <p>Idempotent and safe to call repeatedly: drains until the queue
-     * is empty and {@link VectorSegment#close()} is itself idempotent
+     * <p>Safe to call repeatedly: subsequent calls observe an empty queue
+     * and exit early. {@link VectorSegment#close()} is itself idempotent
      * (its {@code if (odg != null)} guard).
+     *
+     * <p>{@link #unregisterSegmentMemoryEstimate} is called from inside
+     * this drain rather than at {@link #dropSegmentByUuid}'s mutation
+     * site so the on-disk-segment memory counter and the actual heap
+     * (BLink pages, pkData, pkOffsets/pkLengths) release in lockstep
+     * (pr-reviewer follow-up). Releasing the counter eagerly at the
+     * dropSegmentByUuid mutation site would create a window where
+     * {@link #getOnDiskSegmentsEstimatedMemoryBytes} reports a value
+     * lower than the heap actually occupies, biasing the
+     * memory-pressure heuristics low.
      */
     private void drainPendingSegmentClosesUnderCompactionLock() {
         // Sanity-check the lock invariant (assertions are no-ops in production).
@@ -6716,6 +6811,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 : "drainPendingSegmentClosesUnderCompactionLock requires compactionLock";
         VectorSegment seg;
         while ((seg = pendingSegmentCloses.pollFirst()) != null) {
+            unregisterSegmentMemoryEstimate(seg);
             try {
                 seg.close();
             } catch (RuntimeException closeEx) {

--- a/herddb-core/src/test/java/herddb/index/vector/Issue535DropSegmentByUuidRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue535DropSegmentByUuidRaceTest.java
@@ -288,17 +288,19 @@ public class Issue535DropSegmentByUuidRaceTest {
 
     /**
      * Pr-reviewer follow-up: verifies the deferred close fires DURING a
-     * compaction cycle, even for MULTIPLE concurrent drops. The hook drops
-     * two candidates back-to-back, and the test asserts that
+     * compaction cycle, even for MULTIPLE back-to-back drops. The hook
+     * drops two candidates synchronously inside a single cycle and the
+     * test asserts that
      * (a) no CORRUPTION is recorded (the fix held for both drops),
      * (b) both victims are eventually closed (deferred close drained
-     * both queued segments in the cycle's finally block), and
-     * (c) both ABORTED_INPUT_GONE counters increase by exactly the
-     * expected amount — at most one per cycle (the cycle aborts at
-     * the first detected missing input, not per-input).
+     * both queued segments in the cycle's finally block),
+     * (c) neither victim remains in {@code this.segments}, and
+     * (d) the cycle aborts with exactly ONE ABORTED_INPUT_GONE — the
+     * Stage-1 validator short-circuits at the first missing input, so
+     * we get one failure per cycle, not one per dropped segment.
      */
     @Test(timeout = 30_000)
-    public void multipleConcurrentDropsDuringCompactionMustNotCauseCorruption()
+    public void multipleBackToBackDropsDuringCompactionMustNotCauseCorruption()
             throws Exception {
         Path tmpDir = tmpFolder.newFolder("issue535-multi-drop").toPath();
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
@@ -328,11 +330,12 @@ public class Issue535DropSegmentByUuidRaceTest {
             });
 
             long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            long abortedBefore = store.getCompactionFailuresAbortedInputGoneTotal();
             store.runCompactionCycle();
             long corruptionAfter = store.getCompactionFailuresCorruptionTotal();
 
             // (a) No CORRUPTION.
-            assertEquals("no CORRUPTION must be recorded even with TWO concurrent "
+            assertEquals("no CORRUPTION must be recorded even with TWO back-to-back "
                     + "drops during the same cycle (issue #535)",
                     corruptionBefore, corruptionAfter);
 
@@ -347,6 +350,14 @@ public class Issue535DropSegmentByUuidRaceTest {
                 assertFalse(s.segmentId == victim0.segmentId);
                 assertFalse(s.segmentId == victim1.segmentId);
             }
+
+            // (d) Exactly ONE ABORTED_INPUT_GONE — the Stage-1 validator
+            // short-circuits at the first missing input rather than reporting
+            // one failure per dropped segment. This guards against a future
+            // regression where the validator reports per-input failures.
+            assertEquals("exactly one ABORTED_INPUT_GONE per cycle",
+                    abortedBefore + 1L,
+                    store.getCompactionFailuresAbortedInputGoneTotal());
         }
     }
 

--- a/herddb-core/src/test/java/herddb/index/vector/Issue535DropSegmentByUuidRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue535DropSegmentByUuidRaceTest.java
@@ -1,0 +1,395 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #535: the IS-local fallback compaction
+ * repeatedly fails with
+ *
+ * <pre>
+ *   CompactionException: candidate segment N has no on-disk graph (streaming compaction)
+ *       at VectorIndexCompactor.rebuildSegmentStreaming(VectorIndexCompactor.java:782)
+ * </pre>
+ *
+ * on the SAME segment for tens of minutes during a bigann-100M k3s
+ * benchmark with the optimizer enabled.
+ *
+ * <h2>Root cause (pre-fix)</h2>
+ *
+ * {@link PersistentVectorStore#runCompactionCycle} snapshots
+ * {@code this.segments} at the start of a cycle <b>without holding
+ * {@link PersistentVectorStore#stateLock}'s readLock</b>. The cycle then
+ * iterates the snapshot in
+ * {@link VectorIndexCompactor#rebuildSegmentStreaming} reading
+ * {@code seg.onDiskGraph}. If a concurrent
+ * {@link PersistentVectorStore#dropSegmentByUuid} call lands between the
+ * snapshot and the iteration (fired by the optimizer-watcher's
+ * {@code onSegmentReleased} when the external optimizer deprecates an
+ * IS-produced segment), it
+ *
+ * <ol>
+ *   <li>removes the segment from {@code this.segments} under the writeLock,
+ *       and</li>
+ *   <li>calls {@code found.close()} on the segment <b>while the writeLock
+ *       is still held</b> — which sets {@code seg.onDiskGraph = null}
+ *       (the only place that field is ever assigned to {@code null},
+ *       per {@link VectorSegment#close} line 340).</li>
+ * </ol>
+ *
+ * The compaction's snapshot still holds a reference to the (now closed)
+ * {@code VectorSegment} object. When
+ * {@link VectorIndexCompactor#rebuildSegmentStreaming} iterates the
+ * candidates, it sees {@code seg.onDiskGraph == null} and throws
+ * {@code CompactionException(FailureReason.CORRUPTION,
+ *   "candidate segment N has no on-disk graph (streaming compaction)")}.
+ *
+ * <h2>The fix</h2>
+ *
+ * {@link PersistentVectorStore#dropSegmentByUuid} no longer closes the
+ * segment synchronously. It removes the segment from {@code this.segments}
+ * under the writeLock and enqueues the {@code VectorSegment} on
+ * {@code pendingSegmentCloses}. The actual {@link VectorSegment#close}
+ * call is deferred to either
+ *
+ * <ul>
+ *   <li>an opportunistic drain right after the writeLock release (fast
+ *       path: no concurrent compaction → close immediately), or</li>
+ *   <li>the {@link PersistentVectorStore#runCompactionCycle}'s finally
+ *       block (after the cycle's snapshot is no longer being iterated).</li>
+ * </ul>
+ *
+ * Both drain paths hold {@code compactionLock} so the close can never
+ * happen while a cycle is iterating its candidate list.
+ *
+ * <h2>What this test proves</h2>
+ *
+ * <ol>
+ *   <li>A {@code dropSegmentByUuid} call fired DURING a compaction cycle
+ *       (after candidates are picked, before the on-disk-graph iteration
+ *       starts) <b>no longer corrupts the cycle's snapshot</b>. The
+ *       cycle does not throw {@code CompactionException(CORRUPTION,
+ *       "no on-disk graph (streaming compaction)")}.</li>
+ *   <li>The cycle still surfaces the drift cleanly:
+ *       {@link VectorIndexCompactor.FailureReason#ABORTED_INPUT_GONE}
+ *       fires from {@code atomicSwapCompactionResult} when it discovers
+ *       the dropped segment is missing from {@code this.segments} —
+ *       which is the correct, documented response to "an input segment
+ *       disappeared under us".</li>
+ *   <li>The dropped segment's resources are still released — the
+ *       deferred close runs in the cycle's finally block, so
+ *       {@code victim.onDiskGraph} is observed to be {@code null} AFTER
+ *       the cycle completes.</li>
+ *   <li>The baseline (no race) cycle is unaffected: it still merges all
+ *       candidates and produces one merged output.</li>
+ * </ol>
+ */
+public class Issue535DropSegmentByUuidRaceTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static final int DIM = 16;
+
+    @Before
+    public void disableDeferral() {
+        // Allow checkpoints to seal small live shards into on-disk segments
+        // even with very few vectors per shard — keeps the test fast.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static float[] vec(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private PersistentVectorStore newStore(Path tmpDir, MemoryDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE, // compactionIntervalMs — disable the auto loop
+                VectorSimilarityFunction.EUCLIDEAN);
+        // Aggressive policy: 2+ segments → merge. Min bytes = 1 so every cycle
+        // qualifies regardless of segment size.
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    /** Seeds {@code n} on-disk segments via add+checkpoint cycles. */
+    private void seedSegments(PersistentVectorStore store, int n) throws Exception {
+        Random rng = new Random(42);
+        for (int c = 0; c < n; c++) {
+            for (int i = 0; i < 50; i++) {
+                store.addVector(Bytes.from_int(c * 1000 + i), vec(rng));
+            }
+            store.checkpoint();
+        }
+    }
+
+    /**
+     * Stamp a UUID on every segment that does not already carry one. With the
+     * publisher disabled (no {@link herddb.index.vector.SegmentPublisher}
+     * wired into the store) {@code segmentUuid} is not populated by the
+     * normal compaction/checkpoint paths, so the test pre-stamps the field
+     * directly via package-private access — exactly mirroring what
+     * production sees once the optimizer is enabled and segments get
+     * stamped via {@code atomicSwapCompactionResult} (line 2588-2590).
+     */
+    private void stampMissingUuids(List<VectorSegment> segs) {
+        for (VectorSegment seg : segs) {
+            if (seg.segmentUuid == null) {
+                seg.segmentUuid = UUID.randomUUID().toString();
+            }
+        }
+    }
+
+    /**
+     * <b>The fix verification.</b> Runs a single compaction cycle and,
+     * between the candidate selection and the on-disk graph iteration,
+     * calls {@link PersistentVectorStore#dropSegmentByUuid} to drop one
+     * of the candidate segments. Pre-fix, the cycle's iteration of
+     * {@code candidates} surfaced {@code CompactionException(CORRUPTION,
+     * "candidate segment N has no on-disk graph (streaming compaction)")}.
+     * Post-fix, the close is deferred and the cycle either completes
+     * normally (if the cycle's swap also drifts gracefully) or aborts
+     * with {@link
+     * VectorIndexCompactor.FailureReason#ABORTED_INPUT_GONE} —
+     * <b>not</b> {@code CORRUPTION}.
+     */
+    @Test(timeout = 30_000)
+    public void dropSegmentByUuidDuringCompactionMustNotCauseCorruption()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue535-race").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue("setup must produce at least 2 on-disk segments — got "
+                    + initial.size(), initial.size() >= 2);
+
+            stampMissingUuids(initial);
+
+            VectorSegment victim = initial.get(0);
+            final String victimUuid = victim.segmentUuid;
+            final int victimId = victim.segmentId;
+            assertNotNull("victim must have a UUID stamped", victimUuid);
+            assertNotNull("victim must have onDiskGraph populated before the race",
+                    victim.onDiskGraph);
+
+            // Wire the hook. It runs INSIDE runCompactionCycle, AFTER the
+            // candidate list is built, BEFORE rebuildSegment reads
+            // seg.onDiskGraph. Synchronously dropping the victim's UUID
+            // simulates the optimizer-watcher race observed in production.
+            store.setCompactionPostCandidateSelectionHookForTest(() -> {
+                store.dropSegmentByUuid(victimUuid);
+            });
+
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            long abortedBefore = store.getCompactionFailuresAbortedInputGoneTotal();
+
+            // Run the cycle under the race.
+            store.runCompactionCycle();
+
+            // ---------- Post-fix assertions ----------
+
+            // The victim was removed from `this.segments` under the writeLock
+            // before the hook returned, so the post-cycle list must not
+            // contain it.
+            List<VectorSegment> after = store.getOnDiskSegmentsSnapshotForTest();
+            for (VectorSegment s : after) {
+                assertFalse("victim must be removed from segments by dropSegmentByUuid",
+                        s.segmentId == victimId);
+            }
+
+            // CORE INVARIANT (the fix): NO CORRUPTION failure must have
+            // been recorded — the cycle's iteration of `candidates` saw a
+            // non-null `onDiskGraph` on every candidate because the close
+            // was deferred past the iteration window.
+            assertEquals("no CORRUPTION failure must be recorded — that was "
+                    + "issue #535's exact production failure mode",
+                    corruptionBefore, store.getCompactionFailuresCorruptionTotal());
+
+            // Drift-aware behaviour: the cycle's atomicSwapCompactionResult
+            // Stage 1 detects that an input segment vanished and aborts
+            // with ABORTED_INPUT_GONE. This is the EXPECTED, documented
+            // outcome of a race between compaction and segment retirement,
+            // not a regression. (If multiple races accumulate, the counter
+            // increases by at least one per drift event.)
+            assertTrue(
+                    "either compaction succeeded (drift detected pre-rebuild) or "
+                    + "aborted with ABORTED_INPUT_GONE (drift detected at swap); "
+                    + "both are documented graceful outcomes, neither is "
+                    + "CORRUPTION (issue #535)",
+                    store.getCompactionFailuresAbortedInputGoneTotal() > abortedBefore
+                    || store.getCompactionSuccessesTotal() > 0);
+
+            // The deferred close ran in the cycle's finally block: by the
+            // time runCompactionCycle returned, the victim's onDiskGraph
+            // had been nulled out (resources were released).
+            assertNull("deferred close must have run in runCompactionCycle's finally — "
+                    + "victim.onDiskGraph should be null after the cycle ends",
+                    victim.onDiskGraph);
+        }
+    }
+
+    /**
+     * Companion regression test: same scenario but the victim is one of
+     * EXACTLY 2 candidates the policy can match (the minimum count for a
+     * streaming merge). Pre-fix this also produced
+     * {@code CompactionException(CORRUPTION)}; post-fix the cycle must
+     * surface only ABORTED_INPUT_GONE (or succeed) — never CORRUPTION.
+     */
+    @Test(timeout = 30_000)
+    public void dropDuringTwoCandidateCycleMustNotCauseCorruption() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue535-race-two-candidates").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            // Seed exactly 2 segments — the minimum for streaming compaction
+            // to attempt a real merge (fewer than 2 falls back to the legacy
+            // in-memory path which has the SAME null-check but a different
+            // error message).
+            seedSegments(store, 2);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertEquals(2, initial.size());
+            stampMissingUuids(initial);
+
+            VectorSegment victim = initial.get(0);
+            final String victimUuid = victim.segmentUuid;
+
+            store.setCompactionPostCandidateSelectionHookForTest(() -> {
+                store.dropSegmentByUuid(victimUuid);
+            });
+
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            store.runCompactionCycle();
+            long corruptionAfter = store.getCompactionFailuresCorruptionTotal();
+
+            assertEquals(
+                "race must NOT produce a CORRUPTION failure (issue #535 was the "
+                + "candidate segment N has no on-disk graph error)",
+                corruptionBefore, corruptionAfter);
+
+            assertNull("deferred close must have run by the time runCompactionCycle returned",
+                    victim.onDiskGraph);
+        }
+    }
+
+    /**
+     * Without the race (hook is a no-op) the same setup must NOT produce a
+     * CORRUPTION failure AND must complete the compaction successfully —
+     * proves the fix does not regress the happy path.
+     */
+    @Test(timeout = 30_000)
+    public void noRaceMeansSuccessfulCompaction() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue535-no-race").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            stampMissingUuids(initial);
+
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            store.runCompactionCycle();
+            long corruptionAfter = store.getCompactionFailuresCorruptionTotal();
+
+            assertEquals("baseline compaction must NOT produce CORRUPTION failures",
+                    corruptionBefore, corruptionAfter);
+            assertEquals("baseline compaction must complete successfully",
+                    1L, store.getCompactionSuccessesTotal());
+        }
+    }
+
+    /**
+     * Verifies the opportunistic-drain path: when {@code dropSegmentByUuid}
+     * is called while NO compaction is running, the segment is closed
+     * synchronously (preserving the original "close immediately when
+     * safe" behaviour for the common idle-IS case).
+     */
+    @Test(timeout = 30_000)
+    public void dropWhileIdleClosesSegmentSynchronously() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue535-drop-idle").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 3);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue(initial.size() >= 1);
+            stampMissingUuids(initial);
+
+            VectorSegment victim = initial.get(0);
+            assertNotNull("victim must have onDiskGraph populated before the drop",
+                    victim.onDiskGraph);
+
+            store.dropSegmentByUuid(victim.segmentUuid);
+
+            // No compaction running → opportunistic drain succeeded
+            // synchronously inside dropSegmentByUuid. The victim's
+            // onDiskGraph must already be null.
+            assertNull("idle drop must close the segment synchronously via the "
+                    + "opportunistic drain",
+                    victim.onDiskGraph);
+
+            // Sanity: the segment is also removed from `segments`.
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                assertFalse(s.segmentId == victim.segmentId);
+            }
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/Issue535DropSegmentByUuidRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue535DropSegmentByUuidRaceTest.java
@@ -258,19 +258,24 @@ public class Issue535DropSegmentByUuidRaceTest {
                     + "issue #535's exact production failure mode",
                     corruptionBefore, store.getCompactionFailuresCorruptionTotal());
 
-            // Drift-aware behaviour: the cycle's atomicSwapCompactionResult
-            // Stage 1 detects that an input segment vanished and aborts
-            // with ABORTED_INPUT_GONE. This is the EXPECTED, documented
-            // outcome of a race between compaction and segment retirement,
-            // not a regression. (If multiple races accumulate, the counter
-            // increases by at least one per drift event.)
-            assertTrue(
-                    "either compaction succeeded (drift detected pre-rebuild) or "
-                    + "aborted with ABORTED_INPUT_GONE (drift detected at swap); "
-                    + "both are documented graceful outcomes, neither is "
-                    + "CORRUPTION (issue #535)",
-                    store.getCompactionFailuresAbortedInputGoneTotal() > abortedBefore
-                    || store.getCompactionSuccessesTotal() > 0);
+            // Drift-aware behaviour (tightened per pr-reviewer follow-up):
+            // because the victim IS an input to this compaction (it's a
+            // candidate selected by chooseSegmentsToMerge before the hook
+            // fires), atomicSwapCompactionResult's Stage-1 drift check
+            // (line ~2779-2785) is DETERMINISTICALLY tripped. A future
+            // regression in the Stage-1 validation would be caught by
+            // this strict ABORTED_INPUT_GONE assertion. (The looser
+            // "either ABORTED_INPUT_GONE or success" wording would have
+            // missed a Stage-1 regression that silently succeeded with a
+            // missing input.)
+            assertEquals(
+                    "compaction MUST abort with ABORTED_INPUT_GONE — the dropped"
+                    + " input is no longer in this.segments at Stage 1's"
+                    + " drift check (regression guard for Stage-1 validation)",
+                    abortedBefore + 1L,
+                    store.getCompactionFailuresAbortedInputGoneTotal());
+            assertEquals("no successful swap must have been recorded",
+                    0L, store.getCompactionSuccessesTotal());
 
             // The deferred close ran in the cycle's finally block: by the
             // time runCompactionCycle returned, the victim's onDiskGraph
@@ -278,6 +283,171 @@ public class Issue535DropSegmentByUuidRaceTest {
             assertNull("deferred close must have run in runCompactionCycle's finally — "
                     + "victim.onDiskGraph should be null after the cycle ends",
                     victim.onDiskGraph);
+        }
+    }
+
+    /**
+     * Pr-reviewer follow-up: verifies the deferred close fires DURING a
+     * compaction cycle, even for MULTIPLE concurrent drops. The hook drops
+     * two candidates back-to-back, and the test asserts that
+     * (a) no CORRUPTION is recorded (the fix held for both drops),
+     * (b) both victims are eventually closed (deferred close drained
+     * both queued segments in the cycle's finally block), and
+     * (c) both ABORTED_INPUT_GONE counters increase by exactly the
+     * expected amount — at most one per cycle (the cycle aborts at
+     * the first detected missing input, not per-input).
+     */
+    @Test(timeout = 30_000)
+    public void multipleConcurrentDropsDuringCompactionMustNotCauseCorruption()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue535-multi-drop").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue("setup must produce at least 3 segments", initial.size() >= 3);
+            stampMissingUuids(initial);
+
+            VectorSegment victim0 = initial.get(0);
+            VectorSegment victim1 = initial.get(1);
+            final String uuid0 = victim0.segmentUuid;
+            final String uuid1 = victim1.segmentUuid;
+            assertNotNull(victim0.onDiskGraph);
+            assertNotNull(victim1.onDiskGraph);
+
+            // The hook drops BOTH segments before the rebuild iteration. Pre-fix
+            // each drop would have nulled out onDiskGraph immediately; the
+            // iteration would have thrown CORRUPTION on the FIRST one and
+            // never reached the second.
+            store.setCompactionPostCandidateSelectionHookForTest(() -> {
+                store.dropSegmentByUuid(uuid0);
+                store.dropSegmentByUuid(uuid1);
+            });
+
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            store.runCompactionCycle();
+            long corruptionAfter = store.getCompactionFailuresCorruptionTotal();
+
+            // (a) No CORRUPTION.
+            assertEquals("no CORRUPTION must be recorded even with TWO concurrent "
+                    + "drops during the same cycle (issue #535)",
+                    corruptionBefore, corruptionAfter);
+
+            // (b) Both deferred closes ran by the time the cycle returned.
+            assertNull("victim0.onDiskGraph must be null after the cycle "
+                    + "(deferred close drained)", victim0.onDiskGraph);
+            assertNull("victim1.onDiskGraph must be null after the cycle "
+                    + "(deferred close drained)", victim1.onDiskGraph);
+
+            // (c) Neither victim is in this.segments anymore.
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                assertFalse(s.segmentId == victim0.segmentId);
+                assertFalse(s.segmentId == victim1.segmentId);
+            }
+        }
+    }
+
+    /**
+     * Pr-reviewer follow-up: verifies the {@code close()}-path drain.
+     * Holds {@code compactionLock} from a test-controlled thread so the
+     * opportunistic drain in {@code dropSegmentByUuid} is forced to
+     * skip; then closes the store and asserts the queued segment is
+     * still drained (BLink storage entry dropped, on-disk graph nulled
+     * out). Without the {@code close()}-path drain a deferred segment
+     * would leak its BLink storage at shutdown.
+     */
+    @Test(timeout = 30_000)
+    public void dropQueuedSegmentIsDrainedByCloseEvenWhenNoCycleEverRuns()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue535-close-drain").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        final PersistentVectorStore store = newStore(tmpDir, dsm);
+        boolean closed = false;
+        try {
+            store.start();
+            seedSegments(store, 3);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue(initial.size() >= 1);
+            stampMissingUuids(initial);
+
+            VectorSegment victim = initial.get(0);
+            final String victimUuid = victim.segmentUuid;
+            assertNotNull(victim.onDiskGraph);
+
+            // Spawn a holder thread that grabs compactionLock and waits for the
+            // test to signal release. While the holder is parked, the opportunistic
+            // drain in dropSegmentByUuid sees `compactionLock` as busy and skips.
+            // This simulates the (rare in practice but possible in principle) case
+            // where dropSegmentByUuid runs while a compaction is mid-cycle and the
+            // cycle's own finally drain never executes (e.g. the JVM is shut down
+            // mid-cycle).
+            final java.util.concurrent.CountDownLatch holderReady =
+                    new java.util.concurrent.CountDownLatch(1);
+            final java.util.concurrent.CountDownLatch releaseHolder =
+                    new java.util.concurrent.CountDownLatch(1);
+            Thread holder = new Thread(() -> {
+                try {
+                    // Reflect into the private compactionLock field. We can't use a
+                    // public accessor — this is intentional internal state. Holding
+                    // the lock from a test thread mirrors what runCompactionCycle
+                    // would do mid-cycle.
+                    java.lang.reflect.Field lockField =
+                            PersistentVectorStore.class.getDeclaredField("compactionLock");
+                    lockField.setAccessible(true);
+                    java.util.concurrent.locks.ReentrantLock lock =
+                            (java.util.concurrent.locks.ReentrantLock) lockField.get(store);
+                    lock.lock();
+                    try {
+                        holderReady.countDown();
+                        releaseHolder.await();
+                    } finally {
+                        lock.unlock();
+                    }
+                } catch (ReflectiveOperationException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }, "compaction-lock-holder");
+            holder.setDaemon(true);
+            holder.start();
+
+            assertTrue("holder must grab the lock within 5s",
+                    holderReady.await(5, java.util.concurrent.TimeUnit.SECONDS));
+
+            // While the holder owns compactionLock, drop the victim. The
+            // opportunistic drain will skip because compactionLock.tryLock()
+            // returns false.
+            store.dropSegmentByUuid(victimUuid);
+
+            // The victim is removed from segments but NOT closed yet (close was
+            // deferred to the next drain).
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                assertFalse(s.segmentId == victim.segmentId);
+            }
+            assertNotNull("victim.onDiskGraph must still be live — close was deferred",
+                    victim.onDiskGraph);
+
+            // Release the holder. compactionLock is now free, but no compaction
+            // cycle will run because compactionIntervalMs == Long.MAX_VALUE.
+            releaseHolder.countDown();
+            holder.join(5_000);
+
+            // close() drains pendingSegmentCloses under compactionLock.
+            store.close();
+            closed = true;
+
+            // The deferred close ran in close()'s drain.
+            assertNull("close() must have drained the queued segment — "
+                    + "victim.onDiskGraph should be null after store.close()",
+                    victim.onDiskGraph);
+        } finally {
+            if (!closed) {
+                store.close();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #535.

## Root cause

The IS-local fallback compaction can fail with
`CompactionException(CORRUPTION, "candidate segment N has no on-disk graph (streaming compaction)")`
when the optimizer-watcher's `onSegmentReleased` callback fires
during an active `runCompactionCycle`.

`runCompactionCycle` snapshots `this.segments` at the start of a cycle
**without holding `stateLock.readLock()`** (line 2212,
`new ArrayList<>(segments)`) and then iterates the snapshot in
`VectorIndexCompactor.rebuildSegmentStreaming` (line 780) reading
`seg.onDiskGraph`. If a concurrent `dropSegmentByUuid` call lands
between the snapshot and the iteration, it

1. removes the segment from `this.segments` under the writeLock, and
2. calls `found.close()` on the segment **inside that same writeLock**
   — which sets `seg.onDiskGraph = null` (the only place that field is
   ever assigned to `null`, per `VectorSegment.close` line 340).

The compaction's snapshot still holds a reference to the now-closed
`VectorSegment` object. When the iteration in `rebuildSegmentStreaming`
reaches it, `odg == null` fires the CORRUPTION exception.

In the production bigann-100M benchmark this race fires repeatedly
under back-pressure because the optimizer deprecates IS-produced
segments continuously while the IS-local fallback is running flat-out
— producing the steady stream of identical CORRUPTION failures
observed in the issue log for 50+ minutes.

## The fix

`dropSegmentByUuid` no longer closes the segment synchronously. Instead:

- It removes the segment from `this.segments` under the writeLock (as
  before — so future searches and compactions don't see it).
- It enqueues the `VectorSegment` on a new `pendingSegmentCloses` deque
  (instead of calling `seg.close()` directly).
- An **opportunistic drain** runs right after the writeLock release
  (fast path when no compaction is active — preserves the original
  "close immediately on idle" behaviour).
- A **mandatory drain** runs in `runCompactionCycle`'s finally block,
  BEFORE `compactionLock` is released, so the next cycle starts from
  an empty queue.

Both drain paths hold `compactionLock` so the close can never run
while a cycle is iterating its candidate list. The opportunistic drain
also checks `compactionLock.isHeldByCurrentThread()` before `tryLock`
because `ReentrantLock.tryLock` returns true on reentrant calls — a
`dropSegmentByUuid` fired from inside a compaction-thread code path
would otherwise re-enter the lock and close the segment immediately.

## Tests

New `Issue535DropSegmentByUuidRaceTest` reproducer with four cases:

1. `dropSegmentByUuidDuringCompactionMustNotCauseCorruption` — fires
   the race deterministically via a new
   `compactionPostCandidateSelectionHookForTests` and asserts the
   cycle no longer surfaces `CompactionException(CORRUPTION,
   "candidate segment N has no on-disk graph")`. The cycle either
   succeeds or aborts with `ABORTED_INPUT_GONE` (the documented
   graceful response to "input segment vanished").
2. `dropDuringTwoCandidateCycleMustNotCauseCorruption` — same race
   with the minimum 2 candidates streaming compaction requires.
3. `noRaceMeansSuccessfulCompaction` — happy-path regression guard.
4. `dropWhileIdleClosesSegmentSynchronously` — verifies the
   opportunistic drain closes the segment in-line when no compaction
   is running.

Verified locally:

- All 4 new tests green; deterministic across 3 back-to-back runs.
- `herddb-core` compaction + indexing-service compaction + segment
  ownership / optimizer-adoption tests (49 + 29 + 10 = 88 tests) green.
- Hammer suite `DirectMultipleConcurrentUpdatesSuite*` (×2 passes)
  + `BLinkConcurrentSearchInsertTest` green.
- Pre-PR validation (`checkstyle:check apache-rat:check spotbugs:check
  install -DskipTests -Pci`) green.

## Test plan

- [x] New reproducer asserts the race no longer produces CORRUPTION
- [x] Existing compaction + lifecycle tests still pass
- [x] Hammer suite passes twice
- [x] Pre-PR validation passes
- [ ] CI green on the merge

🤖 Implemented by the `pr-worker` agent.