### PR TITLE
issue #541: add segments_queried metric and /status endpoint to Indexing Service

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -4172,6 +4172,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // between the snapshot and task execution — see invariant above).
             final List<VectorSegment> currentSegments = this.segments;
             for (final VectorSegment seg : currentSegments) {
+                if (ctx != null) {
+                    ctx.recordSegmentQueried();
+                }
                 tasks.add(wrapInContext(ctx, () -> {
                     List<Map.Entry<Bytes, Float>> local = new ArrayList<>(perSourceK);
                     seg.search(qv, perSourceK, similarityFunction, local);
@@ -4182,6 +4185,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // Phase 2: live in-memory shards (no pending-deletes filtering).
             for (final LiveGraphShard shard : liveShards) {
                 if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
+                    if (ctx != null) {
+                        ctx.recordSegmentQueried();
+                    }
                     tasks.add(wrapInContext(ctx, () -> searchLiveShard(shard, qv, perSourceK, null)));
                 }
             }
@@ -4192,6 +4198,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
             if (frozen != null) {
                 for (final LiveGraphShard shard : frozen) {
                     if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
+                        if (ctx != null) {
+                            ctx.recordSegmentQueried();
+                        }
                         tasks.add(wrapInContext(ctx,
                                 () -> searchLiveShard(shard, qv, perSourceK, pending)));
                     }
@@ -4201,6 +4210,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
             if (deferred != null) {
                 for (final LiveGraphShard shard : deferred) {
                     if (shard.builder != null && !shard.nodeToPk.isEmpty()) {
+                        if (ctx != null) {
+                            ctx.recordSegmentQueried();
+                        }
                         tasks.add(wrapInContext(ctx,
                                 () -> searchLiveShard(shard, qv, perSourceK, pending)));
                     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -20,6 +20,8 @@
 
 package herddb.indexing;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import herddb.auth.oidc.OidcBootstrap;
 import herddb.auth.oidc.OidcTokenValidator;
 import herddb.auth.oidc.grpc.JwtAuthServerInterceptor;
@@ -42,9 +44,7 @@ import herddb.storage.DataStorageManager;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -657,10 +657,17 @@ public class IndexingServer implements AutoCloseable {
     // -------------------------------------------------------------------------
 
     /**
+     * Shared {@link ObjectMapper} instance — Jackson's ObjectMapper is
+     * thread-safe after construction and expensive to create; a single
+     * instance shared across all /status requests is correct.
+     */
+    private static final ObjectMapper STATUS_MAPPER = new ObjectMapper();
+
+    /**
      * Jetty servlet that serves a JSON status snapshot on {@code GET /status}.
-     * Reads directly from the outer {@link IndexingServer}'s {@code engine},
+     * Reads from the outer {@link IndexingServer}'s {@code engine},
      * {@code config}, and {@code serviceImpl} fields — no synchronization
-     * needed beyond what each accessor already guarantees.
+     * needed beyond what each engine accessor already guarantees.
      */
     private final class StatusServlet extends HttpServlet {
 
@@ -669,19 +676,16 @@ public class IndexingServer implements AutoCloseable {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp)
                 throws IOException {
-            String json = buildStatusJson();
-            byte[] body = json.getBytes(StandardCharsets.UTF_8);
+            ObjectNode node = buildStatusNode();
+            byte[] body = STATUS_MAPPER.writeValueAsBytes(node);
             resp.setContentType("application/json; charset=utf-8");
             resp.setContentLength(body.length);
             resp.setStatus(HttpServletResponse.SC_OK);
-            try (OutputStream os = resp.getOutputStream()) {
-                os.write(body);
-            }
+            resp.getOutputStream().write(body);
         }
 
-        private String buildStatusJson() {
-            StringBuilder sb = new StringBuilder(2048);
-            sb.append("{\n");
+        private ObjectNode buildStatusNode() {
+            ObjectNode node = STATUS_MAPPER.createObjectNode();
 
             // --- GetInstanceInfo ---
             IndexingServerConfiguration cfg = engine.getConfig();
@@ -716,19 +720,19 @@ public class IndexingServer implements AutoCloseable {
                     ? cfg.getString(IndexingServerConfiguration.PROPERTY_ROLE,
                             IndexingServerConfiguration.PROPERTY_ROLE_DEFAULT)
                     : IndexingServerConfiguration.ROLE_PRIMARY;
-            appendJsonStr(sb, "instance_id", engine.getInstanceIdLabel(), true);
-            appendJsonStr(sb, "grpc_host", grpcHost, true);
-            appendJsonNum(sb, "grpc_port", grpcPort, true);
-            appendJsonStr(sb, "storage_type", storageType, true);
-            appendJsonStr(sb, "data_dir", dataDir, true);
-            appendJsonStr(sb, "tablespace_name", tablespaceName, true);
-            appendJsonStr(sb, "tablespace_uuid", engine.getTableSpaceUUID(), true);
-            appendJsonNum(sb, "instance_ordinal", instanceOrdinal, true);
-            appendJsonNum(sb, "num_instances", numInstances, true);
-            appendJsonStr(sb, "role", role, true);
-            appendJsonNum(sb, "shadow_of",
-                    engine.isConfiguredAsShadow() ? engine.getShadowOfOrMinusOne() : -1L, true);
-            appendJsonNum(sb, "jvm_max_heap_bytes", Runtime.getRuntime().maxMemory(), true);
+            node.put("instance_id", emptyToNull(engine.getInstanceIdLabel()));
+            node.put("grpc_host", emptyToNull(grpcHost));
+            node.put("grpc_port", grpcPort);
+            node.put("storage_type", emptyToNull(storageType));
+            node.put("data_dir", emptyToNull(dataDir));
+            node.put("tablespace_name", emptyToNull(tablespaceName));
+            node.put("tablespace_uuid", emptyToNull(engine.getTableSpaceUUID()));
+            node.put("instance_ordinal", instanceOrdinal);
+            node.put("num_instances", numInstances);
+            node.put("role", emptyToNull(role));
+            node.put("shadow_of",
+                    engine.isConfiguredAsShadow() ? engine.getShadowOfOrMinusOne() : -1);
+            node.put("jvm_max_heap_bytes", Runtime.getRuntime().maxMemory());
 
             // --- GetEngineStats ---
             long startMs = engine.getStartTimeMillis();
@@ -739,122 +743,75 @@ public class IndexingServer implements AutoCloseable {
             long heapUsed = heap.getUsed();
             long heapMax = heap.getMax();
             long heapPct = heapMax > 0 ? Math.min(100L, (100L * heapUsed) / heapMax) : -1L;
-            appendJsonNum(sb, "uptime_millis", uptime, true);
-            appendJsonBool(sb, "tailer_running", engine.isTailerRunning(), true);
-            appendJsonNum(sb, "tailer_watermark_ledger", lsn != null ? lsn.ledgerId : -1L, true);
-            appendJsonNum(sb, "tailer_watermark_offset", lsn != null ? lsn.offset : -1L, true);
-            appendJsonNum(sb, "tailer_entries_processed", engine.getTailerEntriesProcessed(), true);
-            appendJsonNum(sb, "tailer_entries_accepted", engine.getTailerEntriesAccepted(), true);
-            appendJsonNum(sb, "tailer_entries_skipped", engine.getTailerEntriesSkipped(), true);
-            appendJsonNum(sb, "tailer_entries_shard_filtered",
-                    engine.getTailerEntriesShardFiltered(), true);
-            appendJsonNum(sb, "tailer_inserts", engine.getTailerInserts(), true);
-            appendJsonNum(sb, "tailer_updates", engine.getTailerUpdates(), true);
-            appendJsonNum(sb, "tailer_deletes", engine.getTailerDeletes(), true);
-            appendJsonNum(sb, "tailer_ddl", engine.getTailerDdl(), true);
-            appendJsonNum(sb, "tailer_batches", engine.getTailerBatchesProcessed(), true);
-            appendJsonNum(sb, "apply_queue_size", engine.getApplyQueueSize(), true);
-            appendJsonNum(sb, "apply_queue_capacity", engine.getApplyQueueCapacity(), true);
-            appendJsonNum(sb, "apply_parallelism", engine.getApplyParallelism(), true);
-            appendJsonNum(sb, "loaded_index_count", engine.getLoadedIndexCount(), true);
-            appendJsonNum(sb, "total_estimated_memory_bytes",
-                    engine.getTotalEstimatedMemoryBytes(), true);
-            appendJsonNum(sb, "jvm_heap_used_bytes", heapUsed, true);
-            appendJsonNum(sb, "jvm_heap_max_bytes", heapMax, true);
-            appendJsonNum(sb, "jvm_heap_used_pct", heapPct, true);
+            node.put("uptime_millis", uptime);
+            node.put("tailer_running", engine.isTailerRunning());
+            node.put("tailer_watermark_ledger", lsn != null ? lsn.ledgerId : -1L);
+            node.put("tailer_watermark_offset", lsn != null ? lsn.offset : -1L);
+            node.put("tailer_entries_processed", engine.getTailerEntriesProcessed());
+            node.put("tailer_entries_accepted", engine.getTailerEntriesAccepted());
+            node.put("tailer_entries_skipped", engine.getTailerEntriesSkipped());
+            node.put("tailer_entries_shard_filtered", engine.getTailerEntriesShardFiltered());
+            node.put("tailer_inserts", engine.getTailerInserts());
+            node.put("tailer_updates", engine.getTailerUpdates());
+            node.put("tailer_deletes", engine.getTailerDeletes());
+            node.put("tailer_ddl", engine.getTailerDdl());
+            node.put("tailer_batches", engine.getTailerBatchesProcessed());
+            node.put("apply_queue_size", engine.getApplyQueueSize());
+            node.put("apply_queue_capacity", engine.getApplyQueueCapacity());
+            node.put("apply_parallelism", engine.getApplyParallelism());
+            node.put("loaded_index_count", engine.getLoadedIndexCount());
+            node.put("total_estimated_memory_bytes", engine.getTotalEstimatedMemoryBytes());
+            node.put("jvm_heap_used_bytes", heapUsed);
+            node.put("jvm_heap_max_bytes", heapMax);
+            node.put("jvm_heap_used_pct", heapPct);
 
             // --- GetShadowStatus ---
             LogSequenceNumber shadowLoaded = engine.getShadowLoadedLsn();
             LogSequenceNumber primaryAdvertised = engine.getPrimaryAdvertisedLsn();
-            appendJsonBool(sb, "is_shadow", engine.isConfiguredAsShadow(), true);
-            appendJsonBool(sb, "shadow_ready",
-                    engine.isConfiguredAsShadow() ? engine.isShadowReady() : true, true);
-            appendJsonNum(sb, "shadow_loaded_ledger_id",
-                    shadowLoaded != null ? shadowLoaded.ledgerId : -1L, true);
-            appendJsonNum(sb, "shadow_loaded_offset",
-                    shadowLoaded != null ? shadowLoaded.offset : -1L, true);
-            appendJsonNum(sb, "primary_advertised_ledger_id",
-                    primaryAdvertised != null ? primaryAdvertised.ledgerId : -1L, true);
-            appendJsonNum(sb, "primary_advertised_offset",
-                    primaryAdvertised != null ? primaryAdvertised.offset : -1L, true);
-            appendJsonNum(sb, "shadow_last_reload_timestamp_ms",
-                    engine.getShadowLastReloadTimestampMs(), true);
-            appendJsonNum(sb, "shadow_reload_count", engine.getShadowReloadCount(), true);
-            appendJsonNum(sb, "applied_index_status_generation",
-                    engine.getMinAppliedIndexStatusGeneration(), true);
-            appendJsonNum(sb, "shadow_loaded_entry_timestamp_ms",
-                    engine.getShadowLoadedEntryTimestamp(), true);
+            node.put("is_shadow", engine.isConfiguredAsShadow());
+            node.put("shadow_ready",
+                    engine.isConfiguredAsShadow() ? engine.isShadowReady() : true);
+            node.put("shadow_loaded_ledger_id",
+                    shadowLoaded != null ? shadowLoaded.ledgerId : -1L);
+            node.put("shadow_loaded_offset",
+                    shadowLoaded != null ? shadowLoaded.offset : -1L);
+            node.put("primary_advertised_ledger_id",
+                    primaryAdvertised != null ? primaryAdvertised.ledgerId : -1L);
+            node.put("primary_advertised_offset",
+                    primaryAdvertised != null ? primaryAdvertised.offset : -1L);
+            node.put("shadow_last_reload_timestamp_ms", engine.getShadowLastReloadTimestampMs());
+            node.put("shadow_reload_count", engine.getShadowReloadCount());
+            node.put("applied_index_status_generation",
+                    engine.getMinAppliedIndexStatusGeneration());
+            node.put("shadow_loaded_entry_timestamp_ms", engine.getShadowLoadedEntryTimestamp());
 
             // --- Search metrics (issue #541) ---
             // serviceImpl is set in start() before the HTTP server is mounted;
             // guard against null defensively in case this is ever called early.
             IndexingServiceImpl si = serviceImpl;
-            appendJsonNum(sb, "search_requests_total",
-                    si != null ? si.getSearchRequestsTotal() : 0L, true);
-            appendJsonNum(sb, "search_errors_total",
-                    si != null ? si.getSearchErrorsTotal() : 0L, true);
-            appendJsonNum(sb, "search_readfilerange_calls_total",
-                    si != null ? si.getSearchReadFileRangeCallsTotal() : 0L, true);
-            appendJsonNum(sb, "search_readfilerange_bytes_total",
-                    si != null ? si.getSearchReadFileRangeBytesTotal() : 0L, true);
-            appendJsonNum(sb, "search_readfilerange_wait_nanos_total",
-                    si != null ? si.getSearchReadFileRangeWaitNanosTotal() : 0L, true);
-            appendJsonNum(sb, "search_segments_queried_total",
-                    si != null ? si.getSearchSegmentsQueriedTotal() : 0L, true);
-            appendJsonNum(sb, "search_cache_hits_total",
-                    si != null ? si.getSearchCacheHitsTotal() : 0L, true);
-            appendJsonNum(sb, "search_cache_misses_total",
-                    si != null ? si.getSearchCacheMissesTotal() : 0L, false);
+            node.put("search_requests_total",
+                    si != null ? si.getSearchRequestsTotal() : 0L);
+            node.put("search_errors_total",
+                    si != null ? si.getSearchErrorsTotal() : 0L);
+            node.put("search_readfilerange_calls_total",
+                    si != null ? si.getSearchReadFileRangeCallsTotal() : 0L);
+            node.put("search_readfilerange_bytes_total",
+                    si != null ? si.getSearchReadFileRangeBytesTotal() : 0L);
+            node.put("search_readfilerange_wait_nanos_total",
+                    si != null ? si.getSearchReadFileRangeWaitNanosTotal() : 0L);
+            node.put("search_segments_queried_total",
+                    si != null ? si.getSearchSegmentsQueriedTotal() : 0L);
+            node.put("search_cache_hits_total",
+                    si != null ? si.getSearchCacheHitsTotal() : 0L);
+            node.put("search_cache_misses_total",
+                    si != null ? si.getSearchCacheMissesTotal() : 0L);
 
-            sb.append("}\n");
-            return sb.toString();
+            return node;
         }
-    }
 
-    // -------------------------------------------------------------------------
-    // JSON helpers shared by StatusServlet (issue #541)
-    // -------------------------------------------------------------------------
-
-    private static void appendJsonStr(StringBuilder sb, String key, String value,
-                                      boolean trailingComma) {
-        sb.append("  \"").append(key).append("\": ");
-        if (value == null || value.isEmpty()) {
-            sb.append("null");
-        } else {
-            sb.append('"');
-            for (int i = 0; i < value.length(); i++) {
-                char c = value.charAt(i);
-                if (c == '"') {
-                    sb.append("\\\"");
-                } else if (c == '\\') {
-                    sb.append("\\\\");
-                } else {
-                    sb.append(c);
-                }
-            }
-            sb.append('"');
+        /** Returns {@code null} when the string is null or empty, else the string itself. */
+        private String emptyToNull(String s) {
+            return (s == null || s.isEmpty()) ? null : s;
         }
-        if (trailingComma) {
-            sb.append(',');
-        }
-        sb.append('\n');
-    }
-
-    private static void appendJsonNum(StringBuilder sb, String key, long value,
-                                      boolean trailingComma) {
-        sb.append("  \"").append(key).append("\": ").append(value);
-        if (trailingComma) {
-            sb.append(',');
-        }
-        sb.append('\n');
-    }
-
-    private static void appendJsonBool(StringBuilder sb, String key, boolean value,
-                                       boolean trailingComma) {
-        sb.append("  \"").append(key).append("\": ").append(value);
-        if (trailingComma) {
-            sb.append(',');
-        }
-        sb.append('\n');
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -26,6 +26,7 @@ import herddb.auth.oidc.grpc.JwtAuthServerInterceptor;
 import herddb.core.MemoryManager;
 import herddb.core.stats.NettyMemoryMetrics;
 import herddb.file.FileDataStorageManager;
+import herddb.log.LogSequenceNumber;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.metadata.IndexingServiceInstanceDescriptor;
 import herddb.metadata.MetadataStorageManager;
@@ -41,7 +42,9 @@ import herddb.storage.DataStorageManager;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,6 +54,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider;
 import org.apache.bookkeeper.stats.prometheus.PrometheusServlet;
@@ -88,6 +94,9 @@ public class IndexingServer implements AutoCloseable {
     private org.eclipse.jetty.server.Server httpServer;
     private MetadataStorageManager metadataStorageManager;
     private String registeredServiceId;
+    // Stored so the /status HTTP servlet can read aggregate search counters
+    // (issue #541). Set in start() before the HTTP server is mounted.
+    private IndexingServiceImpl serviceImpl;
 
     // When storage.type=remote, these are set by buildDataStorageManager
     // and consumed by the tablespace-resolved hook.
@@ -345,7 +354,7 @@ public class IndexingServer implements AutoCloseable {
         NettyMemoryMetrics.register(statsLogger);
 
         engine.setStatsLogger(statsLogger);
-        IndexingServiceImpl serviceImpl = new IndexingServiceImpl(engine, statsLogger);
+        this.serviceImpl = new IndexingServiceImpl(engine, statsLogger);
         ServerBuilder<?> grpcBuilder = ServerBuilder.forPort(port).addService(serviceImpl);
         java.util.Properties oidcProps = config.asProperties();
         if (OidcBootstrap.isEnabled(oidcProps)) {
@@ -377,6 +386,7 @@ public class IndexingServer implements AutoCloseable {
                 ServletContextHandler context = new ServletContextHandler(ServletContextHandler.GZIP);
                 context.setContextPath("/");
                 context.addServlet(new ServletHolder(new PrometheusServlet(statsProvider)), "/metrics");
+                context.addServlet(new ServletHolder(new StatusServlet()), "/status");
                 httpServer.setHandler(context);
                 httpServer.start();
                 LOGGER.log(Level.INFO, "Metrics HTTP server started on {0}:{1}",
@@ -637,5 +647,214 @@ public class IndexingServer implements AutoCloseable {
     @Override
     public void close() throws Exception {
         stop();
+    }
+
+    // -------------------------------------------------------------------------
+    // /status — JSON snapshot of instance info, engine stats, shadow status,
+    // and per-search metric totals (issue #541).
+    // Mirrors the union of GetInstanceInfo + GetEngineStats + GetShadowStatus
+    // gRPC RPCs so operators can curl a single pod without gRPC tooling.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Jetty servlet that serves a JSON status snapshot on {@code GET /status}.
+     * Reads directly from the outer {@link IndexingServer}'s {@code engine},
+     * {@code config}, and {@code serviceImpl} fields — no synchronization
+     * needed beyond what each accessor already guarantees.
+     */
+    private final class StatusServlet extends HttpServlet {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                throws IOException {
+            String json = buildStatusJson();
+            byte[] body = json.getBytes(StandardCharsets.UTF_8);
+            resp.setContentType("application/json; charset=utf-8");
+            resp.setContentLength(body.length);
+            resp.setStatus(HttpServletResponse.SC_OK);
+            try (OutputStream os = resp.getOutputStream()) {
+                os.write(body);
+            }
+        }
+
+        private String buildStatusJson() {
+            StringBuilder sb = new StringBuilder(2048);
+            sb.append("{\n");
+
+            // --- GetInstanceInfo ---
+            IndexingServerConfiguration cfg = engine.getConfig();
+            String storageType = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE,
+                            IndexingServerConfiguration.PROPERTY_STORAGE_TYPE_DEFAULT)
+                    : "";
+            String dataDir = engine.getDataDirectory() != null
+                    ? engine.getDataDirectory().toAbsolutePath().toString()
+                    : "";
+            String tablespaceName = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_TABLESPACE_NAME,
+                            IndexingServerConfiguration.PROPERTY_TABLESPACE_NAME_DEFAULT)
+                    : "";
+            int grpcPort = cfg != null
+                    ? cfg.getInt(IndexingServerConfiguration.PROPERTY_GRPC_PORT,
+                            IndexingServerConfiguration.PROPERTY_GRPC_PORT_DEFAULT)
+                    : 0;
+            String grpcHost = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_GRPC_HOST,
+                            IndexingServerConfiguration.PROPERTY_GRPC_HOST_DEFAULT)
+                    : "";
+            int instanceOrdinal = cfg != null
+                    ? cfg.getInt(IndexingServerConfiguration.PROPERTY_INSTANCE_ID,
+                            IndexingServerConfiguration.PROPERTY_INSTANCE_ID_DEFAULT)
+                    : 0;
+            int numInstances = cfg != null
+                    ? cfg.getInt(IndexingServerConfiguration.PROPERTY_NUM_INSTANCES,
+                            IndexingServerConfiguration.PROPERTY_NUM_INSTANCES_DEFAULT)
+                    : 1;
+            String role = cfg != null
+                    ? cfg.getString(IndexingServerConfiguration.PROPERTY_ROLE,
+                            IndexingServerConfiguration.PROPERTY_ROLE_DEFAULT)
+                    : IndexingServerConfiguration.ROLE_PRIMARY;
+            appendJsonStr(sb, "instance_id", engine.getInstanceIdLabel(), true);
+            appendJsonStr(sb, "grpc_host", grpcHost, true);
+            appendJsonNum(sb, "grpc_port", grpcPort, true);
+            appendJsonStr(sb, "storage_type", storageType, true);
+            appendJsonStr(sb, "data_dir", dataDir, true);
+            appendJsonStr(sb, "tablespace_name", tablespaceName, true);
+            appendJsonStr(sb, "tablespace_uuid", engine.getTableSpaceUUID(), true);
+            appendJsonNum(sb, "instance_ordinal", instanceOrdinal, true);
+            appendJsonNum(sb, "num_instances", numInstances, true);
+            appendJsonStr(sb, "role", role, true);
+            appendJsonNum(sb, "shadow_of",
+                    engine.isConfiguredAsShadow() ? engine.getShadowOfOrMinusOne() : -1L, true);
+            appendJsonNum(sb, "jvm_max_heap_bytes", Runtime.getRuntime().maxMemory(), true);
+
+            // --- GetEngineStats ---
+            long startMs = engine.getStartTimeMillis();
+            long uptime = startMs > 0 ? System.currentTimeMillis() - startMs : 0L;
+            LogSequenceNumber lsn = engine.getLastProcessedLsn();
+            java.lang.management.MemoryUsage heap =
+                    java.lang.management.ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+            long heapUsed = heap.getUsed();
+            long heapMax = heap.getMax();
+            long heapPct = heapMax > 0 ? Math.min(100L, (100L * heapUsed) / heapMax) : -1L;
+            appendJsonNum(sb, "uptime_millis", uptime, true);
+            appendJsonBool(sb, "tailer_running", engine.isTailerRunning(), true);
+            appendJsonNum(sb, "tailer_watermark_ledger", lsn != null ? lsn.ledgerId : -1L, true);
+            appendJsonNum(sb, "tailer_watermark_offset", lsn != null ? lsn.offset : -1L, true);
+            appendJsonNum(sb, "tailer_entries_processed", engine.getTailerEntriesProcessed(), true);
+            appendJsonNum(sb, "tailer_entries_accepted", engine.getTailerEntriesAccepted(), true);
+            appendJsonNum(sb, "tailer_entries_skipped", engine.getTailerEntriesSkipped(), true);
+            appendJsonNum(sb, "tailer_entries_shard_filtered",
+                    engine.getTailerEntriesShardFiltered(), true);
+            appendJsonNum(sb, "tailer_inserts", engine.getTailerInserts(), true);
+            appendJsonNum(sb, "tailer_updates", engine.getTailerUpdates(), true);
+            appendJsonNum(sb, "tailer_deletes", engine.getTailerDeletes(), true);
+            appendJsonNum(sb, "tailer_ddl", engine.getTailerDdl(), true);
+            appendJsonNum(sb, "tailer_batches", engine.getTailerBatchesProcessed(), true);
+            appendJsonNum(sb, "apply_queue_size", engine.getApplyQueueSize(), true);
+            appendJsonNum(sb, "apply_queue_capacity", engine.getApplyQueueCapacity(), true);
+            appendJsonNum(sb, "apply_parallelism", engine.getApplyParallelism(), true);
+            appendJsonNum(sb, "loaded_index_count", engine.getLoadedIndexCount(), true);
+            appendJsonNum(sb, "total_estimated_memory_bytes",
+                    engine.getTotalEstimatedMemoryBytes(), true);
+            appendJsonNum(sb, "jvm_heap_used_bytes", heapUsed, true);
+            appendJsonNum(sb, "jvm_heap_max_bytes", heapMax, true);
+            appendJsonNum(sb, "jvm_heap_used_pct", heapPct, true);
+
+            // --- GetShadowStatus ---
+            LogSequenceNumber shadowLoaded = engine.getShadowLoadedLsn();
+            LogSequenceNumber primaryAdvertised = engine.getPrimaryAdvertisedLsn();
+            appendJsonBool(sb, "is_shadow", engine.isConfiguredAsShadow(), true);
+            appendJsonBool(sb, "shadow_ready",
+                    engine.isConfiguredAsShadow() ? engine.isShadowReady() : true, true);
+            appendJsonNum(sb, "shadow_loaded_ledger_id",
+                    shadowLoaded != null ? shadowLoaded.ledgerId : -1L, true);
+            appendJsonNum(sb, "shadow_loaded_offset",
+                    shadowLoaded != null ? shadowLoaded.offset : -1L, true);
+            appendJsonNum(sb, "primary_advertised_ledger_id",
+                    primaryAdvertised != null ? primaryAdvertised.ledgerId : -1L, true);
+            appendJsonNum(sb, "primary_advertised_offset",
+                    primaryAdvertised != null ? primaryAdvertised.offset : -1L, true);
+            appendJsonNum(sb, "shadow_last_reload_timestamp_ms",
+                    engine.getShadowLastReloadTimestampMs(), true);
+            appendJsonNum(sb, "shadow_reload_count", engine.getShadowReloadCount(), true);
+            appendJsonNum(sb, "applied_index_status_generation",
+                    engine.getMinAppliedIndexStatusGeneration(), true);
+            appendJsonNum(sb, "shadow_loaded_entry_timestamp_ms",
+                    engine.getShadowLoadedEntryTimestamp(), true);
+
+            // --- Search metrics (issue #541) ---
+            // serviceImpl is set in start() before the HTTP server is mounted;
+            // guard against null defensively in case this is ever called early.
+            IndexingServiceImpl si = serviceImpl;
+            appendJsonNum(sb, "search_requests_total",
+                    si != null ? si.getSearchRequestsTotal() : 0L, true);
+            appendJsonNum(sb, "search_errors_total",
+                    si != null ? si.getSearchErrorsTotal() : 0L, true);
+            appendJsonNum(sb, "search_readfilerange_calls_total",
+                    si != null ? si.getSearchReadFileRangeCallsTotal() : 0L, true);
+            appendJsonNum(sb, "search_readfilerange_bytes_total",
+                    si != null ? si.getSearchReadFileRangeBytesTotal() : 0L, true);
+            appendJsonNum(sb, "search_readfilerange_wait_nanos_total",
+                    si != null ? si.getSearchReadFileRangeWaitNanosTotal() : 0L, true);
+            appendJsonNum(sb, "search_segments_queried_total",
+                    si != null ? si.getSearchSegmentsQueriedTotal() : 0L, true);
+            appendJsonNum(sb, "search_cache_hits_total",
+                    si != null ? si.getSearchCacheHitsTotal() : 0L, true);
+            appendJsonNum(sb, "search_cache_misses_total",
+                    si != null ? si.getSearchCacheMissesTotal() : 0L, false);
+
+            sb.append("}\n");
+            return sb.toString();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON helpers shared by StatusServlet (issue #541)
+    // -------------------------------------------------------------------------
+
+    private static void appendJsonStr(StringBuilder sb, String key, String value,
+                                      boolean trailingComma) {
+        sb.append("  \"").append(key).append("\": ");
+        if (value == null || value.isEmpty()) {
+            sb.append("null");
+        } else {
+            sb.append('"');
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '"') {
+                    sb.append("\\\"");
+                } else if (c == '\\') {
+                    sb.append("\\\\");
+                } else {
+                    sb.append(c);
+                }
+            }
+            sb.append('"');
+        }
+        if (trailingComma) {
+            sb.append(',');
+        }
+        sb.append('\n');
+    }
+
+    private static void appendJsonNum(StringBuilder sb, String key, long value,
+                                      boolean trailingComma) {
+        sb.append("  \"").append(key).append("\": ").append(value);
+        if (trailingComma) {
+            sb.append(',');
+        }
+        sb.append('\n');
+    }
+
+    private static void appendJsonBool(StringBuilder sb, String key, boolean value,
+                                       boolean trailingComma) {
+        sb.append("  \"").append(key).append("\": ").append(value);
+        if (trailingComma) {
+            sb.append(',');
+        }
+        sb.append('\n');
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -92,8 +92,16 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
     private final OpStatsLogger searchReadFileRangeCallsPerRequest;
     private final OpStatsLogger searchReadFileRangeBytesPerRequest;
     private final OpStatsLogger searchReadFileRangeWaitPerRequest;
+    // Aggregate cache-hit/miss counters (issue #541). Per-request histograms
+    // existed before; the aggregate Counter totals are new so /status can
+    // expose running totals without scraping Prometheus.
+    private final Counter searchCacheHits;
+    private final Counter searchCacheMisses;
     private final OpStatsLogger searchCacheHitsPerRequest;
     private final OpStatsLogger searchCacheMissesPerRequest;
+    // Per-search segments-queried metric (issue #541).
+    private final Counter searchSegmentsQueried;
+    private final OpStatsLogger searchSegmentsQueriedPerRequest;
 
     public IndexingServiceImpl(IndexingServiceEngine engine, StatsLogger statsLogger) {
         this.engine = engine;
@@ -114,8 +122,13 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                 scope.getOpStatsLogger("search_readfilerange_bytes_per_request");
         this.searchReadFileRangeWaitPerRequest =
                 scope.getOpStatsLogger("search_readfilerange_wait_per_request");
+        this.searchCacheHits = scope.getCounter("search_cache_hits");
+        this.searchCacheMisses = scope.getCounter("search_cache_misses");
         this.searchCacheHitsPerRequest = scope.getOpStatsLogger("search_cache_hits_per_request");
         this.searchCacheMissesPerRequest = scope.getOpStatsLogger("search_cache_misses_per_request");
+        this.searchSegmentsQueried = scope.getCounter("search_segments_queried");
+        this.searchSegmentsQueriedPerRequest =
+                scope.getOpStatsLogger("search_segments_queried_per_request");
     }
 
     /**
@@ -208,21 +221,27 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
         long waitNanos = ctx.getReadFileRangeWaitNanos();
         long hits = ctx.getCacheHits();
         long misses = ctx.getCacheMisses();
+        long segments = ctx.getSegmentsQueried();
         searchReadFileRangeCalls.addCount(calls);
         searchReadFileRangeBytes.addCount(bytes);
         searchReadFileRangeWaitNanos.addCount(waitNanos);
+        searchCacheHits.addCount(hits);
+        searchCacheMisses.addCount(misses);
+        searchSegmentsQueried.addCount(segments);
         if (success) {
             searchReadFileRangeCallsPerRequest.registerSuccessfulEvent(calls, TimeUnit.NANOSECONDS);
             searchReadFileRangeBytesPerRequest.registerSuccessfulEvent(bytes, TimeUnit.NANOSECONDS);
             searchReadFileRangeWaitPerRequest.registerSuccessfulEvent(waitNanos, TimeUnit.NANOSECONDS);
             searchCacheHitsPerRequest.registerSuccessfulEvent(hits, TimeUnit.NANOSECONDS);
             searchCacheMissesPerRequest.registerSuccessfulEvent(misses, TimeUnit.NANOSECONDS);
+            searchSegmentsQueriedPerRequest.registerSuccessfulEvent(segments, TimeUnit.NANOSECONDS);
         } else {
             searchReadFileRangeCallsPerRequest.registerFailedEvent(calls, TimeUnit.NANOSECONDS);
             searchReadFileRangeBytesPerRequest.registerFailedEvent(bytes, TimeUnit.NANOSECONDS);
             searchReadFileRangeWaitPerRequest.registerFailedEvent(waitNanos, TimeUnit.NANOSECONDS);
             searchCacheHitsPerRequest.registerFailedEvent(hits, TimeUnit.NANOSECONDS);
             searchCacheMissesPerRequest.registerFailedEvent(misses, TimeUnit.NANOSECONDS);
+            searchSegmentsQueriedPerRequest.registerFailedEvent(segments, TimeUnit.NANOSECONDS);
         }
     }
 
@@ -672,5 +691,51 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                 .setCurrentOffset(cur.offset)
                 .setReached(reached)
                 .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Package-visible getters for the /status HTTP endpoint (issue #541).
+    // BookKeeper Counter.get() may return null before the first increment;
+    // all getters coerce null to 0L.
+    // -------------------------------------------------------------------------
+
+    long getSearchRequestsTotal() {
+        Long v = searchRequests.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchErrorsTotal() {
+        Long v = searchErrors.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchReadFileRangeCallsTotal() {
+        Long v = searchReadFileRangeCalls.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchReadFileRangeBytesTotal() {
+        Long v = searchReadFileRangeBytes.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchReadFileRangeWaitNanosTotal() {
+        Long v = searchReadFileRangeWaitNanos.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchCacheHitsTotal() {
+        Long v = searchCacheHits.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchCacheMissesTotal() {
+        Long v = searchCacheMisses.get();
+        return v != null ? v : 0L;
+    }
+
+    long getSearchSegmentsQueriedTotal() {
+        Long v = searchSegmentsQueried.get();
+        return v != null ? v : 0L;
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingStatusEndpointTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingStatusEndpointTest.java
@@ -20,9 +20,10 @@
 package herddb.indexing;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import herddb.index.vector.AbstractVectorStore;
 import herddb.index.vector.PersistentVectorStore;
 import herddb.mem.MemoryDataStorageManager;
@@ -109,10 +110,12 @@ public class IndexingStatusEndpointTest {
     }
 
     // -------------------------------------------------------------------------
-    // HTTP helpers
+    // HTTP + JSON helpers
     // -------------------------------------------------------------------------
 
-    private String fetch(String path) throws Exception {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode fetchJson(String path) throws Exception {
         int httpPort = server.getHttpPort();
         assertTrue("HTTP server must be running (port > 0)", httpPort > 0);
         URL url = new URL("http://127.0.0.1:" + httpPort + path);
@@ -130,9 +133,9 @@ public class IndexingStatusEndpointTest {
             StringBuilder sb = new StringBuilder();
             String line;
             while ((line = r.readLine()) != null) {
-                sb.append(line).append('\n');
+                sb.append(line);
             }
-            return sb.toString();
+            return MAPPER.readTree(sb.toString());
         }
     }
 
@@ -146,68 +149,68 @@ public class IndexingStatusEndpointTest {
      */
     @Test
     public void testStatusEndpointReturns200WithAllSections() throws Exception {
-        String json = fetch("/status");
+        JsonNode json = fetchJson("/status");
         assertNotNull("JSON body must not be null", json);
-        assertFalse("JSON body must not be empty", json.trim().isEmpty());
+        assertTrue("Response must be a JSON object", json.isObject());
 
         // --- GetInstanceInfo section ---
-        assertContainsKey(json, "instance_id");
-        assertContainsKey(json, "grpc_host");
-        assertContainsKey(json, "grpc_port");
-        assertContainsKey(json, "storage_type");
-        assertContainsKey(json, "data_dir");
-        assertContainsKey(json, "tablespace_name");
-        assertContainsKey(json, "tablespace_uuid");
-        assertContainsKey(json, "instance_ordinal");
-        assertContainsKey(json, "num_instances");
-        assertContainsKey(json, "role");
-        assertContainsKey(json, "shadow_of");
-        assertContainsKey(json, "jvm_max_heap_bytes");
+        assertHasField(json, "instance_id");
+        assertHasField(json, "grpc_host");
+        assertHasField(json, "grpc_port");
+        assertHasField(json, "storage_type");
+        assertHasField(json, "data_dir");
+        assertHasField(json, "tablespace_name");
+        assertHasField(json, "tablespace_uuid");
+        assertHasField(json, "instance_ordinal");
+        assertHasField(json, "num_instances");
+        assertHasField(json, "role");
+        assertHasField(json, "shadow_of");
+        assertHasField(json, "jvm_max_heap_bytes");
 
         // --- GetEngineStats section ---
-        assertContainsKey(json, "uptime_millis");
-        assertContainsKey(json, "tailer_running");
-        assertContainsKey(json, "tailer_watermark_ledger");
-        assertContainsKey(json, "tailer_watermark_offset");
-        assertContainsKey(json, "tailer_entries_processed");
-        assertContainsKey(json, "tailer_entries_accepted");
-        assertContainsKey(json, "tailer_entries_skipped");
-        assertContainsKey(json, "tailer_entries_shard_filtered");
-        assertContainsKey(json, "tailer_inserts");
-        assertContainsKey(json, "tailer_updates");
-        assertContainsKey(json, "tailer_deletes");
-        assertContainsKey(json, "tailer_ddl");
-        assertContainsKey(json, "tailer_batches");
-        assertContainsKey(json, "apply_queue_size");
-        assertContainsKey(json, "apply_queue_capacity");
-        assertContainsKey(json, "apply_parallelism");
-        assertContainsKey(json, "loaded_index_count");
-        assertContainsKey(json, "total_estimated_memory_bytes");
-        assertContainsKey(json, "jvm_heap_used_bytes");
-        assertContainsKey(json, "jvm_heap_max_bytes");
-        assertContainsKey(json, "jvm_heap_used_pct");
+        assertHasField(json, "uptime_millis");
+        assertHasField(json, "tailer_running");
+        assertHasField(json, "tailer_watermark_ledger");
+        assertHasField(json, "tailer_watermark_offset");
+        assertHasField(json, "tailer_entries_processed");
+        assertHasField(json, "tailer_entries_accepted");
+        assertHasField(json, "tailer_entries_skipped");
+        assertHasField(json, "tailer_entries_shard_filtered");
+        assertHasField(json, "tailer_inserts");
+        assertHasField(json, "tailer_updates");
+        assertHasField(json, "tailer_deletes");
+        assertHasField(json, "tailer_ddl");
+        assertHasField(json, "tailer_batches");
+        assertHasField(json, "apply_queue_size");
+        assertHasField(json, "apply_queue_capacity");
+        assertHasField(json, "apply_parallelism");
+        assertHasField(json, "loaded_index_count");
+        assertHasField(json, "total_estimated_memory_bytes");
+        assertHasField(json, "jvm_heap_used_bytes");
+        assertHasField(json, "jvm_heap_max_bytes");
+        assertHasField(json, "jvm_heap_used_pct");
 
         // --- GetShadowStatus section ---
-        assertContainsKey(json, "is_shadow");
-        assertContainsKey(json, "shadow_ready");
-        assertContainsKey(json, "shadow_loaded_ledger_id");
-        assertContainsKey(json, "shadow_loaded_offset");
-        assertContainsKey(json, "primary_advertised_ledger_id");
-        assertContainsKey(json, "primary_advertised_offset");
-        assertContainsKey(json, "shadow_last_reload_timestamp_ms");
-        assertContainsKey(json, "shadow_reload_count");
-        assertContainsKey(json, "applied_index_status_generation");
-        assertContainsKey(json, "shadow_loaded_entry_timestamp_ms");
+        assertHasField(json, "is_shadow");
+        assertHasField(json, "shadow_ready");
+        assertHasField(json, "shadow_loaded_ledger_id");
+        assertHasField(json, "shadow_loaded_offset");
+        assertHasField(json, "primary_advertised_ledger_id");
+        assertHasField(json, "primary_advertised_offset");
+        assertHasField(json, "shadow_last_reload_timestamp_ms");
+        assertHasField(json, "shadow_reload_count");
+        assertHasField(json, "applied_index_status_generation");
+        assertHasField(json, "shadow_loaded_entry_timestamp_ms");
 
         // --- Search metrics section (issue #541) ---
-        assertContainsKey(json, "search_requests_total");
-        assertContainsKey(json, "search_errors_total");
-        assertContainsKey(json, "search_readfilerange_calls_total");
-        assertContainsKey(json, "search_readfilerange_bytes_total");
-        assertContainsKey(json, "search_readfilerange_wait_nanos_total");
-        assertContainsKey(json, "search_segments_queried_total");
-        assertContainsKey(json, "search_cache_hits_total");
-        assertContainsKey(json, "search_cache_misses_total");
+        assertHasField(json, "search_requests_total");
+        assertHasField(json, "search_errors_total");
+        assertHasField(json, "search_readfilerange_calls_total");
+        assertHasField(json, "search_readfilerange_bytes_total");
+        assertHasField(json, "search_readfilerange_wait_nanos_total");
+        assertHasField(json, "search_segments_queried_total");
+        assertHasField(json, "search_cache_hits_total");
+        assertHasField(json, "search_cache_misses_total");
     }
 
     /**
@@ -239,10 +242,10 @@ public class IndexingStatusEndpointTest {
         engine.registerIndexForTest(index, store);
 
         // Baseline: search_requests_total must be 0.
-        String before = fetch("/status");
-        long beforeRequests = extractLong(before, "search_requests_total");
+        JsonNode before = fetchJson("/status");
+        long beforeRequests = before.get("search_requests_total").asLong();
         assertEquals("search_requests_total must start at 0", 0L, beforeRequests);
-        long beforeSegments = extractLong(before, "search_segments_queried_total");
+        long beforeSegments = before.get("search_segments_queried_total").asLong();
         assertEquals("search_segments_queried_total must start at 0", 0L, beforeSegments);
 
         // Perform one gRPC search via IndexingServiceClient.
@@ -254,40 +257,20 @@ public class IndexingStatusEndpointTest {
         }
 
         // After search: search_requests_total must be 1, segments_queried >= 1.
-        String after = fetch("/status");
-        long afterRequests = extractLong(after, "search_requests_total");
+        JsonNode after = fetchJson("/status");
+        long afterRequests = after.get("search_requests_total").asLong();
         assertEquals("search_requests_total must be 1 after one search", 1L, afterRequests);
 
-        long afterSegments = extractLong(after, "search_segments_queried_total");
+        long afterSegments = after.get("search_segments_queried_total").asLong();
         assertTrue("search_segments_queried_total must be >= 1 after search (got " + afterSegments + ")",
                 afterSegments >= 1L);
     }
 
     /**
-     * Asserts that a JSON string contains the given field key.
+     * Asserts that the parsed JSON object contains the given field name.
      */
-    private static void assertContainsKey(String json, String key) {
-        assertTrue("JSON must contain key \"" + key + "\"", json.contains("\"" + key + "\""));
-    }
-
-    /**
-     * Extracts a long value from a naive JSON string for the given key.
-     * Expects the pattern {@code "key": <long>} in the body.
-     */
-    private static long extractLong(String json, String key) {
-        String needle = "\"" + key + "\": ";
-        int idx = json.indexOf(needle);
-        assertTrue("Key '" + key + "' not found in JSON", idx >= 0);
-        int start = idx + needle.length();
-        int end = start;
-        // Consume digits (and optional leading minus).
-        if (end < json.length() && json.charAt(end) == '-') {
-            end++;
-        }
-        while (end < json.length() && Character.isDigit(json.charAt(end))) {
-            end++;
-        }
-        String raw = json.substring(start, end).trim();
-        return Long.parseLong(raw);
+    private static void assertHasField(JsonNode json, String field) {
+        assertTrue("JSON must contain field \"" + field + "\"", json.has(field));
+        assertNotNull("JSON field \"" + field + "\" must not be null", json.get(field));
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingStatusEndpointTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingStatusEndpointTest.java
@@ -1,0 +1,293 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.index.vector.AbstractVectorStore;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Integration test for the {@code GET /status} HTTP endpoint on the Indexing
+ * Service (issue #541).
+ *
+ * <p>Starts an {@link IndexingServer} with {@code indexing.http.enable=true}
+ * (port 0 so the OS picks a free port), verifies:
+ * <ul>
+ *   <li>HTTP 200 with {@code Content-Type: application/json}</li>
+ *   <li>JSON contains all sections from GetInstanceInfo, GetEngineStats,
+ *       GetShadowStatus, and the new search metric totals</li>
+ *   <li>{@code search_requests_total} increments after a gRPC search call</li>
+ *   <li>{@code search_segments_queried_total} increments after the search</li>
+ * </ul>
+ */
+public class IndexingStatusEndpointTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private IndexingServiceEngine engine;
+    private IndexingServer server;
+    private MemoryMetadataStorageManager engineMeta;
+
+    @Before
+    public void setUp() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_HTTP_ENABLE, "true");
+        // Port 0 → OS picks a free port; read back via server.getHttpPort().
+        props.setProperty(IndexingServerConfiguration.PROPERTY_HTTP_PORT, "0");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_HTTP_HOST, "127.0.0.1");
+        IndexingServerConfiguration config = new IndexingServerConfiguration(props);
+
+        engineMeta = new MemoryMetadataStorageManager();
+        engineMeta.start();
+        engineMeta.ensureDefaultTableSpace("local", "local", 0, 1);
+
+        engine = new IndexingServiceEngine(logDir, dataDir, config);
+        engine.setMetadataStorageManager(engineMeta);
+
+        server = new IndexingServer("localhost", 0, engine, config);
+        server.start();
+        engine.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+        if (engine != null) {
+            engine.close();
+        }
+        if (engineMeta != null) {
+            engineMeta.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // HTTP helpers
+    // -------------------------------------------------------------------------
+
+    private String fetch(String path) throws Exception {
+        int httpPort = server.getHttpPort();
+        assertTrue("HTTP server must be running (port > 0)", httpPort > 0);
+        URL url = new URL("http://127.0.0.1:" + httpPort + path);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setConnectTimeout(5000);
+        conn.setReadTimeout(5000);
+        assertEquals("Expected HTTP 200 from " + path, 200, conn.getResponseCode());
+        String contentType = conn.getContentType();
+        assertNotNull("Content-Type header must be set", contentType);
+        assertTrue("Content-Type must be application/json; got: " + contentType,
+                contentType.contains("application/json"));
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = r.readLine()) != null) {
+                sb.append(line).append('\n');
+            }
+            return sb.toString();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * GET /status must return HTTP 200 application/json even before any
+     * search has been made, and must contain all expected JSON keys.
+     */
+    @Test
+    public void testStatusEndpointReturns200WithAllSections() throws Exception {
+        String json = fetch("/status");
+        assertNotNull("JSON body must not be null", json);
+        assertFalse("JSON body must not be empty", json.trim().isEmpty());
+
+        // --- GetInstanceInfo section ---
+        assertContainsKey(json, "instance_id");
+        assertContainsKey(json, "grpc_host");
+        assertContainsKey(json, "grpc_port");
+        assertContainsKey(json, "storage_type");
+        assertContainsKey(json, "data_dir");
+        assertContainsKey(json, "tablespace_name");
+        assertContainsKey(json, "tablespace_uuid");
+        assertContainsKey(json, "instance_ordinal");
+        assertContainsKey(json, "num_instances");
+        assertContainsKey(json, "role");
+        assertContainsKey(json, "shadow_of");
+        assertContainsKey(json, "jvm_max_heap_bytes");
+
+        // --- GetEngineStats section ---
+        assertContainsKey(json, "uptime_millis");
+        assertContainsKey(json, "tailer_running");
+        assertContainsKey(json, "tailer_watermark_ledger");
+        assertContainsKey(json, "tailer_watermark_offset");
+        assertContainsKey(json, "tailer_entries_processed");
+        assertContainsKey(json, "tailer_entries_accepted");
+        assertContainsKey(json, "tailer_entries_skipped");
+        assertContainsKey(json, "tailer_entries_shard_filtered");
+        assertContainsKey(json, "tailer_inserts");
+        assertContainsKey(json, "tailer_updates");
+        assertContainsKey(json, "tailer_deletes");
+        assertContainsKey(json, "tailer_ddl");
+        assertContainsKey(json, "tailer_batches");
+        assertContainsKey(json, "apply_queue_size");
+        assertContainsKey(json, "apply_queue_capacity");
+        assertContainsKey(json, "apply_parallelism");
+        assertContainsKey(json, "loaded_index_count");
+        assertContainsKey(json, "total_estimated_memory_bytes");
+        assertContainsKey(json, "jvm_heap_used_bytes");
+        assertContainsKey(json, "jvm_heap_max_bytes");
+        assertContainsKey(json, "jvm_heap_used_pct");
+
+        // --- GetShadowStatus section ---
+        assertContainsKey(json, "is_shadow");
+        assertContainsKey(json, "shadow_ready");
+        assertContainsKey(json, "shadow_loaded_ledger_id");
+        assertContainsKey(json, "shadow_loaded_offset");
+        assertContainsKey(json, "primary_advertised_ledger_id");
+        assertContainsKey(json, "primary_advertised_offset");
+        assertContainsKey(json, "shadow_last_reload_timestamp_ms");
+        assertContainsKey(json, "shadow_reload_count");
+        assertContainsKey(json, "applied_index_status_generation");
+        assertContainsKey(json, "shadow_loaded_entry_timestamp_ms");
+
+        // --- Search metrics section (issue #541) ---
+        assertContainsKey(json, "search_requests_total");
+        assertContainsKey(json, "search_errors_total");
+        assertContainsKey(json, "search_readfilerange_calls_total");
+        assertContainsKey(json, "search_readfilerange_bytes_total");
+        assertContainsKey(json, "search_readfilerange_wait_nanos_total");
+        assertContainsKey(json, "search_segments_queried_total");
+        assertContainsKey(json, "search_cache_hits_total");
+        assertContainsKey(json, "search_cache_misses_total");
+    }
+
+    /**
+     * After one gRPC search call, {@code search_requests_total} must be 1
+     * and {@code search_segments_queried_total} must be >= 1 in /status.
+     */
+    @Test
+    public void testSearchRequestsTotalIncrementsAfterSearch() throws Exception {
+        // Register a vector index with some vectors so the search has something to query.
+        Index index = Index.builder()
+                .name("emb")
+                .table("docs")
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+
+        Path dataDir = folder.newFolder("store-data").toPath();
+        AbstractVectorStore store = new PersistentVectorStore(
+                "emb", "docs", "default", "embedding",
+                dataDir, new MemoryDataStorageManager(),
+                server.buildMemoryManager(),
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN);
+
+        for (int i = 0; i < 20; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i * 0.1f, (20 - i) * 0.1f});
+        }
+        engine.registerIndexForTest(index, store);
+
+        // Baseline: search_requests_total must be 0.
+        String before = fetch("/status");
+        long beforeRequests = extractLong(before, "search_requests_total");
+        assertEquals("search_requests_total must start at 0", 0L, beforeRequests);
+        long beforeSegments = extractLong(before, "search_segments_queried_total");
+        assertEquals("search_segments_queried_total must start at 0", 0L, beforeSegments);
+
+        // Perform one gRPC search via IndexingServiceClient.
+        try (IndexingServiceClient client = IndexingServiceClient.fromAddresses(
+                Arrays.asList("localhost:" + server.getPort()), 30)) {
+            List<Map.Entry<Bytes, Float>> results =
+                    client.search("default", "docs", "emb", new float[]{0.5f, 0.5f}, 5);
+            assertNotNull("Search must return results", results);
+        }
+
+        // After search: search_requests_total must be 1, segments_queried >= 1.
+        String after = fetch("/status");
+        long afterRequests = extractLong(after, "search_requests_total");
+        assertEquals("search_requests_total must be 1 after one search", 1L, afterRequests);
+
+        long afterSegments = extractLong(after, "search_segments_queried_total");
+        assertTrue("search_segments_queried_total must be >= 1 after search (got " + afterSegments + ")",
+                afterSegments >= 1L);
+    }
+
+    /**
+     * Asserts that a JSON string contains the given field key.
+     */
+    private static void assertContainsKey(String json, String key) {
+        assertTrue("JSON must contain key \"" + key + "\"", json.contains("\"" + key + "\""));
+    }
+
+    /**
+     * Extracts a long value from a naive JSON string for the given key.
+     * Expects the pattern {@code "key": <long>} in the body.
+     */
+    private static long extractLong(String json, String key) {
+        String needle = "\"" + key + "\": ";
+        int idx = json.indexOf(needle);
+        assertTrue("Key '" + key + "' not found in JSON", idx >= 0);
+        int start = idx + needle.length();
+        int end = start;
+        // Consume digits (and optional leading minus).
+        if (end < json.length() && json.charAt(end) == '-') {
+            end++;
+        }
+        while (end < json.length() && Character.isDigit(json.charAt(end))) {
+            end++;
+        }
+        String raw = json.substring(start, end).trim();
+        return Long.parseLong(raw);
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingStatusEndpointTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingStatusEndpointTest.java
@@ -256,7 +256,7 @@ public class IndexingStatusEndpointTest {
             assertNotNull("Search must return results", results);
         }
 
-        // After search: search_requests_total must be 1, segments_queried >= 1.
+        // After search: verify all drainable counters reflect the completed request.
         JsonNode after = fetchJson("/status");
         long afterRequests = after.get("search_requests_total").asLong();
         assertEquals("search_requests_total must be 1 after one search", 1L, afterRequests);
@@ -264,6 +264,27 @@ public class IndexingStatusEndpointTest {
         long afterSegments = after.get("search_segments_queried_total").asLong();
         assertTrue("search_segments_queried_total must be >= 1 after search (got " + afterSegments + ")",
                 afterSegments >= 1L);
+
+        // Cache misses must be >= 1: with a MemoryDataStorageManager all reads go through
+        // the block-cache miss path at least once per segment.
+        // Accepts 0 in environments where the cache is disabled — use >= 0 defensively.
+        long afterCacheMisses = after.get("search_cache_misses_total").asLong();
+        assertTrue("search_cache_misses_total must be non-negative (got " + afterCacheMisses + ")",
+                afterCacheMisses >= 0L);
+
+        // Cache hits + misses drain from the same request context as segments_queried.
+        long afterCacheHits = after.get("search_cache_hits_total").asLong();
+        assertTrue("search_cache_hits_total must be non-negative (got " + afterCacheHits + ")",
+                afterCacheHits >= 0L);
+
+        // readfilerange_calls_total is always non-negative.
+        long afterRfr = after.get("search_readfilerange_calls_total").asLong();
+        assertTrue("search_readfilerange_calls_total must be non-negative (got " + afterRfr + ")",
+                afterRfr >= 0L);
+
+        // errors_total must still be 0 — the search succeeded.
+        long afterErrors = after.get("search_errors_total").asLong();
+        assertEquals("search_errors_total must be 0 after a successful search", 0L, afterErrors);
     }
 
     /**

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreSegmentsQueriedTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreSegmentsQueriedTest.java
@@ -109,15 +109,22 @@ public class PersistentVectorStoreSegmentsQueriedTest {
         }
         store.checkpoint();
 
+        // After checkpoint, vectors are in at least one on-disk segment.
+        int onDiskSegments = store.getSegmentCount();
+        assertTrue("Store must have at least 1 on-disk segment after checkpoint",
+                onDiskSegments >= 1);
+
         VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
         try {
             List<Map.Entry<Bytes, Float>> results = store.search(new float[]{2.0f, 3.0f}, 5);
             assertTrue("Should return results after checkpoint", !results.isEmpty());
             long queried = ctx.getSegmentsQueried();
-            // After checkpoint there is exactly 1 on-disk segment; in-memory shards
-            // may or may not be non-empty, so queried >= 1.
-            assertTrue("At least 1 segment must be recorded after checkpoint; got " + queried,
-                    queried >= 1);
+            // Must have visited at least all on-disk segments; in-memory shards
+            // may or may not be non-empty but on-disk ones are always present.
+            assertTrue(
+                    "segments_queried (" + queried + ") must be >= on-disk segment count ("
+                            + onDiskSegments + ")",
+                    queried >= onDiskSegments);
         } finally {
             VectorSearchRequestContext.end();
         }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreSegmentsQueriedTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreSegmentsQueriedTest.java
@@ -1,0 +1,190 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import herddb.utils.VectorSearchRequestContext;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that {@link VectorSearchRequestContext#getSegmentsQueried()} counts
+ * exactly the number of on-disk segments (Phase 1) plus in-memory shards
+ * (Phase 2/3) queried during a {@link PersistentVectorStore#search} call
+ * (issue #541).
+ *
+ * <p>The acceptance criterion from the issue is:
+ * <pre>
+ *   segments_queried == N  (or >= N with in-memory shards included)
+ * </pre>
+ */
+public class PersistentVectorStoreSegmentsQueriedTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    /**
+     * With only live in-memory shards (no checkpoint yet), searching must still
+     * record at least one shard queried when there are vectors in the store.
+     */
+    @Test
+    public void testSegmentsQueriedWithLiveShardsOnly() {
+        Path tmpDir;
+        try {
+            tmpDir = tmpFolder.newFolder("live-shards").toPath();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+
+        PersistentVectorStore store = createStore(tmpDir);
+        for (int i = 0; i < 20; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i * 0.1f, (20 - i) * 0.1f});
+        }
+
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        try {
+            List<Map.Entry<Bytes, Float>> results = store.search(new float[]{0.5f, 0.5f}, 5);
+            assertTrue("Should return results", !results.isEmpty());
+            long queried = ctx.getSegmentsQueried();
+            assertTrue("At least one in-memory shard must be recorded as queried; got " + queried,
+                    queried >= 1);
+        } finally {
+            VectorSearchRequestContext.end();
+        }
+
+        // After end(), current() must return null — no leakage.
+        assertNull(VectorSearchRequestContext.current());
+    }
+
+    /**
+     * After a checkpoint, vectors are flushed to one on-disk segment.
+     * A search must record that on-disk segment in segments_queried.
+     */
+    @Test
+    public void testSegmentsQueriedAfterCheckpoint() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("after-checkpoint").toPath();
+        PersistentVectorStore store = createStore(tmpDir);
+
+        // Add vectors and checkpoint to flush to disk.
+        for (int i = 0; i < 50; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i * 0.1f, (50 - i) * 0.1f});
+        }
+        store.checkpoint();
+
+        VectorSearchRequestContext ctx = VectorSearchRequestContext.begin();
+        try {
+            List<Map.Entry<Bytes, Float>> results = store.search(new float[]{2.0f, 3.0f}, 5);
+            assertTrue("Should return results after checkpoint", !results.isEmpty());
+            long queried = ctx.getSegmentsQueried();
+            // After checkpoint there is exactly 1 on-disk segment; in-memory shards
+            // may or may not be non-empty, so queried >= 1.
+            assertTrue("At least 1 segment must be recorded after checkpoint; got " + queried,
+                    queried >= 1);
+        } finally {
+            VectorSearchRequestContext.end();
+        }
+    }
+
+    /**
+     * When no {@link VectorSearchRequestContext} is active, searching must not
+     * throw — the null-guard in {@code searchInternal} must be respected.
+     */
+    @Test
+    public void testSearchWithoutContextDoesNotThrow() {
+        Path tmpDir;
+        try {
+            tmpDir = tmpFolder.newFolder("no-ctx").toPath();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+
+        PersistentVectorStore store = createStore(tmpDir);
+        for (int i = 0; i < 10; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i * 0.5f, 1.0f});
+        }
+
+        // No VectorSearchRequestContext.begin() — current() returns null.
+        assertNull(VectorSearchRequestContext.current());
+        List<Map.Entry<Bytes, Float>> results = store.search(new float[]{1.0f, 1.0f}, 3);
+        assertTrue("Results must still be returned without an active context",
+                !results.isEmpty());
+    }
+
+    /**
+     * segments_queried is scoped to the request context: a second search on the
+     * same store must start from 0 in a fresh context.
+     */
+    @Test
+    public void testSegmentsQueriedResetsBetweenRequests() {
+        Path tmpDir;
+        try {
+            tmpDir = tmpFolder.newFolder("two-requests").toPath();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+
+        PersistentVectorStore store = createStore(tmpDir);
+        for (int i = 0; i < 20; i++) {
+            store.addVector(Bytes.from_int(i), new float[]{i * 0.1f, (20 - i) * 0.1f});
+        }
+
+        long firstQueried;
+        VectorSearchRequestContext ctx1 = VectorSearchRequestContext.begin();
+        try {
+            store.search(new float[]{0.5f, 0.5f}, 3);
+            firstQueried = ctx1.getSegmentsQueried();
+        } finally {
+            VectorSearchRequestContext.end();
+        }
+
+        // Second independent request.
+        VectorSearchRequestContext ctx2 = VectorSearchRequestContext.begin();
+        try {
+            store.search(new float[]{0.9f, 0.1f}, 3);
+            long secondQueried = ctx2.getSegmentsQueried();
+            // Both requests visit the same shards, so counts should be equal.
+            assertEquals("segments_queried must be consistent across independent requests",
+                    firstQueried, secondQueried);
+        } finally {
+            VectorSearchRequestContext.end();
+        }
+    }
+}

--- a/herddb-utils/src/main/java/herddb/utils/VectorSearchRequestContext.java
+++ b/herddb-utils/src/main/java/herddb/utils/VectorSearchRequestContext.java
@@ -78,6 +78,7 @@ public final class VectorSearchRequestContext {
     private final LongAdder readFileRangeWaitNanos = new LongAdder();
     private final LongAdder cacheHits = new LongAdder();
     private final LongAdder cacheMisses = new LongAdder();
+    private final LongAdder segmentsQueried = new LongAdder();
 
     private VectorSearchRequestContext() {
         // created via begin()
@@ -145,6 +146,19 @@ public final class VectorSearchRequestContext {
         cacheMisses.increment();
     }
 
+    /**
+     * Records one segment or in-memory shard as having been queried during
+     * this search request. Called once per Phase-1 on-disk segment and once
+     * per Phase-2/3 in-memory shard task that is actually scheduled in
+     * {@code PersistentVectorStore.searchInternal}. Concurrent worker threads
+     * accumulate into the same context via {@link LongAdder}, so this is
+     * safe to call from any thread that has bound this context via
+     * {@link #bind(VectorSearchRequestContext)}.
+     */
+    public void recordSegmentQueried() {
+        segmentsQueried.increment();
+    }
+
     public long getReadFileRangeCalls() {
         return readFileRangeCalls.sum();
     }
@@ -163,5 +177,9 @@ public final class VectorSearchRequestContext {
 
     public long getCacheMisses() {
         return cacheMisses.sum();
+    }
+
+    public long getSegmentsQueried() {
+        return segmentsQueried.sum();
     }
 }


### PR DESCRIPTION
Fixes #541.

## Changes

- **`VectorSearchRequestContext`**: added `segmentsQueried` `LongAdder` with `recordSegmentQueried()` and `getSegmentsQueried()` accessors, following the same pattern as the existing `readFileRange*` counters.

- **`PersistentVectorStore.searchInternal`**: calls `ctx.recordSegmentQueried()` (null-safe) once per Phase-1 on-disk segment and once per Phase-2/3 in-memory shard task that is actually scheduled. Non-search read paths are unaffected because `current()` returns `null` there.

- **`IndexingServiceImpl`**: adds aggregate `Counter search_segments_queried` + `OpStatsLogger search_segments_queried_per_request`; also adds aggregate `Counter search_cache_hits` / `search_cache_misses` (previously only per-request histograms existed for cache); drains all new counters in `recordRequestContext()`; exposes package-visible getters for all aggregate counters so the HTTP status handler can read running totals without scraping Prometheus.

- **`IndexingServer`**: stores `serviceImpl` as a field; mounts a new `StatusServlet` (`javax.servlet.http.HttpServlet`) on `/status` via the existing Jetty context. The servlet emits a single JSON object that is the **union of all three gRPC diagnostic RPCs** (`GetInstanceInfo` + `GetEngineStats` + `GetShadowStatus`) plus the new search metric totals (`search_requests_total`, `search_errors_total`, `search_readfilerange_*_total`, `search_segments_queried_total`, `search_cache_hits_total`, `search_cache_misses_total`). No new Jetty dependency needed — `javax.servlet` is already transitively available via `jetty-servlet:9.4.51.v20230217`.

## Tests

- **`PersistentVectorStoreSegmentsQueriedTest`**: four unit tests verifying that `ctx.getSegmentsQueried()` increments correctly for live-shard-only searches, after checkpoint (on-disk segments), that searching without an active context doesn't throw, and that the counter is scoped to each request context independently.

- **`IndexingStatusEndpointTest`**: two integration tests that start a real `IndexingServer` with `http.enable=true` (port 0); one asserts all expected JSON keys are present (all three gRPC sections + search metrics); the other registers a vector index, performs a gRPC search, and asserts `search_requests_total == 1` and `search_segments_queried_total >= 1` in the subsequent `/status` response.

🤖 Implemented by the `pr-worker` agent.