### PR TITLE
issue #551: fix unsafe file deletion creating zombie segments

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3068,8 +3068,46 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // deleted only after the "switch to the new segments" is committed to
         // both metadata stores (IndexStatus + ZK). See the Stage 1 block above
         // for the full rationale.
+        //
+        // The variable defaults to false: input files are queued for deletion
+        // ONLY when one of three explicit paths flips it to true (publisher
+        // null, null-UUID inputs, or a successful deprecateInputs). Any new
+        // code path that exits this block without explicit handling will
+        // therefore default to "do not delete" — fail-safe.
         boolean inputsSafeToDelete = false;
-        if (publisherSnapshot != null && stagedInfo != null) {
+        if (publisherSnapshot == null) {
+            // No publisher: no ZK metadata to coordinate. IndexStatus is the
+            // sole metadata store and is already durable (Stage 2), so the
+            // switch is fully committed. Safe to delete input files.
+            inputsSafeToDelete = true;
+        } else if (stagedInfo == null) {
+            // Publisher attached, but no merged output was ever staged. There
+            // are two ways to land here:
+            //   (a) `mergedOutput == null` — empty-result compaction (every
+            //       PK in the inputs was tombstoned; the rebuild produced
+            //       nothing). The inputs were nevertheless removed from
+            //       `this.segments` and from IndexStatus.
+            //   (b) `mergedOutput != null` but the caller never built
+            //       `stagedInfo` for it (defensive; should not happen with
+            //       the current code path).
+            // In BOTH cases we did NOT call deprecateInputs on the inputs,
+            // so ZK still shows them as ACTIVE. Deleting their files here
+            // would re-create the zombie-segment hazard this PR is closing.
+            // Leave `inputsSafeToDelete = false` and let the optimizer fold
+            // the orphan ACTIVE inputs on its next tick (the same recovery
+            // path used when deprecateInputs fails — see below).
+            if (!inputs.isEmpty()) {
+                LOGGER.log(Level.WARNING,
+                        "vector store {0}: empty-result / unstaged compaction with"
+                                + " publisher attached — {1} input segments remain"
+                                + " ACTIVE in ZK; their files will NOT be queued for"
+                                + " deletion to avoid zombie-segment failure. Optimizer"
+                                + " will fold orphan ACTIVE inputs on next tick.",
+                        new Object[]{indexName, inputs.size()});
+            }
+        } else {
+            // publisher != null && stagedInfo != null: the standard
+            // merged-output path.
             try {
                 publisherSnapshot.commitStagedSegments(stagedInfo);
             } catch (RuntimeException e) {
@@ -3099,19 +3137,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             new Object[]{indexName, inputInfosForRegistry.size(),
                                     e.getMessage()});
                     // Intentionally leave inputsSafeToDelete = false. The input
-                    // files stay in MinIO as orphans-but-intact (no zombie). A
-                    // follow-up cleanup mechanism is required to reclaim them.
+                    // files stay in MinIO as orphans-but-intact (no zombie). The
+                    // optimizer's existing orphan-ACTIVE fold path (see
+                    // IndexOptimizerEngine) reclaims them on the next merge
+                    // covering this region — typically minutes, not indefinite.
                 }
             } else {
-                // No inputs to deprecate (e.g. the very first checkpoint with
-                // a publisher attached but no merge). No files to delete either.
+                // Either inputInfosForRegistry is empty (all inputs had null
+                // segmentUuid — the very-first-checkpoint-with-publisher case;
+                // no ZK record exists to be inconsistent with) or mergedOutput
+                // is null (caught by the stagedInfo == null branch above; this
+                // path is defensive only). Safe to queue: there is nothing in
+                // ZK to leave behind.
                 inputsSafeToDelete = true;
             }
