### PR TITLE
issue #559: pipeline page flushes during WAL recovery

### DIFF
--- a/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
@@ -71,6 +71,18 @@ public interface AbstractTableManager extends AutoCloseable {
     }
 
     /**
+     * Issue #559: waits for all in-flight recovery-scoped page flushes to
+     * complete. During WAL replay {@link TableManager} pipelines
+     * eviction-driven page writes through a recovery-scoped batch instead of
+     * blocking the recovery thread on every remote write; this method joins
+     * that batch so callers can guarantee a fully persisted page state before
+     * a checkpoint runs. It is a no-op for table managers that do not replay a
+     * WAL (e.g. system tables) or when no recovery flush is pending.
+     */
+    default void awaitRecoveryFlushes() {
+    }
+
+    /**
      * Check if the table manage has been fully started
      */
     boolean isStarted();

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -248,6 +248,23 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             new java.util.concurrent.atomic.AtomicLong();
 
     /**
+     * Issue #559: recovery-scoped batch that pipelines eviction-driven page
+     * flushes across commit boundaries during WAL replay. Created lazily on the
+     * first recovery apply and joined once by {@link #awaitRecoveryFlushes()}
+     * before the post-recovery checkpoint runs. {@code null} outside recovery.
+     *
+     * <p>Unlike the per-commit batch used by live {@link #onTransactionCommit}
+     * calls (issue #448), this batch is <em>not</em> awaited after every commit:
+     * recovery runs single-threaded with no concurrent Phase C checkpoint, so
+     * remote page writes of one commit can safely overlap the replay of the
+     * next, keeping slow remote storage flushes off the recovery critical path.
+     * The single recovery thread per tablespace is the only producer, so no
+     * extra synchronization is needed around the field itself; {@code volatile}
+     * gives the (possibly different) checkpoint thread a consistent view.</p>
+     */
+    private volatile CheckpointFlushBatch recoveryFlushBatch;
+
+    /**
      * Allow checkpoint
      */
     private final StampedLock checkpointLock = new StampedLock();
@@ -1090,9 +1107,20 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         private final Semaphore permits;
         private final List<CompletableFuture<Void>> futures = new ArrayList<>();
 
+        /**
+         * Issue #559: a long-lived recovery-scoped batch would otherwise retain
+         * one {@link CompletableFuture} per flushed page for the whole WAL
+         * replay. {@link #submit(Runnable)} drops already-completed successful
+         * futures once the list grows past this bound, keeping the retained set
+         * roughly at the in-flight count. Futures that completed exceptionally
+         * are kept so {@link #awaitAll()} still surfaces their failure.
+         */
+        private final int pruneThreshold;
+
         CheckpointFlushBatch(ExecutorService executor, int parallelism) {
             this.executor = executor;
             this.permits = new Semaphore(Math.max(1, parallelism));
+            this.pruneThreshold = Math.max(64, Math.max(1, parallelism) * 8);
         }
 
         void submit(Runnable flushAction) throws DataStorageManagerException {
@@ -1112,6 +1140,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }, executor);
             synchronized (futures) {
                 futures.add(future);
+                if (futures.size() > pruneThreshold) {
+                    // Drop completed successful futures; keep pending and
+                    // exceptionally-completed ones so awaitAll() still reports
+                    // the first failure.
+                    futures.removeIf(f -> f.isDone() && !f.isCompletedExceptionally());
+                }
             }
         }
 
@@ -1317,6 +1351,42 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      */
     public long getParallelUnloadsCount() {
         return parallelUnloadsCount.get();
+    }
+
+    /**
+     * Issue #559: returns the recovery-scoped {@link CheckpointFlushBatch},
+     * creating it on first use. Called only on the single recovery thread of
+     * the owning tablespace, so the lazy initialization needs no extra locking.
+     */
+    private CheckpointFlushBatch getOrCreateRecoveryFlushBatch() {
+        CheckpointFlushBatch batch = recoveryFlushBatch;
+        if (batch == null) {
+            batch = new CheckpointFlushBatch(
+                    tableSpaceManager.getCheckpointFlushExecutor(), checkpointFlushParallelism);
+            recoveryFlushBatch = batch;
+        }
+        return batch;
+    }
+
+    /**
+     * Issue #559: joins every in-flight recovery-scoped page flush and clears
+     * the batch. Invoked by {@code TableSpaceManager.recover()} before the
+     * post-recovery checkpoint and, defensively, at the start of
+     * {@link #checkpoint(boolean)} so a checkpoint never persists a
+     * {@code keyToPage} entry pointing at a page whose {@code writePage} is
+     * still running on the checkpoint-flush executor. A no-op when no recovery
+     * flush is pending.
+     */
+    @Override
+    public void awaitRecoveryFlushes() {
+        CheckpointFlushBatch batch = recoveryFlushBatch;
+        if (batch != null) {
+            try {
+                batch.awaitAll();
+            } finally {
+                recoveryFlushBatch = null;
+            }
+        }
     }
 
     /**
@@ -2449,9 +2519,21 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
          * keyToPage.put(...) and lastAppliedSequenceNumber.updateAndGet(...)
          * remain on this thread, in program order: only the I/O of pages that
          * are no longer being written to is parallelized.
+         *
+         * Issue #559: during recovery there is no concurrent Phase C checkpoint
+         * (recovery runs single-threaded and the post-recovery checkpoint only
+         * starts once replay is done), so the per-commit awaitAll() is not
+         * needed for correctness — it only serialises slow remote page writes
+         * onto the recovery critical path. In that case we reuse a single
+         * recovery-scoped batch across every commit so flushes of commit N
+         * overlap the replay of commit N+1, and join it once in
+         * awaitRecoveryFlushes() before the post-recovery checkpoint.
          */
