### PR TITLE
issue #538: rebuild newSegments at Stage 3 to fix Stage-3 republish race

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2849,33 +2849,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
             long stage3Start = System.nanoTime();
             stateLock.writeLock().lock();
             try {
-                // Re-apply pendingCompactionDeletes to merged under
-                // writeLock, catching any PKs that arrived after the
-                // lock-free lateDeletes.forEach in runCompactionCycle and
-                // during Stages 1+2 of this method (issue #462, pr-reviewer
-                // pass-1 BLOCK fix). Without this re-apply: a removeVector(X)
-                // arriving during Stages 1+2 finds X in an input segment
-                // (still in this.segments until Stage 3), seg.deletePk
-                // succeeds on the input — but the input is about to be
-                // discarded, lateDeletes.forEach already ran on merged, and
-                // X stays in merged. The set is closed in
-                // runCompactionCycle's finally block right after this method
-                // returns, so this is the last opportunity to apply.
+                // Re-apply pendingCompactionDeletes (issue #462 + #538):
+                // the late-deletes reapply happens BELOW, AFTER
+                // finalNewSegments is built, so the apply covers the full
+                // set of segments being published — mergedOutput AND any
+                // segments preserved from `this.segments` (including
+                // adoptions that landed in the Stage 1 → Stage 3 window).
+                // The reapply must run BEFORE the publish so a throw
+                // unwinds with both the counter and `this.segments`
+                // unchanged. See the corresponding block below.
                 //
-                // Cost: O(|pendingCompactionDeletes|) BLink scans on
-                // mergedOutput. Bounded by application's delete rate ×
-                // (lock-free Stage 1+2 duration). Each seg.deletePk on a
-                // missing PK is a single BLink search returning null, so
-                // entries already absorbed by lateDeletes.forEach return
-                // quickly and only the late-arrivers do meaningful work.
-                if (mergedOutput != null) {
-                    PagedPkSet lateDeletesReapply = this.pendingCompactionDeletes;
-                    if (lateDeletesReapply != null) {
-                        VectorSegment merged = mergedOutput;
-                        lateDeletesReapply.forEach(merged::deletePk);
-                    }
-                    registerSegmentMemoryEstimate(mergedOutput);
-                }
                 // Issue #538 (root cause of the residual race tracked in
                 // issue #537): REBUILD `finalNewSegments` from the CURRENT
                 // `this.segments` rather than publishing the stale Stage-1
@@ -2939,6 +2922,63 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 }
                 if (mergedOutput != null) {
                     finalNewSegments.add(mergedOutput);
+                }
+
+                // Issue #538 (pr-reviewer pass-5 follow-up): reapply
+                // `pendingCompactionDeletes` to ALL segments being
+                // published, not just {@code mergedOutput}.
+                //
+                // The PRE-fix-5 reapply applied only to {@code mergedOutput}:
+                // a remove that lands DURING the compaction cycle would
+                // have been:
+                //   (a) applied to existing on-disk segments by
+                //       removeVector's direct iteration of
+                //       {@code this.segments} at the time of the call;
+                //   (b) added to {@code pendingCompactionDeletes} for
+                //       the lock-free re-apply at the end of Stage 1
+                //       (which targeted mergedOutput, the only segment
+                //       removeVector couldn't iterate); AND
+                //   (c) re-applied to mergedOutput here under writeLock
+                //       to catch arrivals after Stage 1's lock-free
+                //       forEach.
+                //
+                // With round-1 preserving adoptions in finalNewSegments,
+                // an adoption landing AFTER a removeVector(P) but BEFORE
+                // Stage 3 was MISSED by step (a) (the adopted segment
+                // was not yet in {@code this.segments} when removeVector
+                // ran) and by step (c) (the reapply targeted only
+                // mergedOutput). Result: P stayed live in the adopted
+                // segment after Stage 3 — a silent removeVector loss.
+                //
+                // The structural twin of the Phase C Stage 2 fix at
+                // line 5119-5128 (issue #538 pr-reviewer pass-3): iterate
+                // {@code finalNewSegments} so the reapply covers
+                // adoptions. `seg.deletePk` is idempotent; for pks
+                // already deleted by Stage 1's lock-free forEach,
+                // the iteration silently returns false on each segment.
+                //
+                // ORDERING (matching round-4 Phase C Stage 2): the
+                // reapply runs BEFORE
+                // {@code registerSegmentMemoryEstimate(mergedOutput)}
+                // AND BEFORE the {@code this.segments = ...} publish
+                // AND BEFORE the {@code unregisterSegmentMemoryEstimate}
+                // loop over inputs. A throw from `seg.deletePk` leaves
+                // both the counter and `this.segments` unchanged.
+                if (!finalNewSegments.isEmpty()) {
+                    PagedPkSet lateDeletesReapply = this.pendingCompactionDeletes;
+                    if (lateDeletesReapply != null) {
+                        lateDeletesReapply.forEach(pk -> {
+                            for (VectorSegment seg : finalNewSegments) {
+                                if (seg.deletePk(pk)) {
+                                    return;
+                                }
+                            }
+                        });
+                    }
+                }
+
+                if (mergedOutput != null) {
+                    registerSegmentMemoryEstimate(mergedOutput);
                 }
                 this.segments = new java.util.concurrent.CopyOnWriteArrayList<>(
                         finalNewSegments);

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -5038,37 +5038,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 }
             }
 
-            // Re-apply pendingCheckpointDeletes to preloadedSegments under
-            // writeLock to catch any PKs that arrived in the BLink-backed
-            // pending set after Stage 1's lock-free forEach (issue #462,
-            // pr-reviewer pass-1 BLOCK fix). BLink.scan is weakly consistent:
-            // late-arriver inserts that land left of the iterator's current
-            // position are missed by Stage 1.
+            // Note: late-arriving deletes from {@link #pendingCheckpointDeletes}
+            // are reapplied below, AFTER {@code finalNewSegments} is built —
+            // see the second {@code pendingForReapply.forEach} block. The
+            // reapply was moved out of this position (where it iterated only
+            // {@code preloadedSegments}) to {@code finalNewSegments} to also
+            // cover adopted segments that landed in the Phase A → Stage 2
+            // window (issue #538 pr-reviewer pass-3 follow-up).
             //
-            // We restrict the re-apply to preloadedSegments (not all
-            // newSegments) because removeVector itself directly applies the
-            // delete to existing on-disk segments via its iteration of
-            // `this.segments` (see PersistentVectorStore.removeVector). The
-            // gap is only the preloaded segments that aren't in
-            // `this.segments` until Stage 2's publish below — removeVector
-            // can't see them, so the late-arriver path through
-            // pendingCheckpointDeletes is the only mechanism.
-            //
-            // Cost: O(|pending| × |preloadedSegments|) with preloadedSegments
-            // typically 1 segment. Each seg.deletePk on a missing PK is a
-            // single BLink search that returns null quickly, so this is fast
-            // even when most pending entries were already applied in Stage 1.
-            PagedPkSet pendingForReapply = this.pendingCheckpointDeletes;
-            if (pendingForReapply != null && !preloadedSegments.isEmpty()) {
-                pendingForReapply.forEach(pk -> {
-                    for (VectorSegment seg : preloadedSegments) {
-                        if (seg.deletePk(pk)) {
-                            return;
-                        }
-                    }
-                });
-            }
-
             // Issue #455: sealedSegments + mergeableSegments together cover
             // every segment that was previously in this.segments (their union
             // was built by the Phase A partition loop), so they remain
@@ -5118,12 +5095,51 @@ public class PersistentVectorStore extends AbstractVectorStore {
             //
             // ArrayList + final wrap minimises the writeLock window vs.
             // {@code CopyOnWriteArrayList.add}-in-loop (each {@code add}
-            // would re-copy the entire backing array, O(N²)).
+            // would re-copy the entire backing array, O(N²)). The
+            // CopyOnWriteArrayList constructor still allocates one backing
+            // array of size N, so the saving is O(N²) → O(N).
             List<VectorSegment> currentAtStage2 = this.segments;
             ArrayList<VectorSegment> finalNewSegments = new ArrayList<>(
                     currentAtStage2.size() + preloadedSegments.size());
             finalNewSegments.addAll(currentAtStage2);
             finalNewSegments.addAll(preloadedSegments);
+
+            // Issue #538 (pr-reviewer pass-3 follow-up): reapply
+            // late-arriving deletes in `pendingCheckpointDeletes` to ALL
+            // segments being published, not just `preloadedSegments`.
+            //
+            // Stage 1's lock-free apply at line ~4998 iterates the Phase-A
+            // snapshot of `this.segments` plus `preloadedSegments`. With
+            // the round-3 fix, `finalNewSegments` may ALSO contain segments
+            // that landed via `adoptExternalSegment` during the Phase A →
+            // Stage 2 window. Those adopted segments did not see the
+            // Stage-1 apply, and `removeVector`'s direct iteration over
+            // `this.segments` only sees segments present at the moment of
+            // the removeVector call — if the removeVector arrived BEFORE
+            // the adoption, the adopted segment did not receive the delete.
+            //
+            // Re-applying to the full {@code finalNewSegments} here ensures
+            // any late delete is honoured by the adopted segment too.
+            // `seg.deletePk` is idempotent: for pks already removed in
+            // Stage 1 it returns false (BLink miss) and the loop continues
+            // to the next segment.
+            //
+            // Cost: O(|pending| × |finalNewSegments|). The constant
+            // factor is small because each `deletePk` is a single BLink
+            // search (~1 μs); typical |pending| at this point is bounded by
+            // the application's remove-rate × Phase B duration (seconds),
+            // typically a few hundred entries.
+            PagedPkSet pendingForReapply = this.pendingCheckpointDeletes;
+            if (pendingForReapply != null && !finalNewSegments.isEmpty()) {
+                pendingForReapply.forEach(pk -> {
+                    for (VectorSegment seg : finalNewSegments) {
+                        if (seg.deletePk(pk)) {
+                            return;
+                        }
+                    }
+                });
+            }
+
             this.segments = new java.util.concurrent.CopyOnWriteArrayList<>(finalNewSegments);
 
             int maxOrd = -1;
@@ -5158,7 +5174,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
             currentDeferredVectors.set(0);  // Deferred shards have been restored to live set
             closePendingCheckpointDeletesQuietly();
             this.liveVectorCapDuringCheckpoint = Integer.MAX_VALUE;
-            dirty.set(totalLiveSize() > 0);
+            // Issue #538 (pr-reviewer pass-3 follow-up): OR-pattern so a
+            // concurrent {@link #dropSegmentByUuid} or
+            // {@link #adoptExternalSegment} that landed in the Phase A →
+            // Stage 2 window and set {@code dirty=true} is preserved. With
+            // the OLD overwrite ({@code dirty.set(totalLiveSize() > 0)})
+            // the dirty signal was clobbered on a quiet index — the
+            // IndexStatus-vs-segments drift this fix introduces would
+            // then persist indefinitely because the next periodic
+            // checkpoint would see {@code dirty == false} and skip.
+            // Matches the OR pattern in {@link #atomicSwapCompactionResult}
+            // Stage 3 (used to signal a similar drift case).
+            dirty.set(dirty.get() || totalLiveSize() > 0);
 
             recordSegmentSizeDistribution();
         } finally {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -5038,29 +5038,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 }
             }
 
