### PR TITLE
issue #562: defer checkpoint during segment-count back-pressure to stop micro-segment growth

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -186,13 +186,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * ingest has stopped mid-shard (issue #90).
      *
      * <p>Initialized from system property
-     * {@code herddb.vectorindex.maxCheckpointDeferralMs}. Default: 60 s.
+     * {@code herddb.vectorindex.maxCheckpointDeferralMs}. Default: 10 min
+     * (600 s) — wide enough to cover one full segment-count back-pressure
+     * safety-timeout cycle ({@code compactionBackpressureMaxWaitMs}, default
+     * 5 min) so a single timeout no longer forces a micro-segment checkpoint
+     * (issue #562).
      * Non-final to let unit tests override after class load; production
      * code should only read, never write.
      */
     public static volatile long maxCheckpointDeferralMs =
             Math.max(0L, Long.getLong(
-                    "herddb.vectorindex.maxCheckpointDeferralMs", 60_000L));
+                    "herddb.vectorindex.maxCheckpointDeferralMs", 600_000L));
 
     /**
      * How many Phase B segment builds may run concurrently. Each parallel
@@ -554,11 +558,23 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private final Object vectorIndexCompactionWakeup = new Object();
     private volatile boolean vectorIndexCompactionWakeupPending;
 
+    /**
+     * Default minimum number of candidate segments a compaction run must be
+     * able to pick before the byte-threshold trigger fires. Configurable via
+     * system property {@code herddb.vectorindex.compactionMinCount} (issue
+     * #562); clamped to a minimum of 1. {@link herddb.indexing.IndexingServiceEngine}
+     * passes this constant to {@link #configureCompaction} so the property
+     * takes effect in production deployments.
+     */
+    public static final int DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT =
+            Math.max(1, Integer.getInteger(
+                    "herddb.vectorindex.compactionMinCount", 4));
+
     /** Compaction policy knobs — defaults match IndexingServerConfiguration. */
     private volatile long vectorIndexCompactionIntervalMs = 5L * 60_000L;
     private volatile long vectorIndexCompactionMinBytes = 256L * 1024 * 1024;
     private volatile long vectorIndexCompactionMaxBytes = 1024L * 1024 * 1024;