-        final CheckpointFlushBatch unloadBatch = new CheckpointFlushBatch(
-                tableSpaceManager.getCheckpointFlushExecutor(), checkpointFlushParallelism);
+        final boolean pipelineRecoveryFlushes = recovery;
+        final CheckpointFlushBatch unloadBatch = pipelineRecoveryFlushes
+                ? getOrCreateRecoveryFlushBatch()
+                : new CheckpointFlushBatch(
+                        tableSpaceManager.getCheckpointFlushExecutor(), checkpointFlushParallelism);
         try {
             Map<Bytes, Record> changedRecords = transaction.changedRecords.get(table.name);
             // transaction is still holding locks on each record, so we can change records
@@ -2501,8 +2583,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
              * preserves the issue #157 invariant — Phase C, when it observes
              * activeCommitApplies == 0, must see both the LSN update and a
              * quiescent page state for every commit that already passed.
+             *
+             * Issue #559: skipped during recovery — the recovery-scoped batch
+             * is joined once by awaitRecoveryFlushes() before the post-recovery
+             * checkpoint, so consecutive commits do not block each other.
              */
-            unloadBatch.awaitAll();
+            if (!pipelineRecoveryFlushes) {
+                unloadBatch.awaitAll();
+            }
             /*
              * Publish the commit's LSN as "last fully applied" BEFORE releasing the
              * apply slot. Phase C drains activeCommitApplies to zero; the JMM
@@ -2531,11 +2619,19 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
              * separately in a multi-catch. Catching (RuntimeException | Error)
              * deliberately excludes checked exceptions that the apply path
              * does not declare.
+             *
+             * Issue #559: during recovery the batch is shared across commits
+             * and drained centrally — by awaitRecoveryFlushes() on the success
+             * path or by TableSpaceManager's abort-path best-effort drain — so
+             * it is not joined here, where doing so would block on flushes of
+             * unrelated commits.
              */
-            try {
-                unloadBatch.awaitAll();
-            } catch (DataStorageManagerException secondary) {
-                primary.addSuppressed(secondary);
+            if (!pipelineRecoveryFlushes) {
+                try {
+                    unloadBatch.awaitAll();
+                } catch (DataStorageManagerException secondary) {
+                    primary.addSuppressed(secondary);
+                }
             }
             throw primary;
         } finally {
@@ -2647,8 +2743,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         transaction.registerRecordUpdate(this.table.name, key, value, writeResult);
                     }
                 } else {
+                    // Issue #559: route eviction-driven flushes of non-transactional
+                    // recovery DML through the recovery-scoped batch so they pipeline
+                    // instead of blocking the replay thread on each remote write.
+                    CheckpointFlushBatch nonTxBatch = recovery ? getOrCreateRecoveryFlushBatch() : null;
                     try {
-                        applyUpdate(key, value);
+                        applyUpdate(key, value, nonTxBatch);
                     } catch (PageNotFoundException e) {
                         if (recovery) {
                             // During recovery, the key may have been updated during the table
@@ -2658,7 +2758,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                     "{0}.{1} recovery: re-applying update for key {2} as delete+insert",
                                     new Object[]{table.tablespace, table.name, key});
                             keyToPage.remove(key);
-                            applyInsert(key, value, false);
+                            applyInsert(key, value, false, nonTxBatch);
                         } else {
                             throw e;
                         }
@@ -2683,8 +2783,10 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         transaction.registerInsertOnTable(table.name, key, value, writeResult);
                     }
                 } else {
+                    // Issue #559: see the UPDATE branch above.
+                    CheckpointFlushBatch nonTxBatch = recovery ? getOrCreateRecoveryFlushBatch() : null;
                     try {
-                        applyInsert(key, value, false);
+                        applyInsert(key, value, false, nonTxBatch);
                     } catch (IllegalStateException e) {
                         if (recovery && e.getMessage() != null && e.getMessage().contains("already present")) {
                             // During recovery, a key may already be present in keyToPage if it was
@@ -2697,7 +2799,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                             + "(stale keyToPage entry from concurrent checkpoint)",
                                     new Object[]{table.tablespace, table.name, key});
                             keyToPage.remove(key);
-                            applyInsert(key, value, false);
+                            applyInsert(key, value, false, nonTxBatch);
                         } else {
                             throw e;
                         }
@@ -2867,10 +2969,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }
     }
 
-    private void applyUpdate(Bytes key, Bytes value) throws DataStorageManagerException {
-        applyUpdate(key, value, null);
-    }
-
     /**
      * Apply an UPDATE effect to the in-memory state.
      *
@@ -2879,6 +2977,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      * does not fit and the record is re-inserted onto a fresh page) are
      * dispatched to the batch instead of running synchronously on the caller
      * thread. See {@link #applyInsert(Bytes, Bytes, boolean, CheckpointFlushBatch)}.
+     * Callers that do not want batched unloads (live non-transactional DML)
+     * pass {@code null}.
      */
     private void applyUpdate(Bytes key, Bytes value,
             CheckpointFlushBatch unloadBatch) throws DataStorageManagerException {
@@ -3924,6 +4024,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             double dirtyThreshold, double fillThreshold,
             long checkpointTargetTime, long cleanupTargetTime, long compactionTargetTime, boolean pin
     ) throws DataStorageManagerException {
+        // Issue #559: defensively join any pending recovery-scoped page flushes
+        // before checkpointing. TableSpaceManager.recover() already does this
+        // before the post-recovery checkpoint, but recoverForLeadership() hands
+        // control back to a live server whose first checkpoint may be triggered
+        // from another path; joining here guarantees Phase C never persists a
+        // keyToPage entry pointing at a page whose writePage is still running.
+        awaitRecoveryFlushes();
         // Issue #403: serialize concurrent checkpoint(...) invocations on this
         // table. Without this lock the activator-thread-driven
         // runLocalTableCheckPoints could overlap with an admin-triggered

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -516,32 +516,68 @@ public class TableSpaceManager {
             }
         });
 