-            // Note: late-arriving deletes from {@link #pendingCheckpointDeletes}
-            // are reapplied below, AFTER {@code finalNewSegments} is built —
-            // see the second {@code pendingForReapply.forEach} block. The
-            // reapply was moved out of this position (where it iterated only
-            // {@code preloadedSegments}) to {@code finalNewSegments} to also
-            // cover adopted segments that landed in the Phase A → Stage 2
-            // window (issue #538 pr-reviewer pass-3 follow-up).
-            //
-            // Issue #455: sealedSegments + mergeableSegments together cover
-            // every segment that was previously in this.segments (their union
-            // was built by the Phase A partition loop), so they remain
-            // registered.  Only the freshly-built preloadedSegments need to
-            // join the on-disk memory counter here.
-            //
-            // Capture snapshots BEFORE publishing newSegments: if any
-            // estimatedInMemoryBytes() call were ever to throw (e.g. an
-            // unforeseen failure inside BLink.getUsedMemory()), unwinding
-            // before the publish leaves both this.segments and the counter
-            // consistent — no half-updated-counter window.
-            for (VectorSegment seg : preloadedSegments) {
-                registerSegmentMemoryEstimate(seg);
-            }
-
             // Issue #538: REBUILD `finalNewSegments` from the CURRENT
             // `this.segments` rather than publishing the stale Phase-A
             // snapshot. Between Phase A's writeLock release and this
@@ -5124,6 +5101,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // Stage 1 it returns false (BLink miss) and the loop continues
             // to the next segment.
             //
+            // ORDERING (pr-reviewer pass-4 follow-up): the reapply runs
+            // BEFORE {@code registerSegmentMemoryEstimate} so that if
+            // {@code seg.deletePk} throws (e.g. an unchecked
+            // {@code UncheckedIOException} bubbling out of a BLink page
+            // unload), unwinding leaves the counter UNCHANGED and
+            // {@code this.segments} still pointing at the OLD list — no
+            // half-updated state. Matches the {@link
+            // #atomicSwapCompactionResult} Stage-3 ordering of "reapply →
+            // register → publish".
+            //
             // Cost: O(|pending| × |finalNewSegments|). The constant
             // factor is small because each `deletePk` is a single BLink
             // search (~1 μs); typical |pending| at this point is bounded by
@@ -5138,6 +5125,26 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         }
                     }
                 });
+            }
+
+            // Issue #455: sealedSegments + mergeableSegments together cover
+            // every segment that was previously in this.segments (their union
+            // was built by the Phase A partition loop), so they remain
+            // registered.  Only the freshly-built preloadedSegments need to
+            // join the on-disk memory counter here.
+            //
+            // Capture snapshots BEFORE publishing newSegments: if any
+            // estimatedInMemoryBytes() call were ever to throw (e.g. an
+            // unforeseen failure inside BLink.getUsedMemory()), unwinding
+            // before the publish leaves both this.segments and the counter
+            // consistent — no half-updated-counter window.
+            //
+            // Issue #538 pr-reviewer pass-4: ordering is now `reapply →
+            // register → publish`, so a throw in the reapply above also
+            // leaves the counter untouched. Same invariant as the
+            // {@link #atomicSwapCompactionResult} Stage-3 ordering.
+            for (VectorSegment seg : preloadedSegments) {
+                registerSegmentMemoryEstimate(seg);
             }
 
             this.segments = new java.util.concurrent.CopyOnWriteArrayList<>(finalNewSegments);

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2883,11 +2883,65 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     }
                     registerSegmentMemoryEstimate(mergedOutput);
                 }
-                this.segments = newSegments;
+                // Issue #538 (root cause of the residual race tracked in
+                // issue #537): REBUILD `finalNewSegments` from the CURRENT
+                // `this.segments` rather than publishing the stale Stage-1
+                // `newSegments`. Between Stage 1's snapshot and this Stage 3
+                // window a concurrent {@link #dropSegmentByUuid} (typically
+                // fired by the optimizer-watcher's {@code onSegmentReleased}
+                // when the optimizer deprecates a NON-input segment in ZK)
+                // may have removed segments from {@code this.segments} and
+                // queued them on {@link #pendingSegmentCloses}. Publishing
+                // the Stage-1 `newSegments` would silently RE-INSERT those
+                // dropped segments — the cycle's finally drain would then
+                // close them, leaving an orphan in {@code this.segments}
+                // with {@code onDiskGraph == null}. That orphan trips the
+                // null-check at {@code VectorIndexCompactor
+                // .rebuildSegmentStreaming:780} on every subsequent cycle,
+                // producing the persistent failure loop reported in issues
+                // #535 and #538.
+                //
+                // The rebuild here is correct because:
+                //   - we EXCLUDE all `inputs` by segmentId (the swap's intent);
+                //   - we INCLUDE everything else from the CURRENT
+                //     `this.segments`, so segments dropped between Stage 1
+                //     and now are NOT republished AND segments adopted
+                //     between Stage 1 and now (via
+                //     {@link #adoptExternalSegment}) ARE preserved;
+                //   - we add `mergedOutput` exactly once.
+                //
+                // The persisted IndexStatus from Stage 2 may diverge slightly
+                // from the published `this.segments` if a non-input drop
+                // landed in the Stage 1→3 window. {@code dirty.set(true)}
+                // below forces the next checkpoint to repersist; in the
+                // restart window between this swap and that checkpoint the
+                // IndexStatus references the dropped segment, but
+                // {@code loadFusedPQSegment} will fail on it cleanly (the
+                // optimizer has deleted the multipart files) and recovery
+                // is bounded by the existing reconcile-on-restart path.
+                List<VectorSegment> currentAtStage3 = this.segments;
+                List<VectorSegment> finalNewSegments =
+                        new java.util.concurrent.CopyOnWriteArrayList<>();
+                for (VectorSegment s : currentAtStage3) {
+                    if (!inputIds.contains(s.segmentId)) {
+                        finalNewSegments.add(s);
+                    }
+                }
+                if (mergedOutput != null) {
+                    finalNewSegments.add(mergedOutput);
+                }
+                this.segments = finalNewSegments;
                 for (VectorSegment in : inputs) {
                     unregisterSegmentMemoryEstimate(in);
                 }
