### PR TITLE
issue #542: propagate merger upgrade from engine to OptimizerTaskConsumer

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -1012,6 +1012,13 @@ public final class IndexOptimizerMain {
             }
             this.merger = upgraded;
             engine.upgradeMerger(upgraded, mergerDataStorageManager);
+            // Issue #542: propagate the upgrade to the task consumer.
+            // taskConsumer.merger was private final before this fix and was
+            // never updated, causing every merge to be declined by the stale
+            // NoopMerger even after the engine was correctly upgraded.
+            if (taskConsumer != null) {
+                taskConsumer.setMerger(upgraded);
+            }
             LOGGER.log(Level.INFO,
                     "maybeUpgradeMerger: successfully upgraded to {0}",
                     upgraded.getClass().getSimpleName());

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerTaskConsumer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerTaskConsumer.java
@@ -80,7 +80,15 @@ public final class OptimizerTaskConsumer {
     private final OptimizerTaskRegistry taskRegistry;
     private final SegmentRegistryClient segmentRegistry;
     private final SegmentRevalidator revalidator;
-    private final SegmentMerger merger;
+    /**
+     * Active merger. Declared {@code volatile} (not {@code final}) so that
+     * {@link IndexOptimizerMain#maybeUpgradeMerger()} can propagate a
+     * NoopMerger → RemoteSegmentMerger upgrade to this consumer after startup
+     * (issue #542). The upgrade write happens inside the {@code synchronized}
+     * {@code maybeUpgradeMerger()} method; the {@code volatile} keyword ensures
+     * visibility for the unsynchronized {@link #consumeOneTask()} reader.
+     */
+    private volatile SegmentMerger merger;
     private final String tablespaceUuid;
     private final String workerId;
     private final long retentionMillis;
@@ -150,6 +158,29 @@ public final class OptimizerTaskConsumer {
         }
         tasksClaimedTotal.incrementAndGet();
         return executeClaimedTask(claimed);
+    }
+
+    /**
+     * Returns the currently active merger. {@code volatile} read; safe to call
+     * from any thread without synchronization. Exposed for observability and
+     * testing (e.g. verifying that a NoopMerger → RemoteSegmentMerger upgrade
+     * propagated to the consumer — issue #542).
+     */
+    public SegmentMerger getMerger() {
+        return merger;
+    }
+
+    /**
+     * Replaces the active merger. Called by
+     * {@link IndexOptimizerMain#maybeUpgradeMerger()} under {@code synchronized}
+     * to propagate a late-binding upgrade (issue #542). The
+     * {@code volatile} write is visible to the unsynchronized
+     * {@link #consumeOneTask()} reader on the scheduler thread.
+     *
+     * @param newMerger the new merger — must not be {@code null}
+     */
+    public void setMerger(SegmentMerger newMerger) {
+        this.merger = Objects.requireNonNull(newMerger, "newMerger");
     }
 
     public long getTasksClaimedTotal() {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerTaskConsumer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerTaskConsumer.java
@@ -179,7 +179,11 @@ public final class OptimizerTaskConsumer {
      *
      * @param newMerger the new merger — must not be {@code null}
      */
-    public void setMerger(SegmentMerger newMerger) {
+    /**
+     * Package-private: only {@link IndexOptimizerMain#maybeUpgradeMerger()} is
+     * expected to call this from production code.
+     */
+    void setMerger(SegmentMerger newMerger) {
         this.merger = Objects.requireNonNull(newMerger, "newMerger");
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/OptimizerMergerLateBindingTest.java
@@ -253,6 +253,64 @@ public class OptimizerMergerLateBindingTest {
     }
 
     /**
+     * Issue #542 — upgrade must reach the task consumer.
+     *
+     * <p>Before the fix, {@link OptimizerTaskConsumer#merger} was {@code private final}
+     * and captured the startup-time {@link IndexOptimizerMain.NoopMerger}. Every merge
+     * task was then declined by the stale reference even though the engine's own field
+     * was correctly upgraded to a real merger. This test verifies that after a
+     * watcher-driven upgrade (the same upgrade path tested in
+     * {@link #watcherDrivenUpgradeReplacesNoopMergerWhenFileServerRegisters}),
+     * {@code main.getTaskConsumer().getMerger()} is no longer a {@link IndexOptimizerMain.NoopMerger}.
+     */
+    @Test
+    public void mergerUpgradePropagatesFromEngineToTaskConsumer() throws Exception {
+        Properties props = baseProps();
+        // Short debounce so the watcher-triggered tick fires quickly.
+        props.setProperty(OptimizerConfiguration.PROPERTY_EVENT_DEBOUNCE_MS, "50");
+
+        IndexOptimizerMain main = new IndexOptimizerMain(new OptimizerConfiguration(props));
+        main.mergerBuilderForTests = servers -> new InMemorySegmentMerger();
+
+        try {
+            main.start();
+            assertNotNull("engine must be initialised", main.getEngine());
+            assertNotNull("taskConsumer must be initialised", main.getTaskConsumer());
+
+            // No file server at startup → consumer's merger is also NoopMerger.
+            assertTrue("taskConsumer.getMerger() must be NoopMerger before upgrade",
+                    main.getTaskConsumer().getMerger() instanceof IndexOptimizerMain.NoopMerger);
+
+            // Register a file server: ZK watch fires → maybeUpgradeMerger() upgrades
+            // the engine AND — since issue #542 is fixed — the task consumer.
+            registerFileServer(FILE_SERVER_ID, FILE_SERVER_ADDR);
+
+            // Wait for the upgrade to complete (up to 10 s).
+            long deadline = System.currentTimeMillis() + 10_000L;
+            while (System.currentTimeMillis() < deadline) {
+                if (!(main.getTaskConsumer().getMerger() instanceof IndexOptimizerMain.NoopMerger)) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+
+            // Core assertion for issue #542: the consumer must see the new merger.
+            assertFalse("taskConsumer.getMerger() must NOT be NoopMerger after upgrade (issue #542)",
+                    main.getTaskConsumer().getMerger() instanceof IndexOptimizerMain.NoopMerger);
+            assertTrue("taskConsumer.getMerger() must be InMemorySegmentMerger after upgrade",
+                    main.getTaskConsumer().getMerger() instanceof InMemorySegmentMerger);
+
+            // Sanity: engine and main-level fields are also upgraded (pre-existing behaviour).
+            assertFalse("engine.getMerger() must not be NoopMerger",
+                    main.getEngine().getMerger() instanceof IndexOptimizerMain.NoopMerger);
+            assertFalse("main.getMerger() must not be NoopMerger",
+                    main.getMerger() instanceof IndexOptimizerMain.NoopMerger);
+        } finally {
+            main.shutdown();
+        }
+    }
+
+    /**
      * Issue #507 — churn resilience: the merger stays real after file-server churn.
      *
      * <p>Once the optimizer upgrades from {@link IndexOptimizerMain.NoopMerger} to a real


### PR DESCRIPTION
Fixes #542.

## Changes
- **`OptimizerTaskConsumer.java`**: Changed `private final SegmentMerger merger` to `private volatile SegmentMerger merger`. Added `getMerger()` (for observability/testing) and `setMerger(SegmentMerger)` (called by the upgrade path). The `volatile` keyword ensures the unsynchronized `consumeOneTask()` reader always sees the write performed inside `maybeUpgradeMerger()`'s `synchronized` block.
- **`IndexOptimizerMain.java`**: In `maybeUpgradeMerger()`, after the existing `engine.upgradeMerger(upgraded, mergerDataStorageManager)` call, also calls `taskConsumer.setMerger(upgraded)` so all three references — the main-level field, the engine field, and the consumer field — are kept in sync on every upgrade.

## Tests
- **`OptimizerMergerLateBindingTest#mergerUpgradePropagatesFromEngineToTaskConsumer`** (new): registers a file server after startup, waits for the watcher-driven upgrade to fire, then asserts that `main.getTaskConsumer().getMerger()` is no longer a `NoopMerger`. This is the direct regression test for #542.
- All 4 `OptimizerMergerLateBindingTest` tests and all 11 `OptimizerTaskConsumerIntegrationTest` tests pass.

## Root cause
`IndexOptimizerMain.start()` constructed `OptimizerTaskConsumer` with the startup-time `NoopMerger`. When `maybeUpgradeMerger()` later upgraded the engine, it updated only `IndexOptimizerMain.this.merger` and `engine.activeMerger`, leaving the consumer's `private final` field permanently bound to `NoopMerger`. This caused 20,313 "NoopMerger declining merge" log lines on bigann-100M Run 4 and zero external merges ever committing.

🤖 Implemented by the `pr-worker` agent.