-        if (dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)) {
-            // In shared-storage mode, replicas get their state from S3 checkpoints.
-            // No WAL replay needed — the CheckpointFollowerThread will handle updates.
-            LOGGER.log(Level.INFO, "{0} shared-storage mode: skipping WAL recovery for {1}, state loaded from checkpoint at {2}",
-                    new Object[]{nodeId, tableSpaceName, logSequenceNumber});
-        } else if (LogSequenceNumber.START_OF_TIME.equals(logSequenceNumber)
-                && dbmanager.getServerConfiguration().getBoolean(ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT, ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT_DEFAULT)) {
-            LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is forced (" + ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT + "=true) for tableSpace " + tableSpaceName);
-            downloadTableSpaceData();
-            log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), false);
-        } else {
-            try {
-                log.recovery(logSequenceNumber, new ApplyEntryOnRecovery(), false);
-            } catch (FullRecoveryNeededException fullRecoveryNeeded) {
-                LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is needed for tableSpace " + tableSpaceName, fullRecoveryNeeded);
+        boolean recoveryReplayCompleted = false;
+        try {
+            if (dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)) {
+                // In shared-storage mode, replicas get their state from S3 checkpoints.
+                // No WAL replay needed — the CheckpointFollowerThread will handle updates.
+                LOGGER.log(Level.INFO, "{0} shared-storage mode: skipping WAL recovery for {1}, state loaded from checkpoint at {2}",
+                        new Object[]{nodeId, tableSpaceName, logSequenceNumber});
+            } else if (LogSequenceNumber.START_OF_TIME.equals(logSequenceNumber)
+                    && dbmanager.getServerConfiguration().getBoolean(ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT, ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT_DEFAULT)) {
+                LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is forced (" + ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT + "=true) for tableSpace " + tableSpaceName);
                 downloadTableSpaceData();
                 log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), false);
+            } else {
+                try {
+                    log.recovery(logSequenceNumber, new ApplyEntryOnRecovery(), false);
+                } catch (FullRecoveryNeededException fullRecoveryNeeded) {
+                    LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is needed for tableSpace " + tableSpaceName, fullRecoveryNeeded);
+                    downloadTableSpaceData();
+                    log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), false);
+                }
+            }
+            recoveryReplayCompleted = true;
+        } finally {
+            recoveryInProgress = false;
+            if (!recoveryReplayCompleted) {
+                // Issue #559: recovery aborted — drain any in-flight recovery page
+                // flushes best-effort so checkpoint-flush executor tasks do not keep
+                // touching pages after we unwind.
+                drainRecoveryFlushesBestEffort();
             }
         }
-        recoveryInProgress = false;
+        // Issue #559: recovery replay pipelines eviction-driven page flushes through a
+        // recovery-scoped batch (see TableManager). Wait for every in-flight remote page
+        // write to finish before the post-recovery checkpoint, otherwise Phase C could
+        // persist a keyToPage entry pointing at a page whose writePage has not completed.
+        for (AbstractTableManager tableManager : tables.values()) {
+            tableManager.awaitRecoveryFlushes();
+        }
         if (!dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)
                 && !LogSequenceNumber.START_OF_TIME.equals(actualLogSequenceNumber)) {
             LOGGER.log(Level.INFO, "Recovery finished for {0} seqNum {1}", new Object[]{tableSpaceName, actualLogSequenceNumber});
             checkpoint(false, false, false);
         }
 
+    }
+
+    /**
+     * Issue #559: drains pending recovery-scoped page flushes on every table
+     * manager without propagating failures. Used on the abort path of
+     * {@link #recover(TableSpace)} / {@link #recoverForLeadership()} where the
+     * boot is failing anyway — the goal is only to stop checkpoint-flush
+     * executor tasks from touching pages of a half-initialized table manager.
+     */
+    private void drainRecoveryFlushesBestEffort() {
+        for (AbstractTableManager tableManager : tables.values()) {
+            try {
+                tableManager.awaitRecoveryFlushes();
+            } catch (RuntimeException drainError) {
+                LOGGER.log(Level.WARNING, "error draining recovery page flushes during aborted recovery of "
+                        + tableSpaceName, drainError);
+            }
+        }
     }
 
     void recoverForLeadership() throws DataStorageManagerException, LogNotAvailableException {
@@ -551,9 +587,24 @@ public class TableSpaceManager {
         recoveryInProgress = true;
         actualLogSequenceNumber = log.getLastSequenceNumber();
         LOGGER.log(Level.INFO, "recovering tablespace {0} log from sequence number {1}, with fencing", new Object[]{tableSpaceName, actualLogSequenceNumber});
-        log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), true);
+        boolean recoveryReplayCompleted = false;
+        try {
+            log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), true);
+            recoveryReplayCompleted = true;
+        } finally {
+            recoveryInProgress = false;
+            if (!recoveryReplayCompleted) {
+                // Issue #559: see recover(TableSpace).
+                drainRecoveryFlushesBestEffort();
+            }
+        }
+        // Issue #559: wait for in-flight recovery page flushes before declaring
+        // recovery finished, so the first checkpoint after leadership recovery
+        // sees a fully persisted page state.
+        for (AbstractTableManager tableManager : tables.values()) {
+            tableManager.awaitRecoveryFlushes();
+        }
         LOGGER.log(Level.INFO, "Recovery (with fencing) finished for {0}", tableSpaceName);
