### PR TITLE
issue #570: prioritize merging micro-segments to relieve back-pressure faster

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -572,6 +572,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
             Math.max(1, Integer.getInteger(
                     "herddb.vectorindex.compactionMinCount", 4));
 
+    /**
+     * Default live-node count below which a segment is treated as a
+     * micro-segment by the compaction scheduler's micro-segment fast path
+     * (issue #570). Micro-segments are produced by memory-pressure
+     * checkpoints flushing a near-empty live shard; merging them is
+     * essentially free and reclaims segment-count slots immediately.
+     * Configurable in production via
+     * {@code vector.index.compaction.microsegment.max.nodes}; {@code 0}
+     * disables the fast path.
+     */
+    public static final long DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES = 1000L;
+
     /** Compaction policy knobs — defaults match IndexingServerConfiguration. */
     private volatile long vectorIndexCompactionIntervalMs = 5L * 60_000L;
     private volatile long vectorIndexCompactionMinBytes = 256L * 1024 * 1024;
@@ -584,6 +596,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * tailing catch-up when each checkpoint produces many small segments.
      */
     private volatile int vectorIndexCompactionMaxCount = 200;
+    /**
+     * Micro-segment fast-path threshold (issue #570): when at least two
+     * on-disk segments have a live-node count strictly below this value the
+     * compaction cycle merges only those micro-segments, relieving
+     * segment-count back-pressure quickly. {@code 0} disables the fast path.
+     */
+    private volatile long vectorIndexCompactionMicroSegmentMaxNodes =
+            DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES;
     private volatile long vectorIndexCompactionRetentionMs = 10L * 60_000L;
     /**
      * When {@code true} (the default), the per-cycle byte cap and segment
@@ -1885,6 +1905,25 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
+     * Sets the micro-segment fast-path threshold (issue #570). When at least
+     * two on-disk segments have a live-node count strictly below
+     * {@code microSegmentMaxNodes}, the next compaction cycle merges only
+     * those micro-segments — a cheap, fast cycle that reclaims segment-count
+     * slots and relieves back-pressure quickly. A value of {@code 0} (or
+     * negative) disables the fast path, restoring the pre-#570 behaviour.
+     * Can be called at any time to re-tune a running store.
+     */
+    public void setCompactionMicroSegmentMaxNodes(long microSegmentMaxNodes) {
+        this.vectorIndexCompactionMicroSegmentMaxNodes =
+                Math.max(0L, microSegmentMaxNodes);
+    }
+
+    /** Returns the current micro-segment fast-path threshold (issue #570). */
+    public long getCompactionMicroSegmentMaxNodes() {
+        return vectorIndexCompactionMicroSegmentMaxNodes;
+    }
+
+    /**
      * Sets the segment-count back-pressure threshold (issue #354).
      * {@link #addVectorInternal} will block when {@code segments.size()}
      * exceeds this value, waking the compaction thread first.
@@ -2343,7 +2382,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     vectorIndexCompactionMinCount,
                     vectorIndexCompactionMinBytes,
                     effectiveMaxBytes,
-                    effectiveMaxCount);
+                    effectiveMaxCount,
+                    vectorIndexCompactionMicroSegmentMaxNodes);
             if (candidates.isEmpty()) {
                 if (snapshot.size() >= COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD) {
                     LOGGER.log(Level.WARNING,

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -263,7 +263,31 @@ final class VectorIndexCompactor {
      * (the live-node count), not {@code estimatedSizeBytes}: a freshly
      * checkpointed micro-segment has a tiny node count, and a large segment
      * whose PKs have mostly been tombstoned is also cheap to re-merge since
-     * the rebuild only re-inserts the authoritative live vectors.
+     * the rebuild only re-inserts the authoritative live vectors. A segment
+     * with {@code size() == 0} (every PK tombstoned) is therefore also a
+     * micro-segment — preferring it for merge is intentional, as it reclaims
+     * a full segment-count slot at near-zero rebuild cost.
+     *
+     * <p><b>Re-merge of the micro-segment output is expected and bounded.</b>
+     * The merged output of a micro-segment cycle has a live-node count equal
+     * to the sum of its inputs, which may itself still be below
+     * {@code microSegmentMaxNodes}. While memory-pressure checkpoints keep
+     * producing fresh micro-segments, each subsequent cycle re-merges that
+     * growing output with the new arrivals. This is deliberate: every such
+     * cycle still reduces the segment count (≥ 2 inputs collapse to 1) and
+     * the work per cycle is bounded by {@code microSegmentMaxNodes} live
+     * nodes — cheap by construction. Once the output crosses
+     * {@code microSegmentMaxNodes} it graduates and is no longer re-merged.
+     *
+     * <p><b>Large segments are deliberately deprioritised while
+     * micro-segments are present.</b> Under sustained micro-segment
+     * production (the abnormal, memory-pressure condition this fast path
+     * targets) the fast path may fire on every cycle, deferring large-segment
+     * compaction. This is the intended trade-off: back-pressure relief —
+     * keeping the segment count bounded so the tailer can make progress —
+     * takes priority over the search-latency benefit of merging large
+     * segments. When micro-segment production stops, no cycle has ≥ 2
+     * micro-segments and the normal tiered policy resumes for large segments.
      *
      * <p>Returns an empty list when neither the byte threshold nor the
      * count trigger is satisfied.
@@ -316,11 +340,14 @@ final class VectorIndexCompactor {
         // anyway — if at least two candidates are micro-segments, merge ONLY
         // those instead of the byte-capped `picked` set above. This is a far
         // cheaper cycle that reclaims segment-count slots quickly; larger
-        // segments are deferred to a later cycle. `sorted` is already
-        // smallest-bytes-first, so the micro-segment sub-list inherits that
-        // ordering. The same maxTotalBytes write-amplification cap is applied
-        // (it never bites for genuine micro-segments, but keeps the bound
-        // honest for low / mostly-tombstoned large segments).
+        // segments are deferred to a later cycle. The micro scan walks the
+        // full `sorted` candidate list (not `picked`), so `microPicked` may
+        // be disjoint from `picked` — that is intentional: `picked` only
+        // decided whether the cycle fires, not what it merges. `sorted` is
+        // already smallest-bytes-first, so the micro-segment sub-list
+        // inherits that ordering. The same maxTotalBytes write-amplification
+        // cap is applied (it never bites for genuine micro-segments, but
+        // keeps the bound honest for low / mostly-tombstoned large segments).
         if (microSegmentMaxNodes > 0L) {
             List<VectorSegment> microPicked = new ArrayList<>();
             long microTotal = 0L;

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -208,6 +208,24 @@ final class VectorIndexCompactor {
     }
 
     /**
+     * Backward-compatible 5-arg entry point: equivalent to the 6-arg
+     * {@link #chooseSegmentsToMerge(List, int, long, long, int, long)}
+     * with the micro-segment fast path disabled
+     * ({@code microSegmentMaxNodes == 0}).
+     *
+     * <p>Package-private for unit tests.
+     */
+    static List<VectorSegment> chooseSegmentsToMerge(
+            List<VectorSegment> candidates,
+            int minCount,
+            long minTotalBytes,
+            long maxTotalBytes,
+            int maxCount) {
+        return chooseSegmentsToMerge(candidates, minCount, minTotalBytes,
+                maxTotalBytes, maxCount, /*microSegmentMaxNodes*/ 0L);
+    }
+
+    /**
      * Picks the subset of {@code candidates} to merge in this compaction
      * run, applying:
      * <ul>
@@ -224,17 +242,45 @@ final class VectorIndexCompactor {
      *       and avoid rewriting already-large segments.</li>
      * </ul>
      *
+     * <p><b>Micro-segment fast path (issue #570).</b> When this method has
+     * already decided that the cycle <em>will</em> compact (one of the
+     * triggers above fired) and {@code microSegmentMaxNodes > 0}, the picked
+     * set is re-prioritised: if at least two candidates are micro-segments
+     * — segments whose live-node count is strictly below
+     * {@code microSegmentMaxNodes} — the cycle merges <em>only</em> the
+     * micro-segments instead of the byte-capped selection. Micro-segments
+     * (typically a handful of nodes, produced by memory-pressure checkpoints
+     * flushing a near-empty live shard) each consume a full slot in the
+     * segment count yet contribute negligibly to search quality; merging
+     * them is essentially free and reclaims slots immediately, relieving
+     * segment-count back-pressure in seconds instead of waiting for a
+     * multi-minute large merge. Larger segments are deferred to a subsequent
+     * cycle (which, once no micro-segments remain, runs the normal policy).
+     * The fast path never makes the cycle compact when it otherwise would
+     * not — it only changes <em>which</em> segments are merged.
+     *
+     * <p>The micro-segment classification uses {@link VectorSegment#size()}
+     * (the live-node count), not {@code estimatedSizeBytes}: a freshly
+     * checkpointed micro-segment has a tiny node count, and a large segment
+     * whose PKs have mostly been tombstoned is also cheap to re-merge since
+     * the rebuild only re-inserts the authoritative live vectors.
+     *
      * <p>Returns an empty list when neither the byte threshold nor the
      * count trigger is satisfied.
      *
      * <p>Package-private for unit tests.
+     *
+     * @param microSegmentMaxNodes live-node count below which a segment is
+     *     treated as a micro-segment; {@code 0} (or negative) disables the
+     *     micro-segment fast path.
      */
     static List<VectorSegment> chooseSegmentsToMerge(
             List<VectorSegment> candidates,
             int minCount,
             long minTotalBytes,
             long maxTotalBytes,
-            int maxCount) {
+            int maxCount,
+            long microSegmentMaxNodes) {
         if (candidates == null || candidates.size() < minCount) {
             return new ArrayList<>();
         }
@@ -252,19 +298,48 @@ final class VectorIndexCompactor {
             total += seg.estimatedSizeBytes;
         }
 
-        // Standard byte-threshold trigger.
-        if (picked.size() >= minCount && total >= minTotalBytes) {
-            return picked;
+        // Decide whether this cycle compacts at all:
+        //  - the standard byte-threshold trigger, or
+        //  - the count-based trigger (issue #285): fire even if the byte
+        //    threshold is not met when too many segments have accumulated.
+        //    This guards against the scenario where every segment is
+        //    individually small (e.g. catch-up with tiny shards) and the
+        //    sum never reaches minTotalBytes despite hundreds of segments
+        //    building up.
+        boolean byteTrigger = picked.size() >= minCount && total >= minTotalBytes;
+        boolean countTrigger = picked.size() >= maxCount;
+        if (!byteTrigger && !countTrigger) {
+            return new ArrayList<>();
         }
-        // Count-based trigger (issue #285): fire even if the byte threshold
-        // is not met when too many segments have accumulated.  This guards
-        // against the scenario where every segment is individually small
-        // (e.g. catch-up with tiny shards) and the sum never reaches
-        // minTotalBytes despite hundreds of segments building up.
-        if (picked.size() >= maxCount) {
-            return picked;
+
+        // Micro-segment fast path (issue #570): the cycle is going to compact
+        // anyway — if at least two candidates are micro-segments, merge ONLY
+        // those instead of the byte-capped `picked` set above. This is a far
+        // cheaper cycle that reclaims segment-count slots quickly; larger
+        // segments are deferred to a later cycle. `sorted` is already
+        // smallest-bytes-first, so the micro-segment sub-list inherits that
+        // ordering. The same maxTotalBytes write-amplification cap is applied
+        // (it never bites for genuine micro-segments, but keeps the bound
+        // honest for low / mostly-tombstoned large segments).
+        if (microSegmentMaxNodes > 0L) {
+            List<VectorSegment> microPicked = new ArrayList<>();
+            long microTotal = 0L;
+            for (VectorSegment seg : sorted) {
+                if (seg.size() >= microSegmentMaxNodes) {
+                    continue;
+                }
+                if (!microPicked.isEmpty()
+                        && microTotal + seg.estimatedSizeBytes > maxTotalBytes) {
+                    break;
+                }
+                microPicked.add(seg);
+                microTotal += seg.estimatedSizeBytes;
+            }
+            if (microPicked.size() >= 2) {
+                return microPicked;
+            }
         }
-        return new ArrayList<>();
+        return picked;
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-core/src/test/java/herddb/index/vector/Issue570MicroSegmentCompactionTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue570MicroSegmentCompactionTest.java
@@ -55,17 +55,21 @@ public class Issue570MicroSegmentCompactionTest {
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
+    /** Saved so {@link #restoreDeferral()} restores the exact prior value. */
+    private int savedMinLiveVectorsForCheckpoint;
+
     @Before
     public void disableDeferral() {
         // One checkpoint == one on-disk segment, regardless of how few
         // vectors it carries — this is exactly how memory-pressure
         // checkpoints produce micro-segments in production.
+        savedMinLiveVectorsForCheckpoint = PersistentVectorStore.minLiveVectorsForCheckpoint;
         PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
     }
 
     @After
     public void restoreDeferral() {
-        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectorsForCheckpoint;
     }
 
     private static void addVectors(PersistentVectorStore store, Random rng,

--- a/herddb-core/src/test/java/herddb/index/vector/Issue570MicroSegmentCompactionTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue570MicroSegmentCompactionTest.java
@@ -1,0 +1,192 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end regression test for issue #570: the compaction scheduler must
+ * prefer merging micro-segments first.
+ *
+ * <p>Memory-pressure checkpoints flush a near-empty live shard as a tiny
+ * on-disk segment (a "micro-segment"). Each micro-segment consumes a full
+ * slot in the segment count, keeping the Indexing Service in segment-count
+ * back-pressure. The fix makes a compaction cycle merge only the
+ * micro-segments when at least two are present — a cheap, fast cycle that
+ * reclaims slots quickly — while leaving larger segments for the normal
+ * tiered policy on subsequent cycles.
+ *
+ * <p>This test wires a {@link PersistentVectorStore} with an unreachable byte
+ * threshold and a {@code maxCount} equal to the segment count, so the issue
+ * #285 count trigger fires but the byte trigger does not. Without the
+ * micro-segment fast path the count trigger would merge the whole backlog
+ * (large segments included); with it, only the micro-segments are merged.
+ */
+public class Issue570MicroSegmentCompactionTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        // One checkpoint == one on-disk segment, regardless of how few
+        // vectors it carries — this is exactly how memory-pressure
+        // checkpoints produce micro-segments in production.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private static void addVectors(PersistentVectorStore store, Random rng,
+                                    int dim, int base, int count) throws Exception {
+        for (int i = 0; i < count; i++) {
+            float[] vec = new float[dim];
+            for (int d = 0; d < dim; d++) {
+                vec[d] = rng.nextFloat();
+            }
+            store.addVector(Bytes.from_int(base + i), vec);
+        }
+    }
+
+    /**
+     * Builds 6 micro-segments (3 vectors each) and 2 larger segments (50
+     * vectors each), with the micro-segment threshold set to 10 nodes and
+     * {@code maxCount} equal to the 8 on-disk segments so the count trigger
+     * fires. A single compaction cycle must merge only the 6 micro-segments
+     * into one, dropping the segment count from 8 to 3, and a follow-up
+     * cycle (no micro-segments left, no trigger satisfied) must be a no-op.
+     */
+    @Test
+    public void microSegmentsAreMergedFirst() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx570", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ Long.MAX_VALUE / 2,   // unreachably high
+                /*maxBytes*/ Long.MAX_VALUE,
+                /*minCount*/ 2,
+                /*maxCount*/ 8,                    // == segment count: count trigger fires
+                /*retentionMs*/ 0);
+        // Micro-segment threshold of 10 live nodes: the 3-vector checkpoints
+        // are micro-segments, the 50-vector checkpoints are not.
+        store.setCompactionMicroSegmentMaxNodes(10);
+
+        try (store) {
+            store.start();
+            Random rng = new Random(570);
+            int dim = 8;
+
+            // 6 micro-segments of 3 vectors each (distinct PKs per segment).
+            for (int c = 0; c < 6; c++) {
+                addVectors(store, rng, dim, /*base*/ 1_000 + c * 100, /*count*/ 3);
+                store.checkpoint();
+            }
+            // 2 larger, non-micro segments of 50 vectors each.
+            for (int c = 0; c < 2; c++) {
+                addVectors(store, rng, dim, /*base*/ 100_000 + c * 1_000, /*count*/ 50);
+                store.checkpoint();
+            }
+
+            int segmentsBefore = store.getSegmentCount();
+            assertEquals("expected 8 on-disk segments before compaction",
+                    8, segmentsBefore);
+            long totalNodesBefore = totalLiveNodes(store);
+            assertEquals("setup must hold 6*3 + 2*50 live vectors",
+                    118L, totalNodesBefore);
+            long successesBefore = store.getCompactionSuccessesTotal();
+
+            store.runCompactionCycle();
+
+            assertEquals("micro-segment fast path must produce one successful compaction",
+                    successesBefore + 1, store.getCompactionSuccessesTotal());
+            assertEquals("no consecutive failures expected",
+                    0, store.getCompactionConsecutiveFailures());
+            // 6 micro-segments collapse into 1; the 2 larger segments are
+            // untouched → 1 + 2 = 3 segments remain.
+            assertEquals("only the 6 micro-segments must have been merged",
+                    3, store.getSegmentCount());
+
+            // No live vector may be lost by the merge.
+            assertEquals("merge must preserve every live vector",
+                    totalNodesBefore, totalLiveNodes(store));
+
+            // The merged output (highest generation) must hold exactly the
+            // 6*3 = 18 micro-segment nodes; the two 50-node segments must
+            // remain untouched.
+            List<VectorSegment> post = store.getOnDiskSegmentsSnapshotForTest();
+            VectorSegment merged = post.stream()
+                    .max(java.util.Comparator.comparingLong(s -> s.generation))
+                    .orElseThrow(() -> new AssertionError("no merged segment"));
+            assertEquals("merged segment must hold all 18 micro-segment nodes",
+                    18L, merged.size());
+            int untouchedLarge = 0;
+            for (VectorSegment s : post) {
+                if (s != merged) {
+                    assertEquals("large segments must be left untouched",
+                            50L, s.size());
+                    untouchedLarge++;
+                }
+            }
+            assertEquals("both large segments must survive untouched", 2, untouchedLarge);
+
+            // Second cycle: no micro-segments remain (merged output has 18
+            // nodes, the two large segments have 50 each — all above the
+            // 10-node threshold) and the byte/count triggers are unreachable,
+            // so the cycle must be a no-op.
+            long successesAfterFirst = store.getCompactionSuccessesTotal();
+            int segmentsAfterFirst = store.getSegmentCount();
+            store.runCompactionCycle();
+            assertEquals("follow-up cycle must not fire — no micro-segments left",
+                    successesAfterFirst, store.getCompactionSuccessesTotal());
+            assertEquals("segment count must be stable after the follow-up cycle",
+                    segmentsAfterFirst, store.getSegmentCount());
+        }
+    }
+
+    /** Sums the live-node count across every on-disk segment. */
+    private static long totalLiveNodes(PersistentVectorStore store) {
+        long total = 0L;
+        for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+            total += s.size();
+        }
+        return total;
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorMicroSegmentTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorMicroSegmentTest.java
@@ -219,4 +219,87 @@ public class VectorIndexCompactorMicroSegmentTest {
                 /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
         assertTrue("below minCount → no compaction at all", picked.isEmpty());
     }
+
+    /**
+     * A fully-tombstoned segment ({@code size() == 0}) is classified as a
+     * micro-segment regardless of its on-disk byte size — reclaiming it is
+     * cheap (the rebuild re-inserts no live vector) and frees a full slot.
+     */
+    @Test
+    public void zeroLiveNodeSegmentIsClassifiedAsMicro() {
+        List<VectorSegment> cand = new ArrayList<>();
+        cand.add(seg(1, 500L * MB, 0));   // large on disk, every PK tombstoned
+        cand.add(seg(2, 64L, 3));         // genuine micro-segment
+        for (int i = 3; i < 7; i++) {
+            cand.add(seg(i, 100L * MB, 100_000)); // large, live
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 200L * MB,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 200,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertEquals("the 0-node and the 3-node segments are both micro",
+                2, picked.size());
+        // Smallest-bytes-first: the 64-byte micro before the 500 MB dead one.
+        assertEquals(List.of(2, 1), ids(picked));
+    }
+
+    /**
+     * Steady-state coverage with the shipped production default threshold
+     * ({@code DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES} = 1000):
+     * under a sustained supply of fresh 3-node micro-segments, the merged
+     * micro-output is itself a micro-segment and gets re-merged each cycle —
+     * but the work per cycle stays bounded by the threshold (it never
+     * approaches large-segment scale), and the growing output eventually
+     * graduates past the threshold, so the re-merge is a finite sawtooth
+     * rather than unbounded write amplification.
+     */
+    @Test
+    public void mergedMicroOutputIsReMergedButWorkStaysBounded() {
+        final long threshold =
+                PersistentVectorStore.DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES;
+        int nextId = 0;
+        List<VectorSegment> live = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            live.add(seg(nextId++, 4096L, 3));
+        }
+        long maxWorkNodes = 0L;
+        boolean sawGraduatedSegment = false;
+        final int cycles = 600;
+        for (int c = 0; c < cycles; c++) {
+            // maxCount = 2 → the issue #285 count trigger fires every cycle.
+            List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                    new ArrayList<>(live), /*minCount*/ 2,
+                    /*minBytes*/ Long.MAX_VALUE / 2, /*maxBytes*/ Long.MAX_VALUE,
+                    /*maxCount*/ 2, /*microSegmentMaxNodes*/ threshold);
+            assertTrue("cycle " + c + ": a cycle with >= 2 micro-segments must fire",
+                    picked.size() >= 2);
+            long workNodes = 0L;
+            long workBytes = 0L;
+            for (VectorSegment s : picked) {
+                assertTrue("only micro-segments must be merged by the fast path",
+                        s.size() < threshold);
+                workNodes += s.size();
+                workBytes += s.estimatedSizeBytes;
+            }
+            maxWorkNodes = Math.max(maxWorkNodes, workNodes);
+            // Simulate the merge: the inputs collapse into a single output.
+            live.removeAll(picked);
+            VectorSegment merged = seg(nextId++, workBytes, (int) workNodes);
+            live.add(merged);
+            if (merged.size() >= threshold) {
+                sawGraduatedSegment = true;
+            }
+            // A memory-pressure checkpoint flushes two fresh 3-node shards.
+            live.add(seg(nextId++, 4096L, 3));
+            live.add(seg(nextId++, 4096L, 3));
+        }
+        assertTrue("per-cycle merge work must stay bounded by the micro "
+                        + "threshold, was " + maxWorkNodes,
+                maxWorkNodes < 2L * threshold);
+        assertTrue("the growing micro output must eventually graduate past "
+                + "the threshold (re-merge is a finite sawtooth)", sawGraduatedSegment);
+        boolean graduatedPresent = live.stream().anyMatch(s -> s.size() >= threshold);
+        assertTrue("graduated segments must be left alone by the fast path",
+                graduatedPresent);
+    }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorMicroSegmentTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorMicroSegmentTest.java
@@ -1,0 +1,222 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Policy tests for the micro-segment fast path of
+ * {@link VectorIndexCompactor#chooseSegmentsToMerge} (issue #570).
+ *
+ * <p>A micro-segment is an on-disk segment whose live-node count is below the
+ * configured {@code microSegmentMaxNodes} threshold. When a compaction cycle
+ * <em>is going to fire anyway</em> (one of the byte / count triggers is
+ * satisfied) and at least two micro-segments are present, the scheduler must
+ * merge <em>only</em> the micro-segments — a cheap, fast cycle that reclaims
+ * segment-count slots quickly — deferring the larger segments to a later
+ * cycle. The fast path must never cause a cycle to compact when the normal
+ * triggers would not.
+ */
+public class VectorIndexCompactorMicroSegmentTest {
+
+    private static final long MICRO_MAX_NODES = 1000L;
+    private static final long MB = 1024L * 1024L;
+
+    /** Builds a segment with the given id, byte size and live-node count. */
+    private static VectorSegment seg(int id, long sizeBytes, int liveNodes) {
+        VectorSegment s = new VectorSegment(id);
+        s.estimatedSizeBytes = sizeBytes;
+        s.liveCount.set(liveNodes);
+        return s;
+    }
+
+    private static List<Integer> ids(List<VectorSegment> segs) {
+        List<Integer> out = new ArrayList<>(segs.size());
+        for (VectorSegment s : segs) {
+            out.add(s.segmentId);
+        }
+        return out;
+    }
+
+    /**
+     * Headline scenario: a heap of large segments plus several 3-node
+     * micro-segments. The byte trigger fires (the large segments push the
+     * total over {@code minBytes}); without the fast path the byte-capped
+     * selection would include large segments and take minutes. The fast
+     * path must instead return only the micro-segments.
+     */
+    @Test
+    public void microSegmentsMergedFirstWhenCompactionFires() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            cand.add(seg(i, 300L * MB, 100_000)); // large, graduated segments
+        }
+        for (int i = 10; i < 14; i++) {
+            cand.add(seg(i, 4096L, 3)); // micro-segments
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 256L * MB,
+                /*maxBytes*/ 1024L * MB, /*maxCount*/ 200,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertEquals("only the 4 micro-segments must be picked", 4, picked.size());
+        for (VectorSegment s : picked) {
+            assertTrue("picked segment must be a micro-segment, got id=" + s.segmentId
+                    + " nodes=" + s.size(), s.size() < MICRO_MAX_NODES);
+        }
+    }
+
+    /**
+     * The fast path must NOT make a cycle compact when neither the byte nor
+     * the count trigger fires — it only re-prioritises a cycle that is
+     * already going to run.
+     */
+    @Test
+    public void noCompactionWhenTriggersDoNotFire() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            cand.add(seg(i, 64L, 3)); // 6 tiny micro-segments
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1024L * MB,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 1000,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertTrue("no trigger fired → no compaction, even with micro-segments",
+                picked.isEmpty());
+    }
+
+    /** Picked micro-segments are ordered smallest-bytes-first. */
+    @Test
+    public void microSegmentsReturnedSmallestBytesFirst() {
+        List<VectorSegment> cand = new ArrayList<>();
+        cand.add(seg(1, 9000L, 5));
+        cand.add(seg(2, 1000L, 5));
+        cand.add(seg(3, 5000L, 5));
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1L,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 200,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertEquals(List.of(2, 3, 1), ids(picked));
+    }
+
+    /**
+     * The fast path drains <em>all</em> micro-segments in a single cycle
+     * (bounded only by the byte cap, not by {@code maxCount}) — this is what
+     * collapses a backlog of micro-segments in one cheap pass.
+     */
+    @Test
+    public void allMicroSegmentsDrainedInOneCycle() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            cand.add(seg(i, 100L + i, 3));
+        }
+        // Byte threshold unreachable; the issue #285 count trigger fires.
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1024L * MB,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 10,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertEquals("all 20 micro-segments must be merged in one cycle",
+                20, picked.size());
+    }
+
+    /**
+     * With exactly one micro-segment the fast path cannot form a merge (it
+     * needs two inputs), so the cycle falls back to the normal byte-capped
+     * selection — which includes the larger segments.
+     */
+    @Test
+    public void singleMicroSegmentYieldsNormalSelection() {
+        List<VectorSegment> cand = new ArrayList<>();
+        cand.add(seg(99, 64L, 3)); // the only micro-segment
+        for (int i = 0; i < 4; i++) {
+            cand.add(seg(i, 50L * MB, 50_000));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 100L * MB,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 200,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertEquals("normal byte-capped selection includes every candidate",
+                5, picked.size());
+    }
+
+    /** With no micro-segments at all the normal policy is used unchanged. */
+    @Test
+    public void noMicroSegmentsUsesNormalPolicy() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            cand.add(seg(i, 50L * MB, 50_000));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 200L * MB,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 100,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertEquals("normal byte trigger fires with all 5 segments", 5, picked.size());
+    }
+
+    /**
+     * {@code microSegmentMaxNodes == 0} disables the fast path entirely: the
+     * cycle then merges the byte-capped selection (large segments included),
+     * and the 6-arg overload behaves identically to the legacy 5-arg one.
+     */
+    @Test
+    public void zeroThresholdDisablesFastPath() {
+        List<VectorSegment> cand = new ArrayList<>();
+        cand.add(seg(1, 64L, 3));        // micro
+        cand.add(seg(2, 64L, 3));        // micro
+        for (int i = 3; i < 6; i++) {
+            cand.add(seg(i, 100L * MB, 100_000)); // large
+        }
+        List<VectorSegment> disabled = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 200L * MB,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 200,
+                /*microSegmentMaxNodes*/ 0L);
+        assertEquals("disabled fast path → normal selection of all 5 segments",
+                5, disabled.size());
+        // The legacy 5-arg overload must produce the same result.
+        List<VectorSegment> legacy = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, 2, 200L * MB, Long.MAX_VALUE, 200);
+        assertEquals(ids(disabled), ids(legacy));
+        // Sanity: with the fast path enabled the same input merges only the
+        // two micro-segments instead.
+        List<VectorSegment> enabled = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, 2, 200L * MB, Long.MAX_VALUE, 200, MICRO_MAX_NODES);
+        assertEquals(2, enabled.size());
+    }
+
+    /**
+     * The fast path is still gated by the overall {@code minCount} guard: a
+     * candidate set smaller than {@code minCount} yields no compaction even
+     * if it contains two micro-segments.
+     */
+    @Test
+    public void fastPathHonoursMinCountGuard() {
+        List<VectorSegment> cand = new ArrayList<>();
+        cand.add(seg(1, 64L, 3));
+        cand.add(seg(2, 64L, 3));
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 4, /*minBytes*/ 1L,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 200,
+                /*microSegmentMaxNodes*/ MICRO_MAX_NODES);
+        assertTrue("below minCount → no compaction at all", picked.isEmpty());
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -243,6 +243,21 @@ public final class IndexingServerConfiguration {
     public static final int PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT_DEFAULT = 200;
 
     /**
+     * Micro-segment fast-path threshold (issue #570): live-node count below
+     * which an on-disk segment is treated as a micro-segment. When at least
+     * two micro-segments are present, the compaction scheduler merges only
+     * those — a trivial, fast cycle that reclaims segment-count slots and
+     * relieves back-pressure quickly, instead of being stuck behind a
+     * multi-minute large merge. Micro-segments are produced by
+     * memory-pressure checkpoints flushing a near-empty live shard.
+     * Default is {@code 1000}. Set to {@code 0} to disable the fast path.
+     */
+    public static final String PROPERTY_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES =
+            "vector.index.compaction.microsegment.max.nodes";
+    public static final long PROPERTY_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES_DEFAULT =
+            1000L;
+
+    /**
      * How long old segment files remain on-disk after a compaction swap
      * before the reaper may physically delete them. Also gated by
      * {@code shadowAckedGeneration}: reclaim waits for the later of the

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -769,6 +769,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             final int vectorCompactionMaxCount = config.getInt(
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT,
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MAX_COUNT_DEFAULT);
+            // Micro-segment fast-path threshold (issue #570).
+            final long vectorCompactionMicroSegmentMaxNodes = config.getLong(
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES,
+                    IndexingServerConfiguration
+                            .PROPERTY_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES_DEFAULT);
             final boolean vectorCompactionTieredEnabled = config.getBoolean(
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_TIERED_ENABLED,
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_TIERED_ENABLED_DEFAULT);
@@ -804,12 +809,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             LOGGER.log(Level.INFO,
                     "vector index compaction: tieredEnabled={0}, backpressureSegments={1}, "
                             + "backpressureMaxWaitMs={2}, localKickFraction={3},"
-                            + " localEnabledWithOptimizer={4}, streamingEnabled={5}",
+                            + " localEnabledWithOptimizer={4}, streamingEnabled={5},"
+                            + " microSegmentMaxNodes={6}",
                     new Object[]{vectorCompactionTieredEnabled, vectorCompactionBackpressureSegments,
                             vectorCompactionBackpressureMaxWaitMs,
                             vectorCompactionLocalKickFraction,
                             vectorCompactionLocalEnabledWithOptimizer,
-                            vectorCompactionStreamingEnabled});
+                            vectorCompactionStreamingEnabled,
+                            vectorCompactionMicroSegmentMaxNodes});
             // Async IO pipeline for FusedPQ search (issue #547).
             // Config key takes precedence over the system property.
             final boolean vectorSearchAsyncPipelineEnabled = config.getBoolean(
@@ -907,6 +914,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         vectorCompactionMaxCount,
                         vectorCompactionRetentionMs);
                 store.setTieredCompactionEnabled(vectorCompactionTieredEnabled);
+                store.setCompactionMicroSegmentMaxNodes(vectorCompactionMicroSegmentMaxNodes);
                 store.setCompactionBackpressureThreshold(vectorCompactionBackpressureSegments);
                 store.setCompactionBackpressureMaxWaitMs(vectorCompactionBackpressureMaxWaitMs);
                 store.setLocalCompactionKickFraction(vectorCompactionLocalKickFraction);


### PR DESCRIPTION
Fixes #570.

## Problem

When the Indexing Service accumulates many on-disk segments (150+),
segment-count back-pressure blocks `addVector`. Memory-pressure
checkpoints flush near-empty live shards as tiny "micro-segments" (1–10
nodes). The IS-local compaction scheduler `VectorIndexCompactor.chooseSegmentsToMerge`
sorts smallest-first by *bytes*, but its byte-capped selection still
pulls in large (~100k-node) segments — so a single compaction cycle
takes minutes, and back-pressure stays on the whole time, even though
merging the dozen 3-node micro-segments would have reclaimed slots in
seconds.

## Changes

- `VectorIndexCompactor.chooseSegmentsToMerge` — added a 6-arg overload
  with a `microSegmentMaxNodes` parameter. Once the cycle has decided to
  compact (byte or count trigger fired), it re-prioritises the
  selection: if ≥2 candidates are micro-segments (live-node count below
  the threshold) it merges *only* those — a cheap, fast cycle —
  deferring larger segments to a later cycle. The fast path never makes
  a cycle compact when the normal triggers would not. The legacy 5-arg
  method delegates with the fast path disabled, so existing callers are
  unaffected.
- `PersistentVectorStore` — added the `vectorIndexCompactionMicroSegmentMaxNodes`
  knob (default 1000) with a `setCompactionMicroSegmentMaxNodes` setter /
  getter, and wired it into the compaction loop.
- `IndexingServerConfiguration` — added the
  `vector.index.compaction.microsegment.max.nodes` property (default
  1000; `0` disables the fast path).
- `IndexingServiceEngine` — reads the new property and applies it to
  every `PersistentVectorStore`; included it in the compaction INFO log.

## Tests

- `VectorIndexCompactorMicroSegmentTest` — policy unit tests: micro
  re-prioritisation when a cycle fires, no compaction when no trigger
  fires, smallest-bytes-first ordering, draining all micro-segments in
  one cycle, single-micro fallback to normal selection, no-micro
  passthrough, threshold `0` disables the path (equivalent to the 5-arg
  overload), and the `minCount` guard.
- `Issue570MicroSegmentCompactionTest` — end-to-end: builds 6 micro-
  segments + 2 larger segments, verifies a compaction cycle merges only
  the micro-segments (8 → 3 segments), preserves every live vector, and
  that the follow-up cycle is a no-op.
- Existing compaction regression tests (`VectorIndexCompactorChooseTest`,
  `Issue285SegmentCountCompactionTest`, `Issue354TieredCompactionTest`,
  `VectorIndexStreamingCompactionTest`, and the broader compaction e2e
  set) all pass, as do the `DirectMultipleConcurrentUpdatesSuite` hammer
  suites (run twice) and `BLinkConcurrentSearchInsertTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)