-                dirty.set(dirty.get() || totalLiveSize() > 0);
+                // Issue #538: force a fresh checkpoint persist whenever the
+                // Stage 1→3 window observed drift (segments dropped or
+                // adopted). Without this, the IndexStatus on disk would
+                // continue to reference the stale Stage-1 snapshot until
+                // some unrelated operation marks the store dirty.
+                boolean stage1Stage3Drift = finalNewSegments.size()
+                        != newSegments.size();
+                dirty.set(dirty.get() || stage1Stage3Drift || totalLiveSize() > 0);
             } finally {
                 stateLock.writeLock().unlock();
             }

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2753,22 +2753,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         checkpointLock.lock();
         try {
             // ---------- STAGE 1 — validate + build (no writeLock). ----------
-            // checkpointLock is the outermost serialiser of segments mutations,
-            // so the volatile read of `this.segments` is stable for the
-            // duration of this method.
-            //
-            // KNOWN RACE (issue #537): dropSegmentByUuid does NOT take
-            // checkpointLock; it only takes stateLock.writeLock(). So a
-            // drop landing between this read of `current` and Stage 3's
-            // writeLock-protected publish can:
-            //   - remove a NON-INPUT segment from `this.segments`, and
-            //   - leave it queued in pendingSegmentCloses;
-            // then Stage 3 publishes `newSegments` built from `current`
-            // (which still has the dropped segment) and re-inserts it
-            // into `this.segments`. The cycle's finally then closes the
-            // re-published segment, leaving it visible to subsequent
-            // searches / compactions with onDiskGraph == null. Tracked
-            // separately; outside the scope of issue #535.
+            // checkpointLock serialises compactions and checkpoints, but
+            // does NOT exclude {@link #dropSegmentByUuid} (which takes only
+            // {@code stateLock.writeLock()}). A drop landing in the Stage 1
+            // → Stage 3 window can therefore mutate {@code this.segments}
+            // under our feet. Stage 3 below handles this by REBUILDING the
+            // published list from {@code this.segments} read freshly under
+            // writeLock (issue #538), so the Stage-1 `newSegments` is now a
+            // lower-bound estimate used only for the persist in Stage 2 and
+            // for the pre-lock registry coordination above.
             List<VectorSegment> current = this.segments;
             // Canonical pre-sizing: HashSet rounds up to the next power of two,
             // so we want capacity = ceil(size / loadFactor). 0.75f is the
@@ -2910,18 +2903,30 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 //     {@link #adoptExternalSegment}) ARE preserved;
                 //   - we add `mergedOutput` exactly once.
                 //
-                // The persisted IndexStatus from Stage 2 may diverge slightly
-                // from the published `this.segments` if a non-input drop
-                // landed in the Stage 1→3 window. {@code dirty.set(true)}
-                // below forces the next checkpoint to repersist; in the
-                // restart window between this swap and that checkpoint the
-                // IndexStatus references the dropped segment, but
-                // {@code loadFusedPQSegment} will fail on it cleanly (the
-                // optimizer has deleted the multipart files) and recovery
-                // is bounded by the existing reconcile-on-restart path.
+                // The persisted IndexStatus from Stage 2 may diverge from
+                // the published `this.segments` if a drop or adoption
+                // landed in the Stage 1 → Stage 3 window. The next
+                // checkpoint repersists consistently because the two
+                // mutating callers ({@link #dropSegmentByUuid} and
+                // {@link #adoptExternalSegment}) both call
+                // {@code dirty.set(true)} themselves. In the (short) window
+                // between this swap and the next checkpoint a restart would
+                // load a stale IndexStatus referencing a segment whose
+                // multipart files were already deleted by the optimizer;
+                // {@code start()}'s all-or-nothing load would FAIL on it,
+                // looping the IS until the next checkpoint cadence (~60 s
+                // by default). The pre-fix code had exactly the same
+                // restart-window risk via the orphan-in-segments state
+                // (the loaded segment would have {@code onDiskGraph==null}
+                // and crash on first use); the fix does not enlarge it.
+                // ArrayList + final wrap keeps the writeLock window tight
+                // vs. {@code CopyOnWriteArrayList.add}-in-loop (each add
+                // re-copies the entire backing array — O(N²)).
                 List<VectorSegment> currentAtStage3 = this.segments;
-                List<VectorSegment> finalNewSegments =
-                        new java.util.concurrent.CopyOnWriteArrayList<>();
+                int expectedSize = currentAtStage3.size() - inputs.size()
+                        + (mergedOutput != null ? 1 : 0);
+                ArrayList<VectorSegment> finalNewSegments =
+                        new ArrayList<>(Math.max(0, expectedSize));
                 for (VectorSegment s : currentAtStage3) {
                     if (!inputIds.contains(s.segmentId)) {
                         finalNewSegments.add(s);
@@ -2930,18 +2935,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 if (mergedOutput != null) {
                     finalNewSegments.add(mergedOutput);
                 }
-                this.segments = finalNewSegments;
+                this.segments = new java.util.concurrent.CopyOnWriteArrayList<>(
+                        finalNewSegments);
                 for (VectorSegment in : inputs) {
                     unregisterSegmentMemoryEstimate(in);
                 }
-                // Issue #538: force a fresh checkpoint persist whenever the
-                // Stage 1→3 window observed drift (segments dropped or
-                // adopted). Without this, the IndexStatus on disk would
-                // continue to reference the stale Stage-1 snapshot until
-                // some unrelated operation marks the store dirty.
-                boolean stage1Stage3Drift = finalNewSegments.size()
-                        != newSegments.size();
-                dirty.set(dirty.get() || stage1Stage3Drift || totalLiveSize() > 0);
+                // Note: we deliberately do NOT add an explicit drift-detection
+                // dirty bit here. The two mutators that produce drift —
+                // {@link #dropSegmentByUuid} and {@link #adoptExternalSegment}
+                // — both call {@code dirty.set(true)} themselves, so the
+                // next checkpoint already runs to repersist IndexStatus
+                // consistently. A drift bit based on
+                // {@code finalNewSegments.size() != newSegments.size()}
+                // would miss the (rare but possible) "1 drop + 1 adoption"
+                // case anyway; a set-based check would be correct but
+                // redundant.
+                dirty.set(dirty.get() || totalLiveSize() > 0);
             } finally {
                 stateLock.writeLock().unlock();
             }
@@ -5070,10 +5079,62 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 registerSegmentMemoryEstimate(seg);
             }
 
-            this.segments = newSegments;
+            // Issue #538: REBUILD `finalNewSegments` from the CURRENT
+            // `this.segments` rather than publishing the stale Phase-A
+            // snapshot. Between Phase A's writeLock release and this
+            // Stage-2 writeLock acquisition (which spans the slow Phase B
+            // I/O and Phase C-prep loads), a concurrent
+            // {@link #dropSegmentByUuid} (fired by the optimizer-watcher's
+            // {@code onSegmentReleased}) may have removed segments from
+            // {@code this.segments} AND opportunistically closed them via
+            // the deferred-close drain (PR #536) — because the checkpoint
+            // holds only {@code checkpointLock}, NOT {@code compactionLock},
+            // so the drain's {@code compactionLock.tryLock} from
+            // {@code drainPendingSegmentClosesOpportunistically} succeeds.
+            // Publishing the Phase-A snapshot (which still contains those
+            // segments) would silently RE-INSERT closed segments into
+            // {@code this.segments}, leaving orphans with
+            // {@code onDiskGraph == null}. This is the structural twin of
+            // the compaction-side bug fixed in
+            // {@link #atomicSwapCompactionResult} Stage 3; both surfaces
+            // produced the production failure mode reported in issues
+            // #535 / #537 / #538.
+            //
+            // The rebuild filters {@code sealedSegments} and
+            // {@code mergeableSegments} (the Phase-A view of pre-existing
+            // segments) by membership in {@code currentAtStage2}: any
+            // segment dropped during the Phase A → Stage 2 window is
+            // excluded. {@code preloadedSegments} are always included
+            // (they are brand-new and not yet in {@code this.segments}).
+            // ArrayList + final wrap minimises the writeLock window vs.
+            // {@code CopyOnWriteArrayList.add}-in-loop (each {@code add}
+            // would re-copy the entire backing array, O(N²)).
+            List<VectorSegment> currentAtStage2 = this.segments;
+            java.util.HashSet<Integer> currentIdsAtStage2 = new java.util.HashSet<>(
+                    (int) (currentAtStage2.size() / 0.75f) + 1);
+            for (VectorSegment s : currentAtStage2) {
+                currentIdsAtStage2.add(s.segmentId);
+            }
+            int expectedSize = sealedSegments.size() + mergeableSegments.size()
+                    + preloadedSegments.size();
+            ArrayList<VectorSegment> finalNewSegments = new ArrayList<>(expectedSize);
+            for (VectorSegment sealed : sealedSegments) {
+                if (currentIdsAtStage2.contains(sealed.segmentId)) {
+                    finalNewSegments.add(sealed);
+                }
+            }
+            for (VectorSegment mergeable : mergeableSegments) {
+                if (currentIdsAtStage2.contains(mergeable.segmentId)) {
+                    finalNewSegments.add(mergeable);
+                }
+            }
+            // preloadedSegments are brand-new (built in Phase B from live
+            // shards) so they are never in `currentAtStage2`; always include.
+            finalNewSegments.addAll(preloadedSegments);
+            this.segments = new java.util.concurrent.CopyOnWriteArrayList<>(finalNewSegments);
 
             int maxOrd = -1;
-            for (VectorSegment seg : newSegments) {
+            for (VectorSegment seg : finalNewSegments) {
                 if (seg.maxOrdinal > maxOrd) {
                     maxOrd = seg.maxOrdinal;
                 }
@@ -5084,7 +5145,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             LOGGER.log(Level.INFO,
                     "checkpoint {0} Phase C: {1} nodes across {2} segments (FusedPQ), "
                             + "{3} new live inserts during checkpoint",
-                    new Object[]{indexName, totalNodes, newSegments.size(), totalLiveSize()});
+                    new Object[]{indexName, totalNodes, finalNewSegments.size(), totalLiveSize()});
 
             // No vectorStorage cleanup needed: each shard owns its own per-shard
             // VectorStorage (issue #256). Dropping the reference to the old shards

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2912,13 +2912,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 // {@code dirty.set(true)} themselves. In the (short) window
                 // between this swap and the next checkpoint a restart would
                 // load a stale IndexStatus referencing a segment whose
-                // multipart files were already deleted by the optimizer;
-                // {@code start()}'s all-or-nothing load would FAIL on it,
-                // looping the IS until the next checkpoint cadence (~60 s
-                // by default). The pre-fix code had exactly the same
-                // restart-window risk via the orphan-in-segments state
-                // (the loaded segment would have {@code onDiskGraph==null}
-                // and crash on first use); the fix does not enlarge it.
+                // multipart files were already deleted by the optimizer.
+                // {@code start()}'s {@code loadFromStatus} is all-or-nothing
+                // (it runs BEFORE {@link #reconcileWithIndexStatus}), so
+                // it would FAIL on the deleted segment and the IS process
+                // would crash-loop until manual operator intervention OR
+                // until the optimizer's retention has not yet expired
+                // (typical retention >> checkpoint cadence, so this is
+                // unlikely in practice). The pre-fix code had exactly the
+                // same restart-window risk via the orphan-in-segments
+                // state (the loaded segment would have
+                // {@code onDiskGraph==null} and crash on first use); the
+                // fix does not enlarge it.
                 // ArrayList + final wrap keeps the writeLock window tight
                 // vs. {@code CopyOnWriteArrayList.add}-in-loop (each add
                 // re-copies the entire backing array — O(N²)).
@@ -5100,36 +5105,24 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // produced the production failure mode reported in issues
             // #535 / #537 / #538.
             //
-            // The rebuild filters {@code sealedSegments} and
-            // {@code mergeableSegments} (the Phase-A view of pre-existing
-            // segments) by membership in {@code currentAtStage2}: any
-            // segment dropped during the Phase A → Stage 2 window is
-            // excluded. {@code preloadedSegments} are always included
-            // (they are brand-new and not yet in {@code this.segments}).
+            // Concurrent {@link #adoptExternalSegment} is also handled
+            // correctly: an adoption landed in the Phase A → Stage 2
+            // window is in {@code currentAtStage2} but was NOT in the
+            // Phase-A snapshot. Iterating {@code currentAtStage2}
+            // directly (rather than the snapshot) preserves the adoption.
+            // {@code preloadedSegments} are the NEW segments produced by
+            // this checkpoint's Phase B from live shards; they are
+            // guaranteed to not be in {@code currentAtStage2} (Phase B's
+            // segment IDs are freshly allocated), so concatenating is
+            // collision-free.
+            //
             // ArrayList + final wrap minimises the writeLock window vs.
             // {@code CopyOnWriteArrayList.add}-in-loop (each {@code add}
             // would re-copy the entire backing array, O(N²)).
             List<VectorSegment> currentAtStage2 = this.segments;
-            java.util.HashSet<Integer> currentIdsAtStage2 = new java.util.HashSet<>(
-                    (int) (currentAtStage2.size() / 0.75f) + 1);
-            for (VectorSegment s : currentAtStage2) {
-                currentIdsAtStage2.add(s.segmentId);
-            }
-            int expectedSize = sealedSegments.size() + mergeableSegments.size()
-                    + preloadedSegments.size();
-            ArrayList<VectorSegment> finalNewSegments = new ArrayList<>(expectedSize);
-            for (VectorSegment sealed : sealedSegments) {
-                if (currentIdsAtStage2.contains(sealed.segmentId)) {
-                    finalNewSegments.add(sealed);
-                }
-            }
-            for (VectorSegment mergeable : mergeableSegments) {
-                if (currentIdsAtStage2.contains(mergeable.segmentId)) {
-                    finalNewSegments.add(mergeable);
-                }
-            }
-            // preloadedSegments are brand-new (built in Phase B from live
-            // shards) so they are never in `currentAtStage2`; always include.
+            ArrayList<VectorSegment> finalNewSegments = new ArrayList<>(
+                    currentAtStage2.size() + preloadedSegments.size());
+            finalNewSegments.addAll(currentAtStage2);
             finalNewSegments.addAll(preloadedSegments);
             this.segments = new java.util.concurrent.CopyOnWriteArrayList<>(finalNewSegments);
 

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -533,20 +533,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *       joined, so a queued segment is never leaked at shutdown.</li>
      * </ul>
      *
-     * <p><b>Known residual race (issue #537):</b> the drain holds
-     * {@code compactionLock} but NOT {@link #stateLock}'s writeLock, so
-     * it does not serialize with concurrent {@code searchInternal}
-     * callers. The drain is safe in the common case because
-     * {@code dropSegmentByUuid} removes the segment from
+     * <p>Search safety: the drain holds {@code compactionLock} but NOT
+     * {@link #stateLock}'s writeLock, so it does not directly serialize
+     * with concurrent {@code searchInternal} callers. Safety nevertheless
+     * holds because {@code dropSegmentByUuid} removes the segment from
      * {@code this.segments} under the writeLock (which waits for all
-     * in-flight {@code searchInternal} readLock holders), so the next
-     * search snapshot won't see the queued segment. However, when
-     * {@code atomicSwapCompactionResult}'s Stage-3 publish races with
-     * {@code dropSegmentByUuid} as described in issue #537, the
-     * just-dropped segment can be re-published into {@code this.segments}
-     * by the Stage-3 writeLock window; the drain then closes a segment
-     * that is observable to new searches. That residual race is tracked
-     * separately and not addressed by this field.
+     * in-flight {@code searchInternal} readLock holders), so any later
+     * search snapshot of {@code this.segments} will not see the queued
+     * segment. The Stage-3 publish in
+     * {@code atomicSwapCompactionResult} (issue #537, now fixed by
+     * issue #538's rebuild-from-current-segments at Stage 3 / Phase C
+     * Stage 2) also reads from {@code this.segments} under the writeLock
+     * and therefore never re-introduces a queued segment.
      */
     private final ConcurrentLinkedDeque<VectorSegment>
             pendingSegmentCloses = new ConcurrentLinkedDeque<>();
@@ -3505,8 +3503,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 // either (a) finishes before we publish `newList` (writeLock waits
                 // for outstanding readLock holders) or (b) starts after we publish
                 // `newList` and never sees `found`. Either way, no search will
-                // dereference `found.onDiskGraph` after we drain (modulo issue
-                // #537's Stage-1-snapshot-then-republish residual race).
+                // dereference `found.onDiskGraph` after we drain. The
+                // {@code atomicSwapCompactionResult} Stage-3 rebuild and the
+                // {@code doCheckpointFusedPQThreePhase} Phase C Stage 2 rebuild
+                // (both fixed by issue #538) read `this.segments` under the
+                // writeLock and never re-introduce a removed segment.
                 pendingSegmentCloses.add(found);
             } finally {
                 stateLock.writeLock().unlock();
@@ -4152,12 +4153,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
         //      waited for the readLock to release). Either way the drain's
         //      seg.close() is invisible to in-flight searches.
         //
-        //      RESIDUAL RACE (issue #537): atomicSwapCompactionResult's Stage-3
-        //      writeLock window can re-publish a just-dropped segment into
-        //      this.segments. In that narrow window a new search starting AFTER
-        //      Stage 3 and BEFORE the cycle's finally-drain CAN observe the
-        //      queued segment and then race the drain's close. Tracked
-        //      separately; not addressed by issue #535's fix.
+        //      The Stage-3 republish race tracked separately in issue #537 has
+        //      been FIXED by issue #538: both atomicSwapCompactionResult Stage 3
+        //      and doCheckpointFusedPQThreePhase Phase C Stage 2 now rebuild
+        //      `finalNewSegments` from a fresh read of `this.segments` under
+        //      the writeLock, so a just-dropped segment is never re-introduced
+        //      by either publish path.
         //   2. Live in-memory shards (Phase 2): liveShards is updated under the
         //      write lock during addVectorInternal's shard-rotation path; holding
         //      the read lock keeps the shard list stable across task creation.

--- a/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
@@ -630,8 +630,8 @@ public class Issue538Stage3RepublishRaceTest {
      * Test-only {@link VectorSegment} subclass that records every
      * {@code deletePk} invocation in a thread-safe list and returns
      * {@code false} so the reapply loop continues to subsequent segments.
-     * Used by
-     * {@link #removeBeforeAdoptionDuringCheckpointMustNotResurrectDeletedPk}
+     * Used by {@link
+     * #stage2ReapplyMustCoverAdoptedSegmentsForPendingCheckpointDeletes}
      * to verify that the Stage-2 late-deletes reapply DOES iterate
      * adopted segments (a regression introduced by the round-3 fix
      * that preserves adoptions in the published list).
@@ -650,6 +650,29 @@ public class Issue538Stage3RepublishRaceTest {
             // Return false so the reapply loop continues — we are a
             // pure observer, not an absorber.
             return false;
+        }
+    }
+
+    /**
+     * Test-only {@link VectorSegment} subclass that THROWS on every
+     * {@code deletePk} invocation. Used by
+     * {@link #stage2ReapplyThrowMustNotLeavePartialCounterUpdate} to
+     * verify that a throw from the late-deletes reapply unwinds
+     * cleanly: {@code onDiskSegmentsEstimatedMemoryBytes} stays at its
+     * pre-Stage-2 value (preloadedSegments were not yet registered)
+     * AND {@code this.segments} stays at the OLD list (publish did
+     * not happen). Locks in the "reapply → register → publish"
+     * ordering invariant.
+     */
+    private static final class ThrowingVectorSegment extends VectorSegment {
+        ThrowingVectorSegment(int segmentId) {
+            super(segmentId);
+        }
+
+        @Override
+        boolean deletePk(Bytes key) {
+            throw new RuntimeException(
+                    "synthetic deletePk failure (issue #538 pr-reviewer pass-4 test)");
         }
     }
 
@@ -870,6 +893,93 @@ public class Issue538Stage3RepublishRaceTest {
                     + "iteration, once by the reapply over finalNewSegments). "
                     + "Got " + hits + " invocations; expected >= 2.",
                     hits >= 2);
+        }
+    }
+
+    /**
+     * Pr-reviewer pass-4 follow-up: locks in the "reapply → register →
+     * publish" ordering invariant in Phase C Stage 2. If
+     * {@code seg.deletePk} throws during the reapply, the failure must
+     * unwind cleanly: {@code onDiskSegmentsEstimatedMemoryBytes}
+     * unchanged (preloadedSegments NOT yet registered) and
+     * {@code this.segments} unchanged (publish did not happen).
+     *
+     * <p>Pre-fix-4 the order was "register → reapply → publish", so a
+     * reapply throw left the counter incremented for every preloaded
+     * segment while {@code this.segments} still pointed at the OLD
+     * list — a half-updated state. Post-fix-4 the register runs AFTER
+     * the reapply, so a reapply throw never advances the counter.
+     */
+    @Test(timeout = 60_000)
+    public void stage2ReapplyThrowMustNotLeavePartialCounterUpdate()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-reapply-throw").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 3);
+
+            final Bytes pkToRemove = Bytes.from_int(999_999_002);
+            final ThrowingVectorSegment thrower = new ThrowingVectorSegment(1_000_000_004);
+            thrower.segmentUuid = UUID.randomUUID().toString();
+            thrower.generation = 9999L;
+
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                try {
+                    // Order matters: call removeVector FIRST so the pk is
+                    // added to pendingCheckpointDeletes (removeVector also
+                    // iterates this.segments — at this point thrower is
+                    // NOT yet injected, so removeVector does not hit the
+                    // thrower). Then inject thrower so Stage 2's reapply
+                    // will iterate it and trigger the throw.
+                    store.removeVector(pkToRemove);
+                    addSegmentViaReflection(store, thrower);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            long counterBefore = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            List<VectorSegment> segmentsBefore = store.getOnDiskSegmentsSnapshotForTest();
+
+            // Trigger checkpoint. The Phase C Stage 2 reapply will call
+            // thrower.deletePk(pk) and throw. The checkpoint must
+            // propagate the exception, but with the post-fix-4 ordering
+            // the counter and this.segments are unchanged.
+            store.addVector(Bytes.from_int(6666), vec(new Random(6666)));
+            boolean checkpointThrew = false;
+            try {
+                store.checkpoint();
+            } catch (Exception e) {
+                checkpointThrew = true;
+            }
+            assertTrue("checkpoint must propagate the synthetic"
+                    + " thrower's RuntimeException from the reapply path",
+                    checkpointThrew);
+
+            // CORE assertion: the counter did NOT advance during the
+            // failed Stage 2. This proves the register-after-reapply
+            // ordering is in effect.
+            assertEquals("on-disk-segments memory counter must be unchanged"
+                    + " when the Stage-2 reapply throws — preloadedSegments"
+                    + " must NOT have been registered before the reapply"
+                    + " (post-fix-4 ordering: reapply → register → publish)",
+                    counterBefore, store.getOnDiskSegmentsEstimatedMemoryBytes());
+
+            // this.segments did not advance either: the publish was after
+            // the (failed) reapply.
+            List<VectorSegment> segmentsAfter = store.getOnDiskSegmentsSnapshotForTest();
+            // The thrower was injected via reflection, so it IS in the
+            // current segments list (we don't undo that). But the
+            // preloaded segments (from this checkpoint's Phase B) must
+            // NOT have been published — verify by checking the size
+            // didn't grow past `before.size() + 1` (the +1 is the
+            // reflection-injected thrower; the preloaded segment would
+            // be +2).
+            assertEquals("this.segments must not include the preloaded segment"
+                    + " when the Stage-2 reapply threw (publish did not run)",
+                    segmentsBefore.size() + 1, segmentsAfter.size());
         }
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
@@ -304,6 +304,11 @@ public class Issue538Stage3RepublishRaceTest {
      * would throw {@code candidate segment N has no on-disk graph
      * (streaming compaction)}. Post-fix the victim is gone and the next
      * cycle proceeds normally on remaining segments.
+     *
+     * <p>This test also asserts the second cycle actually executed work
+     * (compaction success counter advanced), to catch a regression where
+     * the policy silently finds no candidates and the "no corruption"
+     * assertion passes vacuously.
      */
     @Test(timeout = 30_000)
     public void noCorruptionOnNextCycleAfterRacingCompaction() throws Exception {
@@ -331,22 +336,92 @@ public class Issue538Stage3RepublishRaceTest {
 
             // First cycle: the race fires.
             long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            long successesBefore = store.getCompactionSuccessesTotal();
             store.runCompactionCycle();
+            long corruptionAfterFirst = store.getCompactionFailuresCorruptionTotal();
+            assertEquals("first cycle must not record CORRUPTION (the race shifts"
+                    + " the symptom to the NEXT cycle, not this one)",
+                    corruptionBefore, corruptionAfterFirst);
 
-            // Disarm the hook so subsequent cycles run normally.
+            // Disarm the hook so the second cycle runs without the race.
             store.setAtomicSwapPostPersistHookForTest(null);
 
-            // Second cycle: must NOT trip the no-on-disk-graph check.
-            // Pre-fix this is where issue #538's persistent failure loop
-            // would start; post-fix the cycle either compacts the remaining
-            // healthy segments or exits with no candidates — either way no
-            // CORRUPTION is recorded.
+            // Loosen the policy so the second cycle compacts everything still
+            // present — including the (post-fix) merged output from cycle 1
+            // and the remaining non-input segments. Pre-fix the orphaned
+            // victim would be republished and selected here, tripping the
+            // no-on-disk-graph check. Post-fix the orphan is gone and the
+            // cycle merges the remaining healthy segments cleanly.
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+
             store.runCompactionCycle();
 
             assertEquals(
                 "no CORRUPTION on the cycle following the race — that was"
                 + " the persistent-failure loop reported in issue #538",
                 corruptionBefore, store.getCompactionFailuresCorruptionTotal());
+
+            // Catch the silent "no candidates" trap: the second cycle MUST
+            // have done useful work (i.e. a compaction succeeded), otherwise
+            // the no-corruption assertion above is vacuous.
+            assertTrue("the second cycle must have produced at least one"
+                    + " successful compaction (regression guard against"
+                    + " 'no candidates' masking a real failure)",
+                    store.getCompactionSuccessesTotal() > successesBefore);
+        }
+    }
+
+    /**
+     * Coverage gap (pr-reviewer follow-up): exercises a drop landing during
+     * Stage 2's slow {@code persistIndexStatusMultiSegment} I/O (using
+     * {@code atomicSwapPostBuildHook}, which fires AFTER Stage 1 build but
+     * BEFORE Stage 2 persist — i.e. the long lock-free window). The fix
+     * must protect this window too, not just the immediate pre-Stage-3
+     * window. Post-fix the dropped segment is NOT republished regardless
+     * of which sub-window the drop landed in.
+     */
+    @Test(timeout = 30_000)
+    public void dropDuringStage2PersistIsNotRepublishedByStage3() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-stage2-race").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            stampMissingUuids(initial);
+
+            VectorSegment largest = initial.get(0);
+            for (VectorSegment s : initial) {
+                if (s.estimatedSizeBytes > largest.estimatedSizeBytes) {
+                    largest = s;
+                }
+            }
+            final int victimId = largest.segmentId;
+            final String victimUuid = largest.segmentUuid;
+
+            // PostBuildHook fires AFTER Stage 1 builds newSegments and BEFORE
+            // Stage 2 starts the slow persist. Drop the victim here. With the
+            // fix, Stage 3 re-reads this.segments and excludes the dropped
+            // segment.
+            store.setAtomicSwapPostBuildHookForTest(() -> {
+                store.dropSegmentByUuid(victimUuid);
+            });
+
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            store.runCompactionCycle();
+
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                assertFalse("victim dropped during Stage 1 → Stage 2 must NOT"
+                        + " be republished by Stage 3 (issue #538: the fix"
+                        + " must protect the full Stage 1 → Stage 3 window,"
+                        + " not just the immediate pre-Stage-3 sub-window)",
+                        s.segmentId == victimId);
+            }
+            assertEquals("no CORRUPTION recorded",
+                    corruptionBefore, store.getCompactionFailuresCorruptionTotal());
         }
     }
 
@@ -367,6 +442,102 @@ public class Issue538Stage3RepublishRaceTest {
             assertEquals("baseline compaction must succeed", before + 1L, after);
             assertEquals("no CORRUPTION on the baseline", 0L,
                     store.getCompactionFailuresCorruptionTotal());
+        }
+    }
+
+    /**
+     * Coverage gap (pr-reviewer follow-up): the symmetric race in
+     * {@link PersistentVectorStore#doCheckpointFusedPQThreePhase Phase C
+     * Stage 2}. Structurally identical to the compaction Stage-3 race:
+     * Phase A snapshots {@code segments} into
+     * {@code sealedSegments + mergeableSegments} under writeLock, then
+     * releases writeLock for the slow Phase B I/O and Phase C-prep loads.
+     * Phase C Stage 2 re-acquires writeLock and publishes
+     * {@code this.segments = newSegments} (the Phase-A snapshot +
+     * preloadedSegments).
+     *
+     * <p>Between Phase A and Phase C Stage 2, a concurrent
+     * {@code dropSegmentByUuid} can:
+     *
+     * <ol>
+     *   <li>remove a segment from {@code this.segments} under writeLock,</li>
+     *   <li>opportunistically drain {@code pendingSegmentCloses} (the
+     *       checkpoint does NOT hold {@code compactionLock}, only
+     *       {@code checkpointLock}, so the drain's tryLock succeeds),</li>
+     *   <li>close the dropped segment ({@code onDiskGraph = null}).</li>
+     * </ol>
+     *
+     * Phase C Stage 2 then republishes the dropped (now-closed) segment
+     * into {@code this.segments} — same observable failure mode as #538.
+     *
+     * <p>This test fires the drop from {@code phaseCPostDeletesApplyHook}
+     * (already exists at {@code PersistentVectorStore.java:1315}). The
+     * hook runs inside Phase C, AFTER Stage 1's pending-deletes apply and
+     * BEFORE Stage 2's writeLock acquisition.
+     */
+    @Test(timeout = 60_000)
+    public void dropSegmentByUuidDuringCheckpointMustNotBeRepublishedByPhaseCStage2()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-checkpoint-race").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            // Seed via direct addVector + checkpoint (the existing
+            // seedSegments uses this pattern); the checkpoint we'll race
+            // is the one triggered by the next addVector+checkpoint pair.
+            seedSegments(store, 4);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue("seedSegments must produce at least 3 segments",
+                    initial.size() >= 3);
+            stampMissingUuids(initial);
+
+            // Pick the smallest segment as the drop victim. Any segment
+            // would do (the bug doesn't care about size for checkpoint),
+            // but the smallest is a stable choice.
+            VectorSegment smallest = initial.get(0);
+            for (VectorSegment s : initial) {
+                if (s.estimatedSizeBytes < smallest.estimatedSizeBytes) {
+                    smallest = s;
+                }
+            }
+            final VectorSegment victim = smallest;
+            final String victimUuid = victim.segmentUuid;
+            final int victimId = victim.segmentId;
+            assertNotNull("victim must have a UUID stamped", victimUuid);
+            assertNotNull("victim must have onDiskGraph populated", victim.onDiskGraph);
+
+            // Install the hook BEFORE triggering the next checkpoint. The
+            // hook fires inside Phase C, in the lock-free window before
+            // Stage 2's writeLock acquisition.
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                store.dropSegmentByUuid(victimUuid);
+            });
+
+            // Add one more vector + checkpoint to trigger a new checkpoint
+            // cycle. The checkpoint's Phase A snapshots the current segment
+            // list (which includes the victim); during Phase C the hook
+            // drops the victim; Phase C Stage 2 must NOT republish it.
+            store.addVector(Bytes.from_int(99999), vec(new Random(99)));
+            store.checkpoint();
+
+            // Post-fix assertions.
+            List<VectorSegment> after = store.getOnDiskSegmentsSnapshotForTest();
+            for (VectorSegment s : after) {
+                assertFalse("victim must NOT be republished by Phase C Stage 2"
+                        + " — this is the symmetric checkpoint twin of"
+                        + " issue #538's compaction Stage-3 republish bug",
+                        s.segmentId == victimId);
+            }
+
+            // The deferred-close drain ran during the dropSegmentByUuid's
+            // opportunistic call (compactionLock was free during checkpoint),
+            // so the victim's onDiskGraph is null.
+            assertNull("victim.onDiskGraph must be null after the deferred-close"
+                    + " drain that the checkpoint-window drop opportunistically"
+                    + " triggered",
+                    victim.onDiskGraph);
         }
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
@@ -897,6 +897,95 @@ public class Issue538Stage3RepublishRaceTest {
     }
 
     /**
+     * Pr-reviewer pass-5 follow-up: symmetric compaction-side test for
+     * the reapply-covers-adopted-segments invariant. Mirrors
+     * {@link #stage2ReapplyMustCoverAdoptedSegmentsForPendingCheckpointDeletes}
+     * but exercises {@code atomicSwapCompactionResult} Stage 3 with
+     * {@code pendingCompactionDeletes} (the compaction-cycle counterpart
+     * to {@code pendingCheckpointDeletes}).
+     *
+     * <p>Pre-fix-5 the Stage 3 reapply targeted ONLY {@code mergedOutput}
+     * — a {@code removeVector(P)} that ran during the cycle, followed
+     * by an {@code adoptExternalSegment} landing in the Stage 1 →
+     * Stage 3 window, would leave {@code P} live in the adopted
+     * segment after the cycle. Post-fix-5 the reapply iterates the
+     * entire {@code finalNewSegments} (currentAtStage3 - inputs +
+     * mergedOutput), so the adopted segment receives the pending
+     * delete and the {@code TrackingVectorSegment} observes the
+     * invocation.
+     */
+    @Test(timeout = 30_000)
+    public void stage3CompactionReapplyMustCoverAdoptedSegmentsForPendingCompactionDeletes()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-compaction-reapply").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            stampMissingUuids(initial);
+
+            final Bytes pkToRemove = Bytes.from_int(999_999_003);
+            final TrackingVectorSegment tracker = new TrackingVectorSegment(1_000_000_005);
+            tracker.segmentUuid = UUID.randomUUID().toString();
+            tracker.generation = 9999L;
+
+            // Use atomicSwapPostBuildHook (fires AFTER Stage 1 build,
+            // BEFORE Stage 2 persist). Order matters: removeVector FIRST
+            // so the pk lands in pendingCompactionDeletes without
+            // touching the tracker (tracker not yet injected); then
+            // inject the tracker so Stage 3's reapply iterates it.
+            store.setAtomicSwapPostBuildHookForTest(() -> {
+                try {
+                    store.removeVector(pkToRemove);
+                    addSegmentViaReflection(store, tracker);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            store.runCompactionCycle();
+
+            // Precondition: the tracker is in the published segments
+            // (the round-1 fix preserves adoptions through Stage 3).
+            boolean trackerInSegments = false;
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                if (s.segmentId == tracker.segmentId) {
+                    trackerInSegments = true;
+                    break;
+                }
+            }
+            assertTrue("tracker must be in this.segments post-publish "
+                    + "(round-1 fix preserves adoptions)", trackerInSegments);
+
+            // CORE assertion: the tracker's deletePk(pkToRemove) MUST
+            // have been called at least once by the Stage-3 reapply.
+            // (We never invoked it via removeVector — the tracker was
+            // injected AFTER removeVector.) Pre-fix-5 the reapply
+            // targeted only mergedOutput, so the tracker would NOT see
+            // pkToRemove. Post-fix-5 the reapply iterates
+            // finalNewSegments which includes the tracker.
+            int hits = 0;
+            for (Bytes b : tracker.deletePkInvocations) {
+                if (pkToRemove.equals(b)) {
+                    hits++;
+                }
+            }
+            assertTrue("Stage-3 compaction reapply must iterate adopted "
+                    + "segments — tracker.deletePk(pkToRemove) must be "
+                    + "invoked at least once by the reapply over "
+                    + "finalNewSegments. Got " + hits + " invocations; "
+                    + "expected >= 1. Pre-fix-5 the reapply targeted "
+                    + "only mergedOutput, leaving pendingCompactionDeletes "
+                    + "unapplied to adopted segments (issue #538 pr-reviewer "
+                    + "pass-5).",
+                    hits >= 1);
+        }
+    }
+
+    /**
      * Pr-reviewer pass-4 follow-up: locks in the "reapply → register →
      * publish" ordering invariant in Phase C Stage 2. If
      * {@code seg.deletePk} throws during the reapply, the failure must

--- a/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
@@ -604,6 +604,14 @@ public class Issue538Stage3RepublishRaceTest {
      * {@code adoptExternalSegment} setup (pre-written multipart files,
      * BLink storage init, jvector graph load) would dominate the test
      * boilerplate without exercising the bug.
+     *
+     * <p>Production-vs-test divergence: real
+     * {@link PersistentVectorStore#adoptExternalSegment} acquires
+     * {@code stateLock.writeLock()} before mutating {@code segments}.
+     * This helper does NOT — it relies on the test running the hook
+     * callback on the same thread as the cycle (which is the case for
+     * every hook in this test file), so there is no concurrent writer
+     * and no visibility concern.
      */
     private static void addSegmentViaReflection(PersistentVectorStore store,
             VectorSegment seg) throws ReflectiveOperationException {
@@ -616,6 +624,33 @@ public class Issue538Stage3RepublishRaceTest {
                 new java.util.concurrent.CopyOnWriteArrayList<>(current);
         newList.add(seg);
         f.set(store, newList);
+    }
+
+    /**
+     * Test-only {@link VectorSegment} subclass that records every
+     * {@code deletePk} invocation in a thread-safe list and returns
+     * {@code false} so the reapply loop continues to subsequent segments.
+     * Used by
+     * {@link #removeBeforeAdoptionDuringCheckpointMustNotResurrectDeletedPk}
+     * to verify that the Stage-2 late-deletes reapply DOES iterate
+     * adopted segments (a regression introduced by the round-3 fix
+     * that preserves adoptions in the published list).
+     */
+    private static final class TrackingVectorSegment extends VectorSegment {
+        final java.util.List<Bytes> deletePkInvocations =
+                java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+        TrackingVectorSegment(int segmentId) {
+            super(segmentId);
+        }
+
+        @Override
+        boolean deletePk(Bytes key) {
+            deletePkInvocations.add(key);
+            // Return false so the reapply loop continues — we are a
+            // pure observer, not an absorber.
+            return false;
+        }
     }
 
     /**
@@ -711,6 +746,130 @@ public class Issue538Stage3RepublishRaceTest {
                     + " drain that the checkpoint-window drop opportunistically"
                     + " triggered",
                     victim.onDiskGraph);
+
+            // Pr-reviewer pass-3 follow-up: the dirty bit MUST remain true
+            // after a race-affected checkpoint, even when
+            // `totalLiveSize() == 0`. Pre-fix-3 the Stage-2 OVERWRITE
+            // `dirty.set(totalLiveSize() > 0)` clobbered the `dirty=true`
+            // signal that {@code dropSegmentByUuid} set in the Phase A →
+            // Stage 2 window, leaving the next periodic checkpoint to skip
+            // (it would observe `dirty == false`) and the IndexStatus-vs-
+            // segments drift introduced by the rebuild would persist
+            // indefinitely. Post-fix-3 the Stage-2 OR pattern
+            // `dirty.set(dirty.get() || totalLiveSize() > 0)` preserves
+            // the signal so the next checkpoint repersists IndexStatus
+            // and heals the drift.
+            assertTrue("dirty bit must be preserved past the race-affected"
+                    + " checkpoint so the next periodic checkpoint runs"
+                    + " and repersists IndexStatus (issue #538 pr-reviewer"
+                    + " pass-3: Stage-2 must OR-merge the `dirty=true`"
+                    + " signal from the in-window dropSegmentByUuid /"
+                    + " adoptExternalSegment, not overwrite it with"
+                    + " totalLiveSize()>0)",
+                    store.isDirty());
+        }
+    }
+
+    /**
+     * Pr-reviewer pass-3 follow-up: with the round-3 fix preserving
+     * adopted segments in {@code this.segments} past the checkpoint,
+     * the Stage-2 late-deletes reapply must ALSO iterate those adopted
+     * segments. Otherwise a {@code removeVector(P)} that arrived during
+     * the checkpoint (placing {@code P} in
+     * {@code pendingCheckpointDeletes}) BEFORE the adoption would
+     * leave {@code P} live in the adopted segment after the checkpoint
+     * — a stale-data window.
+     *
+     * <p>This test injects a {@link TrackingVectorSegment} via reflection
+     * inside {@code phaseCPostDeletesApplyHook} (the Phase A → Stage 2
+     * lock-free window), then calls {@code removeVector} from the same
+     * hook so that {@code P} is added to {@code pendingCheckpointDeletes}.
+     * Post-fix the Stage-2 reapply iterates {@code finalNewSegments},
+     * which includes the adopted tracking segment, calling its
+     * {@code deletePk(P)}. The test asserts the tracking segment's
+     * invocation log contains {@code P} at least twice — once from
+     * {@code removeVector}'s direct iteration of {@code this.segments}
+     * and once from the Stage-2 reapply.
+     *
+     * <p>Pre-fix-3 the reapply iterates {@code preloadedSegments} only;
+     * the tracking segment is silently bypassed, so the invocation count
+     * is 1 instead of 2.
+     */
+    @Test(timeout = 60_000)
+    public void stage2ReapplyMustCoverAdoptedSegmentsForPendingCheckpointDeletes()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-reapply-adopted").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 3);
+
+            // The pk we will remove during the checkpoint. Pick a value
+            // that's NOT in the seeded segments (so removeVector does not
+            // find it in any real segment — keeps the test focused on the
+            // reapply path). Any non-empty Bytes works.
+            final Bytes pkToRemove = Bytes.from_int(999_999_001);
+
+            final TrackingVectorSegment tracker = new TrackingVectorSegment(1_000_000_003);
+            tracker.segmentUuid = UUID.randomUUID().toString();
+            tracker.generation = 9999L;
+
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                try {
+                    // 1. Inject the tracking segment into this.segments so
+                    //    Stage 2's rebuild of finalNewSegments will include
+                    //    it (currentAtStage2 + preloadedSegments).
+                    addSegmentViaReflection(store, tracker);
+                    // 2. Call removeVector(pkToRemove). Since a checkpoint
+                    //    is in progress (pendingCheckpointDeletes != null),
+                    //    the pk goes onto pendingCheckpointDeletes. The
+                    //    pk is also tried against every segment via
+                    //    removeVector's iteration of this.segments —
+                    //    this includes the tracking segment, so the
+                    //    tracker sees a removeVector-direct invocation.
+                    store.removeVector(pkToRemove);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            // Trigger the checkpoint cycle.
+            store.addVector(Bytes.from_int(7777), vec(new Random(7777)));
+            store.checkpoint();
+
+            // Confirm the tracker is in the published segment list (the
+            // round-3 fix preserves adoptions; precondition for the
+            // reapply to have a chance to iterate it).
+            boolean trackerInSegments = false;
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                if (s.segmentId == tracker.segmentId) {
+                    trackerInSegments = true;
+                    break;
+                }
+            }
+            assertTrue("tracker must be in this.segments post-publish "
+                    + "(round-3 fix); precondition for the reapply assertion",
+                    trackerInSegments);
+
+            // CORE assertion: the tracker's deletePk was invoked at least
+            // TWICE for pkToRemove — once by removeVector's direct
+            // iteration of this.segments, AND once by Stage 2's late-
+            // deletes reapply over finalNewSegments. Pre-fix-3 the reapply
+            // iterated `preloadedSegments` only (which does not contain
+            // the tracker), so the invocation count would be 1.
+            int hits = 0;
+            for (Bytes b : tracker.deletePkInvocations) {
+                if (pkToRemove.equals(b)) {
+                    hits++;
+                }
+            }
+            assertTrue("Stage-2 late-deletes reapply must iterate adopted "
+                    + "segments — tracker.deletePk(pkToRemove) must be "
+                    + "invoked at least twice (once by removeVector's direct "
+                    + "iteration, once by the reapply over finalNewSegments). "
+                    + "Got " + hits + " invocations; expected >= 2.",
+                    hits >= 2);
         }
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
@@ -373,16 +373,21 @@ public class Issue538Stage3RepublishRaceTest {
     }
 
     /**
-     * Coverage gap (pr-reviewer follow-up): exercises a drop landing during
-     * Stage 2's slow {@code persistIndexStatusMultiSegment} I/O (using
-     * {@code atomicSwapPostBuildHook}, which fires AFTER Stage 1 build but
-     * BEFORE Stage 2 persist — i.e. the long lock-free window). The fix
-     * must protect this window too, not just the immediate pre-Stage-3
-     * window. Post-fix the dropped segment is NOT republished regardless
-     * of which sub-window the drop landed in.
+     * Coverage gap (pr-reviewer follow-up): exercises a drop landing in
+     * the Stage 1 → Stage 2 sub-window (via {@code atomicSwapPostBuildHook},
+     * which fires AFTER Stage 1 build and BEFORE Stage 2 persist). The fix
+     * must protect the FULL Stage 1 → Stage 3 window, not just the
+     * immediate pre-Stage-3 sub-window. Post-fix the dropped segment is
+     * NOT republished regardless of which sub-window the drop landed in.
+     *
+     * <p>The three sub-windows (Stage 1 → Stage 2, during Stage 2 persist,
+     * Stage 2 → Stage 3) are equivalent under the fix because Stage 3
+     * rebuilds {@code finalNewSegments} from a fresh read of
+     * {@code this.segments} under the writeLock — so the test only needs
+     * to cover one of them; the other two share the same code path.
      */
     @Test(timeout = 30_000)
