### PR TITLE
issue #563: suppress spurious memory-pressure checkpoint with 0 live vectors

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3730,7 +3730,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
         return r;
     }
 
-    private boolean shouldTriggerMemoryPressureCheckpoint() {
+    // Package-private (not private) so MemoryPressureTriggerZeroLiveVectorsTest
+    // can exercise the issue #563 zero-live-vectors guard as a whitebox test.
+    boolean shouldTriggerMemoryPressureCheckpoint() {
+        // Issue #563: skip the trigger entirely when there are no live vectors
+        // to checkpoint. A memory-pressure checkpoint only moves the live HNSW
+        // shard onto disk; it cannot reduce the on-disk segment pkData/BLink
+        // footprint that {@link #estimatedMemoryUsageBytes()} (and the global
+        // budget) also count. With many on-disk segments that footprint alone
+        // can permanently exceed the 70% threshold, so without this guard the
+        // compaction loop fires a spurious, no-op Phase A every cycle even
+        // though live_node_count is 0.
+        if (getLiveNodeCount() == 0) {
+            return false;
+        }
         // Check global budget first (covers all stores sharing the same heap)
         if (memoryBudget != null) {
             boolean trigger = memoryBudget.isAboveThreshold(0.7);
@@ -4538,6 +4551,43 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
         // On-disk segments: O(1) read of the incremental counter (issue #455).
         total += onDiskSegmentsEstimatedMemoryBytes.get();
+        return total;
+    }
+
+    /**
+     * Returns the estimated heap footprint of the in-memory HNSW shards only —
+     * the live, frozen, and deferred {@link LiveGraphShard} graphs — excluding
+     * the on-disk segment pkData/pkOffsets/pkLengths/BLink contribution that
+     * {@link #estimatedMemoryUsageBytes()} additionally counts.
+     *
+     * <p>Issue #563: this is the figure that genuinely shrinks when a
+     * checkpoint runs (the live shard is snapshotted onto disk and reset to
+     * empty). The memory-pressure checkpoint trigger and the
+     * {@code live_vectors_memory_bytes} diagnostic field must use this value
+     * rather than {@link #estimatedMemoryUsageBytes()}: the on-disk segment
+     * footprint is managed independently (segment eviction / compaction) and
+     * counting it toward the live-vector limit produces spurious, no-op
+     * Phase A triggers once enough segments accumulate.
+     *
+     * @return estimated bytes of heap occupied by the live/frozen/deferred shards
+     */
+    public long getLiveShardMemoryBytes() {
+        long total = 0;
+        for (LiveGraphShard shard : liveShards) {
+            total += shardMemoryBytes(shard);
+        }
+        List<LiveGraphShard> frozen = frozenShards;
+        if (frozen != null) {
+            for (LiveGraphShard shard : frozen) {
+                total += shardMemoryBytes(shard);
+            }
+        }
+        List<LiveGraphShard> deferred = deferredShards;
+        if (deferred != null) {
+            for (LiveGraphShard shard : deferred) {
+                total += shardMemoryBytes(shard);
+            }
+        }
         return total;
     }
 
@@ -8039,8 +8089,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
         return lastPhaseCWriteLockNanos.get();
     }
 
+    /**
+     * Returns the estimated heap footprint of the live (in-memory) vectors.
+     *
+     * <p>Issue #563: this used to delegate to {@link #estimatedMemoryUsageBytes()},
+     * which also includes the on-disk segment pkData/BLink footprint — so the
+     * {@code live_vectors_memory_bytes} diagnostic field reported gigabytes of
+     * "live" memory even when {@code live_node_count} was 0. It now returns the
+     * live/frozen/deferred shard footprint only; the on-disk contribution is
+     * surfaced separately via {@link #getOnDiskSegmentsEstimatedMemoryBytes()}.
+     */
     public long getLiveVectorsMemoryBytes() {
-        return estimatedMemoryUsageBytes();
+        return getLiveShardMemoryBytes();
     }
 
     public long getTotalBackpressureCount() {

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3733,15 +3733,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
     // Package-private (not private) so MemoryPressureTriggerZeroLiveVectorsTest
     // can exercise the issue #563 zero-live-vectors guard as a whitebox test.
     boolean shouldTriggerMemoryPressureCheckpoint() {
-        // Issue #563: skip the trigger entirely when there are no live vectors
-        // to checkpoint. A memory-pressure checkpoint only moves the live HNSW
-        // shard onto disk; it cannot reduce the on-disk segment pkData/BLink
-        // footprint that {@link #estimatedMemoryUsageBytes()} (and the global
-        // budget) also count. With many on-disk segments that footprint alone
-        // can permanently exceed the 70% threshold, so without this guard the
-        // compaction loop fires a spurious, no-op Phase A every cycle even
-        // though live_node_count is 0.
-        if (getLiveNodeCount() == 0) {
+        // Issue #563: skip the trigger entirely when there are no in-memory
+        // vectors to checkpoint. A memory-pressure checkpoint only moves the
+        // in-memory HNSW shards onto disk; it cannot reduce the on-disk segment
+        // pkData/BLink footprint that {@link #estimatedMemoryUsageBytes()} (and
+        // the global budget) also count. With many on-disk segments that
+        // footprint alone can permanently exceed the 70% threshold, so without
+        // this guard the compaction loop fires a spurious, no-op Phase A every
+        // cycle even though there are 0 live vectors.
+        //
+        // The count spans live + frozen + deferred shards — the same shard set
+        // {@link #getLiveShardMemoryBytes()} measures — so a checkpoint that
+        // defers shards (parking un-persisted vectors in deferredShards) is not
+        // mistaken for an empty store.
+        if (liveFrozenDeferredNodeCount() == 0) {
             return false;
         }
         // Check global budget first (covers all stores sharing the same heap)
@@ -7906,6 +7911,39 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
         return totalLiveSize() + frozenCount;
+    }
+
+    /**
+     * Total number of in-memory vectors across the live, frozen, and deferred
+     * shards — every vector that a checkpoint could still flush to disk.
+     *
+     * <p>Differs from {@link #getLiveNodeCount()}, which omits
+     * {@code deferredShards} for historical diagnostic reasons. The
+     * memory-pressure checkpoint guard (issue #563) uses this fuller count so
+     * it stays consistent with {@link #getLiveShardMemoryBytes()}: a Phase A
+     * byte-cap deferral parks shards holding genuine un-persisted vectors in
+     * {@code deferredShards}, and those must not be mistaken for "nothing to
+     * checkpoint".
+     *
+     * <p>The three list reads are intentionally non-atomic — the value is a
+     * best-effort snapshot for the compaction loop, which re-evaluates the
+     * condition on every cycle.
+     */
+    int liveFrozenDeferredNodeCount() {
+        int count = totalLiveSize();
+        List<LiveGraphShard> frozen = frozenShards;
+        if (frozen != null) {
+            for (LiveGraphShard shard : frozen) {
+                count += shard.nodeToPk.size();
+            }
+        }
+        List<LiveGraphShard> deferred = deferredShards;
+        if (deferred != null) {
+            for (LiveGraphShard shard : deferred) {
+                count += shard.nodeToPk.size();
+            }
+        }
+        return count;
     }
 
     public int getOnDiskNodeCount() {

--- a/herddb-core/src/test/java/herddb/index/vector/MemoryPressureTriggerZeroLiveVectorsTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/MemoryPressureTriggerZeroLiveVectorsTest.java
@@ -29,6 +29,10 @@ import herddb.utils.Bytes;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import java.nio.file.Path;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -60,6 +64,25 @@ public class MemoryPressureTriggerZeroLiveVectorsTest {
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     private static final int DIM = 32;
+
+    private int savedMinLiveVectorsForCheckpoint;
+
+    /**
+     * Disable the min-live-vectors checkpoint gate so every explicit
+     * {@code checkpoint()} call in these tests runs immediately instead of
+     * being deferred (the gate would otherwise skip checkpoints whose live
+     * shard is below the threshold once at least one segment exists).
+     */
+    @Before
+    public void disableMinLiveVectorsGate() {
+        savedMinLiveVectorsForCheckpoint = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreMinLiveVectorsGate() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectorsForCheckpoint;
+    }
 
     private float[] randomVector(Random rng) {
         float[] v = new float[DIM];
@@ -208,6 +231,104 @@ public class MemoryPressureTriggerZeroLiveVectorsTest {
             assertEquals("estimatedMemoryUsageBytes must be live-shard memory plus"
                     + " the on-disk segment footprint",
                     live + onDisk, total);
+        }
+    }
+
+    private PersistentVectorStore createDeferralStore(Path tmpDir,
+            MemoryDataStorageManager dsm, MemoryManager mm) {
+        // maxLiveGraphSize=100 forces a fresh live shard every 100 vectors;
+        // maxLiveBytesPerCheckpoint=64 KiB forces Phase A to snapshot only the
+        // first shard and defer the rest into deferredShards.
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vector_col",
+                "vidx_uuid", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true /* fusedPQ */, 2_000_000_000L,
+                100 /* maxLiveGraphSize */,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Long.MAX_VALUE /* maxVectorMemoryBytes */, null /* budget */,
+                64 * 1024 /* maxLiveBytesPerCheckpoint */, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    /**
+     * Issue #563 review follow-up: the zero-live-vectors guard counts live +
+     * frozen + <em>deferred</em> shards (via {@code liveFrozenDeferredNodeCount()}),
+     * matching {@link PersistentVectorStore#getLiveShardMemoryBytes()}. When a
+     * Phase A byte-cap deferral parks un-persisted vectors in
+     * {@code deferredShards}, those must be counted — otherwise a future caller
+     * could mistake a deferral window for an empty store. The test also
+     * verifies the deferral path loses no vectors, including across a restart.
+     */
+    @Test(timeout = 120_000)
+    public void guardCountsDeferredShardsAndDeferralLosesNoVectors() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("deferred-shards").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        final int totalVectors = 600;
+
+        // Captured inside the Phase B hook, which runs on the checkpoint thread
+        // while Phase A's deferredShards are still populated (Phase C rejoins
+        // them only after Phase B completes).
+        AtomicBoolean deferralObservedAtHook = new AtomicBoolean(false);
+        AtomicInteger hookLiveNodeCount = new AtomicInteger(-1);
+        AtomicInteger hookLiveFrozenDeferredCount = new AtomicInteger(-1);
+
+        try (PersistentVectorStore store = createDeferralStore(tmpDir, dsm, mm)) {
+            store.start();
+            store.setCheckpointPhaseBHook(() -> {
+                if (store.getCurrentDeferredVectors() > 0) {
+                    deferralObservedAtHook.set(true);
+                    hookLiveNodeCount.set(store.getLiveNodeCount());
+                    hookLiveFrozenDeferredCount.set(store.liveFrozenDeferredNodeCount());
+                }
+            });
+
+            Random rng = new Random(123);
+            for (int i = 0; i < totalVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng));
+            }
+
+            store.checkpoint();
+
+            // The 64 KiB per-checkpoint byte cap must have forced a deferral.
+            assertTrue("the small per-checkpoint byte cap must force a Phase A deferral",
+                    store.getDeferralEvents() > 0);
+            assertTrue("the Phase B hook must have observed populated deferred shards",
+                    deferralObservedAtHook.get());
+            // The decisive guard-consistency assertion: while deferredShards
+            // held un-persisted vectors, liveFrozenDeferredNodeCount() (used by
+            // the issue #563 guard) counted them — getLiveNodeCount(), which
+            // omits deferred shards, reported strictly fewer.
+            assertTrue("liveFrozenDeferredNodeCount must include the deferred"
+                    + " shards that getLiveNodeCount omits (live+frozen="
+                    + hookLiveNodeCount.get() + ", live+frozen+deferred="
+                    + hookLiveFrozenDeferredCount.get() + ")",
+                    hookLiveFrozenDeferredCount.get() > hookLiveNodeCount.get());
+
+            // No vector is lost across the deferral: the deferred shards were
+            // rejoined into liveShards, so the store still holds every vector.
+            assertEquals("a deferral must not drop any vector",
+                    totalVectors, store.size());
+
+            // Drain every remaining (previously deferred) live vector to disk.
+            int guard = 0;
+            while (store.getLiveNodeCount() > 0 && guard++ < 50) {
+                store.checkpoint();
+            }
+            assertEquals("repeated checkpoints must flush every deferred vector",
+                    0, store.getLiveNodeCount());
+            assertEquals("every vector must end up on disk", totalVectors,
+                    store.getOnDiskNodeCount());
+        }
+
+        // Restart against the same storage: every vector must survive the
+        // deferral + checkpoint cycle.
+        try (PersistentVectorStore reloaded = createDeferralStore(tmpDir, dsm, mm)) {
+            reloaded.start();
+            assertEquals("no vector may be lost across deferral + restart",
+                    totalVectors, reloaded.size());
         }
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/MemoryPressureTriggerZeroLiveVectorsTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/MemoryPressureTriggerZeroLiveVectorsTest.java
@@ -1,0 +1,213 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #563.
+ *
+ * <p>Before the fix, {@link PersistentVectorStore#shouldTriggerMemoryPressureCheckpoint()}
+ * compared the <em>total</em> estimated memory — which includes the in-memory
+ * footprint of every on-disk {@link VectorSegment} (pkData/pkOffsets/pkLengths
+ * arrays + the BLink pk-to-ordinal tree) — against the live-vector memory
+ * limit. Once enough segments accumulated, that on-disk footprint alone
+ * permanently exceeded the 70% early-checkpoint threshold, so the compaction
+ * loop fired a spurious, no-op Phase A every second even though
+ * {@code live_node_count} was 0.
+ *
+ * <p>The fix adds a guard: when there are no live vectors a memory-pressure
+ * checkpoint is a no-op (it cannot reduce the on-disk segment footprint), so
+ * the trigger is suppressed. It also fixes
+ * {@link PersistentVectorStore#getLiveVectorsMemoryBytes()} so the
+ * {@code live_vectors_memory_bytes} diagnostic field reports only the
+ * live/frozen/deferred shard footprint, with the on-disk segment footprint
+ * surfaced separately via
+ * {@link PersistentVectorStore#getOnDiskSegmentsEstimatedMemoryBytes()}.
+ */
+public class MemoryPressureTriggerZeroLiveVectorsTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static final int DIM = 32;
+
+    private float[] randomVector(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * A global budget that always reports the index is above the 70%
+     * early-checkpoint threshold — exactly the steady state the issue
+     * describes once 150+ on-disk segments have accumulated — while reporting
+     * that hard ingestion back-pressure is NOT active, so {@code addVector}
+     * never blocks and the test stays deterministic.
+     */
+    private static final class AlwaysAboveThresholdBudget implements VectorMemoryBudget {
+        @Override
+        public long totalEstimatedMemoryUsageBytes() {
+            return 1_925_744_608L;
+        }
+
+        @Override
+        public long maxMemoryBytes() {
+            return 2_126_008_811L;
+        }
+
+        @Override
+        public boolean isMemoryPressureActive() {
+            // No hard back-pressure: addVector must never block in this test.
+            return false;
+        }
+
+        @Override
+        public boolean isAboveThreshold(double fraction) {
+            // Always above the early-checkpoint threshold.
+            return true;
+        }
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, VectorMemoryBudget budget) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        // compactionIntervalMs = Long.MAX_VALUE: the background compaction loop
+        // parks immediately and the test drives checkpoints explicitly.
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vector_col",
+                "vidx_uuid", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true /* fusedPQ */, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Long.MAX_VALUE /* maxVectorMemoryBytes */, budget, 0, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    /**
+     * The core issue #563 assertion: with the global budget permanently above
+     * the early-checkpoint threshold, the trigger must still fire while there
+     * are live vectors to checkpoint, but must be suppressed once a checkpoint
+     * has drained the live shard ({@code live_node_count == 0}).
+     */
+    @Test(timeout = 120_000)
+    public void triggerSuppressedWhenZeroLiveVectorsButFiresWithLiveVectors() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("trigger-guard").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir, new AlwaysAboveThresholdBudget())) {
+            store.start();
+
+            // Empty store: nothing to checkpoint, so no trigger.
+            assertEquals(0, store.getLiveNodeCount());
+            assertFalse("an empty store must not trigger an early checkpoint",
+                    store.shouldTriggerMemoryPressureCheckpoint());
+
+            // Add live vectors. The budget reports over-threshold, so the
+            // trigger MUST fire — the guard must not suppress a legitimate
+            // early checkpoint.
+            Random rng = new Random(42);
+            for (int i = 0; i < 600; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng));
+            }
+            assertTrue("live vectors must be present before checkpoint",
+                    store.getLiveNodeCount() > 0);
+            assertTrue("with live vectors and an over-threshold budget the"
+                    + " memory-pressure trigger must fire",
+                    store.shouldTriggerMemoryPressureCheckpoint());
+
+            // Checkpoint drains the live shard onto disk.
+            store.checkpoint();
+            assertEquals("checkpoint must drain every live vector",
+                    0, store.getLiveNodeCount());
+            assertTrue("checkpoint must have produced on-disk segment memory",
+                    store.getOnDiskSegmentsEstimatedMemoryBytes() > 0);
+
+            // Issue #563: the budget is STILL over threshold (the on-disk
+            // segment footprint never shrinks), but there are 0 live vectors,
+            // so a checkpoint would be a no-op — the trigger must be suppressed.
+            assertFalse("with 0 live vectors the memory-pressure trigger must be"
+                    + " suppressed even when the global budget is over threshold",
+                    store.shouldTriggerMemoryPressureCheckpoint());
+        }
+    }
+
+    /**
+     * Verifies that {@link PersistentVectorStore#getLiveVectorsMemoryBytes()}
+     * reports only the live/frozen/deferred shard footprint and excludes the
+     * on-disk segment footprint, which is surfaced separately. Before the fix
+     * it delegated to {@code estimatedMemoryUsageBytes()} and so reported the
+     * full total — making {@code live_vectors_memory_bytes} misleadingly large
+     * (gigabytes of "live" memory with {@code live_node_count == 0}).
+     */
+    @Test(timeout = 120_000)
+    public void liveVectorsMemoryExcludesOnDiskSegmentFootprint() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("live-mem-accounting").toPath();
+        // No budget + unlimited per-store limit: no back-pressure and no
+        // spurious background checkpoints, so the test is deterministic.
+        try (PersistentVectorStore store = createStore(tmpDir, null)) {
+            store.start();
+
+            Random rng = new Random(7);
+            for (int i = 0; i < 600; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng));
+            }
+
+            // Before checkpoint: every vector is live; the on-disk estimate is 0.
+            assertEquals("no on-disk segments before the first checkpoint",
+                    0, store.getOnDiskSegmentsEstimatedMemoryBytes());
+            assertEquals("getLiveVectorsMemoryBytes must equal getLiveShardMemoryBytes",
+                    store.getLiveShardMemoryBytes(), store.getLiveVectorsMemoryBytes());
+
+            store.checkpoint();
+
+            assertEquals("checkpoint must drain every live vector",
+                    0, store.getLiveNodeCount());
+
+            long live = store.getLiveVectorsMemoryBytes();
+            long onDisk = store.getOnDiskSegmentsEstimatedMemoryBytes();
+            long total = store.estimatedMemoryUsageBytes();
+
+            assertTrue("checkpoint must produce on-disk segment memory, got " + onDisk,
+                    onDisk > 0);
+            assertEquals("getLiveVectorsMemoryBytes must report only the live"
+                    + " shard footprint", store.getLiveShardMemoryBytes(), live);
+            // The decisive check: estimatedMemoryUsageBytes() == live + on-disk.
+            // Before the fix getLiveVectorsMemoryBytes() == estimatedMemoryUsageBytes(),
+            // so this equality (with onDisk > 0) could not hold.
+            assertEquals("estimatedMemoryUsageBytes must be live-shard memory plus"
+                    + " the on-disk segment footprint",
+                    live + onDisk, total);
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -3827,6 +3827,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.segmentCount = pvs.getSegmentCount();
             d.liveShardCount = pvs.getLiveShardCount();
             d.liveVectorsMemoryBytes = pvs.getLiveVectorsMemoryBytes();
+            d.ondiskSegmentMemoryBytes = pvs.getOnDiskSegmentsEstimatedMemoryBytes();
             d.onDiskSizeBytes = pvs.getEstimatedSizeBytes();
             d.dirty = pvs.isDirty();
             d.fusedPQEnabled = pvs.isFusedPQEnabled();
@@ -5272,6 +5273,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         public int liveShardCount;
         public long estimatedMemoryBytes;
         public long liveVectorsMemoryBytes;
+        // Issue #563: in-memory footprint of the on-disk VectorSegment objects
+        // (pkData/pkOffsets/pkLengths arrays + BLink pk-to-ordinal trees).
+        // Reported separately from liveVectorsMemoryBytes so operators can tell
+        // genuine live-vector memory apart from on-disk segment overhead.
+        public long ondiskSegmentMemoryBytes;
         public long onDiskSizeBytes;
         public boolean dirty;
         // In-memory tailer position; diagnostic only. See IndexStatusInfo.

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -347,6 +347,7 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setLiveShardCount(details.liveShardCount)
                     .setEstimatedMemoryBytes(details.estimatedMemoryBytes)
                     .setLiveVectorsMemoryBytes(details.liveVectorsMemoryBytes)
+                    .setOndiskSegmentMemoryBytes(details.ondiskSegmentMemoryBytes)
                     .setOndiskSizeBytes(details.onDiskSizeBytes)
                     .setDirty(details.dirty)
                     .setTailerLsnLedger(details.tailerLsnLedger)

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -511,6 +511,7 @@ public final class IndexingAdminCli {
         m.put("live_shard_count", r.getLiveShardCount());
         m.put("estimated_memory_bytes", r.getEstimatedMemoryBytes());
         m.put("live_vectors_memory_bytes", r.getLiveVectorsMemoryBytes());
+        m.put("ondisk_segment_memory_bytes", r.getOndiskSegmentMemoryBytes());
         m.put("ondisk_size_bytes", r.getOndiskSizeBytes());
         m.put("dirty", r.getDirty());
         m.put("tailer_lsn_ledger", r.getTailerLsnLedger());

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -196,6 +196,13 @@ message DescribeIndexResponse {
     // Issue #451 — exposed so operators can verify what sharding configuration
     // an index is actually running with from the admin CLI.
     int32 num_shards = 30;
+    // In-memory footprint of the on-disk VectorSegment objects: the
+    // pkData/pkOffsets/pkLengths arrays plus the BLink pk-to-ordinal trees,
+    // snapshotted at segment registration time. Reported separately from
+    // live_vectors_memory_bytes (issue #563) so operators can distinguish
+    // genuine live-vector heap from on-disk segment overhead — the latter
+    // grows with segment_count and does not shrink on checkpoint.
+    int64 ondisk_segment_memory_bytes = 31;
 }
 
 message ListPrimaryKeysRequest {


### PR DESCRIPTION
Fixes #563.

## Root cause

`PersistentVectorStore.shouldTriggerMemoryPressureCheckpoint()` compared the
*total* estimated memory against the live-vector memory limit. That total —
via `estimatedMemoryUsageBytes()` — includes the in-memory footprint of every
on-disk `VectorSegment` (the `pkData`/`pkOffsets`/`pkLengths` arrays plus the
BLink pk-to-ordinal tree, tracked in `onDiskSegmentsEstimatedMemoryBytes`).

Once 150+ on-disk segments accumulated, that on-disk footprint alone (~1.93
GiB) permanently exceeded 70% of the configured global limit (~2.13 GiB), so
the compaction loop fired a spurious, no-op Phase A every second even though
`live_node_count` was 0 — wasting CPU/IO and slowing long compactions.

A memory-pressure checkpoint only snapshots the in-memory HNSW shards onto
disk; it cannot shrink the on-disk segment footprint, so once the live shards
are empty the trigger can only ever produce no-ops.

## Changes

- **`PersistentVectorStore.java`**: add a guard at the top of
  `shouldTriggerMemoryPressureCheckpoint()` — when there are no in-memory
  vectors the trigger is suppressed (a checkpoint would be a no-op). The guard
  uses a new `liveFrozenDeferredNodeCount()` helper spanning live + frozen +
  **deferred** shards, the same shard set as `getLiveShardMemoryBytes()`, so a
  Phase A byte-cap deferral that parks un-persisted vectors in `deferredShards`
  is never mistaken for an empty store. Add `getLiveShardMemoryBytes()`
  (live/frozen/deferred shard footprint only, excluding on-disk segments) and
  fix `getLiveVectorsMemoryBytes()` to use it, so the `live_vectors_memory_bytes`
  diagnostic no longer reports gigabytes of "live" memory with 0 live vectors.
  The trigger method is now package-private for whitebox testing.
- **`indexing_service.proto`**: add `ondisk_segment_memory_bytes = 31` to
  `DescribeIndexResponse` (backward-compatible proto3 field).
- **`IndexingServiceEngine.java`**: add `ondiskSegmentMemoryBytes` to
  `IndexDetails`, populated from `getOnDiskSegmentsEstimatedMemoryBytes()`.
- **`IndexingServiceImpl.java`**: surface the new field in the describe-index
  response.
- **`IndexingAdminCli.java`**: print `ondisk_segment_memory_bytes` in
  `describe-index` output.

## Tests

New `herddb.index.vector.MemoryPressureTriggerZeroLiveVectorsTest`:
- `triggerSuppressedWhenZeroLiveVectorsButFiresWithLiveVectors` — with a
  global budget permanently over the 70% threshold, the trigger still fires
  while live vectors are present, but is suppressed once a checkpoint drains
  the live shard.
- `liveVectorsMemoryExcludesOnDiskSegmentFootprint` — after checkpoint,
  `estimatedMemoryUsageBytes() == getLiveVectorsMemoryBytes() +
  getOnDiskSegmentsEstimatedMemoryBytes()` with a non-zero on-disk footprint
  (this equality could not hold before the fix).
- `guardCountsDeferredShardsAndDeferralLosesNoVectors` — forces a Phase A
  byte-cap deferral, asserts via the Phase B hook that
  `liveFrozenDeferredNodeCount()` counts the deferred shards that
  `getLiveNodeCount()` omits, and verifies the deferral loses no vectors
  including across a restart.

Regression-checked existing vector-index checkpoint/diagnostics suites —
`OnDiskSegmentMemoryAccountingTest`, `PersistentVectorStoreEstimatedMemoryCounterTest`,
`AsyncCheckpointTriggerTest`, `IndexingServiceDiagnosticsGrpcTest`,
`PersistentVectorStoreConcurrentCheckpointTest`, `PersistentVectorStoreLifecycleTest`,
`CheckpointAndSaveWatermarkTest` — all green.

Hammer suites (per `CLAUDE.md`, this change touches the checkpoint pipeline):
- `DirectMultipleConcurrentUpdatesSuiteNoIndexesTest`,
  `DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest`,
  `DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest` — 12/12 green.
- `BLinkConcurrentSearchInsertTest` — green.

🤖 Implemented by the `pr-worker` agent.