-        } else {
-            // No publisher: no ZK coordination required. The IndexStatus is the
-            // sole metadata store and is already durable, so the switch is
-            // committed. Safe to delete input files.
-            inputsSafeToDelete = true;
         }
 
         if (inputsSafeToDelete) {
@@ -5092,6 +5131,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // durable state; the next successful indexCheckpoint cycle either
             // re-uses them (preload retry) or rewrites them. On restart, the
             // segments load cleanly because the files survive on disk.
+            //
+            // Defence in depth (pr-reviewer pass on #552): the
+            // `provisionalPageIds` tracker is currently DEAD CODE — no caller
+            // populates it; only the multipart tracker is fed by
+            // {@link #trackProvisionalMultipartFile}. A future contributor
+            // who reintroduces page-level tracking must NOT use this code
+            // path to delete pages after Phase B has persisted IndexStatus
+            // (same zombie-segment failure mode as multipart). The assert
+            // makes that constraint load-bearing: if anyone populates the
+            // page tracker in Phase B, they MUST either drain it before
+            // Phase C-prep can fail, or re-design this handler.
+            List<Long> stalePages = this.provisionalPageIds;
+            assert stalePages == null || stalePages.isEmpty()
+                    : "provisionalPageIds populated but not handled in Phase C-prep "
+                            + "rollback (would leak pages OR re-create zombie-segment "
+                            + "hazard if reintroduced naively); see issue #551 review.";
             this.provisionalPageIds = null;
             this.provisionalMultipartFiles = null;
             consecutiveCheckpointFailures.incrementAndGet();

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -2664,12 +2664,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *   estimates, set {@code dirty}.</li>
      * </ol>
      *
-     * <p>Failure handling is preserved verbatim from the prior single-window
-     * implementation: {@code queueSegmentPendingDelete} runs <em>before</em>
-     * the persist (Stage 1), so a Stage-2 throw leaves {@code pendingDeletes}
-     * populated exactly as today and the in-memory {@code segments} is never
-     * republished. {@link #runCompactionCycle}'s existing {@code catch}
-     * blocks observe the failure and record it.
+     * <p>Failure handling (issue #551): {@code queueSegmentPendingDelete}
+     * runs <em>after</em> the post-swap {@code deprecateInputs} succeeds,
+     * not in Stage 1. This honours the invariant that input files are
+     * deleted only after the switch has been committed to both IndexStatus
+     * (Stage 2) AND the ZK registry (post-swap). If {@code deprecateInputs}
+     * fails the input files are NOT queued: they remain in MinIO as orphans
+     * (intact but no longer referenced by IndexStatus) until a follow-up
+     * cleanup mechanism reclaims them. This is strictly safer than the
+     * pre-#551 behaviour where files were deleted by the retention reaper
+     * regardless of ZK state, producing zombie segments (ZK shows ACTIVE
+     * but files are gone) that broke every subsequent optimizer task
+     * touching them. {@link #runCompactionCycle}'s existing {@code catch}
+     * blocks observe Stage-2/Stage-3 failures and record them as before.
      */
     private void atomicSwapCompactionResult(List<VectorSegment> inputs,
                                             VectorSegment mergedOutput,
@@ -2830,12 +2837,23 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 newSegments.add(mergedOutput);
             }
 
-            // Queue inputs for retention-aware deletion. Same ordering as the
-            // pre-#462 implementation (queue BEFORE persist) so the failure
-            // semantics are unchanged.
-            for (VectorSegment in : inputs) {
-                queueSegmentPendingDelete(in, vectorIndexCompactionRetentionMs);
-            }
+            // Issue #551: Inputs are NOT queued for retention-aware deletion here.
+            // The queue is deferred to the post-swap block, after deprecateInputs()
+            // succeeds (i.e. after the ZK registry has confirmed the inputs are
+            // DEPRECATED). The previous ordering (queue BEFORE persist) created a
+            // zombie-segment failure mode: if deprecateInputs() failed in the
+            // post-swap block, the inputs remained ACTIVE in ZK but their files
+            // were physically deleted by the retention reaper after
+            // vectorIndexCompactionRetentionMs (10 minutes by default). Every
+            // optimizer task subsequently targeting these phantom-ACTIVE segments
+            // would fail to read their files — the symptom that motivated this
+            // issue (4,222+ failed merges on bigann-100M).
+            //
+            // The new ordering is: persist IndexStatus (Stage 2), publish to
+            // this.segments (Stage 3), then commit ZK ACTIVE→DEPRECATED, and ONLY
+            // THEN queue files for retention-aware deletion. This honours the
+            // invariant that files are deleted only after the "switch to the new
+            // segments" is committed to metadata (both IndexStatus AND ZK).
 
             Runnable postBuildHook = atomicSwapPostBuildHook;
             if (postBuildHook != null) {
@@ -3043,6 +3061,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // reconcile-on-restart (commit) or the next optimizer tick (deprecate).
         // Best-effort by design — we never roll back a durable IndexStatus
         // change because of a registry hiccup.
+        //
+        // Issue #551: Input files are queued for retention-aware deletion HERE
+        // (not in Stage 1 as before), and only after the ZK registry confirms
+        // the inputs are DEPRECATED. This honours the invariant that files are
+        // deleted only after the "switch to the new segments" is committed to
+        // both metadata stores (IndexStatus + ZK). See the Stage 1 block above
+        // for the full rationale.
+        boolean inputsSafeToDelete = false;
         if (publisherSnapshot != null && stagedInfo != null) {
             try {
                 publisherSnapshot.commitStagedSegments(stagedInfo);
@@ -3059,13 +3085,38 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 try {
                     publisherSnapshot.deprecateInputs(inputInfosForRegistry,
                             mergedOutput.segmentUuid, retentionUntil);
+                    // ZK now shows the inputs as DEPRECATED. The switch is fully
+                    // committed (IndexStatus + ZK) so it is safe to schedule the
+                    // input files for deletion.
+                    inputsSafeToDelete = true;
                 } catch (RuntimeException e) {
                     LOGGER.log(Level.WARNING,
                             "vector store {0}: deprecate of {1} input segments failed;"
-                                    + " optimizer will fold orphan ACTIVE inputs on next tick: {2}",
+                                    + " input files will NOT be queued for deletion to"
+                                    + " avoid zombie-segment failure (files would be"
+                                    + " deleted while ZK still shows ACTIVE). Optimizer"
+                                    + " will fold orphan ACTIVE inputs on next tick: {2}",
                             new Object[]{indexName, inputInfosForRegistry.size(),
                                     e.getMessage()});
+                    // Intentionally leave inputsSafeToDelete = false. The input
+                    // files stay in MinIO as orphans-but-intact (no zombie). A
+                    // follow-up cleanup mechanism is required to reclaim them.
                 }
+            } else {
+                // No inputs to deprecate (e.g. the very first checkpoint with
+                // a publisher attached but no merge). No files to delete either.
+                inputsSafeToDelete = true;
+            }
+        } else {
+            // No publisher: no ZK coordination required. The IndexStatus is the
+            // sole metadata store and is already durable, so the switch is
+            // committed. Safe to delete input files.
+            inputsSafeToDelete = true;
+        }
+
+        if (inputsSafeToDelete) {
+            for (VectorSegment in : inputs) {
+                queueSegmentPendingDelete(in, vectorIndexCompactionRetentionMs);
             }
         }
     }
@@ -5021,12 +5072,28 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 seg.close();
                 dropSegmentBLinkStorage(seg);
             }
-            // Phase B had already persisted an IndexStatus containing these new
-            // segments, so the artefacts are now referenced on disk. We still
-            // call rollbackProvisionalArtefacts as a best-effort to delete them
-            // directly; any that fail to delete will be reconciled by the next
-            // successful indexCheckpoint sweep.
-            rollbackProvisionalArtefacts();
+            // Issue #551: Phase B has ALREADY persisted an IndexStatus referencing
+            // these new segments (persistIndexStatusMultiSegment ran near the end of
+            // doCheckpointFusedPQPhaseB and returned successfully — otherwise we
+            // would be in the Phase-B catch block above, not here). The PROVISIONAL
+            // znodes were also best-effort committed to ACTIVE.
+            //
+            // Calling rollbackProvisionalArtefacts() at this point would physically
+            // delete MinIO files that are now durably referenced by the persisted
+            // IndexStatus, creating the zombie-segment failure mode observed on
+            // bigann-100M: ZK shows ACTIVE, files are gone, every subsequent
+            // optimizer task targeting that segment fails (4,222+ failed merges in
+            // the production incident that motivated this issue). On IS restart,
+            // reconcileWithIndexStatus promotes any PROVISIONAL znode whose UUID is
+            // in IndexStatus to ACTIVE without checking file existence; the IS then
+            // crash-loops on the first load attempt.
+            //
+            // Clear the trackers WITHOUT deleting. The new segments belong to the
+            // durable state; the next successful indexCheckpoint cycle either
+            // re-uses them (preload retry) or rewrites them. On restart, the
+            // segments load cleanly because the files survive on disk.
+            this.provisionalPageIds = null;
+            this.provisionalMultipartFiles = null;
             consecutiveCheckpointFailures.incrementAndGet();
             totalCheckpointFailures.incrementAndGet();
             recoverFromPhaseBFailure(snapshotShards);

--- a/herddb-core/src/test/java/herddb/index/vector/CompactionDeprecateInputsFailureSafetyTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/CompactionDeprecateInputsFailureSafetyTest.java
@@ -1,0 +1,293 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #551 (Root Cause B): zombie segments caused
+ * by the retention reaper deleting input files while ZK still shows them
+ * as ACTIVE.
+ *
+ * <p>Pre-fix code in {@link PersistentVectorStore#atomicSwapCompactionResult}
+ * queued input segments for retention-aware deletion in Stage 1 (BEFORE
+ * {@code persistIndexStatusMultiSegment}), independent of whether the
+ * post-swap {@code deprecateInputs} call subsequently succeeded. If
+ * {@code deprecateInputs} threw (e.g. transient ZK error), the inputs
+ * remained ACTIVE in ZK but the retention reaper would still physically
+ * delete their files after the retention deadline elapsed —
+ * the textbook zombie-segment failure mode.
+ *
+ * <p>Post-fix, {@code queueSegmentPendingDelete} runs <em>only</em> in
+ * the post-swap block when {@code deprecateInputs} succeeds. If
+ * {@code deprecateInputs} throws, the inputs are NOT queued: their
+ * files stay in MinIO as orphans (intact but unreferenced by
+ * IndexStatus), which is strictly safer than a zombie.
+ *
+ * <p>This test installs a {@link SegmentPublisher} that throws on
+ * {@code deprecateInputs} and asserts that {@code pendingDeletes} stays
+ * empty after a successful local compaction merge.
+ */
+public class CompactionDeprecateInputsFailureSafetyTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, MemoryDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    /**
+     * THE FIX: when {@code deprecateInputs} throws, input segment files
+     * must NOT be added to {@code pendingDeletes}. Without this guard the
+     * retention reaper deletes them after the retention deadline while
+     * ZK still shows them as ACTIVE → zombie.
+     */
+    @Test(timeout = 30_000)
+    public void deprecateInputsFailureMustNotQueueInputFilesForDeletion() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue551-deprecateInputs").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        FailingDeprecatePublisher publisher = new FailingDeprecatePublisher();
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.setSegmentPublisher(publisher);
+            store.start();
+
+            Random rng = new Random(551);
+            int dim = 16;
+            // Produce enough segments to give the compactor candidates.
+            for (int c = 0; c < 4; c++) {
+                for (int i = 0; i < 300; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("test setup must produce >= 2 segments to allow a merge",
+                    segmentsBefore >= 2);
+
+            // Pre-condition: pendingDeletes is empty at this point. The
+            // checkpoints above did NOT call queueSegmentPendingDelete on
+            // any segment (queue happens only via compaction, not via plain
+            // checkpoint).
+            assertEquals("baseline: no pending deletes before compaction",
+                    0, store.getPendingDeletesSnapshot().size());
+
+            // Run a compaction cycle. atomicSwapCompactionResult will:
+            //   - stage merged output PROVISIONAL (publisher.stageNewSegments — no-op)
+            //   - revalidate inputs ACTIVE (publisher.revalidateInputsActive — true)
+            //   - persist IndexStatus (Stage 2 — succeeds)
+            //   - swap this.segments (Stage 3 — succeeds)
+            //   - commit merged output ACTIVE (publisher.commitStagedSegments — no-op)
+            //   - deprecate inputs (publisher.deprecateInputs — THROWS)
+            //
+            // Pre-fix: the Stage-1 queueSegmentPendingDelete loop has already
+            // populated pendingDeletes; the deprecateInputs throw is logged
+            // but the queued entries remain → zombie hazard.
+            // Post-fix: queueSegmentPendingDelete runs ONLY after
+            // deprecateInputs succeeds, so a throw here leaves pendingDeletes
+            // empty.
+            store.runCompactionCycle();
+
+            // ----- Post-fix assertions -----
+
+            // (A) The compaction must have actually succeeded (the throw is
+            //     in the post-swap best-effort block, NOT in the swap proper).
+            //     If the compactor itself didn't run, the test isn't
+            //     exercising the right path.
+            assertEquals("compaction must have completed successfully",
+                    1, store.getCompactionSuccessesTotal());
+            assertTrue("segment count must shrink after a successful merge — "
+                            + "before=" + segmentsBefore
+                            + ", after=" + store.getSegmentCount(),
+                    store.getSegmentCount() < segmentsBefore);
+
+            // (B) deprecateInputs must have been called (and thrown).
+            //     If it wasn't called, the test path is broken — the
+            //     compaction took a different branch.
+            assertTrue("publisher.deprecateInputs must have been called at"
+                            + " least once (deprecate-on-merge path)",
+                    publisher.deprecateInputsCalls.get() >= 1);
+
+            // (C) THE FIX: pendingDeletes must be empty. Pre-fix it would
+            //     hold at least 2 entries per input segment (graph + map);
+            //     post-fix it stays empty because the deprecate throw
+            //     prevents the queue.
+            //
+            //     A non-empty pendingDeletes here is the precise zombie-
+            //     creation hazard: the next reapExpiredPendingDeletes pass
+            //     after the retention deadline would physically delete the
+            //     input files while ZK still shows them as ACTIVE.
+            List<PersistentVectorStore.PendingDelete> pending =
+                    store.getPendingDeletesSnapshot();
+            assertEquals("pendingDeletes must be empty when deprecateInputs"
+                            + " failed (issue #551 root cause B). Found entries: "
+                            + pending,
+                    0, pending.size());
+        }
+    }
+
+    /**
+     * THE COMPLEMENTARY CASE: when {@code deprecateInputs} succeeds, input
+     * segment files MUST be queued for retention-aware deletion. This
+     * pins the fix on the happy path so a future change cannot
+     * accidentally over-correct and leak files in the steady state.
+     */
+    @Test(timeout = 30_000)
+    public void deprecateInputsSuccessQueuesInputFilesForDeletion() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue551-deprecateInputs-ok").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        SuccessfulPublisher publisher = new SuccessfulPublisher();
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.setSegmentPublisher(publisher);
+            store.start();
+
+            Random rng = new Random(552);
+            int dim = 16;
+            for (int c = 0; c < 4; c++) {
+                for (int i = 0; i < 300; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("test setup must produce >= 2 segments to allow a merge",
+                    segmentsBefore >= 2);
+            assertEquals(0, store.getPendingDeletesSnapshot().size());
+
+            store.runCompactionCycle();
+
+            assertEquals(1, store.getCompactionSuccessesTotal());
+            assertTrue("segment count must shrink",
+                    store.getSegmentCount() < segmentsBefore);
+            assertTrue("deprecateInputs must have been called",
+                    publisher.deprecateInputsCalls.get() >= 1);
+
+            // Happy path: pendingDeletes must hold entries for the input
+            // files (graph + map per input). Without this, the fix would
+            // be over-correct and leak files in steady state.
+            List<PersistentVectorStore.PendingDelete> pending =
+                    store.getPendingDeletesSnapshot();
+            assertTrue("pendingDeletes must hold the swapped-out input files"
+                            + " when deprecateInputs succeeds — got " + pending.size(),
+                    pending.size() >= 2);
+        }
+    }
+
+    /**
+     * Minimal {@link SegmentPublisher} that always throws on
+     * {@code deprecateInputs}. Other methods are best-effort no-ops:
+     * stage/commit return cleanly (mirroring the ZK fast path) and
+     * revalidate returns {@code true} so the local compactor doesn't
+     * abort the merge for a different reason.
+     */
+    private static final class FailingDeprecatePublisher implements SegmentPublisher {
+
+        final AtomicInteger deprecateInputsCalls = new AtomicInteger();
+
+        @Override
+        public void stageNewSegments(List<NewSegmentInfo> segments) {
+            // no-op: success
+        }
+
+        @Override
+        public void commitStagedSegments(List<NewSegmentInfo> segments) {
+            // no-op: success
+        }
+
+        @Override
+        public boolean revalidateInputsActive(List<NewSegmentInfo> inputs) {
+            return true;
+        }
+
+        @Override
+        public void deprecateInputs(List<NewSegmentInfo> inputs, String replacementUuid,
+                                    long retentionUntilEpochMillis) {
+            deprecateInputsCalls.incrementAndGet();
+            throw new RuntimeException(
+                    "test-injected deprecateInputs failure (issue #551 root cause B)");
+        }
+    }
+
+    /** Companion publisher that always succeeds (used by the happy-path test). */
+    private static final class SuccessfulPublisher implements SegmentPublisher {
+
+        final AtomicInteger deprecateInputsCalls = new AtomicInteger();
+
+        @Override
+        public void stageNewSegments(List<NewSegmentInfo> segments) {
+        }
+
+        @Override
+        public void commitStagedSegments(List<NewSegmentInfo> segments) {
+        }
+
+        @Override
+        public boolean revalidateInputsActive(List<NewSegmentInfo> inputs) {
+            return true;
+        }
+
+        @Override
+        public void deprecateInputs(List<NewSegmentInfo> inputs, String replacementUuid,
+                                    long retentionUntilEpochMillis) {
+            deprecateInputsCalls.incrementAndGet();
+            // no throw — happy path
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/CompactionDeprecateInputsFailureSafetyTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/CompactionDeprecateInputsFailureSafetyTest.java
@@ -146,10 +146,22 @@ public class CompactionDeprecateInputsFailureSafetyTest {
 
             // ----- Post-fix assertions -----
 
-            // (A) The compaction must have actually succeeded (the throw is
-            //     in the post-swap best-effort block, NOT in the swap proper).
-            //     If the compactor itself didn't run, the test isn't
-            //     exercising the right path.
+            // (A.1) The compactor must have SELECTED candidates this cycle.
+            // pr-reviewer pass on #552: without this, a regression where
+            // configureCompaction() parameters silently stop matching the
+            // candidates would degrade the test into "compaction did nothing,
+            // pendingDeletes is empty for the wrong reason" and the
+            // assertion below would pass for an unrelated reason.
+            assertEquals("compaction must have run exactly one cycle",
+                    1, store.getCompactionRunsTotal());
+            assertTrue("compactor must have selected >= 2 inputs (got "
+                            + store.getCompactionLastInputSegments() + ")",
+                    store.getCompactionLastInputSegments() >= 2);
+
+            // (A.2) The compaction must have actually succeeded (the throw is
+            //       in the post-swap best-effort block, NOT in the swap
+            //       proper). If the compactor itself didn't run, the test
+            //       isn't exercising the right path.
             assertEquals("compaction must have completed successfully",
                     1, store.getCompactionSuccessesTotal());
             assertTrue("segment count must shrink after a successful merge — "
@@ -160,12 +172,12 @@ public class CompactionDeprecateInputsFailureSafetyTest {
             // (B) deprecateInputs must have been called (and thrown).
             //     If it wasn't called, the test path is broken — the
             //     compaction took a different branch.
-            assertTrue("publisher.deprecateInputs must have been called at"
-                            + " least once (deprecate-on-merge path)",
-                    publisher.deprecateInputsCalls.get() >= 1);
+            assertEquals("publisher.deprecateInputs must have been called"
+                            + " exactly once (deprecate-on-merge path)",
+                    1, publisher.deprecateInputsCalls.get());
 
             // (C) THE FIX: pendingDeletes must be empty. Pre-fix it would
-            //     hold at least 2 entries per input segment (graph + map);
+            //     hold exactly 2 entries per input segment (graph + map);
             //     post-fix it stays empty because the deprecate throw
             //     prevents the queue.
             //
@@ -175,9 +187,9 @@ public class CompactionDeprecateInputsFailureSafetyTest {
             //     input files while ZK still shows them as ACTIVE.
             List<PersistentVectorStore.PendingDelete> pending =
                     store.getPendingDeletesSnapshot();
-            assertEquals("pendingDeletes must be empty when deprecateInputs"
-                            + " failed (issue #551 root cause B). Found entries: "
-                            + pending,
+            assertEquals("pendingDeletes must be EXACTLY empty when"
+                            + " deprecateInputs failed (issue #551 root cause B)."
+                            + " Found entries: " + pending,
                     0, pending.size());
         }
     }
@@ -216,17 +228,111 @@ public class CompactionDeprecateInputsFailureSafetyTest {
             assertEquals(1, store.getCompactionSuccessesTotal());
             assertTrue("segment count must shrink",
                     store.getSegmentCount() < segmentsBefore);
-            assertTrue("deprecateInputs must have been called",
-                    publisher.deprecateInputsCalls.get() >= 1);
+            assertEquals("deprecateInputs must have been called exactly once",
+                    1, publisher.deprecateInputsCalls.get());
 
-            // Happy path: pendingDeletes must hold entries for the input
-            // files (graph + map per input). Without this, the fix would
-            // be over-correct and leak files in steady state.
+            // Compactor must have actually selected candidates this cycle.
+            long selected = store.getCompactionLastInputSegments();
+            assertTrue("compactor must have selected >= 2 inputs (got "
+                            + selected + ")",
+                    selected >= 2);
+
+            // Happy path: pendingDeletes must hold EXACTLY 2 entries per
+            // selected input (graph + map). pr-reviewer pass on #552: the
+            // previous `>= 2` assertion was too loose — a regression that
+            // queued only the graph (or only the first input) would still
+            // pass. The deterministic expectation is `2 * selected`.
             List<PersistentVectorStore.PendingDelete> pending =
                     store.getPendingDeletesSnapshot();
-            assertTrue("pendingDeletes must hold the swapped-out input files"
-                            + " when deprecateInputs succeeds — got " + pending.size(),
-                    pending.size() >= 2);
+            assertEquals("pendingDeletes must hold EXACTLY 2 entries per"
+                            + " selected input (graph + map) when deprecateInputs"
+                            + " succeeds — selected=" + selected
+                            + ", pending=" + pending,
+                    2L * selected, (long) pending.size());
+        }
+    }
+
+    /**
+     * pr-reviewer pass on #552 follow-up #2: empty-result compaction
+     * (rebuild returns {@code null}) with a publisher attached must NOT
+     * queue input files for deletion, because {@code deprecateInputs}
+     * was not called on them (ZK still shows ACTIVE). Pre-fix this
+     * branch fell through to the `else` and queued the files — same
+     * zombie-segment hazard as the {@code deprecateInputs}-fails case.
+     *
+     * <p>The test forces every PK to be tombstoned before running the
+     * compactor, so {@code VectorIndexCompactor.rebuildSegment} returns
+     * {@code null} and the IS takes the empty-result branch in
+     * {@code runCompactionCycle}.
+     */
+    @Test(timeout = 30_000)
+    public void emptyResultCompactionWithPublisherMustNotQueueInputsForDeletion()
+            throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue551-emptyResult").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        TrackingPublisher publisher = new TrackingPublisher();
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.setSegmentPublisher(publisher);
+            store.start();
+
+            Random rng = new Random(553);
+            int dim = 16;
+            java.util.List<Bytes> allPks = new java.util.ArrayList<>();
+            for (int c = 0; c < 4; c++) {
+                for (int i = 0; i < 200; i++) {
+                    Bytes pk = Bytes.from_int(c * 10_000 + i);
+                    allPks.add(pk);
+                    store.addVector(pk, vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            int segmentsBefore = store.getSegmentCount();
+            assertTrue("test setup must produce >= 2 segments",
+                    segmentsBefore >= 2);
+            assertEquals(0, store.getPendingDeletesSnapshot().size());
+
+            // Tombstone EVERY PK so the rebuild produces an empty result.
+            for (Bytes pk : allPks) {
+                store.removeVector(pk);
+            }
+
+            // Compaction must take the empty-result branch (rebuild ==
+            // null) → atomicSwapCompactionResult is called with
+            // mergedOutput == null → stagedInfo == null → the new
+            // `else if (stagedInfo == null)` branch fires.
+            store.runCompactionCycle();
+
+            // The compactor ran and succeeded (empty-result is still a
+            // success — the inputs were swapped out).
+            assertEquals(1, store.getCompactionRunsTotal());
+            assertEquals(1, store.getCompactionSuccessesTotal());
+            assertEquals("empty-result compaction must produce zero output"
+                            + " segments",
+                    0, store.getCompactionLastOutputSegments());
+            long selected = store.getCompactionLastInputSegments();
+            assertTrue("empty-result compactor must have selected >= 2"
+                            + " inputs (got " + selected + ")",
+                    selected >= 2);
+
+            // Publisher contract: deprecateInputs was NEVER called (the
+            // empty-result path skips the stage/commit/deprecate sequence
+            // entirely because mergedOutput == null).
+            assertEquals("publisher.deprecateInputs must NOT have been"
+                            + " called on the empty-result path",
+                    0, publisher.deprecateInputsCalls.get());
+
+            // THE FIX: pendingDeletes must be empty. Pre-fix the `else`
+            // branch would have flipped inputsSafeToDelete = true and
+            // queued the input files even though their ZK znodes were
+            // never deprecated → zombie hazard.
+            List<PersistentVectorStore.PendingDelete> pending =
+                    store.getPendingDeletesSnapshot();
+            assertEquals("pendingDeletes must be empty on the empty-result"
+                            + " path with publisher attached (issue #551"
+                            + " pr-reviewer follow-up #1). Found entries: "
+                            + pending,
+                    0, pending.size());
         }
     }
 
@@ -288,6 +394,39 @@ public class CompactionDeprecateInputsFailureSafetyTest {
                                     long retentionUntilEpochMillis) {
             deprecateInputsCalls.incrementAndGet();
             // no throw — happy path
+        }
+    }
+
+    /**
+     * Tracking publisher used by the empty-result-compaction test: counts
+     * every relevant call so the test can assert that {@code deprecateInputs}
+     * was NEVER invoked on that path.
+     */
+    private static final class TrackingPublisher implements SegmentPublisher {
+
+        final AtomicInteger stageCalls = new AtomicInteger();
+        final AtomicInteger commitCalls = new AtomicInteger();
+        final AtomicInteger deprecateInputsCalls = new AtomicInteger();
+
+        @Override
+        public void stageNewSegments(List<NewSegmentInfo> segments) {
+            stageCalls.incrementAndGet();
+        }
+
+        @Override
+        public void commitStagedSegments(List<NewSegmentInfo> segments) {
+            commitCalls.incrementAndGet();
+        }
+
+        @Override
+        public boolean revalidateInputsActive(List<NewSegmentInfo> inputs) {
+            return true;
+        }
+
+        @Override
+        public void deprecateInputs(List<NewSegmentInfo> inputs, String replacementUuid,
+                                    long retentionUntilEpochMillis) {
+            deprecateInputsCalls.incrementAndGet();
         }
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/PhaseCPrepRollbackSafetyTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PhaseCPrepRollbackSafetyTest.java
@@ -151,27 +151,41 @@ public class PhaseCPrepRollbackSafetyTest {
             // new multipart files AND persist IndexStatus referencing them,
             // then Phase C-prep will fail when readMultipartMapDataToTempFile
             // tries to read them back.
+            //
+            // pr-reviewer pass on #552: narrow the catch to the precise
+            // exception types the Phase C-prep handler can rethrow
+            // (IOException from readMultipartMapDataToTempFile,
+            // DataStorageManagerException from the lookup, or RuntimeException
+            // from any defensive wrapping). A swallowed failure (no throw,
+            // no counter bump) must fail the test — that's what assertion
+            // (A) below catches.
             long failuresBefore = store.getConsecutiveCheckpointFailures();
+            boolean threw = false;
             try {
                 store.checkpoint();
-                // The fix path may swallow the IOException and surface it via
-                // the consecutiveCheckpointFailures counter rather than
-                // re-throwing all the way out; tolerate either outcome here.
-            } catch (Exception expected) {
-                // Phase C-prep failure surfaces as IOException/RuntimeException
-                // up the checkpoint stack. Either is acceptable.
+            } catch (RuntimeException expected) {
+                // checkpoint() declares DataStorageManagerException, which
+                // is itself a RuntimeException (via HerdDBInternalException);
+                // any defensive wrap from the rollback/recover handlers is
+                // also a RuntimeException. We deliberately do NOT catch
+                // Throwable here — an Error must still escape so a real
+                // VM-level fault doesn't get masked.
+                threw = true;
             }
 
             // ----- Post-fix assertions -----
 
-            // (A) The checkpoint must have failed (consecutiveCheckpointFailures
-            // bumped by 1). If this fails, the failure injection did not
-            // actually trip the C-prep handler — the rest of the test is
-            // meaningless.
-            assertTrue("Phase C-prep must have failed at least once — "
-                            + "failuresBefore=" + failuresBefore + ", after="
-                            + store.getConsecutiveCheckpointFailures(),
-                    store.getConsecutiveCheckpointFailures() > failuresBefore);
+            // (A) The checkpoint must have failed — surfaced by either a
+            //     thrown exception OR the consecutiveCheckpointFailures
+            //     counter advancing. If NEITHER fired, the failure
+            //     injection did not actually trip the C-prep handler and
+            //     the rest of the test is meaningless. pr-reviewer pass:
+            //     a swallowed failure now fails this assertion immediately.
+            assertTrue("Phase C-prep must have failed — either by throw"
+                            + " (threw=" + threw + ") or by counter bump"
+                            + " (failuresBefore=" + failuresBefore + ", after="
+                            + store.getConsecutiveCheckpointFailures() + ")",
+                    threw || store.getConsecutiveCheckpointFailures() > failuresBefore);
 
             // (B) THE FIX: no delete calls were made against the multipart
             // files that Phase B uploaded in the failing checkpoint. The

--- a/herddb-core/src/test/java/herddb/index/vector/PhaseCPrepRollbackSafetyTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PhaseCPrepRollbackSafetyTest.java
@@ -1,0 +1,286 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #551 (Root Cause A): zombie segments caused
+ * by Phase C-prep failure rolling back artefacts that are already in
+ * IndexStatus.
+ *
+ * <p>The pre-fix code in
+ * {@link PersistentVectorStore#doCheckpointFusedPQThreePhase} called
+ * {@code rollbackProvisionalArtefacts()} in the Phase C-prep failure
+ * handler — which physically deleted the multipart files of the new
+ * segments even though Phase B had already persisted IndexStatus with
+ * those segment UUIDs. The result was a zombie: ZK shows the segment
+ * as ACTIVE (because {@code reconcileWithIndexStatus} promotes any
+ * PROVISIONAL znode whose UUID is in IndexStatus), but the underlying
+ * files are gone.
+ *
+ * <p>This test forces the Phase C-prep failure path by injecting a DSM
+ * that throws on the FIRST {@code multipartIndexReaderSupplier} call
+ * AFTER a checkpoint Phase B has uploaded its files. The assertion is
+ * the heart of the fix: NO {@code deleteMultipartIndexFile} calls
+ * targeting those just-uploaded files must happen during the failure
+ * recovery. Pre-fix this test would observe one delete per (graph, map)
+ * pair of every Phase B segment.
+ */
+public class PhaseCPrepRollbackSafetyTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        // Allow tiny shards to seal so a single checkpoint() call produces
+        // an on-disk segment with real multipart files.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, MemoryDataStorageManager dsm) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    /**
+     * Phase C-prep failure must NOT delete multipart files that Phase B
+     * already persisted into IndexStatus.
+     *
+     * <p>Pre-fix behaviour (the bug): the failure handler called
+     * {@code rollbackProvisionalArtefacts()} which deleted every entry in
+     * {@code provisionalMultipartFiles}. Those files are durably referenced
+     * by IndexStatus — deleting them creates zombie segments.
+     *
+     * <p>Post-fix behaviour: the failure handler clears the trackers
+     * without deleting, throws the exception, and leaves the files in
+     * place. The next successful checkpoint reconciles state.
+     */
+    @Test(timeout = 30_000)
+    public void phaseCPrepFailureDoesNotDeleteFilesPersistedInIndexStatus() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue551-phaseCprep").toPath();
+        TrackingFailingDsm dsm = new TrackingFailingDsm();
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm)) {
+            store.start();
+
+            // First, run a successful checkpoint so we have a working store
+            // with a few on-disk segments and a clean failure baseline.
+            Random rng = new Random(551);
+            int dim = 16;
+            for (int i = 0; i < 50; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, dim));
+            }
+            store.checkpoint();
+
+            // Snapshot the set of multipart files that exist before the
+            // failing checkpoint — these were created by the successful
+            // first checkpoint above. We use this to identify the NEW
+            // multipart files Phase B will upload in the failing checkpoint.
+            Set<String> filesBefore = dsm.snapshotMultipartFiles();
+
+            // Now add more vectors so the next checkpoint emits at least
+            // one new segment (forcing Phase B to upload new graph + map
+            // files), and arm the DSM to fail Phase C-prep.
+            for (int i = 50; i < 100; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng, dim));
+            }
+
+            // Reset the delete counter to capture only the failure-path
+            // deletes, and arm the failure: the next call to
+            // multipartIndexReaderSupplier will throw.
+            dsm.resetDeleteTracking();
+            dsm.armReaderSupplierFailure(true);
+
+            // Trigger the checkpoint. Phase B will successfully upload the
+            // new multipart files AND persist IndexStatus referencing them,
+            // then Phase C-prep will fail when readMultipartMapDataToTempFile
+            // tries to read them back.
+            long failuresBefore = store.getConsecutiveCheckpointFailures();
+            try {
+                store.checkpoint();
+                // The fix path may swallow the IOException and surface it via
+                // the consecutiveCheckpointFailures counter rather than
+                // re-throwing all the way out; tolerate either outcome here.
+            } catch (Exception expected) {
+                // Phase C-prep failure surfaces as IOException/RuntimeException
+                // up the checkpoint stack. Either is acceptable.
+            }
+
+            // ----- Post-fix assertions -----
+
+            // (A) The checkpoint must have failed (consecutiveCheckpointFailures
+            // bumped by 1). If this fails, the failure injection did not
+            // actually trip the C-prep handler — the rest of the test is
+            // meaningless.
+            assertTrue("Phase C-prep must have failed at least once — "
+                            + "failuresBefore=" + failuresBefore + ", after="
+                            + store.getConsecutiveCheckpointFailures(),
+                    store.getConsecutiveCheckpointFailures() > failuresBefore);
+
+            // (B) THE FIX: no delete calls were made against the multipart
+            // files that Phase B uploaded in the failing checkpoint. The
+            // failure handler must have cleared the tracker WITHOUT
+            // calling deleteMultipartIndexFile.
+            //
+            // Pre-fix, the handler would call rollbackProvisionalArtefacts(),
+            // which deletes every entry in provisionalMultipartFiles. With
+            // at least one new segment emitted in Phase B, that is at
+            // minimum 2 delete calls (graph + map). This assertion catches
+            // any regression that re-introduces those calls.
+            assertEquals("Phase C-prep failure handler must NOT delete any"
+                            + " multipart files (issue #551 root cause A). Files"
+                            + " deleted during recovery: " + dsm.deletedFiles,
+                    0, dsm.deleteCalls.get());
+
+            // (C) The new multipart files that Phase B uploaded BEFORE the
+            // Phase C-prep failure must still exist in the DSM. Pre-fix
+            // they would have been physically deleted; the segments would
+            // then be zombies on the next restart.
+            Set<String> filesAfter = dsm.snapshotMultipartFiles();
+            Set<String> newFiles = new HashSet<>(filesAfter);
+            newFiles.removeAll(filesBefore);
+            assertTrue("Phase B must have uploaded at least one new multipart"
+                            + " file (graph + map for a new segment) before"
+                            + " Phase C-prep failed; nothing new uploaded means"
+                            + " the test is not exercising the right code path."
+                            + " filesBefore=" + filesBefore.size()
+                            + ", filesAfter=" + filesAfter.size(),
+                    !newFiles.isEmpty());
+        }
+    }
+
+    /**
+     * Tracking + failure-injecting wrapper around {@link MemoryDataStorageManager}.
+     * Counts {@code deleteMultipartIndexFile} calls so the test can assert
+     * the failure handler did NOT physically delete the artefacts in
+     * IndexStatus. Optionally fails the next
+     * {@code multipartIndexReaderSupplier} call to drive the Phase C-prep
+     * failure path.
+     */
+    private static final class TrackingFailingDsm extends MemoryDataStorageManager {
+
+        final AtomicInteger deleteCalls = new AtomicInteger();
+        final Set<String> deletedFiles =
+                java.util.Collections.synchronizedSet(new java.util.LinkedHashSet<>());
+        final AtomicBoolean failNextReader = new AtomicBoolean(false);
+
+        void resetDeleteTracking() {
+            deleteCalls.set(0);
+            deletedFiles.clear();
+        }
+
+        void armReaderSupplierFailure(boolean fail) {
+            failNextReader.set(fail);
+        }
+
+        Set<String> snapshotMultipartFiles() {
+            // multipartFiles is the package-private map in MemoryDataStorageManager.
+            // We can't access it directly from this package, so reflect.
+            try {
+                java.lang.reflect.Field f = MemoryDataStorageManager.class
+                        .getDeclaredField("multipartFiles");
+                f.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                java.util.Map<String, byte[]> map = (java.util.Map<String, byte[]>) f.get(this);
+                return new java.util.LinkedHashSet<>(map.keySet());
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(
+                        "MemoryDataStorageManager.multipartFiles layout changed", e);
+            }
+        }
+
+        @Override
+        public void deleteMultipartIndexFile(String tableSpace, String uuid, String fileType)
+                throws DataStorageManagerException {
+            deleteCalls.incrementAndGet();
+            deletedFiles.add(tableSpace + "/" + uuid + "/" + fileType);
+            super.deleteMultipartIndexFile(tableSpace, uuid, fileType);
+        }
+
+        @Override
+        public ReaderSupplier multipartIndexReaderSupplier(
+                String tableSpace, String uuid, String fileType, long fileSize)
+                throws DataStorageManagerException {
+            // Fail exactly once per arm to ensure we trip Phase C-prep but
+            // don't poison subsequent retries / cleanup paths.
+            if (failNextReader.compareAndSet(true, false)) {
+                throw new DataStorageManagerException(
+                        "test-injected reader-supplier failure (Phase C-prep)");
+            }
+            return super.multipartIndexReaderSupplier(tableSpace, uuid, fileType, fileSize);
+        }
+
+        // Make the test deterministic by forcing the slower
+        // multipartIndexReaderSupplier path (default
+        // supportsDirectMultipartDownload() returns false anyway, but we
+        // pin it here so the test cannot become silently broken if a future
+        // refactor flips the default).
+        @Override
+        public boolean supportsDirectMultipartDownload() {
+            return false;
+        }
+
+        @Override
+        public void downloadMultipartIndexFile(String tableSpace, String uuid, String fileType,
+                                               long fileSize, java.nio.file.Path target)
+                throws IOException, DataStorageManagerException {
+            throw new UnsupportedOperationException("test pins reader-supplier path");
+        }
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -747,6 +747,12 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     public CompletableFuture<Boolean> deleteFileAsync(String path) {
+        // Issue #551 forensics: log every delete request issued by the client.
+        // File deletions are the root cause of zombie-segment failure modes
+        // (files gone while metadata still references them); making them
+        // visible in the IS / optimizer logs makes future incidents far
+        // easier to trace from logs alone.
+        LOGGER.log(Level.INFO, "file-server client: deleteFile path={0}", path);
         return retryAsync(() -> doDeleteFileAsync(path), "deleteFile", path, 0);
     }
 
@@ -1068,6 +1074,11 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     public CompletableFuture<Integer> deleteByPrefixAsync(String prefix) {
+        // Issue #551 forensics: log every prefix-delete request. Prefix
+        // deletes are the bulk-removal entry point (DROP INDEX, segment
+        // wholesale wipe) so a stray call here can take out an entire
+        // segment or index in one shot.
+        LOGGER.log(Level.INFO, "file-server client: deleteByPrefix prefix={0}", prefix);
         return retryAsync(() -> doDeleteByPrefixAsync(prefix), "deleteByPrefix", prefix, 0);
     }
 
@@ -1096,6 +1107,15 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
         if (paths == null || paths.isEmpty()) {
             return CompletableFuture.completedFuture(0);
         }
+        // Issue #551 forensics: log every batch-delete request. Batch deletes
+        // are the dominant deletion path in steady-state operation (compaction
+        // input cleanup, retention reaper). Log the count plus the first/last
+        // path so a stuck or runaway reaper is obvious from grep'ing the IS
+        // and optimizer logs (full-list logging at INFO would be too noisy in
+        // healthy operation).
+        LOGGER.log(Level.INFO,
+                "file-server client: deleteFiles count={0} first={1} last={2}",
+                new Object[]{paths.size(), paths.get(0), paths.get(paths.size() - 1)});
         return retryAsync(() -> doDeleteFilesAsync(paths), "deleteFiles", paths.get(0), 0);
     }
 

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -747,11 +747,13 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
     }
 
     public CompletableFuture<Boolean> deleteFileAsync(String path) {
-        // Issue #551 forensics: log every delete request issued by the client.
-        // File deletions are the root cause of zombie-segment failure modes
-        // (files gone while metadata still references them); making them
-        // visible in the IS / optimizer logs makes future incidents far
-        // easier to trace from logs alone.
+        // Issue #551 forensics: log every delete request issued by the
+        // client. File deletions are the root cause of zombie-segment
+        // failure modes (files gone while metadata still references them);
+        // making them visible at INFO is required so the IS / optimizer
+        // logs alone are enough to investigate future incidents. The user
+        // explicitly chose INFO over FINE for this reason despite the
+        // higher log volume on the retention-reaper hot path.
         LOGGER.log(Level.INFO, "file-server client: deleteFile path={0}", path);
         return retryAsync(() -> doDeleteFileAsync(path), "deleteFile", path, 0);
     }


### PR DESCRIPTION
Fixes #551.

## Root causes

Two distinct code paths in the vector-index checkpoint / compaction
pipeline could physically delete MinIO files while ZooKeeper still
showed the corresponding segments as `ACTIVE`. The result was a
zombie segment: every subsequent optimizer task targeting it failed
to read the missing files. On bigann-100M this produced 4,222+ failed
merges and stalled indexing at 16%.

### Root cause A — Phase C-prep failure (primary)

`PersistentVectorStore#doCheckpointFusedPQThreePhase`'s Phase C-prep
failure handler called `rollbackProvisionalArtefacts()` even though
Phase B had already persisted IndexStatus referencing the just-uploaded
multipart files. On IS restart, `reconcileWithIndexStatus` promoted
those segments to ACTIVE (their UUIDs are in IndexStatus), then the IS
crashed trying to load the deleted files.

**Fix:** the Phase C-prep handler now clears the `provisionalPageIds`
and `provisionalMultipartFiles` trackers WITHOUT deleting. The files
belong to the durable state; the next successful checkpoint reconciles
in-memory vs on-disk divergence.

### Root cause B — `deprecateInputs` failure before reaper (secondary)

`atomicSwapCompactionResult` queued input segments for retention-aware
deletion in Stage 1 (before `persistIndexStatusMultiSegment` and before
`deprecateInputs`). If the post-swap `deprecateInputs` failed (transient
ZK error), inputs remained ACTIVE in ZK but the retention reaper still
physically deleted their files after the 10-minute deadline.

**Fix:** `queueSegmentPendingDelete` is now invoked in the post-swap
block, only after `deprecateInputs` succeeds. On `deprecateInputs`
failure the input files remain in MinIO as orphans (intact, no longer
referenced by IndexStatus) until a follow-up cleanup mechanism handles
them — strictly safer than the pre-fix zombie.

## Forensic logging

Per the user's request, INFO-level logging was added to
`RemoteFileServiceClient`'s `deleteFile` / `deleteFiles` /
`deleteByPrefix` entry points. Any future zombie-segment incident is
now far easier to trace from grep'ing the IS and optimizer logs alone.

## Changes

- `PersistentVectorStore.java`: Phase C-prep handler no longer rolls
  back artefacts that are already in IndexStatus; `atomicSwapCompactionResult`
  defers `queueSegmentPendingDelete` to after `deprecateInputs` succeeds.
- `RemoteFileServiceClient.java`: INFO-level logging on all three delete
  RPCs.

## Tests

- `PhaseCPrepRollbackSafetyTest` (new): injects a failure into
  `multipartIndexReaderSupplier` after Phase B has uploaded its files,
  asserts that no `deleteMultipartIndexFile` calls happen during recovery.
- `CompactionDeprecateInputsFailureSafetyTest` (new): installs a fake
  `SegmentPublisher` that throws on `deprecateInputs`, asserts
  `pendingDeletes` stays empty. A companion happy-path test pins
  queueing on `deprecateInputs` success.

## Test plan

- [x] `PhaseCPrepRollbackSafetyTest` (1 test) — green
- [x] `CompactionDeprecateInputsFailureSafetyTest` (2 tests) — green
- [x] Related vector-index regression suite (VectorIndexCompactor*Test,
      Issue538Stage3RepublishRaceTest, Issue372PendingDeletesLeakTest,
      27 tests) — green
- [x] `DirectMultipleConcurrentUpdatesSuite*` hammer suite (12 tests) — green
- [x] `BLinkConcurrentSearchInsertTest` — green
- [x] `LazyValueCacheConcurrentUpdatesSuite*` hammer suite (12 tests) — green
- [x] `RemoteFileServiceClient*` test suite (68 tests, validates new
      delete logging didn't break anything) — green
- [x] Pre-PR validation (`checkstyle:check apache-rat:check spotbugs:check
      install -DskipTests -Pci`) — green

🤖 Implemented by the `pr-worker` agent.