-    public void dropDuringStage2PersistIsNotRepublishedByStage3() throws Exception {
+    public void dropBeforeStage2PersistIsNotRepublishedByStage3() throws Exception {
         Path tmpDir = tmpFolder.newFolder("issue538-stage2-race").toPath();
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
 
@@ -443,6 +448,174 @@ public class Issue538Stage3RepublishRaceTest {
             assertEquals("no CORRUPTION on the baseline", 0L,
                     store.getCompactionFailuresCorruptionTotal());
         }
+    }
+
+    /**
+     * Pr-reviewer follow-up: locks down the compaction Stage 3 comment's
+     * claim that adoptions landing in the Stage 1 → Stage 3 window are
+     * preserved by the rebuild. The hook fires between Stage 2 persist
+     * and Stage 3, simulating a concurrent {@code adoptExternalSegment}
+     * by directly mutating {@code this.segments} (via reflection — full
+     * {@code adoptExternalSegment} requires preexisting multipart files
+     * keyed by externalStorageKey, which would dominate the test
+     * setup). Asserts the synthetic adopted segment is present in
+     * {@code this.segments} after the cycle returns.
+     *
+     * <p>Mirrors the {@code currentAtStage3}-driven rebuild semantics:
+     * any segment in {@code this.segments} when Stage 3 acquires the
+     * writeLock survives the publish, regardless of whether it was in
+     * Stage 1's snapshot.
+     */
+    @Test(timeout = 30_000)
+    public void adoptionDuringCompactionStage1To3MustBePreservedByStage3()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-compaction-adopt").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            stampMissingUuids(initial);
+
+            // Synthetic adopted segment. The Stage 3 publish only iterates
+            // and filters by segmentId, so a minimal VectorSegment with a
+            // unique high ID is sufficient to verify preservation. Real
+            // adoptions land via {@code adoptExternalSegment} from the
+            // optimizer-watcher's {@code onSegmentAssigned} callback; the
+            // observable effect on `this.segments` is identical to the
+            // reflection-driven mutation below.
+            final int adoptedId = 1_000_000_001;
+            final VectorSegment adopted = new VectorSegment(adoptedId);
+            adopted.segmentUuid = UUID.randomUUID().toString();
+            adopted.generation = 9999L;
+
+            // Hook fires BETWEEN Stage 2 persist and Stage 3 publish — same
+            // window where a concurrent adoption could land in production.
+            store.setAtomicSwapPostPersistHookForTest(() -> {
+                try {
+                    addSegmentViaReflection(store, adopted);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            long successesBefore = store.getCompactionSuccessesTotal();
+            store.runCompactionCycle();
+            long successesAfter = store.getCompactionSuccessesTotal();
+
+            assertEquals("compaction must succeed", successesBefore + 1L, successesAfter);
+
+            // The adopted segment is in this.segments after Stage 3 publish.
+            boolean foundAdopted = false;
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                if (s.segmentId == adoptedId) {
+                    foundAdopted = true;
+                    break;
+                }
+            }
+            assertTrue("adoption landed in the Stage 1 → Stage 3 window must"
+                    + " be PRESERVED by the Stage 3 rebuild (the rebuild"
+                    + " iterates `currentAtStage3` and excludes only inputs;"
+                    + " adoptions are not inputs)", foundAdopted);
+        }
+    }
+
+    /**
+     * Pr-reviewer follow-up: companion test for the checkpoint side. With
+     * the fix the Phase C Stage 2 rebuild uses
+     * {@code currentAtStage2 + preloadedSegments}, so an adoption landing
+     * in the Phase A → Stage 2 window is preserved. Pre-fix the rebuild
+     * filtered by membership in {@code sealedSegments + mergeableSegments
+     * + preloadedSegments} — a Phase-A-time snapshot — and silently
+     * dropped any adoption that arrived in the window. This test fails
+     * pre-fix and passes post-fix.
+     */
+    @Test(timeout = 60_000)
+    public void adoptionDuringCheckpointPhaseAToStage2MustNotBeDroppedByStage2()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-checkpoint-adopt").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            // Seed a few on-disk segments so Phase A captures a non-empty
+            // sealed/mergeable list (the bug only fires when the
+            // Phase-A snapshot is non-empty so the rebuild has somewhere
+            // to filter against).
+            seedSegments(store, 3);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue("seedSegments must produce at least 2 segments",
+                    initial.size() >= 2);
+            stampMissingUuids(initial);
+
+            final int adoptedId = 1_000_000_002;
+            final VectorSegment adopted = new VectorSegment(adoptedId);
+            adopted.segmentUuid = UUID.randomUUID().toString();
+            adopted.generation = 9999L;
+
+            // Hook fires after Stage 1's pending-deletes apply and BEFORE
+            // Stage 2's writeLock. This is the Phase A → Stage 2 lock-free
+            // window where real adoptions can land in production (the
+            // optimizer-watcher's onSegmentAssigned does not hold
+            // checkpointLock).
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                try {
+                    addSegmentViaReflection(store, adopted);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            // Trigger a checkpoint. The hook will fire inside Phase C,
+            // adding the synthetic adopted segment to this.segments. With
+            // the fix, Stage 2's rebuild reads `currentAtStage2` and
+            // preserves the adoption. Pre-fix the rebuild iterates only
+            // Phase-A's snapshot and silently drops the adoption.
+            store.addVector(Bytes.from_int(8888), vec(new Random(8888)));
+            store.checkpoint();
+
+            // The adopted segment MUST be in this.segments after the
+            // checkpoint publishes.
+            boolean foundAdopted = false;
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                if (s.segmentId == adoptedId) {
+                    foundAdopted = true;
+                    break;
+                }
+            }
+            assertTrue("adoption landed in the Phase A → Stage 2 window must"
+                    + " be PRESERVED by the Stage 2 rebuild (issue #538"
+                    + " follow-up: the checkpoint-side rebuild must"
+                    + " iterate `currentAtStage2` directly, not"
+                    + " sealed+mergeable+preloaded with currentIds filter)",
+                    foundAdopted);
+        }
+    }
+
+    /**
+     * Reflection-driven equivalent of {@code adoptExternalSegment}'s
+     * end-effect on {@code this.segments}: writes a fresh
+     * {@code CopyOnWriteArrayList} containing the current entries plus
+     * the supplied segment back to the private {@code segments} field.
+     * Used by adoption-window tests where a full
+     * {@code adoptExternalSegment} setup (pre-written multipart files,
+     * BLink storage init, jvector graph load) would dominate the test
+     * boilerplate without exercising the bug.
+     */
+    private static void addSegmentViaReflection(PersistentVectorStore store,
+            VectorSegment seg) throws ReflectiveOperationException {
+        java.lang.reflect.Field f =
+                PersistentVectorStore.class.getDeclaredField("segments");
+        f.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<VectorSegment> current = (List<VectorSegment>) f.get(store);
+        java.util.concurrent.CopyOnWriteArrayList<VectorSegment> newList =
+                new java.util.concurrent.CopyOnWriteArrayList<>(current);
+        newList.add(seg);
+        f.set(store, newList);
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue538Stage3RepublishRaceTest.java
@@ -1,0 +1,372 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Reproducer + fix verification for issue #538: PR #536 (issue #535) is
+ * incomplete. On a real bigann-100M run with the external optimizer
+ * enabled, segments deprecated by the optimizer's own merges end up in
+ * {@link PersistentVectorStore#segments segments} with
+ * {@code onDiskGraph == null} — leading to the same persistent-failure
+ * loop in {@link VectorIndexCompactor#rebuildSegmentStreaming} that
+ * issue #535 was supposed to fix.
+ *
+ * <h2>Root cause</h2>
+ *
+ * {@link PersistentVectorStore#atomicSwapCompactionResult} runs in three
+ * stages:
+ *
+ * <ol>
+ *   <li><b>Stage 1</b> (under {@link PersistentVectorStore#checkpointLock}):
+ *       snapshot {@code current = this.segments}; build
+ *       {@code newSegments = current - inputs + mergedOutput}.</li>
+ *   <li><b>Stage 2</b> (under {@code checkpointLock}, no writeLock):
+ *       {@code persistIndexStatusMultiSegment} — the slow I/O.</li>
+ *   <li><b>Stage 3</b> (under {@code stateLock.writeLock()}):
+ *       publish {@code this.segments = newSegments}.</li>
+ * </ol>
+ *
+ * Between Stages 1 and 3, a concurrent
+ * {@link PersistentVectorStore#dropSegmentByUuid} (typically fired by the
+ * optimizer-watcher's {@code onSegmentReleased} when the optimizer
+ * deprecates a NON-input segment) can:
+ *
+ * <ul>
+ *   <li>Remove the dropped segment from {@code this.segments} under the
+ *       writeLock — the segment is now absent.</li>
+ *   <li>Enqueue the segment on
+ *       {@link PersistentVectorStore#pendingSegmentCloses} for the
+ *       deferred close added by PR #536.</li>
+ * </ul>
+ *
+ * Stage 3 then publishes the <b>stale</b> {@code newSegments} (which
+ * still contains the just-dropped segment), <b>re-inserting</b> the
+ * dropped segment into {@code this.segments}. The cycle's
+ * {@code finally} block then drains
+ * {@code pendingSegmentCloses}, calling {@code seg.close()} on the
+ * re-inserted segment — which nulls {@code seg.onDiskGraph}.
+ *
+ * <p>Result: the dropped segment is back in {@code this.segments} with
+ * {@code onDiskGraph == null}. Every subsequent {@code runCompactionCycle}
+ * picks it as a candidate, hits the null-check at
+ * {@code VectorIndexCompactor.rebuildSegmentStreaming:780}, and throws
+ * {@code CompactionException(CORRUPTION, "candidate segment N has no
+ * on-disk graph (streaming compaction)")} — exactly the production
+ * symptom of issues #535 and #538.
+ *
+ * <h2>Heap-dump evidence (from issue #538)</h2>
+ *
+ * The 3.1 GiB heap dump captured during a stuck IS run shows:
+ * <ul>
+ *   <li>{@code PersistentVectorStore.segments} (a
+ *       {@code CopyOnWriteArrayList}, 85 entries) contains 5 segments
+ *       with {@code onDiskGraph == null} (segmentIds 15, 33, 39, 42,
+ *       45 — all IS-locally-produced).</li>
+ *   <li>{@code pendingSegmentCloses} is empty (the deferred-close drain
+ *       has already run).</li>
+ *   <li>Path-to-GC-roots confirms all 5 are in
+ *       {@code this.segments[…]}.</li>
+ * </ul>
+ *
+ * The Stage-3 republish race is the only path that can produce this
+ * combination of in-{@code segments} + closed + drained.
+ *
+ * <h2>The fix</h2>
+ *
+ * Stage 3 rebuilds {@code newSegments} from the <b>current</b>
+ * {@code this.segments} (read under writeLock), not from Stage 1's
+ * snapshot. A segment dropped between Stage 1 and Stage 3 is therefore
+ * absent from {@code currentAtStage3} and is correctly NOT republished.
+ *
+ * <h2>What this test proves</h2>
+ *
+ * The reproducer uses the existing
+ * {@link PersistentVectorStore#setAtomicSwapPostPersistHookForTest} hook
+ * (which fires AFTER Stage 2 persist but BEFORE Stage 3 publish) to
+ * synchronously call {@code dropSegmentByUuid} on a NON-input segment.
+ * Post-fix, the dropped segment must NOT be present in
+ * {@code this.segments} after the cycle completes.
+ */
+public class Issue538Stage3RepublishRaceTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static final int DIM = 16;
+
+    @Before
+    public void disableDeferral() {
+        // Allow small live shards to seal into on-disk segments, so the
+        // test can produce enough segments quickly.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static float[] vec(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private PersistentVectorStore newStore(Path tmpDir, MemoryDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE, // disable the auto compaction loop
+                VectorSimilarityFunction.EUCLIDEAN);
+        // maxTotalBytes = 25,000 with the 5 seeded segments (≈4.5k / 9k /
+        // 13.5k / 18k / 22.5k = 67.5k total) DETERMINISTICALLY restricts
+        // chooseSegmentsToMerge to picking the 2 smallest segments as
+        // candidates (4.5k + 9k = 13.5k fits; adding the next 13.5k would
+        // overflow 25k). The remaining 3 LARGER segments are non-inputs
+        // and are the only valid targets for the Stage-3 race.
+        //
+        // minCount=2 lets the byte-trigger fire on those 2 candidates.
+        // minBytes=1 makes every cycle qualify regardless of size.
+        // maxCount=Integer.MAX_VALUE — irrelevant given the byte-trigger.
+        store.configureCompaction(Long.MAX_VALUE, 1L, 25_000L, 2, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    /**
+     * Seeds {@code n} on-disk segments via add+checkpoint cycles, with
+     * different vector counts so they have different
+     * {@code estimatedSizeBytes} — that way
+     * {@link VectorIndexCompactor#chooseSegmentsToMerge} (which sorts by
+     * size ascending and respects {@code maxCount}) deterministically
+     * picks the smallest ones as candidates and leaves the larger ones
+     * as non-candidates (the drop victims).
+     */
+    private void seedSegments(PersistentVectorStore store, int n) throws Exception {
+        Random rng = new Random(42);
+        for (int c = 0; c < n; c++) {
+            // Each subsequent checkpoint adds more vectors so the segments
+            // have monotonically increasing sizes; the policy's
+            // sort-ascending + maxCount=2 then deterministically picks the
+            // first two segments as candidates.
+            int n_vectors = 20 + c * 20;
+            for (int i = 0; i < n_vectors; i++) {
+                store.addVector(Bytes.from_int(c * 1000 + i), vec(rng));
+            }
+            store.checkpoint();
+        }
+    }
+
+    /** Stamps a UUID on every segment that doesn't already carry one. */
+    private void stampMissingUuids(List<VectorSegment> segs) {
+        for (VectorSegment seg : segs) {
+            if (seg.segmentUuid == null) {
+                seg.segmentUuid = UUID.randomUUID().toString();
+            }
+        }
+    }
+
+    /**
+     * <b>The fix verification.</b> Fires {@code dropSegmentByUuid} on a
+     * NON-INPUT segment AFTER Stage 2 persist but BEFORE Stage 3 publish.
+     * Pre-fix the segment is re-inserted by Stage 3's stale snapshot;
+     * post-fix Stage 3 rebuilds from {@code this.segments} and the
+     * segment stays dropped.
+     */
+    @Test(timeout = 30_000)
+    public void dropSegmentByUuidBetweenStage2AndStage3IsNotRepublishedByStage3()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-stage3-race").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            // Seed 5 segments with increasing sizes. With maxCount=2 the
+            // policy will pick the 2 smallest as candidates, leaving the
+            // other 3 as drop victims.
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            assertTrue("setup must have at least 5 segments — got " + initial.size(),
+                    initial.size() >= 5);
+            stampMissingUuids(initial);
+
+            // The candidates the policy will pick (2 smallest) are at the
+            // start when sorted by size ascending. To pick a NON-input,
+            // grab the LARGEST segment — the policy with maxCount=2 will
+            // never select it.
+            VectorSegment largest = initial.get(0);
+            for (VectorSegment s : initial) {
+                if (s.estimatedSizeBytes > largest.estimatedSizeBytes) {
+                    largest = s;
+                }
+            }
+            final VectorSegment victim = largest;
+            final String victimUuid = victim.segmentUuid;
+            final int victimId = victim.segmentId;
+            assertNotNull("victim must have a UUID stamped", victimUuid);
+            assertNotNull("victim must have onDiskGraph populated", victim.onDiskGraph);
+
+            // Drop the victim AFTER Stage 2 persist but BEFORE Stage 3
+            // publish. This is the precise race window where #538 fires.
+            store.setAtomicSwapPostPersistHookForTest(() -> {
+                store.dropSegmentByUuid(victimUuid);
+            });
+
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            long successesBefore = store.getCompactionSuccessesTotal();
+
+            store.runCompactionCycle();
+
+            // ----- Post-fix assertions -----
+
+            // The hook removed the victim from this.segments under writeLock,
+            // BEFORE Stage 3 published. Post-fix, Stage 3 must rebuild from
+            // the current this.segments (which doesn't have the victim) and
+            // must NOT re-insert the victim.
+            //
+            // Pre-fix (master @ 9ebb106b), Stage 3 re-inserts the victim:
+            // the next compaction cycle then sees seg.onDiskGraph == null
+            // and throws CompactionException(CORRUPTION) — exactly the
+            // production failure mode in issue #538.
+            List<VectorSegment> after = store.getOnDiskSegmentsSnapshotForTest();
+            for (VectorSegment s : after) {
+                assertFalse("victim must NOT be republished by Stage 3 — that was"
+                        + " issue #538's exact production failure mode (Stage 3"
+                        + " rebuilt newSegments from a stale Stage-1 snapshot,"
+                        + " re-inserting a segment a concurrent dropSegmentByUuid"
+                        + " had just removed)",
+                        s.segmentId == victimId);
+            }
+
+            // The compaction succeeded: a merged output was published.
+            assertEquals("the compaction must have completed successfully",
+                    successesBefore + 1L, store.getCompactionSuccessesTotal());
+
+            // No CORRUPTION error was recorded. (This cycle wouldn't be the
+            // one that fires CORRUPTION — that happens on the NEXT cycle,
+            // when the orphan is picked as a candidate. We assert no
+            // corruption to keep the test focused on the Stage-3 fix.)
+            assertEquals("no CORRUPTION failure on the racing cycle",
+                    corruptionBefore, store.getCompactionFailuresCorruptionTotal());
+
+            // The deferred close drained the victim: onDiskGraph is null.
+            // (This holds both pre-fix and post-fix; it's the
+            // PR #536 / #535 contract.)
+            assertNull("victim.onDiskGraph must be null after the deferred-close drain",
+                    victim.onDiskGraph);
+        }
+    }
+
+    /**
+     * Strict follow-up: a cycle following the racing one must NOT fail with
+     * CORRUPTION on the (no-longer-orphan) victim. Pre-fix the victim would
+     * be back in this.segments with onDiskGraph==null and the next cycle
+     * would throw {@code candidate segment N has no on-disk graph
+     * (streaming compaction)}. Post-fix the victim is gone and the next
+     * cycle proceeds normally on remaining segments.
+     */
+    @Test(timeout = 30_000)
+    public void noCorruptionOnNextCycleAfterRacingCompaction() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-stage3-race-next").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            List<VectorSegment> initial = store.getOnDiskSegmentsSnapshotForTest();
+            stampMissingUuids(initial);
+
+            VectorSegment largest = initial.get(0);
+            for (VectorSegment s : initial) {
+                if (s.estimatedSizeBytes > largest.estimatedSizeBytes) {
+                    largest = s;
+                }
+            }
+            final String victimUuid = largest.segmentUuid;
+
+            store.setAtomicSwapPostPersistHookForTest(() -> {
+                store.dropSegmentByUuid(victimUuid);
+            });
+
+            // First cycle: the race fires.
+            long corruptionBefore = store.getCompactionFailuresCorruptionTotal();
+            store.runCompactionCycle();
+
+            // Disarm the hook so subsequent cycles run normally.
+            store.setAtomicSwapPostPersistHookForTest(null);
+
+            // Second cycle: must NOT trip the no-on-disk-graph check.
+            // Pre-fix this is where issue #538's persistent failure loop
+            // would start; post-fix the cycle either compacts the remaining
+            // healthy segments or exits with no candidates — either way no
+            // CORRUPTION is recorded.
+            store.runCompactionCycle();
+
+            assertEquals(
+                "no CORRUPTION on the cycle following the race — that was"
+                + " the persistent-failure loop reported in issue #538",
+                corruptionBefore, store.getCompactionFailuresCorruptionTotal());
+        }
+    }
+
+    /** Baseline regression guard: a normal compaction succeeds. */
+    @Test(timeout = 30_000)
+    public void noRaceMeansNormalCompaction() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue538-baseline").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+
+        try (PersistentVectorStore store = newStore(tmpDir, dsm)) {
+            store.start();
+            seedSegments(store, 5);
+
+            long before = store.getCompactionSuccessesTotal();
+            store.runCompactionCycle();
+            long after = store.getCompactionSuccessesTotal();
+
+            assertEquals("baseline compaction must succeed", before + 1L, after);
+            assertEquals("no CORRUPTION on the baseline", 0L,
+                    store.getCompactionFailuresCorruptionTotal());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #538. Closes #537.

## Root cause (confirmed by heap dump)

PR #536 (issue #535) left a residual race in
`PersistentVectorStore.atomicSwapCompactionResult`: Stage 3 published a
`newSegments` list built from a **Stage-1 snapshot** of `this.segments`.
A concurrent `dropSegmentByUuid` landing between Stage 1 and Stage 3
(fired by the optimizer-watcher's `onSegmentReleased` when the external
optimizer deprecates a NON-input segment in ZK) removed the segment
from `this.segments` under the writeLock AND queued it on
`pendingSegmentCloses` for the deferred close PR #536 added. Stage 3's
republish then re-inserted that dropped segment into `this.segments`,
and the cycle's finally drain promptly closed the now-republished
segment — leaving it in `this.segments` with `onDiskGraph == null`.

Every subsequent `runCompactionCycle` selected the orphan as a
candidate and tripped the null-check at
`VectorIndexCompactor.rebuildSegmentStreaming:780`, throwing
`CompactionException(CORRUPTION, "candidate segment N has no on-disk
graph (streaming compaction)")` — the exact production symptom from
issues #535 and #538.

## Heap-dump evidence (issue #538 attachment)

3.1 GiB dump captured during a stuck Run 3 of the k3s-local bigann-100M
benchmark with master @ 9ebb106b. Single `PersistentVectorStore`
(`indexName=vidx`) with `segments` (85 entries,
`CopyOnWriteArrayList @ 0x6fb3e0830`) contains **5 segments with
`onDiskGraph == null`** — segmentIds 15, 33, 39, 42, 45 (all
IS-locally-produced). `pendingSegmentCloses` is empty (drain already
ran). Path-to-GC-roots confirms all 5 are slot entries inside
`this.segments` (e.g., seg 15 at index `[6]`, seg 39 at index `[29]`).

## The fix

Stage 3 now rebuilds `finalNewSegments` from the **current**
`this.segments` (read under writeLock), not from the stale Stage-1
snapshot:

```java
List<VectorSegment> currentAtStage3 = this.segments;
List<VectorSegment> finalNewSegments = new CopyOnWriteArrayList<>();
for (VectorSegment s : currentAtStage3) {
    if (!inputIds.contains(s.segmentId)) {
        finalNewSegments.add(s);
    }
}
if (mergedOutput != null) {
    finalNewSegments.add(mergedOutput);
}
this.segments = finalNewSegments;
```

Properties:
- Inputs are excluded (via `inputIds` — the swap's intent).
- Segments dropped between Stage 1 and Stage 3 are NOT republished.
- Segments adopted between Stage 1 and Stage 3 (via
  `adoptExternalSegment`) ARE preserved.
- `mergedOutput` is added exactly once.
- `dirty.set(true)` is also forced whenever the Stage-1 → Stage-3
  segment count changed, so the next checkpoint repersists
  consistently when a drift occurred.

## Tests

New `Issue538Stage3RepublishRaceTest` uses
`atomicSwapPostPersistHookForTest` (fires between Stage 2 persist and
Stage 3 publish) to deterministically reproduce the race:

1. `dropSegmentByUuidBetweenStage2AndStage3IsNotRepublishedByStage3` —
   main reproducer. Configures the policy to pick only 2 candidates
   (leaving 3 non-inputs), drops one of the non-inputs in the hook,
   asserts it is NOT in `this.segments` after the cycle. **Pre-fix
   this test FAILS** with the exact issue #538 symptom (verified
   before applying the fix).
2. `noCorruptionOnNextCycleAfterRacingCompaction` — second cycle after
   the race; asserts no CORRUPTION failure.
3. `noRaceMeansNormalCompaction` — happy-path regression guard.

## Verified locally

- 3 new `Issue538Stage3RepublishRaceTest` tests pass deterministically.
- 66 herddb-core regression tests (compaction, lifecycle, backpressure)
  green.
- 39 herddb-indexing-service tests (compaction + optimizer adoption +
  lifecycle) green.
- Hammer suite `DirectMultipleConcurrentUpdatesSuite*` (×2 passes) and
  `BLinkConcurrentSearchInsertTest` green.
- Pre-PR validation (checkstyle + Apache RAT + SpotBugs) green.

## Test plan

- [x] New reproducer fails pre-fix and passes post-fix
- [x] Existing compaction / lifecycle / optimizer-adoption tests green
- [x] Hammer suite green on 2 passes
- [x] Pre-PR validation green
- [ ] CI green on the merge

🤖 Implemented by the \`pr-worker\` agent.