-        recoveryInProgress = false;
     }
 
     void apply(CommitLogResult position, LogEntry entry, boolean recovery) throws DataStorageManagerException, DDLException {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -539,6 +539,11 @@ public class TableSpaceManager {
             }
             recoveryReplayCompleted = true;
         } finally {
+            // Issue #559: clearing recoveryInProgress here, before the
+            // recovery-flush join below, is intentional and safe — live
+            // commits use their own per-commit flush batch (not the
+            // recovery-scoped one), and any checkpoint that races in joins
+            // the recovery batch itself via TableManager.checkpoint().
             recoveryInProgress = false;
             if (!recoveryReplayCompleted) {
                 // Issue #559: recovery aborted — drain any in-flight recovery page
@@ -551,15 +556,39 @@ public class TableSpaceManager {
         // recovery-scoped batch (see TableManager). Wait for every in-flight remote page
         // write to finish before the post-recovery checkpoint, otherwise Phase C could
         // persist a keyToPage entry pointing at a page whose writePage has not completed.
-        for (AbstractTableManager tableManager : tables.values()) {
-            tableManager.awaitRecoveryFlushes();
-        }
+        awaitRecoveryFlushesOnAllTables();
         if (!dbmanager.getMode().equals(ServerConfiguration.PROPERTY_MODE_SHARED_STORAGE)
                 && !LogSequenceNumber.START_OF_TIME.equals(actualLogSequenceNumber)) {
             LOGGER.log(Level.INFO, "Recovery finished for {0} seqNum {1}", new Object[]{tableSpaceName, actualLogSequenceNumber});
             checkpoint(false, false, false);
         }
 
+    }
+
+    /**
+     * Issue #559: joins the pending recovery-scoped page flushes of every table
+     * manager. Every table manager is drained even if one throws, so a single
+     * failed flush cannot leave the other table managers' checkpoint-flush
+     * executor tasks running against a tablespace that is being torn down. The
+     * first failure (with the rest attached as suppressed) is rethrown only
+     * after every table manager has been drained.
+     */
+    private void awaitRecoveryFlushesOnAllTables() {
+        RuntimeException firstFailure = null;
+        for (AbstractTableManager tableManager : tables.values()) {
+            try {
+                tableManager.awaitRecoveryFlushes();
+            } catch (RuntimeException error) {
+                if (firstFailure == null) {
+                    firstFailure = error;
+                } else if (firstFailure != error) {
+                    firstFailure.addSuppressed(error);
+                }
+            }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
     }
 
     /**
@@ -592,6 +621,8 @@ public class TableSpaceManager {
             log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), true);
             recoveryReplayCompleted = true;
         } finally {
+            // Issue #559: see recover(TableSpace) — clearing recoveryInProgress
+            // before the recovery-flush join below is intentional and safe.
             recoveryInProgress = false;
             if (!recoveryReplayCompleted) {
                 // Issue #559: see recover(TableSpace).
@@ -601,9 +632,7 @@ public class TableSpaceManager {
         // Issue #559: wait for in-flight recovery page flushes before declaring
         // recovery finished, so the first checkpoint after leadership recovery
         // sees a fully persisted page state.
-        for (AbstractTableManager tableManager : tables.values()) {
-            tableManager.awaitRecoveryFlushes();
-        }
+        awaitRecoveryFlushesOnAllTables();
         LOGGER.log(Level.INFO, "Recovery (with fencing) finished for {0}", tableSpaceName);
     }
 

--- a/herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java
+++ b/herddb-core/src/test/java/herddb/core/Issue448BulkInsertParallelUnloadTest.java
@@ -87,10 +87,10 @@ import org.junit.rules.TemporaryFolder;
  *       DML, which goes through {@code apply()} → {@code applyInsert(..., false)}
  *       (the no-batch overload), drives the legacy synchronous path under
  *       eviction without ever bumping the parallel-unloads counter;</li>
- *   <li>{@link #recoveryReplayUnderEvictionPressureUsesNoBatchOverload()} —
- *       recovery / log replay of autocommit entries goes through the
- *       no-batch overload, even under eviction pressure, and reproduces
- *       all rows after restart.</li>
+ *   <li>{@link #recoveryReplayUnderEvictionPressurePipelinesFlushes()} —
+ *       recovery / log replay of autocommit entries routes eviction-driven
+ *       unloads through the recovery-scoped batch (issue #559), even under
+ *       eviction pressure, and reproduces all rows after restart.</li>
  * </ul>
  */
 public class Issue448BulkInsertParallelUnloadTest {
@@ -522,22 +522,28 @@ public class Issue448BulkInsertParallelUnloadTest {
     }
 
     /**
-     * Recovery / log replay must use the no-batch
-     * {@code applyInsert(key, value, false)} overload, even under eviction
-     * pressure. This test produces a commit log with many autocommit-mode
-     * INSERT entries (which are NOT followed by a checkpoint, so they
-     * remain in the log), restarts, and asserts that:
+     * Recovery / log replay routes eviction-driven page unloads through a
+     * recovery-scoped {@code CheckpointFlushBatch} (issue #559), even under
+     * eviction pressure. This test produces a commit log with many
+     * autocommit-mode INSERT entries (which are NOT followed by a checkpoint,
+     * so they remain in the log), restarts, and asserts that:
      *
      * <ul>
      *   <li>recovery completes and every row is present;</li>
      *   <li>the parallel-unloads counter on the restarted
-     *       {@link TableManager} stays at zero throughout the replay —
-     *       proving the no-batch overload is on the recovery path
-     *       (issue #448 review follow-up #5).</li>
+     *       {@link TableManager} is greater than zero — proving the recovery
+     *       replay dispatched eviction-driven unloads through the
+     *       recovery-scoped batch instead of flushing them synchronously on
+     *       the recovery thread (issue #559).</li>
      * </ul>
+     *
+     * <p>This supersedes the issue #448 behaviour where recovery used the
+     * no-batch synchronous overload: recovery runs single-threaded with no
+     * concurrent Phase C checkpoint, so pipelining its page flushes is safe
+     * and keeps slow remote writes off the recovery critical path.
      */
     @Test
-    public void recoveryReplayUnderEvictionPressureUsesNoBatchOverload() throws Exception {
+    public void recoveryReplayUnderEvictionPressurePipelinesFlushes() throws Exception {
         Path dataPath = folder.newFolder("data").toPath();
         Path logsPath = folder.newFolder("logs").toPath();
         Path metadataPath = folder.newFolder("metadata").toPath();
@@ -564,8 +570,8 @@ public class Issue448BulkInsertParallelUnloadTest {
             // existing tests like CheckpointStaleLsnRecoveryTest).
         }
 
-        // Phase 2: restart; recovery replays the log via the no-batch
-        // overload. The parallel-unloads counter must stay at zero.
+        // Phase 2: restart; recovery replays the log through the
+        // recovery-scoped batch. The parallel-unloads counter must grow.
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
@@ -575,8 +581,9 @@ public class Issue448BulkInsertParallelUnloadTest {
             manager.waitForTablespace("tblspace1", 10_000);
             TableManager t1Manager = tableManager(manager);
 
-            assertEquals("recovery path must not bump the parallel-unloads counter",
-                    0L, t1Manager.getParallelUnloadsCount());
+            assertTrue("recovery replay must dispatch eviction-driven unloads through the "
+                            + "recovery-scoped batch: counter=" + t1Manager.getParallelUnloadsCount(),
+                    t1Manager.getParallelUnloadsCount() > 0);
             assertRowCount(manager, loggedRows);
         }
     }

--- a/herddb-core/src/test/java/herddb/core/RecoveryFlushPipeliningTest.java
+++ b/herddb-core/src/test/java/herddb/core/RecoveryFlushPipeliningTest.java
@@ -1,0 +1,430 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core;
+
+import static herddb.core.TestUtils.beginTransaction;
+import static herddb.core.TestUtils.commitTransaction;
+import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.executeUpdate;
+import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
+import static herddb.core.TestUtils.scan;
+import static herddb.model.TransactionContext.NO_TRANSACTION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.server.ServerConfiguration;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #559: pipeline eviction-driven page flushes during
+ * WAL recovery.
+ *
+ * <p>Before the fix, recovery replayed the commit log one entry at a time and,
+ * for every commit, dispatched its eviction-driven page unloads to a
+ * <em>per-commit</em> {@code CheckpointFlushBatch} that was {@code awaitAll()}-ed
+ * before the next commit could be replayed (issue #448). Non-transactional
+ * recovery DML did not batch at all — it flushed each victim page synchronously
+ * on the recovery thread. With a remote (S3/MinIO-backed) data storage manager
+ * each flush is a slow multi-block upload, so recovery serialised those uploads
+ * onto its critical path.
+ *
+ * <p>The fix gives each {@code TableManager} a single recovery-scoped
+ * {@code CheckpointFlushBatch}: page flushes of commit N overlap the replay of
+ * commit N+1, and the batch is joined exactly once — by
+ * {@code awaitRecoveryFlushes()} — before the post-recovery checkpoint runs, so
+ * a checkpoint never persists a {@code keyToPage} entry pointing at a page
+ * whose {@code writePage} has not completed.
+ *
+ * <p>These tests exercise recovery under page-eviction pressure and assert
+ * that:
+ * <ul>
+ *   <li>recovery of transactional commits routes eviction-driven unloads
+ *       through the recovery-scoped batch ({@code getParallelUnloadsCount() > 0}
+ *       on the restarted table manager);</li>
+ *   <li>recovery of non-transactional (autocommit) DML does the same;</li>
+ *   <li>no record is lost or corrupted — every row survives the restart, and
+ *       the post-recovery checkpoint is itself consistent, verified by a
+ *       second restart that recovers from that checkpoint.</li>
+ * </ul>
+ */
+public class RecoveryFlushPipeliningTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Small enough that a handful of rows fill a page, so eviction kicks in
+     * well within each test's row count.
+     */
+    private static final long PAGE_SIZE_BYTES = 2 * 1024L;
+
+    /**
+     * Cap data-page memory at ~16 pages so the page replacement policy is at
+     * capacity quickly and every subsequent page rotation during recovery
+     * yields an eviction victim — exactly the scenario the fix optimizes.
+     */
+    private static final long DATA_MEMORY_BYTES = 32 * 1024L;
+
+    /**
+     * Padded value attached to every row. ~200 B together with the key plus
+     * serializer overhead means roughly half a dozen rows per 2 KiB page, so
+     * a few hundred rows cause many page rotations.
+     */
+    private static final String PADDED_VALUE = repeat("x", 200);
+
+    private static ServerConfiguration baseConfig() {
+        ServerConfiguration cfg = newServerConfigurationWithAutoPort();
+        cfg.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, PAGE_SIZE_BYTES);
+        cfg.set(ServerConfiguration.PROPERTY_MAX_DATA_MEMORY, DATA_MEMORY_BYTES);
+        // Keep the PK budget large so BLink-internal evictions do not dominate;
+        // this test is about data-page evictions on the recovery path.
+        cfg.set(ServerConfiguration.PROPERTY_MAX_PK_MEMORY, 4 * 1024 * 1024L);
+        return cfg;
+    }
+
+    /**
+     * Recovery that replays many transactional commits under eviction pressure
+     * must dispatch eviction-driven page unloads through the recovery-scoped
+     * batch, and every row must survive the restart.
+     */
+    @Test
+    public void transactionalRecoveryPipelinesPageFlushes() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int txnCount = 5;
+        int recordsPerTxn = 200;
+        int totalRows = txnCount * recordsPerTxn;
+
+        // Phase 1: write rows across several transactions, NO checkpoint, close.
+        // DBManager.close() does not force a checkpoint, so the next start
+        // replays the whole commit log.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+            for (int t = 0; t < txnCount; t++) {
+                long tx = beginTransaction(manager, "tblspace1");
+                for (int i = 0; i < recordsPerTxn; i++) {
+                    int row = t * recordsPerTxn + i;
+                    executeUpdate(manager,
+                            "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                            Arrays.asList(String.format("k_%06d", row), PADDED_VALUE),
+                            new TransactionContext(tx));
+                }
+                commitTransaction(manager, "tblspace1", tx);
+            }
+            assertRowCount(manager, totalRows);
+        }
+
+        // Phase 2: restart — recovery replays the transactional commits. The
+        // recovery-scoped batch must have absorbed eviction-driven unloads.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            TableManager t1Manager = tableManager(manager);
+
+            assertTrue("recovery of transactional commits must dispatch eviction-driven "
+                            + "unloads through the recovery-scoped batch: counter="
+                            + t1Manager.getParallelUnloadsCount(),
+                    t1Manager.getParallelUnloadsCount() > 0);
+            assertAllRowsPresent(manager, totalRows);
+        }
+
+        // Phase 3: a second restart recovers from the post-recovery checkpoint
+        // written in phase 2. If that checkpoint had persisted a keyToPage
+        // entry pointing at a page whose async writePage had not completed,
+        // this recovery would lose rows or fail.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            assertAllRowsPresent(manager, totalRows);
+        }
+    }
+
+    /**
+     * Recovery that replays many non-transactional (autocommit) INSERT entries
+     * under eviction pressure must also route eviction-driven unloads through
+     * the recovery-scoped batch, and every row must survive the restart.
+     */
+    @Test
+    public void nonTransactionalRecoveryPipelinesPageFlushes() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int totalRows = 600;
+
+        // Phase 1: write rows with autocommit, NO checkpoint, close.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+            for (int i = 0; i < totalRows; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%06d", i), PADDED_VALUE),
+                        NO_TRANSACTION);
+            }
+            assertRowCount(manager, totalRows);
+        }
+
+        // Phase 2: restart — recovery replays the autocommit INSERT entries.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            TableManager t1Manager = tableManager(manager);
+
+            assertTrue("recovery of non-transactional DML must dispatch eviction-driven "
+                            + "unloads through the recovery-scoped batch: counter="
+                            + t1Manager.getParallelUnloadsCount(),
+                    t1Manager.getParallelUnloadsCount() > 0);
+            assertAllRowsPresent(manager, totalRows);
+        }
+
+        // Phase 3: second restart recovers from the post-recovery checkpoint.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            assertAllRowsPresent(manager, totalRows);
+        }
+    }
+
+    /**
+     * A recovery workload that mixes transactional commits and autocommit DML,
+     * including updates and deletes, must produce the correct durable end
+     * state across two restarts.
+     */
+    @Test
+    public void mixedRecoveryWorkloadIsConsistentAcrossRestarts() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int base = 400;
+        int deletes = 120;
+        int extraInserts = 300;
+        int expectedRows = (base - deletes) + extraInserts;
+        String updatedValue = repeat("u", 200);
+
+        // Phase 1: build a mixed workload, NO checkpoint, close.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpaceAndTable(manager);
+
+            // base rows via autocommit
+            for (int i = 0; i < base; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%06d", i), PADDED_VALUE),
+                        NO_TRANSACTION);
+            }
+            // update the first 'base' rows inside one transaction
+            long updTx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < base; i++) {
+                executeUpdate(manager,
+                        "UPDATE tblspace1.t1 set v1=? where k1=?",
+                        Arrays.asList(updatedValue, String.format("k_%06d", i)),
+                        new TransactionContext(updTx));
+            }
+            commitTransaction(manager, "tblspace1", updTx);
+            // delete a prefix via autocommit
+            for (int i = 0; i < deletes; i++) {
+                executeUpdate(manager,
+                        "DELETE FROM tblspace1.t1 where k1=?",
+                        Arrays.asList(String.format("k_%06d", i)),
+                        NO_TRANSACTION);
+            }
+            // extra inserts inside one transaction
+            long insTx = beginTransaction(manager, "tblspace1");
+            for (int i = 0; i < extraInserts; i++) {
+                executeUpdate(manager,
+                        "INSERT INTO tblspace1.t1(k1,v1) values(?,?)",
+                        Arrays.asList(String.format("k_%06d", base + i), PADDED_VALUE),
+                        new TransactionContext(insTx));
+            }
+            commitTransaction(manager, "tblspace1", insTx);
+            assertRowCount(manager, expectedRows);
+        }
+
+        // Phase 2 + 3: two restarts, each must reproduce the exact end state.
+        for (int restart = 0; restart < 2; restart++) {
+            try (DBManager manager = new DBManager("localhost",
+                    new FileMetadataStorageManager(metadataPath),
+                    new FileDataStorageManager(dataPath),
+                    new FileCommitLogManager(logsPath),
+                    tmpDir, null, baseConfig(), null)) {
+                manager.start();
+                manager.waitForTablespace("tblspace1", 10_000);
+                assertRowCount(manager, expectedRows);
+                Map<String, String> rows = readAllRows(manager);
+                assertEquals("recovery must reproduce the expected number of rows",
+                        expectedRows, rows.size());
+                // deleted rows stay deleted
+                for (int i = 0; i < deletes; i++) {
+                    String key = String.format("k_%06d", i);
+                    assertTrue("deleted key " + key + " must stay deleted",
+                            !rows.containsKey(key));
+                }
+                // surviving updated rows keep their updated value
+                for (int i = deletes; i < base; i++) {
+                    String key = String.format("k_%06d", i);
+                    assertEquals("updated key " + key + " must carry the updated value",
+                            updatedValue, rows.get(key));
+                }
+                // extra inserts are present with the original padded value
+                for (int i = 0; i < extraInserts; i++) {
+                    String key = String.format("k_%06d", base + i);
+                    assertEquals("inserted key " + key + " must be present",
+                            PADDED_VALUE, rows.get(key));
+                }
+            }
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private static void createTableSpaceAndTable(DBManager manager) throws Exception {
+        CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                Collections.singleton("localhost"), "localhost", 1, 0, 0);
+        manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                NO_TRANSACTION);
+        manager.waitForTablespace("tblspace1", 10_000);
+        execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
+                Collections.emptyList());
+    }
+
+    private static TableManager tableManager(DBManager manager) {
+        return (TableManager) manager.getTableSpaceManager("tblspace1").getTableManager("t1");
+    }
+
+    private static void assertRowCount(DBManager manager, int expectedRows) throws Exception {
+        try (DataScanner scanner = scan(manager,
+                "SELECT k1 FROM tblspace1.t1", Collections.emptyList())) {
+            int actual = 0;
+            while (scanner.hasNext()) {
+                scanner.next();
+                actual++;
+            }
+            assertEquals("scan returned wrong number of rows", expectedRows, actual);
+        }
+    }
+
+    /**
+     * Asserts that exactly {@code expectedRows} distinct keys named
+     * {@code k_000000..k_<expectedRows-1>} are present — i.e. no row was lost
+     * and no duplicate/garbage key appeared during recovery.
+     */
+    private static void assertAllRowsPresent(DBManager manager, int expectedRows) throws Exception {
+        Set<String> seen = new HashSet<>();
+        try (DataScanner scanner = scan(manager,
+                "SELECT k1 FROM tblspace1.t1", Collections.emptyList())) {
+            while (scanner.hasNext()) {
+                Object[] row = (Object[]) scanner.next().getValues();
+                assertNotNull("scan row must contain a key", row);
+                seen.add(String.valueOf(row[0]));
+            }
+        }
+        assertEquals("recovery must reproduce exactly the expected number of distinct keys",
+                expectedRows, seen.size());
+        List<String> missing = new ArrayList<>();
+        for (int i = 0; i < expectedRows; i++) {
+            String key = String.format("k_%06d", i);
+            if (!seen.contains(key)) {
+                missing.add(key);
+            }
+        }
+        assertTrue("recovery lost rows: " + missing.subList(0, Math.min(10, missing.size())),
+                missing.isEmpty());
+    }
+
+    /**
+     * Reads the whole table into a {@code key -> value} map via a full scan.
+     */
+    private static Map<String, String> readAllRows(DBManager manager) throws Exception {
+        Map<String, String> rows = new HashMap<>();
+        try (DataScanner scanner = scan(manager,
+                "SELECT k1, v1 FROM tblspace1.t1", Collections.emptyList())) {
+            while (scanner.hasNext()) {
+                Object[] row = (Object[]) scanner.next().getValues();
+                assertNotNull("scan row must not be null", row);
+                rows.put(String.valueOf(row[0]), String.valueOf(row[1]));
+            }
+        }
+        return rows;
+    }
+
+    private static String repeat(String fragment, int count) {
+        StringBuilder sb = new StringBuilder(fragment.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(fragment);
+        }
+        return sb.toString();
+    }
+}