-    private volatile int vectorIndexCompactionMinCount = 4;
+    private volatile int vectorIndexCompactionMinCount = DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT;
     /**
      * Count-based compaction trigger (issue #285): fire compaction when the
      * segment count reaches this ceiling, even if the total-byte threshold
@@ -4909,6 +4925,41 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // left behind by stopped ingest is guaranteed to flush.
             int minLiveGate = minLiveVectorsForCheckpoint;
             long deferralBoundMs = maxCheckpointDeferralMs;
+
+            // Segment-count back-pressure deferral gate (issue #562).
+            //
+            // When the segment count already exceeds the back-pressure
+            // threshold, checkpointing a tiny live shard would seal those few
+            // vectors into a new on-disk micro-segment (e.g. 3 nodes),
+            // incrementing the segment count and making back-pressure WORSE.
+            // Such micro-segments are far below vectorIndexCompactionMinBytes
+            // so tiered compaction never selects them and they accumulate
+            // unboundedly throughout a long compaction cycle.
+            //
+            // While above the threshold we therefore defer UNCONDITIONALLY
+            // (ignoring the time-bounded deferralBoundMs): the trickle of
+            // vectors released by the back-pressure safety timeout can safely
+            // wait in the live shard until compaction drains the segment count
+            // back below the threshold, at which point the time-bounded gate
+            // below resumes governing the flush. The live shard stays bounded
+            // by maxLiveGraphSize rotation, and the memory-pressure escape
+            // hatch still forces a checkpoint if heap is genuinely tight.
+            if (minLiveGate > 0
+                    && totalLiveVectors < minLiveGate
+                    && !anySegmentDirty
+                    && !segments.isEmpty()
+                    && !shouldTriggerMemoryPressureCheckpoint()
+                    && segments.size() > compactionBackpressureThreshold) {
+                LOGGER.log(Level.INFO,
+                        "checkpoint {0}: deferred during segment-count back-pressure "
+                                + "({1} live vectors < {2} threshold, {3} segments > "
+                                + "back-pressure threshold {4}) — avoiding micro-segment creation",
+                        new Object[]{indexName, totalLiveVectors, minLiveGate,
+                                segments.size(), compactionBackpressureThreshold});
+                totalCheckpointsDeferred.incrementAndGet();
+                return false;
+            }
+
             if (minLiveGate > 0
                     && totalLiveVectors < minLiveGate
                     && !anySegmentDirty
@@ -7925,6 +7976,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public long getMaxSegmentSize() {
         return maxSegmentSize;
+    }
+
+    /**
+     * Returns the current minimum candidate-segment count for the byte-threshold
+     * compaction trigger. Defaults to {@link #DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT}
+     * unless overridden by {@link #configureCompaction} (issue #562).
+     */
+    public int getVectorIndexCompactionMinCount() {
+        return vectorIndexCompactionMinCount;
     }
 
     public long getEstimatedSizeBytes() {

--- a/herddb-core/src/test/java/herddb/index/vector/Issue562BackpressureMicroSegmentTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue562BackpressureMicroSegmentTest.java
@@ -1,0 +1,245 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for issue #562: the segment-count back-pressure safety timeout used to
+ * let a small trickle of vectors (one per blocked tailer thread) slip through
+ * every {@code compactionBackpressureMaxWaitMs}; the next checkpoint then sealed
+ * those few vectors into a brand-new on-disk micro-segment (e.g. 3 nodes). Those
+ * micro-segments are far below {@code vectorIndexCompactionMinBytes}, so tiered
+ * compaction never selects them and the segment count grows unboundedly
+ * throughout a long compaction cycle.
+ *
+ * <p>The fix adds an unconditional deferral gate to {@code doCheckpointUnderLock}:
+ * while the on-disk segment count exceeds the back-pressure threshold and the
+ * live shard holds fewer than {@code minLiveVectorsForCheckpoint} vectors, the
+ * checkpoint is deferred regardless of the time-bounded {@code maxCheckpointDeferralMs}.
+ * The trickle waits in the live shard until compaction drains the segment count
+ * back below the threshold.
+ *
+ * <p>This class also covers the companion change that makes the compaction
+ * {@code minCount} configurable via the {@code herddb.vectorindex.compactionMinCount}
+ * system property.
+ */
+public class Issue562BackpressureMicroSegmentTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    /** Saved originals so {@code @After} restores without hard-coding constants. */
+    private int savedMinLiveVectorsForCheckpoint;
+    private long savedMaxCheckpointDeferralMs;
+
+    @Before
+    public void saveStatics() {
+        savedMinLiveVectorsForCheckpoint = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        savedMaxCheckpointDeferralMs = PersistentVectorStore.maxCheckpointDeferralMs;
+    }
+
+    @After
+    public void restoreStatics() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectorsForCheckpoint;
+        PersistentVectorStore.maxCheckpointDeferralMs = savedMaxCheckpointDeferralMs;
+    }
+
+    private static final int DIM = 8;
+
+    private static float[] randomVector(Random rng) {
+        float[] v = new float[DIM];
+        for (int d = 0; d < DIM; d++) {
+            v[d] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    /**
+     * Builds a store with automatic compaction disabled (the test drives
+     * checkpoints manually) and tiered compaction off.
+     */
+    private PersistentVectorStore newStore(Path tmpDir, String name) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                name, "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        // Never auto-select compaction candidates: the test never wants the
+        // background loop to mutate the segment count under it.
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ Long.MAX_VALUE,
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ Integer.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE,
+                /*retentionMs*/ 0);
+        store.setTieredCompactionEnabled(false);
+        return store;
+    }
+
+    /**
+     * Builds {@code threshold + 1} sealed on-disk segments by inserting a batch
+     * of vectors and checkpointing, with the deferral gate disabled so every
+     * checkpoint actually seals a segment.
+     *
+     * @return the segment count after the build (always {@code > threshold}).
+     */
+    private int buildSegmentsAboveThreshold(PersistentVectorStore store, int threshold,
+                                            Random rng) throws Exception {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+        for (int c = 0; c <= threshold; c++) {
+            for (int i = 0; i < 60; i++) {
+                store.addVector(Bytes.from_int(c * 1_000 + i), randomVector(rng));
+            }
+            store.checkpoint();
+        }
+        int segs = store.getSegmentCount();
+        assertTrue("setup must build more than " + threshold + " segments; got " + segs,
+                segs > threshold);
+        return segs;
+    }
+
+    /**
+     * The core regression: while the segment count exceeds the back-pressure
+     * threshold, checkpointing a tiny live shard (the trickle released by the
+     * safety timeout) must be deferred — no micro-segment may be created.
+     */
+    @Test(timeout = 120_000)
+    public void checkpointDeferredDuringSegmentCountBackpressure() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue562-defer").toPath();
+        int threshold = 5;
+        try (PersistentVectorStore store = newStore(tmpDir, "issue562a")) {
+            store.start();
+            Random rng = new Random(562_1);
+
+            // Back-pressure disabled while we build the baseline segments so the
+            // setup inserts never block.
+            store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+            int segs = buildSegmentsAboveThreshold(store, threshold, rng);
+
+            // Re-enable the deferral gate and inject a tiny trickle of vectors —
+            // mimics the ~3 vectors released by the back-pressure safety timeout.
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 1_000;
+            for (int i = 0; i < 3; i++) {
+                store.addVector(Bytes.from_int(900_000 + i), randomVector(rng));
+            }
+
+            // Enter segment-count back-pressure and checkpoint. The fix must
+            // defer it: no new micro-segment, and the deferral counter ticks.
+            store.setCompactionBackpressureThreshold(threshold);
+            long deferredBefore = store.getTotalCheckpointsDeferred();
+
+            boolean ran = store.checkpoint();
+
+            assertFalse("checkpoint must be deferred while above the back-pressure threshold",
+                    ran);
+            assertEquals("no micro-segment may be created during back-pressure",
+                    segs, store.getSegmentCount());
+            assertEquals("the deferral counter must record the skipped checkpoint",
+                    deferredBefore + 1, store.getTotalCheckpointsDeferred());
+        }
+    }
+
+    /**
+     * Once compaction relieves back-pressure (segment count no longer exceeds
+     * the threshold) the unconditional gate must release and the normal,
+     * time-bounded deferral resumes — the pending trickle is sealed.
+     */
+    @Test(timeout = 120_000)
+    public void checkpointResumesWhenBackpressureRelieved() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue562-resume").toPath();
+        int threshold = 5;
+        try (PersistentVectorStore store = newStore(tmpDir, "issue562b")) {
+            store.start();
+            Random rng = new Random(562_2);
+
+            store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+            int segs = buildSegmentsAboveThreshold(store, threshold, rng);
+
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 1_000;
+            for (int i = 0; i < 3; i++) {
+                store.addVector(Bytes.from_int(900_000 + i), randomVector(rng));
+            }
+
+            // While above the threshold the checkpoint is deferred.
+            store.setCompactionBackpressureThreshold(threshold);
+            assertFalse("checkpoint must be deferred while above the threshold",
+                    store.checkpoint());
+            assertEquals("no micro-segment may be created during back-pressure",
+                    segs, store.getSegmentCount());
+
+            // Simulate compaction relieving back-pressure: raise the threshold so
+            // the segment count no longer exceeds it. The unconditional gate must
+            // release; with the time-bounded deferral disabled the checkpoint now
+            // runs and seals the pending trickle into exactly one segment.
+            store.setCompactionBackpressureThreshold(1_000);
+            PersistentVectorStore.maxCheckpointDeferralMs = 0;
+
+            boolean ran = store.checkpoint();
+
+            assertTrue("checkpoint must run once back-pressure is relieved", ran);
+            assertEquals("the pending trickle must now be sealed into one segment",
+                    segs + 1, store.getSegmentCount());
+        }
+    }
+
+    /**
+     * The compaction {@code minCount} is now sourced from the
+     * {@code herddb.vectorindex.compactionMinCount} system property via
+     * {@link PersistentVectorStore#DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT}.
+     * With the property unset it falls back to {@code 4}, and a freshly built
+     * store (no {@code configureCompaction} call) must adopt that constant.
+     */
+    @Test(timeout = 60_000)
+    public void compactionMinCountDefaultsToConfigurableConstant() throws Exception {
+        assertEquals("default compactionMinCount must be 4 when the system property is unset",
+                4, PersistentVectorStore.DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT);
+
+        Path tmpDir = tmpFolder.newFolder("issue562-mincount").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        try (PersistentVectorStore store = new PersistentVectorStore(
+                "issue562c", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE)) {
+            // No configureCompaction() call — the field default must come from
+            // the configurable constant.
+            assertEquals("the vectorIndexCompactionMinCount field must default to the constant",
+                    PersistentVectorStore.DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT,
+                    store.getVectorIndexCompactionMinCount());
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/Issue562BackpressureMicroSegmentTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue562BackpressureMicroSegmentTest.java
@@ -25,8 +25,10 @@ import static org.junit.Assert.assertTrue;
 import herddb.core.MemoryManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import java.nio.file.Path;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -212,6 +214,83 @@ public class Issue562BackpressureMicroSegmentTest {
             assertTrue("checkpoint must run once back-pressure is relieved", ran);
             assertEquals("the pending trickle must now be sealed into one segment",
                     segs + 1, store.getSegmentCount());
+        }
+    }
+
+    /**
+     * Escape-hatch regression guard: the new back-pressure deferral gate must
+     * NOT swallow a checkpoint that {@code shouldTriggerMemoryPressureCheckpoint()}
+     * demands. Even while the segment count exceeds the back-pressure threshold
+     * and the live shard is tiny, an active memory-pressure signal must still
+     * force the checkpoint through — deferring it then would let heap grow
+     * unbounded, a worse failure than a micro-segment.
+     */
+    @Test(timeout = 120_000)
+    public void memoryPressureForcesCheckpointAboveBackpressureThreshold() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue562-mempressure").toPath();
+        int threshold = 5;
+
+        // Budget whose memory-pressure signal is flipped on only for the final
+        // checkpoint. While off it reports zero usage, so the background
+        // compaction loop stays parked during setup; while on it reports
+        // above-the-0.7-threshold-but-not-pressure-active, so
+        // shouldTriggerMemoryPressureCheckpoint() is true yet addVector never
+        // blocks on memory back-pressure.
+        AtomicBoolean memoryPressure = new AtomicBoolean(false);
+        VectorMemoryBudget budget = new VectorMemoryBudget() {
+            @Override
+            public long totalEstimatedMemoryUsageBytes() {
+                return memoryPressure.get() ? 80L : 0L;
+            }
+
+            @Override
+            public long maxMemoryBytes() {
+                return 100L;
+            }
+        };
+
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        try (PersistentVectorStore store = new PersistentVectorStore(
+                "issue562d", "testtable", "tstblspace", "vec", "issue562d_uuid",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN,
+                /*maxVectorMemoryBytes*/ Long.MAX_VALUE,
+                budget,
+                /*maxLiveBytesPerCheckpoint*/ 0,
+                /*segmentPageCacheMaxBytes*/ 0)) {
+            store.configureCompaction(
+                    /*intervalMs*/ Long.MAX_VALUE,
+                    /*minBytes*/ Long.MAX_VALUE,
+                    /*maxBytes*/ Long.MAX_VALUE,
+                    /*minCount*/ Integer.MAX_VALUE,
+                    /*maxCount*/ Integer.MAX_VALUE,
+                    /*retentionMs*/ 0);
+            store.setTieredCompactionEnabled(false);
+            store.start();
+            Random rng = new Random(562_4);
+
+            store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+            int segs = buildSegmentsAboveThreshold(store, threshold, rng);
+
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 1_000;
+            for (int i = 0; i < 3; i++) {
+                store.addVector(Bytes.from_int(900_000 + i), randomVector(rng));
+            }
+
+            // Above the back-pressure threshold AND under memory pressure: the
+            // escape hatch must win — the checkpoint runs despite the tiny shard.
+            store.setCompactionBackpressureThreshold(threshold);
+            memoryPressure.set(true);
+
+            boolean ran = store.checkpoint();
+
+            assertTrue("memory pressure must force the checkpoint through the "
+                    + "back-pressure deferral gate", ran);
+            assertEquals("the trickle must be sealed when memory pressure overrides "
+                    + "the back-pressure gate", segs + 1, store.getSegmentCount());
         }
     }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -903,7 +903,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         vectorCompactionIntervalMs,
                         vectorCompactionMinBytes,
                         vectorCompactionMaxBytes,
