### PR TITLE
issue #567: opt-in jvector OnDiskParallelGraphIndexWriter for vector graph writes

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/GraphWriterFactory.java
+++ b/herddb-core/src/main/java/herddb/index/vector/GraphWriterFactory.java
@@ -1,0 +1,161 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.OnDiskParallelGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.RandomAccessOnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Chooses the jvector on-disk graph writer for the single-graph vector write
+ * sites ({@code PersistentVectorStore.writeFusedPQGraphToTempFile()} and
+ * {@code RemoteSegmentGraphMerger.writeGraph()}).
+ *
+ * <p>By default HerdDB serializes graphs with the <em>sequential</em>
+ * {@link OnDiskGraphIndexWriter}. When the opt-in flag is enabled and the graph
+ * is large enough, this factory instead returns jvector's
+ * {@link OnDiskParallelGraphIndexWriter}, which writes L0 node records
+ * concurrently via an internal worker pool and an {@code AsynchronousFileChannel}.
+ *
+ * <p>The parallel L0 write path is annotated {@code @Experimental} in jvector,
+ * so it stays off by default until validated in benchmarks. Both writers extend
+ * {@link RandomAccessOnDiskGraphIndexWriter} and share the same {@code write},
+ * {@code writeHeader} and {@code close} API, so they are drop-in replacements.
+ *
+ * <p>This factory is intentionally not applied to the Phase B per-shard write
+ * ({@code writeShardAsFusedPQSegment}): Phase B already runs several shard
+ * writers concurrently, so a parallel writer there would oversubscribe the CPU.
+ */
+final class GraphWriterFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(GraphWriterFactory.class.getName());
+
+    /**
+     * Master enable for the parallel writer. System property
+     * {@code herddb.vectorindex.parallelGraphWrite}; default {@code false}.
+     */
+    static final boolean PARALLEL_GRAPH_WRITE =
+            Boolean.getBoolean("herddb.vectorindex.parallelGraphWrite");
+
+    /**
+     * Only graphs with at least this many nodes are written with the parallel
+     * writer; smaller graphs do not amortize the worker-pool setup cost. System
+     * property {@code herddb.vectorindex.parallelGraphWriteMinNodes}; default
+     * {@code 50000}.
+     */
+    static final int PARALLEL_GRAPH_WRITE_MIN_NODES =
+            Math.max(0, Integer.getInteger(
+                    "herddb.vectorindex.parallelGraphWriteMinNodes", 50_000));
+
+    /**
+     * Worker thread count handed to the parallel writer. System property
+     * {@code herddb.vectorindex.graphWriteParallelism}; default {@code 0},
+     * which lets jvector use the number of available processors.
+     */
+    static final int GRAPH_WRITE_PARALLELISM =
+            Math.max(0, Integer.getInteger(
+                    "herddb.vectorindex.graphWriteParallelism", 0));
+
+    /**
+     * Whether the parallel writer should use direct byte buffers. System
+     * property {@code herddb.vectorindex.parallelGraphWriteDirectBuffers};
+     * default {@code false}.
+     */
+    static final boolean PARALLEL_GRAPH_WRITE_DIRECT_BUFFERS =
+            Boolean.getBoolean("herddb.vectorindex.parallelGraphWriteDirectBuffers");
+
+    private GraphWriterFactory() {
+    }
+
+    /**
+     * Opens a graph writer for {@code file}, choosing the parallel writer when
+     * the {@link #PARALLEL_GRAPH_WRITE} flag is enabled and {@code nodeCount} is
+     * at or above {@link #PARALLEL_GRAPH_WRITE_MIN_NODES}.
+     *
+     * @param graph     the graph to serialize
+     * @param file      the target file path (the parallel writer requires a
+     *                  {@link Path} because it uses an asynchronous channel)
+     * @param nodeCount the number of nodes in {@code graph}
+     * @param features  the features to attach, in builder order
+     * @return a writer; the caller must use it in a try-with-resources block
+     */
+    static RandomAccessOnDiskGraphIndexWriter openWriter(
+            ImmutableGraphIndex graph, Path file, int nodeCount,
+            List<Feature> features) throws IOException {
+        boolean parallel = PARALLEL_GRAPH_WRITE
+                && nodeCount >= PARALLEL_GRAPH_WRITE_MIN_NODES;
+        return openWriter(graph, file, features, parallel,
+                GRAPH_WRITE_PARALLELISM, PARALLEL_GRAPH_WRITE_DIRECT_BUFFERS);
+    }
+
+    /**
+     * Deterministic variant that builds exactly the writer requested by
+     * {@code parallel}, ignoring the static configuration. Used by
+     * {@link #openWriter(ImmutableGraphIndex, Path, int, List)} and by tests.
+     *
+     * @param graph         the graph to serialize
+     * @param file          the target file path
+     * @param features      the features to attach, in builder order
+     * @param parallel      when {@code true} build an
+     *                      {@link OnDiskParallelGraphIndexWriter}, otherwise an
+     *                      {@link OnDiskGraphIndexWriter}
+     * @param workerThreads parallel worker threads ({@code 0} = jvector auto);
+     *                      ignored when {@code parallel} is {@code false}
+     * @param directBuffers whether the parallel writer uses direct buffers;
+     *                      ignored when {@code parallel} is {@code false}
+     */
+    static RandomAccessOnDiskGraphIndexWriter openWriter(
+            ImmutableGraphIndex graph, Path file, List<Feature> features,
+            boolean parallel, int workerThreads, boolean directBuffers) throws IOException {
+        if (parallel) {
+            LOGGER.log(Level.INFO,
+                    "vector graph write: using parallel writer for {0} "
+                            + "(workerThreads={1}, directBuffers={2})",
+                    new Object[]{file,
+                            workerThreads == 0 ? "auto" : workerThreads, directBuffers});
+            // withParallelWorkerThreads / withParallelDirectBuffers must be
+            // called before any with(feature): with(...) narrows the static
+            // type to the base AbstractGraphIndexWriter.Builder.
+            OnDiskParallelGraphIndexWriter.Builder builder =
+                    new OnDiskParallelGraphIndexWriter.Builder(graph, file)
+                            .withParallelWorkerThreads(workerThreads)
+                            .withParallelDirectBuffers(directBuffers);
+            for (Feature feature : features) {
+                builder.with(feature);
+            }
+            return builder.build();
+        }
+        LOGGER.log(Level.FINE,
+                "vector graph write: using sequential writer for {0}", file);
+        OnDiskGraphIndexWriter.Builder builder =
+                new OnDiskGraphIndexWriter.Builder(graph, file);
+        for (Feature feature : features) {
+            builder.with(feature);
+        }
+        return builder.build();
+    }
+}

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -43,6 +43,8 @@ import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.RandomAccessOnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
@@ -7017,10 +7019,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
             Path tempFile = Files.createTempFile(tmpDirectory, "herddb-vector-", ".idx");
             boolean success = false;
             try {
-                try (OnDiskGraphIndexWriter writer = new OnDiskGraphIndexWriter.Builder(mergedGraph, tempFile)
-                        .with(new FusedPQ(mergedGraph.maxDegree(), pq))
-                        .with(new InlineVectors(dim))
-                        .build()) {
+                List<Feature> features = List.of(
+                        new FusedPQ(mergedGraph.maxDegree(), pq),
+                        new InlineVectors(dim));
+                try (RandomAccessOnDiskGraphIndexWriter writer =
+                        GraphWriterFactory.openWriter(mergedGraph, tempFile, totalVectors, features)) {
                     ImmutableGraphIndex.View view = mergedGraph.getView();
                     EnumMap<FeatureId, IntFunction<io.github.jbellis.jvector.graph.disk.feature.Feature.State>> suppliers =
                             new EnumMap<>(FeatureId.class);

--- a/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
+++ b/herddb-core/src/main/java/herddb/index/vector/RemoteSegmentGraphMerger.java
@@ -32,8 +32,8 @@ import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
 import io.github.jbellis.jvector.graph.disk.CompactionProgressListener;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexCompactor;
-import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
+import io.github.jbellis.jvector.graph.disk.RandomAccessOnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
@@ -1594,14 +1594,13 @@ public final class RemoteSegmentGraphMerger {
         }
         PQVectors pqv = (pq != null) ? pq.encodeAll(art.ravv, ForkJoinPool.commonPool()) : null;
 
-        OnDiskGraphIndexWriter.Builder writerBuilder = new OnDiskGraphIndexWriter.Builder(
-                graph, graphTempFile);
+        List<Feature> features = new ArrayList<>(2);
         if (useFusedPQ) {
-            writerBuilder.with(new FusedPQ(graph.maxDegree(), pq));
+            features.add(new FusedPQ(graph.maxDegree(), pq));
         }
-        try (OnDiskGraphIndexWriter writer = writerBuilder
-                .with(new InlineVectors(dim))
-                .build()) {
+        features.add(new InlineVectors(dim));
+        try (RandomAccessOnDiskGraphIndexWriter writer =
+                GraphWriterFactory.openWriter(graph, graphTempFile, shardSize, features)) {
             ImmutableGraphIndex.View view = graph.getView();
             EnumMap<FeatureId, IntFunction<Feature.State>> suppliers =
                     new EnumMap<>(FeatureId.class);

--- a/herddb-core/src/test/java/herddb/index/vector/GraphWriterFactoryTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/GraphWriterFactoryTest.java
@@ -1,0 +1,261 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.GraphSearcher;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
+import io.github.jbellis.jvector.graph.OnHeapGraphIndex;
+import io.github.jbellis.jvector.graph.SearchResult;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.OnDiskParallelGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.RandomAccessOnDiskGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.feature.Feature;
+import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
+import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
+import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
+import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
+import io.github.jbellis.jvector.quantization.PQVectors;
+import io.github.jbellis.jvector.quantization.ProductQuantization;
+import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.IntFunction;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for {@link GraphWriterFactory}.
+ *
+ * <p>Proves that the parallel writer ({@link OnDiskParallelGraphIndexWriter})
+ * and the sequential writer ({@link OnDiskGraphIndexWriter}) serialize the same
+ * {@link OnHeapGraphIndex} into graphs that return identical search results,
+ * and that the factory routes to the correct writer based on its static
+ * configuration and the requested node count.
+ *
+ * <p>Plain unit test — exercises jvector and temporary files only, so it does
+ * <em>not</em> carry {@code @Category(ClusterTest.class)}.
+ */
+public class GraphWriterFactoryTest {
+
+    private static final VectorTypeSupport VTS =
+            VectorizationProvider.getInstance().getVectorTypeSupport();
+    private static final VectorSimilarityFunction SIM = VectorSimilarityFunction.COSINE;
+
+    private static final int DIM = 16;
+    private static final int N = 2000;
+
+    /** Graph + quantization built once and reused across all test methods. */
+    private static OnHeapGraphIndex graph;
+    private static VectorStorageRandomAccessVectorValues ravv;
+    private static ProductQuantization pq;
+    private static PQVectors pqv;
+    private static VectorFloat<?>[] queries;
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void buildGraph() throws Exception {
+        Random rng = new Random(0xC0FFEE);
+        VectorStorage storage = new VectorStorage(N);
+        for (int i = 0; i < N; i++) {
+            float[] v = new float[DIM];
+            for (int j = 0; j < DIM; j++) {
+                v[j] = rng.nextFloat();
+            }
+            storage.set(i, VTS.createFloatVector(v));
+        }
+        ravv = new VectorStorageRandomAccessVectorValues(storage, DIM, N);
+
+        BuildScoreProvider bsp = BuildScoreProvider.randomAccessScoreProvider(ravv, SIM);
+        GraphIndexBuilder builder = new GraphIndexBuilder(
+                bsp, DIM, 16, 100, 1.2f, 1.4f, false, false);
+        for (int i = 0; i < N; i++) {
+            builder.addGraphNode(i, ravv.getVector(i));
+        }
+        builder.cleanup();
+        graph = (OnHeapGraphIndex) builder.getGraph();
+
+        int pqSubspaces = Math.max(1, DIM / 4);
+        pq = ProductQuantization.compute(ravv, pqSubspaces, 256, true);
+        pqv = pq.encodeAll(ravv, ForkJoinPool.commonPool());
+
+        queries = new VectorFloat<?>[20];
+        Random qrng = new Random(0xBEEF);
+        for (int q = 0; q < queries.length; q++) {
+            float[] v = new float[DIM];
+            for (int j = 0; j < DIM; j++) {
+                v[j] = qrng.nextFloat();
+            }
+            queries[q] = VTS.createFloatVector(v);
+        }
+    }
+
+    private List<Feature> fusedFeatures() {
+        return List.of(new FusedPQ(graph.maxDegree(), pq), new InlineVectors(DIM));
+    }
+
+    /**
+     * Writes {@link #graph} (with FusedPQ + InlineVectors) to {@code file}
+     * through the deterministic {@code openWriter} overload.
+     */
+    private void writeGraph(Path file, boolean parallel, boolean directBuffers) throws Exception {
+        try (RandomAccessOnDiskGraphIndexWriter writer = GraphWriterFactory.openWriter(
+                graph, file, fusedFeatures(), parallel, 0, directBuffers)) {
+            ImmutableGraphIndex.View view = graph.getView();
+            EnumMap<FeatureId, IntFunction<Feature.State>> suppliers = new EnumMap<>(FeatureId.class);
+            suppliers.put(FeatureId.FUSED_PQ, ordinal -> new FusedPQ.State(view, pqv, ordinal));
+            suppliers.put(FeatureId.INLINE_VECTORS,
+                    ordinal -> new InlineVectors.State(ravv.getVector(ordinal)));
+            writer.write(suppliers);
+        }
+    }
+
+    /**
+     * Reopens the on-disk graph at {@code file} and runs every query in
+     * {@link #queries}. Returns, for each query, the ordered array of result
+     * node ordinals followed by the matching scores, flattened so two runs can
+     * be compared with {@link org.junit.Assert#assertArrayEquals}.
+     */
+    private float[] searchAll(Path file, int topK) throws Exception {
+        SegmentedMappedReader.Supplier supplier = new SegmentedMappedReader.Supplier(file);
+        OnDiskGraphIndex disk = OnDiskGraphIndex.load(supplier);
+        try (GraphSearcher searcher = new GraphSearcher(disk)) {
+            OnDiskGraphIndex.View view = (OnDiskGraphIndex.View) searcher.getView();
+            float[] out = new float[queries.length * topK * 2];
+            int pos = 0;
+            for (VectorFloat<?> q : queries) {
+                ScoreFunction.ExactScoreFunction reranker = view.rerankerFor(q, SIM);
+                DefaultSearchScoreProvider ssp = new DefaultSearchScoreProvider(reranker);
+                SearchResult result = searcher.search(ssp, topK, topK, 0.0f, 0.0f, Bits.ALL);
+                SearchResult.NodeScore[] nodes = result.getNodes();
+                for (int i = 0; i < topK; i++) {
+                    if (i < nodes.length) {
+                        out[pos++] = nodes[i].node;
+                        out[pos++] = nodes[i].score;
+                    } else {
+                        out[pos++] = -1.0f;
+                        out[pos++] = Float.NaN;
+                    }
+                }
+            }
+            return out;
+        } finally {
+            disk.close();
+        }
+    }
+
+    @Test
+    public void parallelAndSequentialProduceEquivalentGraphs() throws Exception {
+        Path dir = tmpFolder.newFolder().toPath();
+        Path sequentialFile = dir.resolve("sequential.idx");
+        Path parallelFile = dir.resolve("parallel.idx");
+
+        writeGraph(sequentialFile, false, false);
+        writeGraph(parallelFile, true, false);
+
+        float[] sequentialResults = searchAll(sequentialFile, 10);
+        float[] parallelResults = searchAll(parallelFile, 10);
+
+        assertArrayEquals(
+                "parallel writer must produce a graph that searches identically to the sequential writer",
+                sequentialResults, parallelResults, 0.0f);
+    }
+
+    @Test
+    public void directBuffersOptionProducesEquivalentGraph() throws Exception {
+        Path dir = tmpFolder.newFolder().toPath();
+        Path sequentialFile = dir.resolve("sequential.idx");
+        Path parallelDirectFile = dir.resolve("parallel-direct.idx");
+
+        writeGraph(sequentialFile, false, false);
+        writeGraph(parallelDirectFile, true, true);
+
+        assertArrayEquals(
+                "parallel writer with direct buffers must produce an equivalent graph",
+                searchAll(sequentialFile, 10), searchAll(parallelDirectFile, 10), 0.0f);
+    }
+
+    @Test
+    public void forcedParallelReturnsParallelWriter() throws Exception {
+        Path file = tmpFolder.newFolder().toPath().resolve("forced-parallel.idx");
+        try (RandomAccessOnDiskGraphIndexWriter writer = GraphWriterFactory.openWriter(
+                graph, file, List.of(new InlineVectors(DIM)), true, 0, false)) {
+            assertTrue("parallel=true must yield an OnDiskParallelGraphIndexWriter",
+                    writer instanceof OnDiskParallelGraphIndexWriter);
+        }
+    }
+
+    @Test
+    public void forcedSequentialReturnsSequentialWriter() throws Exception {
+        Path file = tmpFolder.newFolder().toPath().resolve("forced-sequential.idx");
+        try (RandomAccessOnDiskGraphIndexWriter writer = GraphWriterFactory.openWriter(
+                graph, file, List.of(new InlineVectors(DIM)), false, 0, false)) {
+            assertTrue("parallel=false must yield a (sequential) OnDiskGraphIndexWriter",
+                    writer instanceof OnDiskGraphIndexWriter);
+        }
+    }
+
+    /**
+     * The public {@code openWriter} routes to the parallel writer only when the
+     * {@code herddb.vectorindex.parallelGraphWrite} flag is enabled <em>and</em>
+     * the node count is at or above the configured threshold. The expectations
+     * are derived from the static configuration so the test is correct whether
+     * the suite runs with the flag off (the default) or forced on.
+     */
+    @Test
+    public void publicOpenWriterRoutesByStaticConfigAndNodeCount() throws Exception {
+        Path dir = tmpFolder.newFolder().toPath();
+
+        int aboveThreshold = GraphWriterFactory.PARALLEL_GRAPH_WRITE_MIN_NODES;
+        boolean expectParallelAbove = GraphWriterFactory.PARALLEL_GRAPH_WRITE
+                && aboveThreshold >= GraphWriterFactory.PARALLEL_GRAPH_WRITE_MIN_NODES;
+        try (RandomAccessOnDiskGraphIndexWriter writer = GraphWriterFactory.openWriter(
+                graph, dir.resolve("above.idx"), aboveThreshold, List.of(new InlineVectors(DIM)))) {
+            assertEquals("routing for node count >= threshold",
+                    expectParallelAbove, writer instanceof OnDiskParallelGraphIndexWriter);
+        }
+
+        int belowThreshold = Math.max(0, GraphWriterFactory.PARALLEL_GRAPH_WRITE_MIN_NODES - 1);
+        boolean expectParallelBelow = GraphWriterFactory.PARALLEL_GRAPH_WRITE
+                && belowThreshold >= GraphWriterFactory.PARALLEL_GRAPH_WRITE_MIN_NODES;
+        try (RandomAccessOnDiskGraphIndexWriter writer = GraphWriterFactory.openWriter(
+                graph, dir.resolve("below.idx"), belowThreshold, List.of(new InlineVectors(DIM)))) {
+            assertEquals("routing for node count < threshold",
+                    expectParallelBelow, writer instanceof OnDiskParallelGraphIndexWriter);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #567.

## Changes
- **New `GraphWriterFactory`** (`herddb-core`, package `herddb.index.vector`): package-private, final, non-instantiable helper that selects the jvector on-disk graph writer. It resolves four `herddb.vectorindex.*` system properties into `static final` fields — `parallelGraphWrite` (master enable, default `false`), `parallelGraphWriteMinNodes` (default `50000`), `graphWriteParallelism` (default `0` = jvector auto) and `parallelGraphWriteDirectBuffers` (default `false`) — and routes to either jvector's sequential `OnDiskGraphIndexWriter` or the `@Experimental` parallel `OnDiskParallelGraphIndexWriter`. Both extend `RandomAccessOnDiskGraphIndexWriter`, so they are API drop-in replacements. The parallel-only builder setters are invoked before any `.with(feature)` call, since `.with(...)` narrows the static builder type.
- **`PersistentVectorStore.writeFusedPQGraphToTempFile()`**: builds a `List<Feature>` and obtains the writer from `GraphWriterFactory.openWriter(mergedGraph, tempFile, totalVectors, features)`; the try-with-resources variable is widened to `RandomAccessOnDiskGraphIndexWriter`.
- **`RemoteSegmentGraphMerger.writeGraph()`**: builds a `List<Feature>` (`FusedPQ` only when `useFusedPQ`, then `InlineVectors`) and obtains the writer from `GraphWriterFactory.openWriter(graph, graphTempFile, shardSize, features)`; the try-with-resources variable is widened to `RandomAccessOnDiskGraphIndexWriter`. The now-unused `OnDiskGraphIndexWriter` import is removed.
- **Phase B per-shard writes (`writeShardAsFusedPQSegment`) are intentionally untouched** — Phase B already runs several shard writers concurrently, so a parallel writer there would oversubscribe the CPU.

The sequential writer remains the default; the parallel path is fully opt-in until validated in benchmarks.

## Tests
- **New `GraphWriterFactoryTest`** (`herddb-core`, plain unit test — no `@Category(ClusterTest.class)`):
  - `parallelAndSequentialProduceEquivalentGraphs` — builds a 2000-vector `OnHeapGraphIndex`, writes it with both writers (`FusedPQ` + `InlineVectors`), reopens both via `OnDiskGraphIndex`, runs 20 identical `GraphSearcher` queries and asserts byte-for-byte identical result ordinals and scores.
  - `directBuffersOptionProducesEquivalentGraph` — same equivalence check with `directBuffers=true`.
  - `forcedParallelReturnsParallelWriter` / `forcedSequentialReturnsSequentialWriter` — assert the deterministic overload returns the requested writer type.
  - `publicOpenWriterRoutesByStaticConfigAndNodeCount` — asserts the public entry point routes by the static config and node-count threshold (robust whether the suite runs with the flag on or off).
- Regression-checked existing `VectorSegmentSearchErrorTest`, `RemoteSegmentGraphMerger{,Streaming,CorruptInput,HeterogeneousInput,TombstoneFilter}Test` and `PersistentVectorStoreParallelPhaseBTest` — all green, including a parallel-path opt-in smoke run (`-Dherddb.vectorindex.parallelGraphWrite=true -Dherddb.vectorindex.parallelGraphWriteMinNodes=1`).
- Ran the `DirectMultipleConcurrentUpdatesSuite` checkpoint/concurrency hammer suites as a sanity gate — all green.
- Pre-PR validation (`spotless:check apache-rat:check spotbugs:check install`) passes.

🤖 Implemented by the `pr-worker` agent.