--- a/herddb-core/src/test/java/herddb/core/RecoveryFlushPipeliningTest.java
+++ b/herddb-core/src/test/java/herddb/core/RecoveryFlushPipeliningTest.java
@@ -28,25 +28,30 @@ import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
 import static herddb.core.TestUtils.scan;
 import static herddb.model.TransactionContext.NO_TRANSACTION;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.file.FileCommitLogManager;
 import herddb.file.FileDataStorageManager;
 import herddb.file.FileMetadataStorageManager;
 import herddb.model.DataScanner;
+import herddb.model.Record;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
 import herddb.server.ServerConfiguration;
+import herddb.storage.DataStorageManagerException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -348,16 +353,183 @@ public class RecoveryFlushPipeliningTest {
         }
     }
 
+    /**
+     * Recovery under eviction pressure for a tablespace with several tables
+     * must join the recovery-scoped flush batch of <em>every</em> table before
+     * the post-recovery checkpoint. If any table's batch were skipped, that
+     * table's checkpoint could persist a {@code keyToPage} entry pointing at a
+     * page whose {@code writePage} had not completed, and a later restart from
+     * that checkpoint would lose rows. Two restarts assert exactly that.
+     */
+    @Test
+    public void multiTableRecoveryJoinsEveryTableBatch() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int rowsPerTable = 400;
+        String[] tableNames = {"t1", "t2", "t3"};
+
+        // Phase 1: populate every table, NO checkpoint, close.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpace(manager);
+            for (String tableName : tableNames) {
+                createTable(manager, tableName);
+            }
+            for (String tableName : tableNames) {
+                for (int i = 0; i < rowsPerTable; i++) {
+                    executeUpdate(manager,
+                            "INSERT INTO tblspace1." + tableName + "(k1,v1) values(?,?)",
+                            Arrays.asList(String.format("k_%06d", i), PADDED_VALUE),
+                            NO_TRANSACTION);
+                }
+            }
+        }
+
+        // Phase 2: restart — recovery replays every table under eviction.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            for (String tableName : tableNames) {
+                TableManager tm = (TableManager) manager.getTableSpaceManager("tblspace1")
+                        .getTableManager(tableName);
+                assertTrue("recovery must have exercised the recovery-scoped batch for "
+                                + tableName + ": counter=" + tm.getParallelUnloadsCount(),
+                        tm.getParallelUnloadsCount() > 0);
+                assertTableRowCount(manager, tableName, rowsPerTable);
+            }
+        }
+
+        // Phase 3: second restart recovers from the post-recovery checkpoint
+        // written in phase 2 — every table must still be intact.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            for (String tableName : tableNames) {
+                assertTableRowCount(manager, tableName, rowsPerTable);
+            }
+        }
+    }
+
+    /**
+     * If a recovery-scoped page flush fails (e.g. the remote storage write
+     * throws), {@code awaitRecoveryFlushes()} must surface the failure and the
+     * tablespace boot must fail cleanly rather than silently completing with a
+     * lost page. The failure is injected for a multi-table tablespace, so the
+     * {@code awaitRecoveryFlushesOnAllTables()} loop is exercised with more
+     * than one table manager carrying a pending batch.
+     */
+    @Test
+    public void recoveryFlushFailureAbortsBoot() throws Exception {
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        int rowsPerTable = 400;
+        String[] tableNames = {"t1", "t2"};
+
+        // Phase 1: populate two tables on a healthy data storage manager,
+        // NO checkpoint, close.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            createTableSpace(manager);
+            for (String tableName : tableNames) {
+                createTable(manager, tableName);
+                for (int i = 0; i < rowsPerTable; i++) {
+                    executeUpdate(manager,
+                            "INSERT INTO tblspace1." + tableName + "(k1,v1) values(?,?)",
+                            Arrays.asList(String.format("k_%06d", i), PADDED_VALUE),
+                            NO_TRANSACTION);
+                }
+            }
+        }
+
+        // Phase 2: restart with a data storage manager whose writePage always
+        // fails. Recovery replay dispatches eviction-driven page flushes to the
+        // recovery-scoped batch; every one fails, so awaitRecoveryFlushes()
+        // throws and the tablespace must NOT come up.
+        FailingFileDataStorageManager failingDsm = new FailingFileDataStorageManager(dataPath);
+        failingDsm.armFailure();
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                failingDsm,
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            boolean up = manager.waitForTablespace("tblspace1", 8_000);
+            assertFalse("tablespace must not boot when recovery page flushes fail", up);
+            assertTrue("the failing writePage path must have been exercised during recovery",
+                    failingDsm.failedCalls() > 0);
+        }
+
+        // Phase 3: restart again on a healthy data storage manager — recovery
+        // replays the same WAL (the failed boot persisted nothing) and every
+        // row of every table is reproduced. This proves the failed boot did
+        // not corrupt or partially commit any state.
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmpDir, null, baseConfig(), null)) {
+            manager.start();
+            manager.waitForTablespace("tblspace1", 10_000);
+            for (String tableName : tableNames) {
+                assertTableRowCount(manager, tableName, rowsPerTable);
+            }
+        }
+    }
+
     // ---------- helpers ----------
 
     private static void createTableSpaceAndTable(DBManager manager) throws Exception {
+        createTableSpace(manager);
+        createTable(manager, "t1");
+    }
+
+    private static void createTableSpace(DBManager manager) throws Exception {
         CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
                 Collections.singleton("localhost"), "localhost", 1, 0, 0);
         manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
                 NO_TRANSACTION);
         manager.waitForTablespace("tblspace1", 10_000);