-                        /*minCount*/ 4,
+                        /*minCount*/ PersistentVectorStore.DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT,
                         vectorCompactionMaxCount,
                         vectorCompactionRetentionMs);
                 store.setTieredCompactionEnabled(vectorCompactionTieredEnabled);


### PR DESCRIPTION
Fixes #562.

## Problem
When the segment-count back-pressure safety timeout fires (every
`compactionBackpressureMaxWaitMs`, default 300 s), the blocked tailer
threads are released and insert a few vectors (~3). The next checkpoint's
Phase B sealed those few vectors into a brand-new 3-node on-disk
micro-segment. Because such micro-segments are far below
`vectorIndexCompactionMinBytes` (256 MB), tiered compaction never selects
them, so the segment count grew by 1 every cycle and never came back
down — driving runaway segment/memory growth during multi-hour
compaction cycles.

The existing `minLiveVectorsForCheckpoint` deferral gate failed to stop
this because its time bound (`maxCheckpointDeferralMs`, default 60 s) is
much shorter than the 300 s safety-timeout interval, so it always
released.

## Changes
- `PersistentVectorStore.doCheckpointUnderLock()`: add an unconditional
  deferral gate — while the segment count exceeds the back-pressure
  threshold and the live shard holds fewer than `minLiveVectorsForCheckpoint`
  vectors, the checkpoint is deferred regardless of `maxCheckpointDeferralMs`.
  The trickle waits in the live shard until compaction drains the segment
  count below the threshold; memory-pressure and `dirty`-segment escape
  hatches still force a checkpoint when genuinely needed.
