### PR TITLE
issue #569: warm segment block cache before publish, not after every checkpoint

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -3590,16 +3590,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         }
 
-        // Issue #569: warm the adopted segment's block cache BEFORE it is
-        // published into the searchable `this.segments` list under the write
-        // lock below — and deliberately OUTSIDE the write lock, since warmup
-        // is I/O. An adopted segment is just another freshly-loaded segment
-        // that must be hot before its first ANN query. If a concurrent
-        // adoption wins the idempotency race below the warmup is wasted, but
-        // that is rare and strictly cheaper than a cold first query.
-        warmUpNewSegmentsBeforePublish(
-                java.util.Collections.singletonList(tentative),
-                "adoptExternalSegment");
+        // Issue #569: an adopted segment is published with warmedUp == false
+        // (the VectorSegment default). It is therefore warmed by the next
+        // post-checkpoint warm-all sweep (warmUpBlockCache), which is
+        // idempotent and skips already-warmed segments. We deliberately do
+        // NOT warm inline here: adoption runs on a ZK-watcher dispatch thread
+        // and is rare, the checkpoint/compaction creation paths cover the
+        // warm-before-publish guarantee for IS-produced segments, and the
+        // sweep keeps adopted segments converging to "warm" without adding
+        // I/O to the watcher thread.
 
         // Under write lock: re-check idempotency, then publish.
         boolean alreadyAdopted = false;

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -690,6 +690,31 @@ public class PersistentVectorStore extends AbstractVectorStore {
     final AtomicLong pendingDeletesReapFailuresTotal = new AtomicLong();
 
     // -------------------------------------------------------------------------
+    // Block-cache warmup (issue #322 / #569)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Approximate per-segment byte budget for the BFS block-cache warmup
+     * (issue #322). A value of {@code 0} (the default) or negative disables
+     * warmup entirely. Set by {@code IndexingServiceEngine} from
+     * {@code vector.index.segmentCacheWarmupBytes} via
+     * {@link #setWarmupBytesPerSegment(long)} so the store can warm each new
+     * segment AT CREATION TIME — before it is published into the searchable
+     * {@link #segments} list (issue #569).
+     */
+    private volatile long warmupBytesPerSegment;
+
+    /**
+     * Counter: total number of segments actually BFS-warmed by this store
+     * since start (issue #569). With per-segment warm-at-creation in place,
+     * this rises by exactly one per checkpoint (the new segment) and one per
+     * compaction cycle (the merged output) in steady state; a jump equal to
+     * the running segment count would indicate the post-checkpoint warm-all
+     * is no longer idempotent — i.e. the death spiral has regressed.
+     */
+    final AtomicLong warmedSegmentsTotal = new AtomicLong();
+
+    // -------------------------------------------------------------------------
     // PQ codebook cache (issue #281)
     // -------------------------------------------------------------------------
 
@@ -2446,6 +2471,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         lateDeletes.forEach(merged::deletePk);
                     }
 
+                    // Issue #569: warm the merged output's block cache BEFORE
+                    // the atomic swap publishes it into the searchable
+                    // `this.segments` list. The compaction cycle deliberately
+                    // WAITS for this warmup to complete — it runs synchronously
+                    // on the compaction thread — so the merged segment is hot
+                    // the instant it becomes searchable. The cost is bounded:
+                    // exactly one segment per cycle, capped by the per-segment
+                    // warmup byte budget regardless of the merged size.
+                    warmUpNewSegmentsBeforePublish(
+                            java.util.Collections.singletonList(rebuild.mergedSegment),
+                            "compaction merge output");
+
                     atomicSwapCompactionResult(candidates, rebuild.mergedSegment,
                             rebuild.bytesWritten, rebuild.vectorCount);
 
@@ -3552,6 +3589,17 @@ public class PersistentVectorStore extends AbstractVectorStore {
                 dropSegmentBLinkStorage(tentative);
             }
         }
+
+        // Issue #569: warm the adopted segment's block cache BEFORE it is
+        // published into the searchable `this.segments` list under the write
+        // lock below — and deliberately OUTSIDE the write lock, since warmup
+        // is I/O. An adopted segment is just another freshly-loaded segment
+        // that must be hot before its first ANN query. If a concurrent
+        // adoption wins the idempotency race below the warmup is wasted, but
+        // that is rare and strictly cheaper than a cold first query.
+        warmUpNewSegmentsBeforePublish(
+                java.util.Collections.singletonList(tentative),
+                "adoptExternalSegment");
 
         // Under write lock: re-check idempotency, then publish.
         boolean alreadyAdopted = false;
@@ -4797,6 +4845,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * failures are logged at WARNING and skipped; the warmup is best-effort
      * and never aborts the watermark save.
      *
+     * <p><b>Idempotency (issue #569).</b> Segments are warmed exactly once,
+     * AT CREATION TIME, before they are published into the searchable
+     * {@link #segments} list — checkpoint Phase C-prep and compaction both
+     * call {@link #warmUpSegment} on their freshly-built segment. This
+     * sweep therefore only does real I/O for segments that were never warmed
+     * at creation — i.e. segments loaded by {@code loadFromStatus} on
+     * restart. For an already-warmed segment {@link #warmUpSegment} returns
+     * immediately, so the post-checkpoint warm-all degenerates to a cheap
+     * no-op in steady state. This is what breaks the
+     * warmup→checkpoint→warmup death spiral: the old behaviour re-warmed
+     * <em>all</em> segments after <em>every</em> checkpoint, monopolising
+     * memory and I/O and starving compaction.
+     *
      * <p>In local-file or in-memory storage modes the reads route through the
      * in-memory buffer; they complete without error but have no block-cache
      * effect.
@@ -4813,37 +4874,145 @@ public class PersistentVectorStore extends AbstractVectorStore {
             return;
         }
         long startMs = System.currentTimeMillis();
-        LOGGER.log(Level.INFO,
-                "warmUpBlockCache {0}: warming {1} segments, ~{2} bytes each (BFS from entry node)",
-                new Object[]{indexName, currentSegments.size(), warmupBytesPerSegment});
         int warmedSegments = 0;
         long totalNodesVisited = 0;
         for (VectorSegment seg : currentSegments) {
-            OnDiskGraphIndex odg = seg.onDiskGraph;
-            if (odg == null || seg.graphFileSize <= 0) {
-                continue;
-            }
-            int idUpperBound = odg.getIdUpperBound();
-            if (idUpperBound <= 0) {
-                continue;
-            }
-            // Estimate bytes-per-node: Layer-0 data dominates file size.
-            long approxBytesPerNode = Math.max(1L, seg.graphFileSize / idUpperBound);
-            // Always warm at least the entry node regardless of budget.
-            int nodeLimit = (int) Math.min(
-                    idUpperBound,
-                    Math.max(1L, warmupBytesPerSegment / approxBytesPerNode));
-            int nodesVisited = warmUpSegmentBfs(seg, odg, nodeLimit);
+            // Already-warmed segments (the steady-state case once every
+            // segment is warmed at creation) return 0 here without any I/O.
+            int nodesVisited = warmUpSegment(seg, warmupBytesPerSegment);
             if (nodesVisited > 0) {
                 warmedSegments++;
                 totalNodesVisited += nodesVisited;
             }
         }
         long elapsedMs = System.currentTimeMillis() - startMs;
-        LOGGER.log(Level.INFO,
-                "warmUpBlockCache {0}: warmed {1}/{2} segments, {3} nodes total in {4} ms",
-                new Object[]{indexName, warmedSegments, currentSegments.size(),
-                        totalNodesVisited, elapsedMs});
+        if (warmedSegments > 0) {
+            LOGGER.log(Level.INFO,
+                    "warmUpBlockCache {0}: warmed {1}/{2} segments (others already warm), "
+                            + "{3} nodes total in {4} ms",
+                    new Object[]{indexName, warmedSegments, currentSegments.size(),
+                            totalNodesVisited, elapsedMs});
+        } else {
+            LOGGER.log(Level.FINE,
+                    "warmUpBlockCache {0}: all {1} segments already warm — no-op",
+                    new Object[]{indexName, currentSegments.size()});
+        }
+    }
+
+    /**
+     * Sets the per-segment block-cache warmup byte budget (issue #322 / #569).
+     * A value of {@code 0} or negative disables warmup. Called by
+     * {@code IndexingServiceEngine} before {@link #start()} so that segments
+     * created by subsequent checkpoints and compactions are warmed at
+     * creation time. See {@link #warmupBytesPerSegment}.
+     */
+    public void setWarmupBytesPerSegment(long warmupBytesPerSegment) {
+        this.warmupBytesPerSegment = warmupBytesPerSegment;
+    }
+
+    /**
+     * Total number of segments actually BFS-warmed by this store since start
+     * (issue #569). Exposed for tests and Prometheus exporters.
+     */
+    public long getWarmedSegmentsTotal() {
+        return warmedSegmentsTotal.get();
+    }
+
+    /**
+     * Warms a single segment's block cache (issue #569), idempotently.
+     *
+     * <p>This is the per-segment building block called both by the
+     * post-checkpoint warm-all sweep ({@link #warmUpBlockCache}) and — the
+     * point of issue #569 — directly by the checkpoint and compaction code
+     * paths on a freshly-built segment BEFORE it is published into the
+     * searchable {@link #segments} list. Warming before publish guarantees
+     * the first ANN query against a new segment finds hot cache blocks
+     * instead of issuing cold streaming reads, without the old behaviour of
+     * re-warming every loaded segment after every checkpoint.
+     *
+     * <p>The method is idempotent: once a segment has been warmed (or found
+     * to have nothing to warm) its {@link VectorSegment#warmedUp} flag is set
+     * and subsequent calls return {@code 0} immediately. A real I/O error
+     * leaves the flag unset so the next sweep retries.
+     *
+     * @param seg the segment to warm
+     * @param bytesPerSegment approximate byte budget for the BFS; {@code <= 0}
+     *     disables warmup (no-op, flag left unset so a later enable still works)
+     * @return number of graph nodes visited (0 if disabled, already warm,
+     *     nothing to warm, or an I/O error occurred)
+     */
+    int warmUpSegment(VectorSegment seg, long bytesPerSegment) {
+        if (bytesPerSegment <= 0 || seg == null) {
+            return 0;
+        }
+        if (seg.warmedUp) {
+            return 0;
+        }
+        OnDiskGraphIndex odg = seg.onDiskGraph;
+        if (odg == null || seg.graphFileSize <= 0) {
+            // Nothing to warm — mark warmed so the warm-all sweep skips it
+            // for good rather than re-checking it on every checkpoint.
+            seg.warmedUp = true;
+            return 0;
+        }
+        int idUpperBound = odg.getIdUpperBound();
+        if (idUpperBound <= 0) {
+            seg.warmedUp = true;
+            return 0;
+        }
+        // Estimate bytes-per-node: Layer-0 data dominates file size.
+        long approxBytesPerNode = Math.max(1L, seg.graphFileSize / idUpperBound);
+        // Always warm at least the entry node regardless of budget.
+        int nodeLimit = (int) Math.min(
+                idUpperBound,
+                Math.max(1L, bytesPerSegment / approxBytesPerNode));
+        int nodesVisited = warmUpSegmentBfs(seg, odg, nodeLimit);
+        if (nodesVisited > 0) {
+            seg.warmedUp = true;
+            warmedSegmentsTotal.incrementAndGet();
+            return nodesVisited;
+        }
+        // nodesVisited == 0 means warmUpSegmentBfs hit an I/O error (it
+        // always visits at least the entry node on success). Leave
+        // warmedUp == false so a later sweep retries this segment.
+        return 0;
+    }
+
+    /**
+     * Warms every segment in {@code newSegments} that has not yet been warmed
+     * (issue #569), using the configured {@link #warmupBytesPerSegment}
+     * budget. Called by the checkpoint and compaction paths on their
+     * freshly-built segments BEFORE the segments are published into the
+     * searchable {@link #segments} list.
+     *
+     * <p>No-op when warmup is disabled ({@code warmupBytesPerSegment <= 0}).
+     * Best-effort: per-segment I/O errors are swallowed inside
+     * {@link #warmUpSegment} / {@link #warmUpSegmentBfs} and never abort the
+     * checkpoint or compaction.
+     */
+    private void warmUpNewSegmentsBeforePublish(List<VectorSegment> newSegments,
+                                                String context) {
+        long budget = this.warmupBytesPerSegment;
+        if (budget <= 0 || newSegments == null || newSegments.isEmpty()) {
+            return;
+        }
+        long startMs = System.currentTimeMillis();
+        int warmed = 0;
+        long totalNodes = 0;
+        for (VectorSegment seg : newSegments) {
+            int nodes = warmUpSegment(seg, budget);
+            if (nodes > 0) {
+                warmed++;
+                totalNodes += nodes;
+            }
+        }
+        if (warmed > 0) {
+            LOGGER.log(Level.INFO,
+                    "warmUpBlockCache {0}: pre-publish warm of {1} new segment(s) ({2}), "
+                            + "{3} nodes in {4} ms",
+                    new Object[]{indexName, warmed, context, totalNodes,
+                            System.currentTimeMillis() - startMs});
+        }
     }
 
     /**
@@ -5296,6 +5465,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         this.provisionalPageIds = null;
         this.provisionalMultipartFiles = null;
         consecutiveCheckpointFailures.set(0);
+
+        // Issue #569: warm the block cache of the freshly-built segments NOW —
+        // while they are loaded but still NOT searchable (they join the
+        // visible `this.segments` list only at Phase C Stage 2 below). Warming
+        // here, on the checkpoint thread, means the first ANN query against a
+        // new segment finds hot cache blocks; it also makes the post-checkpoint
+        // warm-all sweep idempotent (each segment is warmed exactly once),
+        // which is what breaks the warmup→checkpoint→warmup death spiral.
+        warmUpNewSegmentsBeforePublish(preloadedSegments, "checkpoint Phase C-prep");
 
         // ---------- Phase C — two-stage protocol (issue #462). ----------
         //

--- a/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorSegment.java
@@ -90,6 +90,24 @@ class VectorSegment implements Closeable {
     volatile boolean dirty;
 
     /**
+     * Whether this segment's block cache has already been warmed (issue #569).
+     *
+     * <p>Set to {@code true} once {@link PersistentVectorStore#warmUpSegment}
+     * has BFS-warmed the segment's Layer-0 graph pages — or once it has
+     * determined there is nothing to warm (no {@code onDiskGraph}). Warming
+     * happens BEFORE the segment is published into the searchable
+     * {@code PersistentVectorStore.segments} list, so the field is always set
+     * before the volatile publish that makes the segment visible to readers.
+     *
+     * <p>Declared {@code volatile} so the post-checkpoint warm-all sweep,
+     * which may run on the dedicated warmup executor thread, observes the
+     * value written by the checkpoint / compaction thread and treats an
+     * already-warmed segment as a no-op (idempotent warm-all — the fix for
+     * the warmup→checkpoint→warmup death spiral).
+     */
+    volatile boolean warmedUp;
+
+    /**
      * Snapshot of {@link #estimatedInMemoryBytes()} captured by
      * {@link PersistentVectorStore}'s incremental on-disk-segment memory
      * counter (issue #455).  Written when the segment is registered with the

--- a/herddb-core/src/test/java/herddb/index/vector/Issue569WarmupBeforePublishTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue569WarmupBeforePublishTest.java
@@ -1,0 +1,291 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.storage.DataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression tests for issue #569 — the warmup→checkpoint→warmup death spiral.
+ *
+ * <p>Before the fix, {@code IndexingServiceEngine} re-warmed the block cache of
+ * <em>every</em> loaded segment after <em>every</em> checkpoint. Once the
+ * indexing service accumulated 150+ segments this took ~135 s, spiked the
+ * heap, immediately re-triggered a memory-pressure checkpoint, and starved
+ * compaction — the segment count then grew without bound and the tailer froze.
+ *
+ * <p>The fix warms each segment exactly once, AT CREATION TIME, before it is
+ * published into the searchable {@code segments} list:
+ * <ul>
+ *   <li>checkpoint Phase C-prep warms the freshly-built segment(s);</li>
+ *   <li>compaction warms the merged output before the atomic swap;</li>
+ * </ul>
+ * which makes the post-checkpoint warm-all sweep an idempotent no-op in steady
+ * state. The only segments warmed by the sweep are restart-loaded ones.
+ */
+public class Issue569WarmupBeforePublishTest {
+
+    /** A budget large enough to fully warm every test segment. */
+    private static final long WARMUP_BUDGET = Long.MAX_VALUE;
+
+    private static final int DIM = 8;
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        // Allow checkpoints to run with the small batches used here.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    private PersistentVectorStore newStore(Path tmpDir, DataStorageManager dsm, String indexUuid) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        // Explicit indexUUID so a reopened store recovers the same checkpoint.
+        return new PersistentVectorStore(
+                "vidx569", "vectable", "tstblspace", "vec", indexUuid, tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0, /*compactionIntervalMs*/ Long.MAX_VALUE);
+    }
+
+    private static void addBatch(PersistentVectorStore store, int checkpointIdx,
+                                 int count, Random rng) throws Exception {
+        for (int i = 0; i < count; i++) {
+            float[] vec = new float[DIM];
+            for (int d = 0; d < DIM; d++) {
+                vec[d] = rng.nextFloat();
+            }
+            store.addVector(Bytes.from_int(checkpointIdx * 100_000 + i), vec);
+        }
+    }
+
+    /**
+     * Every segment produced by a checkpoint must be warmed BEFORE it joins
+     * the searchable segment list — i.e. {@code warmedUp} is already {@code
+     * true} for every segment visible after {@code checkpoint()} returns.
+     */
+    @Test
+    public void checkpointSegmentsAreWarmedBeforePublish() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        DataStorageManager dsm = new MemoryDataStorageManager();
+        try (PersistentVectorStore store = newStore(tmpDir, dsm, "uuid-checkpoint")) {
+            store.setWarmupBytesPerSegment(WARMUP_BUDGET);
+            store.start();
+
+            Random rng = new Random(569);
+            addBatch(store, 0, 300, rng);
+            assertEquals("nothing is warmed before the first checkpoint",
+                    0, store.getWarmedSegmentsTotal());
+
+            store.checkpoint();
+
+            List<VectorSegment> segs = store.getOnDiskSegmentsSnapshotForTest();
+            assertFalse("checkpoint must publish at least one segment", segs.isEmpty());
+            for (VectorSegment s : segs) {
+                assertTrue("every published segment must be warmed before it is searchable",
+                        s.warmedUp);
+            }
+            assertEquals("each new segment warmed exactly once at creation",
+                    segs.size(), (int) store.getWarmedSegmentsTotal());
+        }
+    }
+
+    /**
+     * The core death-spiral regression: across many checkpoints the total
+     * number of segments actually warmed must equal the number of segments
+     * that exist (each warmed exactly once) — it must NOT grow with the
+     * running segment count, and the post-checkpoint warm-all sweep must be
+     * an idempotent no-op.
+     */
+    @Test
+    public void warmupCostStaysBoundedAcrossCheckpoints() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        DataStorageManager dsm = new MemoryDataStorageManager();
+        try (PersistentVectorStore store = newStore(tmpDir, dsm, "uuid-spiral")) {
+            store.setWarmupBytesPerSegment(WARMUP_BUDGET);
+            store.start();
+
+            Random rng = new Random(42);
+            int checkpoints = 6;
+            for (int c = 0; c < checkpoints; c++) {
+                addBatch(store, c, 300, rng);
+                store.checkpoint();
+                // Each segment is warmed exactly once, at creation. If the old
+                // warm-all-after-every-checkpoint behaviour regressed this
+                // counter would grow quadratically (1+2+...+N) and far exceed
+                // the live segment count.
+                assertEquals("checkpoint " + c + ": every segment warmed exactly once",
+                        store.getOnDiskSegmentCount(), (int) store.getWarmedSegmentsTotal());
+            }
+
+            long warmedAfterBuild = store.getWarmedSegmentsTotal();
+            // The post-checkpoint warm-all sweep — what IndexingServiceEngine
+            // invokes — must now find every segment already warm and do no I/O.
+            store.warmUpBlockCache(WARMUP_BUDGET);
+            assertEquals("warm-all sweep must be idempotent — no segment re-warmed",
+                    warmedAfterBuild, store.getWarmedSegmentsTotal());
+            store.warmUpBlockCache(WARMUP_BUDGET);
+            assertEquals("repeated warm-all sweeps stay idempotent",
+                    warmedAfterBuild, store.getWarmedSegmentsTotal());
+        }
+    }
+
+    /**
+     * Compaction must warm its merged output segment BEFORE the atomic swap
+     * publishes it — and exactly once (one extra warmed segment per cycle,
+     * never a re-warm of the surviving segments).
+     */
+    @Test
+    public void compactionMergedOutputIsWarmedBeforePublish() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        DataStorageManager dsm = new MemoryDataStorageManager();
+        try (PersistentVectorStore store = newStore(tmpDir, dsm, "uuid-compaction")) {
+            store.setWarmupBytesPerSegment(WARMUP_BUDGET);
+            // Count-triggered compaction: fires once >= 6 mergeable segments
+            // accumulate (byte trigger kept unreachably high).
+            store.configureCompaction(
+                    /*intervalMs*/ Long.MAX_VALUE,
+                    /*minBytes*/ Long.MAX_VALUE / 2,
+                    /*maxBytes*/ Long.MAX_VALUE,
+                    /*minCount*/ 2,
+                    /*maxCount*/ 6,
+                    /*retentionMs*/ 0);
+            store.start();
+
+            Random rng = new Random(285);
+            for (int c = 0; c < 8; c++) {
+                addBatch(store, c, 300, rng);
+                store.checkpoint();
+            }
+
+            int segmentsBefore = store.getOnDiskSegmentCount();
+            assertTrue("need several segments to exercise a merge, got " + segmentsBefore,
+                    segmentsBefore >= 6);
+            long warmedBefore = store.getWarmedSegmentsTotal();
+            assertEquals("all pre-compaction segments were warmed at creation",
+                    segmentsBefore, (int) warmedBefore);
+
+            store.runCompactionCycle();
+
+            assertTrue("compaction must reduce the segment count",
+                    store.getOnDiskSegmentCount() < segmentsBefore);
+            assertEquals("exactly the merged output is warmed — before it is published",
+                    warmedBefore + 1, store.getWarmedSegmentsTotal());
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                assertTrue("every segment (including the merged output) is warm",
+                        s.warmedUp);
+            }
+        }
+    }
+
+    /**
+     * Segments reloaded by {@code loadFromStatus} on restart start COLD
+     * (they were not created by this store instance). The warm-all sweep
+     * warms them once; a second sweep is a no-op.
+     */
+    @Test
+    public void warmAllWarmsRestartLoadedColdSegments() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        DataStorageManager dsm = new MemoryDataStorageManager();
+
+        int segmentCount;
+        try (PersistentVectorStore store = newStore(tmpDir, dsm, "uuid-restart")) {
+            store.setWarmupBytesPerSegment(WARMUP_BUDGET);
+            store.start();
+            Random rng = new Random(7);
+            for (int c = 0; c < 4; c++) {
+                addBatch(store, c, 300, rng);
+                store.checkpoint();
+            }
+            segmentCount = store.getOnDiskSegmentCount();
+            assertTrue("checkpoints must build some segments", segmentCount > 0);
+        }
+
+        // Reopen against the same storage + index UUID — segments are restored
+        // by loadFromStatus and start cold.
+        try (PersistentVectorStore reopened = newStore(tmpDir, dsm, "uuid-restart")) {
+            reopened.setWarmupBytesPerSegment(WARMUP_BUDGET);
+            reopened.start();
+
+            assertEquals("restart must reload the persisted segments",
+                    segmentCount, reopened.getOnDiskSegmentCount());
+            assertEquals("restart-loaded segments are not warmed at creation",
+                    0, reopened.getWarmedSegmentsTotal());
+            for (VectorSegment s : reopened.getOnDiskSegmentsSnapshotForTest()) {
+                assertFalse("a restart-loaded segment starts cold", s.warmedUp);
+            }
+
+            reopened.warmUpBlockCache(WARMUP_BUDGET);
+            assertEquals("warm-all warms every restart-loaded segment exactly once",
+                    segmentCount, (int) reopened.getWarmedSegmentsTotal());
+            for (VectorSegment s : reopened.getOnDiskSegmentsSnapshotForTest()) {
+                assertTrue("restart-loaded segment is warm after the sweep", s.warmedUp);
+            }
+
+            reopened.warmUpBlockCache(WARMUP_BUDGET);
+            assertEquals("a second warm-all sweep is an idempotent no-op",
+                    segmentCount, (int) reopened.getWarmedSegmentsTotal());
+        }
+    }
+
+    /**
+     * When warmup is disabled ({@code warmupBytesPerSegment <= 0}) no segment
+     * is warmed and the warm-all sweep is a no-op.
+     */
+    @Test
+    public void warmupDisabledLeavesSegmentsUnwarmed() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        DataStorageManager dsm = new MemoryDataStorageManager();
+        try (PersistentVectorStore store = newStore(tmpDir, dsm, "uuid-disabled")) {
+            // warmupBytesPerSegment left at its default of 0 → warmup disabled.
+            store.start();
+            Random rng = new Random(99);
+            addBatch(store, 0, 300, rng);
+            store.checkpoint();
+
+            assertEquals("warmup disabled → no segment is warmed",
+                    0, store.getWarmedSegmentsTotal());
+            for (VectorSegment s : store.getOnDiskSegmentsSnapshotForTest()) {
+                assertFalse("warmup disabled → segment stays cold", s.warmedUp);
+            }
+            store.warmUpBlockCache(0);
+            assertEquals("warm-all with a zero budget is a no-op",
+                    0, store.getWarmedSegmentsTotal());
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -912,6 +912,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 store.setLocalCompactionKickFraction(vectorCompactionLocalKickFraction);
                 store.setLocalCompactionEnabledWithOptimizer(
                         vectorCompactionLocalEnabledWithOptimizer);
+                // Issue #569: hand the warmup byte budget to the store so it can
+                // warm each new segment's block cache AT CREATION TIME (in the
+                // checkpoint Phase C-prep and compaction merge paths), before the
+                // segment becomes searchable. The post-checkpoint warm-all below
+                // (submitWarmupAsyncOrInline) then degenerates to an idempotent
+                // no-op in steady state, breaking the warmup→checkpoint→warmup
+                // death spiral. `warmupBytesPerSegment` is resolved earlier in
+                // start(); the factory lambda runs later (tailer-driven), so the
+                // field is always populated by the time this executes.
+                store.setWarmupBytesPerSegment(this.warmupBytesPerSegment);
                 // Issue #491: when the external index-optimizer is enabled cluster-wide
                 // (indexing.optimizer.enabled=true) AND the metadata storage manager is
                 // ZK-backed, attach a SegmentRegistryPublisher BEFORE start() so that:

--- a/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupTest.java
@@ -44,6 +44,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
@@ -155,6 +156,12 @@ public class BlockCacheWarmupTest {
     private static final class TrackingMemoryDataStorageManager extends MemoryDataStorageManager {
 
         final AtomicLong totalBytesRead = new AtomicLong();
+        /**
+         * When {@code true}, every data-read on a reader handed out AFTER the
+         * flag is set throws {@link IOException} — used to inject a warmup I/O
+         * failure (issue #569) and verify the retry contract.
+         */
+        final AtomicBoolean failReads = new AtomicBoolean(false);
 
         @Override
         public ReaderSupplier multipartIndexReaderSupplier(
@@ -162,7 +169,7 @@ public class BlockCacheWarmupTest {
                 throws DataStorageManagerException {
             ReaderSupplier original = super.multipartIndexReaderSupplier(
                     tableSpace, uuid, fileType, fileSize);
-            return new CountingReaderSupplier(original, totalBytesRead);
+            return new CountingReaderSupplier(original, totalBytesRead, failReads);
         }
     }
 
@@ -170,15 +177,18 @@ public class BlockCacheWarmupTest {
 
         private final ReaderSupplier delegate;
         private final AtomicLong counter;
+        private final AtomicBoolean failReads;
 
-        CountingReaderSupplier(ReaderSupplier delegate, AtomicLong counter) {
+        CountingReaderSupplier(ReaderSupplier delegate, AtomicLong counter,
+                               AtomicBoolean failReads) {
             this.delegate = delegate;
             this.counter = counter;
+            this.failReads = failReads;
         }
 
         @Override
         public RandomAccessReader get() throws IOException {
-            return new CountingReader(delegate.get(), counter);
+            return new CountingReader(delegate.get(), counter, failReads);
         }
 
         @Override
@@ -191,20 +201,31 @@ public class BlockCacheWarmupTest {
 
         private final RandomAccessReader delegate;
         private final AtomicLong counter;
+        private final AtomicBoolean failReads;
 
-        CountingReader(RandomAccessReader delegate, AtomicLong counter) {
+        CountingReader(RandomAccessReader delegate, AtomicLong counter,
+                       AtomicBoolean failReads) {
             this.delegate = delegate;
             this.counter = counter;
+            this.failReads = failReads;
+        }
+
+        private void failIfRequested() throws IOException {
+            if (failReads.get()) {
+                throw new IOException("injected read failure");
+            }
         }
 
         @Override
         public void readFully(byte[] dest) throws IOException {
+            failIfRequested();
             delegate.readFully(dest);
             counter.addAndGet(dest.length);
         }
 
         @Override
         public void readFully(ByteBuffer buffer) throws IOException {
+            failIfRequested();
             int before = buffer.remaining();
             delegate.readFully(buffer);
             counter.addAndGet(before - buffer.remaining());
@@ -212,18 +233,21 @@ public class BlockCacheWarmupTest {
 
         @Override
         public void readFully(long[] longs) throws IOException {
+            failIfRequested();
             delegate.readFully(longs);
             counter.addAndGet((long) longs.length * Long.BYTES);
         }
 
         @Override
         public void read(int[] ints, int offset, int count) throws IOException {
+            failIfRequested();
             delegate.read(ints, offset, count);
             counter.addAndGet((long) count * Integer.BYTES);
         }
 
         @Override
         public void read(float[] floats, int offset, int count) throws IOException {
+            failIfRequested();
             delegate.read(floats, offset, count);
             counter.addAndGet((long) count * Float.BYTES);
         }
@@ -240,6 +264,7 @@ public class BlockCacheWarmupTest {
 
         @Override
         public int readInt() throws IOException {
+            failIfRequested();
             int v = delegate.readInt();
             counter.addAndGet(Integer.BYTES);
             return v;
@@ -247,6 +272,7 @@ public class BlockCacheWarmupTest {
 
         @Override
         public float readFloat() throws IOException {
+            failIfRequested();
             float v = delegate.readFloat();
             counter.addAndGet(Float.BYTES);
             return v;
@@ -254,6 +280,7 @@ public class BlockCacheWarmupTest {
 
         @Override
         public long readLong() throws IOException {
+            failIfRequested();
             long v = delegate.readLong();
             counter.addAndGet(Long.BYTES);
             return v;
@@ -420,6 +447,53 @@ public class BlockCacheWarmupTest {
             dsm.totalBytesRead.set(0);
             store.warmUpBlockCache(budget);
             return dsm.totalBytesRead.get();
+        } finally {
+            store.close();
+        }
+    }
+
+    /**
+     * Issue #569: a warmup that hits an I/O error must NOT mark the segment
+     * warmed — {@code warmUpSegmentBfs} returns 0 and {@code warmUpSegment}
+     * leaves {@code warmedUp == false} so a later sweep retries it. Verifies
+     * the retry contract end to end: a failing {@code warmUpBlockCache}
+     * sweep warms nothing, and a subsequent sweep (after the failure clears)
+     * warms the segment.
+     */
+    @Test
+    public void testWarmupRetriesAfterIoFailure() throws Exception {
+        Path tmpDir = folder.newFolder().toPath();
+        TrackingMemoryDataStorageManager dsm = new TrackingMemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "vectable", "tstuuid", "vec",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE, VectorSimilarityFunction.EUCLIDEAN);
+        store.start();
+        try {
+            Random rng = new Random(569);
+            int dim = 32;
+            for (int i = 0; i < 512; i++) {
+                store.addVector(herddb.utils.Bytes.from_string("pk" + i),
+                        randomVector(rng, dim));
+            }
+            // Checkpoint reads must succeed — only the warmup reads below fail.
+            store.checkpoint();
+
+            // Inject an I/O failure, then attempt the warm-all sweep.
+            dsm.failReads.set(true);
+            store.warmUpBlockCache(Long.MAX_VALUE);
+            assertEquals("a warmup that hits an I/O error must leave the segment "
+                            + "unwarmed (no segment counted as warmed)",
+                    0, store.getWarmedSegmentsTotal());
+
+            // Clear the failure: the next sweep must retry and warm the segment.
+            dsm.failReads.set(false);
+            store.warmUpBlockCache(Long.MAX_VALUE);
+            assertTrue("warmup must retry and succeed once the I/O error clears",
+                    store.getWarmedSegmentsTotal() > 0);
         } finally {
             store.close();
         }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/BlockCacheWarmupTest.java
@@ -337,7 +337,10 @@ public class BlockCacheWarmupTest {
             }
             store.checkpoint();
 
-            // Reset the counter so only warmup reads are measured.
+            // Reset the counter so only warmup reads are measured. The store
+            // never received a setWarmupBytesPerSegment() call, so the
+            // segments built by the checkpoint were NOT warmed at creation
+            // (issue #569) and the warm-all sweep below does the real work.
             dsm.totalBytesRead.set(0);
 
             // Warm with a generous limit — should read whatever is in each segment file.
@@ -345,6 +348,15 @@ public class BlockCacheWarmupTest {
 
             assertTrue("warmup must have issued at least one byte of reads",
                     dsm.totalBytesRead.get() > 0);
+
+            // Issue #569: the warm-all sweep is idempotent — once every
+            // segment is warm a second sweep finds nothing to do and issues
+            // no reads. This is what stops the warmup→checkpoint→warmup
+            // death spiral.
+            dsm.totalBytesRead.set(0);
+            store.warmUpBlockCache(Long.MAX_VALUE);
+            assertEquals("second warm-all sweep must be an idempotent no-op",
+                    0, dsm.totalBytesRead.get());
         } finally {
             store.close();
         }
@@ -359,7 +371,32 @@ public class BlockCacheWarmupTest {
      */
     @Test
     public void testWarmupRespectsLimit() throws Exception {
-        Path tmpDir = folder.newFolder("data").toPath();
+        // Two independent stores built from identical data: one warmed with a
+        // generous budget (full BFS), one with a 1-byte budget (entry node
+        // only). The limited warmup must read strictly less.
+        //
+        // Two stores are required because warmUpBlockCache is idempotent per
+        // segment (issue #569) — once a segment is warmed a second sweep on
+        // the same store does nothing, so the budget cannot be re-exercised
+        // on an already-warmed store.
+        long fullWarmupBytes = measureWarmupBytes(Long.MAX_VALUE);
+        long limitedBytes = measureWarmupBytes(1);
+
+        assertTrue("full warmup must read something", fullWarmupBytes > 0);
+        assertTrue("limited warmup (" + limitedBytes + " bytes) must read less than "
+                        + "full warmup (" + fullWarmupBytes + " bytes)",
+                limitedBytes < fullWarmupBytes);
+    }
+
+    /**
+     * Builds a fresh store, checkpoints 512 vectors into it, then runs a
+     * single {@code warmUpBlockCache(budget)} sweep and returns the number of
+     * bytes that sweep read. The store does not receive a
+     * {@code setWarmupBytesPerSegment()} call, so its segments are cold after
+     * the checkpoint and the sweep does the warming.
+     */
+    private long measureWarmupBytes(long budget) throws Exception {
+        Path tmpDir = folder.newFolder().toPath();
         TrackingMemoryDataStorageManager dsm = new TrackingMemoryDataStorageManager();
         MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
 
@@ -378,20 +415,11 @@ public class BlockCacheWarmupTest {
             }
             store.checkpoint();
 
-            // Full warmup (baseline — visits all nodes via BFS).
+            // 1-byte budget → nodeLimit = max(1, 1/approxBytesPerNode) = 1
+            // (entry node only); a generous budget visits every node via BFS.
             dsm.totalBytesRead.set(0);
-            store.warmUpBlockCache(Long.MAX_VALUE);
-            long fullWarmupBytes = dsm.totalBytesRead.get();
-            assertTrue("full warmup must read something", fullWarmupBytes > 0);
-
-            // 1-byte budget → nodeLimit = max(1, 1/approxBytesPerNode) = 1 (entry node only).
-            // Reads just readInt + neighbor-ID array: a few dozen bytes, strictly
-            // less than a full BFS over all nodes.
-            dsm.totalBytesRead.set(0);
-            store.warmUpBlockCache(1);
-            long limitedBytes = dsm.totalBytesRead.get();
-            assertTrue("limited warmup must read less than full warmup",
-                    limitedBytes < fullWarmupBytes);
+            store.warmUpBlockCache(budget);
+            return dsm.totalBytesRead.get();
         } finally {
             store.close();
         }


### PR DESCRIPTION
Fixes #569.

## Problem

`IndexingServiceEngine` called `PersistentVectorStore.warmUpBlockCache()` after **every** checkpoint, and it BFS-warmed the block cache of **every** loaded segment. Once the indexing service accumulated 150+ on-disk segments this warm-all took ~135 s and loaded ~4 M graph nodes, spiked the heap to 88–92 %, and — the moment it finished — immediately re-triggered a memory-pressure checkpoint. The new checkpoint wrote another micro-segment, the next warm-all was therefore even longer, and the cycle never broke: a warmup→checkpoint→warmup death spiral that starved compaction (segment count never dropped) and froze the IS tailer for 15+ minutes.

## Fix

Warm each segment **exactly once, at creation time, before it becomes searchable** — instead of re-warming all segments after every checkpoint:

- **Checkpoint Phase C-prep** warms the freshly-built segment(s) before the Phase C Stage-2 publish into the searchable `segments` list.
- **Compaction** warms the merged output before `atomicSwapCompactionResult`; the cycle deliberately waits for it (bounded to one segment, capped by the warmup byte budget).

`VectorSegment` carries a new `volatile boolean warmedUp` flag. The post-checkpoint warm-all sweep (`warmUpBlockCache`) now skips already-warmed segments, so it is **idempotent**: it does real I/O only for segments loaded by `loadFromStatus` on restart (or adopted from the external optimizer), and is a cheap no-op in steady state. With no warm-all heap spike there is no spurious memory-pressure checkpoint, so compaction gets its CPU/I-O window — the death spiral cannot recur.

`adoptExternalSegment` does **not** warm inline: an adopted segment is published with `warmedUp == false` and is warmed by the next idempotent warm-all sweep, exactly like a restart-loaded segment (no I/O added to the ZK-watcher dispatch thread).

## Changes
- `PersistentVectorStore.java` — `warmupBytesPerSegment` field + `setWarmupBytesPerSegment`; `warmedSegmentsTotal` metric + getter; new `warmUpSegment` (idempotent per-segment warm) and `warmUpNewSegmentsBeforePublish` helpers; `warmUpBlockCache` skips already-warmed segments; warmup calls added to checkpoint Phase C-prep and compaction.
- `VectorSegment.java` — new `volatile boolean warmedUp` flag.
- `IndexingServiceEngine.java` — hands the configured warmup byte budget to each store via `setWarmupBytesPerSegment`.

## Tests
- New `Issue569WarmupBeforePublishTest` (herddb-core): checkpoint segments warmed before publish; warmup cost stays bounded across checkpoints and the warm-all sweep is idempotent (death-spiral regression); compaction merged output warmed before publish; restart-loaded cold segments warmed once by the sweep; warmup-disabled is a no-op.
- `BlockCacheWarmupTest` (herddb-indexing-service): idempotency assertion added to `testWarmupReadsSegments`; `testWarmupRespectsLimit` reworked to use two independent stores; new `testWarmupRetriesAfterIoFailure` verifies a warmup I/O error leaves the segment unwarmed and a later sweep retries it.

## Validation
- Targeted herddb-core / herddb-indexing-service warmup, compaction and checkpoint tests pass.
- `spotless:check apache-rat:check spotbugs:check` green.
- Hammer suites (per `CLAUDE.md`) all green: `DirectMultipleConcurrentUpdatesSuite` (12 tests), `BLinkConcurrentSearchInsertTest` (1), `LazyValueCacheConcurrentUpdatesSuite` (12).

🤖 Implemented by the `pr-worker` agent.