-        execute(manager, "CREATE TABLE tblspace1.t1 (k1 string primary key, v1 string)",
-                Collections.emptyList());
+    }
+
+    private static void createTable(DBManager manager, String tableName) throws Exception {
+        execute(manager, "CREATE TABLE tblspace1." + tableName
+                + " (k1 string primary key, v1 string)", Collections.emptyList());
+    }
+
+    private static void assertTableRowCount(DBManager manager, String tableName,
+            int expectedRows) throws Exception {
+        try (DataScanner scanner = scan(manager,
+                "SELECT k1 FROM tblspace1." + tableName, Collections.emptyList())) {
+            int actual = 0;
+            while (scanner.hasNext()) {
+                scanner.next();
+                actual++;
+            }
+            assertEquals("table " + tableName + " returned wrong number of rows",
+                    expectedRows, actual);
+        }
     }
 
     private static TableManager tableManager(DBManager manager) {
@@ -426,5 +598,42 @@ public class RecoveryFlushPipeliningTest {
             sb.append(fragment);
         }
         return sb.toString();
+    }
+
+    /**
+     * A {@link FileDataStorageManager} that throws
+     * {@link DataStorageManagerException} from {@link #writePage} when armed.
+     * Used by {@link #recoveryFlushFailureAbortsBoot()} to verify that a
+     * recovery-scoped page-flush failure surfaces through
+     * {@code awaitRecoveryFlushes()} and aborts the tablespace boot.
+     */
+    private static final class FailingFileDataStorageManager extends FileDataStorageManager {
+
+        private final AtomicBoolean armed = new AtomicBoolean();
+        private final java.util.concurrent.atomic.AtomicInteger failedCalls =
+                new java.util.concurrent.atomic.AtomicInteger();
+
+        FailingFileDataStorageManager(Path baseDir) {
+            super(baseDir);
+        }
+
+        void armFailure() {
+            armed.set(true);
+        }
+
+        int failedCalls() {
+            return failedCalls.get();
+        }
+
+        @Override
+        public void writePage(String tableSpace, String uuid, long pageId,
+                Collection<Record> newPage) throws DataStorageManagerException {
+            if (armed.get()) {
+                failedCalls.incrementAndGet();
+                throw new DataStorageManagerException(
+                        "test-injected failure on writePage for page " + pageId);
+            }
+            super.writePage(tableSpace, uuid, pageId, newPage);
+        }
     }
 }