- `PersistentVectorStore.maxCheckpointDeferralMs`: default raised
  60 s → 600 s so one full back-pressure safety-timeout cycle no longer
  outlasts the time-bounded gate.
- `PersistentVectorStore`: the compaction `minCount` is now configurable
  via the new `herddb.vectorindex.compactionMinCount` system property,
  exposed as `DEFAULT_VECTOR_INDEX_COMPACTION_MIN_COUNT` and wired into
  `IndexingServiceEngine.configureCompaction(...)` (was hardcoded `4`).
- New getter `getVectorIndexCompactionMinCount()`.

## Tests
- New `Issue562BackpressureMicroSegmentTest`:
  - `checkpointDeferredDuringSegmentCountBackpressure` — a checkpoint with
    a tiny live shard is deferred (no micro-segment, deferral counter
    increments) while above the back-pressure threshold.
  - `checkpointResumesWhenBackpressureRelieved` — once the threshold is no
    longer exceeded the gate releases and the pending trickle is sealed
    into exactly one segment.
  - `compactionMinCountDefaultsToConfigurableConstant` — verifies the new
    system-property-backed default (4) is adopted by a fresh store.
- Regression: `Issue354SegmentCountBackpressureTest`,
  `Issue370BackpressureDeadlockTest`, `Issue285SegmentCountCompactionTest`,
  `PqCodebookCacheTest` all pass.
- Concurrency hammer suites green (twice): every
  `DirectMultipleConcurrentUpdatesSuite` subclass and
  `BLinkConcurrentSearchInsertTest`.

🤖 Implemented by the `pr-worker` agent.