### PR DESCRIPTION
Fixes #559.

## Problem
On large datasets, `herddb-server` BookKeeper commit-log recovery is excessively slow. The async-profiler wall-clock flamegraph shows recovery serialising on **remote page flushes** (`RemoteFileDataStorageManager.writePage` → MinIO/S3): as the recovery thread replays log records and fills data pages, eviction-driven page writes are flushed to remote storage on the recovery critical path.

Issue #448 already dispatched eviction-driven flushes to the checkpoint-flush executor, but only for live transaction commits, with a **per-commit** `CheckpointFlushBatch` that is `awaitAll()`-ed before the next commit can be replayed. During recovery that means a remote-write pipeline stall at every commit boundary; non-transactional recovery DML was worse — flushed synchronously on the recovery thread with no batching.

## Changes
- `TableManager`: each table manager now lazily creates a single **recovery-scoped** `CheckpointFlushBatch` used for the whole WAL replay. During recovery (`onTransactionCommit` with `recovery == true`, and the non-transactional `apply()` DML path) eviction-driven page unloads go through this shared batch and the per-commit `awaitAll()` is skipped, so flushes of commit N overlap the replay of commit N+1. New `awaitRecoveryFlushes()` joins and clears the batch; it is also called defensively at the start of every checkpoint.
- `TableManager.CheckpointFlushBatch`: `submit(...)` now prunes completed-successful futures once the list grows past a bound, so a long recovery does not retain one `CompletableFuture` per flushed page (failed futures are kept so `awaitAll()` still surfaces them).
- `AbstractTableManager`: new `default void awaitRecoveryFlushes()` (no-op for system tables).
- `TableSpaceManager`: `recover()` / `recoverForLeadership()` join all recovery-scoped batches **before** the post-recovery checkpoint, so a checkpoint never persists a `keyToPage` entry pointing at a page whose `writePage` is still running; an abort path drains them best-effort.
- Live commits are unchanged — they keep a fresh per-commit batch and the per-commit `awaitAll()`, preserving the issue #157 invariant. Recovery runs single-threaded with no concurrent Phase C checkpoint, so pipelining its flushes is safe.

## Tests
- New `RecoveryFlushPipeliningTest` — recovers transactional, non-transactional, and mixed workloads under page-eviction pressure; asserts the recovery-scoped batch was exercised (`getParallelUnloadsCount() > 0`) and that every row survives two restarts (the second restart recovers from the post-recovery checkpoint, proving it is consistent).
- Updated `Issue448BulkInsertParallelUnloadTest.recoveryReplayUnderEvictionPressure*` — recovery now intentionally uses the batched path; the test asserts the new behaviour.
- Ran the `DirectMultipleConcurrentUpdatesSuite` and `LazyValueCacheConcurrentUpdatesSuite` hammer suites plus `BLinkConcurrentSearchInsertTest` twice — all green.

🤖 Implemented by the `pr-worker` agent.