### PR TITLE
Push-based indexing: gRPC ingestion for the indexing service (testing only)

### DIFF
--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -297,6 +297,50 @@ Rules that apply to every workload, including user-specified ones:
 
 ---
 
+## gRPC push mode (testing-only, no server)
+
+When the user asks to run the benchmark in **gRPC push mode** — also called
+"push-based indexing", "`--protocol grpc`", or "no-server bench" — the
+topology changes: there is **no HerdDB server and no BookKeeper**. VectorBench
+serializes commit-log entries itself and pushes them straight into the
+indexing service over the `PushEntries` gRPC RPC.
+
+Enable it by setting, in `values.yaml`, **before** `./install.sh`:
+
+```yaml
+pushIndexingMode:
+  enabled: true
+```
+
+`./install.sh` then renders the `herddb-server` and `herddb-bookkeeper`
+StatefulSets at **0 replicas**; ZooKeeper, the file server, the index
+optimizer, MinIO and the tools pod stay up, and the indexing service runs
+with `indexing.log.type=push`.
+
+Run the workload with `--protocol grpc`, pointed at one indexing-service pod:
+
+```
+./scripts/run-bench.sh --background --protocol grpc \
+    --grpc-endpoint herddb-indexing-service-0.herddb-indexing-service:9850 \
+    --dataset sift10k -n 10000 --ingest-threads 8 --batch-size 10000
+```
+
+Differences from the JDBC workflow — apply these whenever push mode is used:
+
+- **Ingestion only.** gRPC mode runs no query/recall phase. Do NOT pass
+  `--checkpoint` or `--wait-for-indexes` (there is no server to checkpoint;
+  pushed entries are applied directly). `--ingest-max-ops` is ignored.
+  VectorBench verifies the run itself by polling the indexed vector count
+  over gRPC (`GetIndexStatus`).
+- **Supervision.** There is no `herddb-server` or `herddb-bookkeeper` pod —
+  do not flag them missing/`fatal`. Supervise the indexing-service,
+  file-server and optimizer pods as usual; `indexing-admin describe-index`
+  (`vector_count`) is the authoritative progress signal.
+- **Single endpoint.** Push mode drives exactly one indexing-service pod,
+  even when `indexingService.replicaCount > 1`.
+
+---
+
 ## Workflow
 
 1. **Preflight.** Check that `docker`, `helm`, `kubectl`, and `gh` are on

--- a/.claude/agents/herddb-k3s-bench.md
+++ b/.claude/agents/herddb-k3s-bench.md
@@ -322,16 +322,17 @@ Run the workload with `--protocol grpc`, pointed at one indexing-service pod:
 ```
 ./scripts/run-bench.sh --background --protocol grpc \
     --grpc-endpoint herddb-indexing-service-0.herddb-indexing-service:9850 \
-    --dataset sift10k -n 10000 --ingest-threads 8 --batch-size 10000
+    --dataset sift10k -n 10000 --batch-size 10000
 ```
 
 Differences from the JDBC workflow — apply these whenever push mode is used:
 
 - **Ingestion only.** gRPC mode runs no query/recall phase. Do NOT pass
   `--checkpoint` or `--wait-for-indexes` (there is no server to checkpoint;
-  pushed entries are applied directly). `--ingest-max-ops` is ignored.
-  VectorBench verifies the run itself by polling the indexed vector count
-  over gRPC (`GetIndexStatus`).
+  pushed entries are applied directly). gRPC ingestion is single-threaded, so
+  `--ingest-threads` and `--ingest-max-ops` are ignored. VectorBench verifies
+  the run itself by polling the indexed vector count over gRPC
+  (`GetIndexStatus`).
 - **Supervision.** There is no `herddb-server` or `herddb-bookkeeper` pod —
   do not flag them missing/`fatal`. Supervise the indexing-service,
   file-server and optimizer pods as usual; `indexing-admin describe-index`

--- a/.claude/agents/herddb-local-bench.md
+++ b/.claude/agents/herddb-local-bench.md
@@ -262,16 +262,17 @@ service sharing a commit log on disk). Instead, from the repo root:
    every argument to VectorBench):
    ```
    vector-testings/run.sh --protocol grpc --grpc-endpoint localhost:9850 \
-       --dataset sift10k -n 10000 --ingest-threads 8 --batch-size 10000
+       --dataset sift10k -n 10000 --batch-size 10000
    ```
 
 Differences from the JDBC workflow — apply these whenever push mode is used:
 
 - **Ingestion only.** gRPC mode runs no query/recall phase. Do NOT pass
   `--checkpoint` or `--wait-for-indexes` (there is no server to checkpoint;
-  pushed entries are applied directly). `--ingest-max-ops` is ignored.
-  VectorBench verifies the run itself by polling the indexed vector count
-  over gRPC (`GetIndexStatus`).
+  pushed entries are applied directly). gRPC ingestion is single-threaded, so
+  `--ingest-threads` and `--ingest-max-ops` are ignored. VectorBench verifies
+  the run itself by polling the indexed vector count over gRPC
+  (`GetIndexStatus`).
 - **Supervision.** There is only one process — the indexing service. There
   is no `herddb-server` to poll; do not flag it missing. Watch the
   indexing-service log and `bin/indexing-admin.sh describe-index`

--- a/.claude/agents/herddb-local-bench.md
+++ b/.claude/agents/herddb-local-bench.md
@@ -238,6 +238,47 @@ Rules that apply to every workload, including user-specified ones:
 
 ---
 
+## gRPC push mode (testing-only, no server)
+
+When the user asks to run the benchmark in **gRPC push mode** — also called
+"push-based indexing", "`--protocol grpc`", or "no-server bench" — the
+topology is just a single indexing service running with
+`indexing.log.type=push`: **no HerdDB server and no commit log**. VectorBench
+serializes commit-log entries itself and pushes them straight in over the
+`PushEntries` gRPC RPC.
+
+This mode does NOT use `./install.sh` (which installs a server + indexing
+service sharing a commit log on disk). Instead, from the repo root:
+
+1. Start one indexing service in standalone push mode — a single-line
+   invocation of the herddb-services launcher:
+   ```
+   herddb-services/test-start-indexing-service-push.sh
+   ```
+   It unzips the distribution and starts the indexing service in standalone
+   push mode, gRPC on `localhost:9850`. No server, BookKeeper or ZooKeeper.
+
+2. Run the workload with `--protocol grpc` (the `run.sh` launcher forwards
+   every argument to VectorBench):
+   ```
+   vector-testings/run.sh --protocol grpc --grpc-endpoint localhost:9850 \
+       --dataset sift10k -n 10000 --ingest-threads 8 --batch-size 10000
+   ```
+
+Differences from the JDBC workflow — apply these whenever push mode is used:
+
+- **Ingestion only.** gRPC mode runs no query/recall phase. Do NOT pass
+  `--checkpoint` or `--wait-for-indexes` (there is no server to checkpoint;
+  pushed entries are applied directly). `--ingest-max-ops` is ignored.
+  VectorBench verifies the run itself by polling the indexed vector count
+  over gRPC (`GetIndexStatus`).
+- **Supervision.** There is only one process — the indexing service. There
+  is no `herddb-server` to poll; do not flag it missing. Watch the
+  indexing-service log and `bin/indexing-admin.sh describe-index`
+  (`vector_count`).
+
+---
+
 ## Workflow
 
 1. **Preflight.** Check that `java`, `unzip`, `curl`, and `gh` are on

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingPushClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingPushClient.java
@@ -1,0 +1,125 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import com.google.protobuf.UnsafeByteOperations;
+import herddb.indexing.proto.GetIndexStatusRequest;
+import herddb.indexing.proto.GetIndexStatusResponse;
+import herddb.indexing.proto.IndexingServiceGrpc;
+import herddb.indexing.proto.PushEntriesRequest;
+import herddb.indexing.proto.PushEntriesResponse;
+import herddb.indexing.proto.PushedLogEntry;
+import herddb.log.LogSequenceNumber;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.netty.buffer.ByteBuf;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thin gRPC client for the testing-only push-based indexing API. Built for
+ * test tooling (the {@code VectorBench} {@code --protocol grpc} mode) that
+ * feeds serialized {@link herddb.log.LogEntry} objects straight into an
+ * indexing service running with {@code indexing.log.type=push}.
+ *
+ * <p>The channel deliberately uses <b>no deadline</b>: {@code PushEntries}
+ * blocks server-side while the bounded push buffer is full (during a
+ * checkpoint/compaction), so a finite deadline would spuriously abort
+ * ingestion. The inbound message-size cap is raised so batched pushes of many
+ * INSERT entries are not rejected by gRPC's 4&nbsp;MiB default.
+ *
+ * @author enrico.olivelli
+ */
+public final class IndexingPushClient implements AutoCloseable {
+
+    /** Matches {@code IndexingServerConfiguration.PROPERTY_GRPC_MAX_MESSAGE_SIZE_DEFAULT}. */
+    public static final int DEFAULT_MAX_MESSAGE_SIZE = 64 * 1024 * 1024;
+
+    private final ManagedChannel channel;
+    private final IndexingServiceGrpc.IndexingServiceBlockingStub stub;
+
+    /** Connects to {@code endpoint} ({@code host:port}) with the default message-size cap. */
+    public IndexingPushClient(String endpoint) {
+        this(endpoint, DEFAULT_MAX_MESSAGE_SIZE);
+    }
+
+    public IndexingPushClient(String endpoint, int maxMessageSize) {
+        this.channel = ManagedChannelBuilder.forTarget(endpoint)
+                .usePlaintext()
+                .maxInboundMessageSize(maxMessageSize)
+                .build();
+        // No withDeadlineAfter(): PushEntries may park for the full duration
+        // of a server-side checkpoint/compaction.
+        this.stub = IndexingServiceGrpc.newBlockingStub(channel);
+    }
+
+    /**
+     * Pushes a batch of {@code (LSN, serialized-LogEntry)} pairs. The
+     * {@code serializedEntries} {@link ByteBuf}s are wrapped <em>zero-copy</em>
+     * into the protobuf request — the caller retains ownership and MUST
+     * {@code release()} them after this method returns.
+     *
+     * <p>Blocks until the indexing service has accepted every entry into its
+     * push buffer.
+     *
+     * @param lsns              client-assigned log sequence numbers, in
+     *                          strictly increasing order
+     * @param serializedEntries matching {@code LogEntry.serializeAsByteBuf()}
+     *                          buffers, one per LSN
+     * @return the server's acknowledgement (accepted count + tailer watermark)
+     */
+    public PushEntriesResponse pushEntries(List<LogSequenceNumber> lsns, List<ByteBuf> serializedEntries) {
+        if (lsns.size() != serializedEntries.size()) {
+            throw new IllegalArgumentException("lsns (" + lsns.size() + ") and entries ("
+                    + serializedEntries.size() + ") size mismatch");
+        }
+        PushEntriesRequest.Builder request = PushEntriesRequest.newBuilder();
+        for (int i = 0; i < lsns.size(); i++) {
+            LogSequenceNumber lsn = lsns.get(i);
+            ByteBuf buf = serializedEntries.get(i);
+            request.addEntries(PushedLogEntry.newBuilder()
+                    .setLsnLedger(lsn.ledgerId)
+                    .setLsnOffset(lsn.offset)
+                    .setEntry(UnsafeByteOperations.unsafeWrap(buf.nioBuffer()))
+                    .build());
+        }
+        return stub.pushEntries(request.build());
+    }
+
+    /** Queries an index's status — used to verify the indexed vector count. */
+    public GetIndexStatusResponse getIndexStatus(String tablespace, String table, String index) {
+        return stub.getIndexStatus(GetIndexStatusRequest.newBuilder()
+                .setTablespace(tablespace)
+                .setTable(table)
+                .setIndex(index)
+                .build());
+    }
+
+    @Override
+    public void close() {
+        channel.shutdown();
+        try {
+            channel.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServer.java
@@ -367,7 +367,12 @@ public class IndexingServer implements AutoCloseable {
 
         engine.setStatsLogger(statsLogger);
         this.serviceImpl = new IndexingServiceImpl(engine, statsLogger);
-        ServerBuilder<?> grpcBuilder = ServerBuilder.forPort(port).addService(serviceImpl);
+        int maxInboundMessageSize = config.getInt(
+                IndexingServerConfiguration.PROPERTY_GRPC_MAX_MESSAGE_SIZE,
+                IndexingServerConfiguration.PROPERTY_GRPC_MAX_MESSAGE_SIZE_DEFAULT);
+        ServerBuilder<?> grpcBuilder = ServerBuilder.forPort(port)
+                .addService(serviceImpl)
+                .maxInboundMessageSize(maxInboundMessageSize);
         java.util.Properties oidcProps = config.asProperties();
         if (OidcBootstrap.isEnabled(oidcProps)) {
             try {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -657,6 +657,18 @@ public final class IndexingServerConfiguration {
     public static final String PROPERTY_TABLESPACE_NAME = "indexing.tablespace.name";
     public static final String PROPERTY_TABLESPACE_NAME_DEFAULT = TableSpace.DEFAULT;
 
+    /**
+     * Explicit tablespace UUID. Normally the indexing service resolves the
+     * UUID of {@link #PROPERTY_TABLESPACE_NAME} from the cluster metadata
+     * (registered by a HerdDB server). In push mode ({@code indexing.log.type=push})
+     * there may be no server at all, so this key lets an operator pin the
+     * storage namespace explicitly — and keep multiple push-mode instances
+     * plus the index optimizer on the same UUID. When empty, push mode derives
+     * a deterministic UUID from the tablespace name.
+     */
+    public static final String PROPERTY_TABLESPACE_UUID = "indexing.tablespace.uuid";
+    public static final String PROPERTY_TABLESPACE_UUID_DEFAULT = "";
+
     public static final String PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS = "indexing.tablespace.wait.poll.interval.ms";
     public static final int PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS_DEFAULT = 2_000;
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -40,6 +40,15 @@ public final class IndexingServerConfiguration {
     public static final String PROPERTY_GRPC_PORT = "indexing.grpc.port";
     public static final int PROPERTY_GRPC_PORT_DEFAULT = 9850;
 
+    /**
+     * Maximum inbound gRPC message size (bytes) accepted by the indexing
+     * service server. gRPC's 4 MiB default is too small for batched
+     * {@code PushEntries} requests carrying many serialized INSERT entries;
+     * 64 MiB leaves ample head-room while still bounding memory.
+     */
+    public static final String PROPERTY_GRPC_MAX_MESSAGE_SIZE = "indexing.grpc.max.message.size";
+    public static final int PROPERTY_GRPC_MAX_MESSAGE_SIZE_DEFAULT = 64 * 1024 * 1024;
+
     // HTTP / metrics
     public static final String PROPERTY_HTTP_ENABLE = "indexing.http.enable";
     public static final boolean PROPERTY_HTTP_ENABLE_DEFAULT = false;
@@ -610,6 +619,26 @@ public final class IndexingServerConfiguration {
     // Log tailing mode
     public static final String PROPERTY_LOG_TYPE = "indexing.log.type";
     public static final String PROPERTY_LOG_TYPE_DEFAULT = "file";
+
+    /**
+     * Value of {@link #PROPERTY_LOG_TYPE} selecting the testing-only
+     * push-based tailer: commit-log entries are pushed in over the
+     * {@code PushEntries} gRPC RPC instead of being tailed from a file or a
+     * BookKeeper ledger. Mutually exclusive with {@code file} / {@code bookkeeper}.
+     * In this mode the indexing service needs neither a HerdDB server nor a
+     * materialised commit log.
+     */
+    public static final String PROPERTY_LOG_TYPE_PUSH = "push";
+
+    /**
+     * Capacity (number of entries) of the fixed-size in-memory buffer used by
+     * the push-based tailer ({@code indexing.log.type=push}). The
+     * {@code PushEntries} RPC blocks once the buffer is full — this is the
+     * ingestion back-pressure while the tailer is stalled in a
+     * checkpoint/compaction.
+     */
+    public static final String PROPERTY_LOG_PUSH_BUFFER_CAPACITY = "indexing.log.push.buffer.capacity";
+    public static final int PROPERTY_LOG_PUSH_BUFFER_CAPACITY_DEFAULT = 10_000;
 
     // BookKeeper/ZooKeeper settings (for log.type=bookkeeper)
     // Use SAME keys as ServerConfiguration so config can be copy/pasted

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -543,6 +543,19 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         return table + "." + index;
     }
 
+    /**
+     * Derives a stable 32-hex-char tablespace UUID from the tablespace name.
+     * Used by push mode when no HerdDB server has registered the tablespace in
+     * the metadata store: a name-based UUID is identical across restarts and
+     * across sibling push-mode instances, so they all resolve the same storage
+     * namespace without any coordination.
+     */
+    private static String deterministicTableSpaceUuid(String tablespaceName) {
+        return java.util.UUID.nameUUIDFromBytes(
+                        tablespaceName.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                .toString().replace("-", "");
+    }
+
     public IndexingServiceEngine(Path logDirectory, Path dataDirectory, IndexingServerConfiguration config) {
         this.logDirectory = logDirectory;
         this.dataDirectory = dataDirectory;
@@ -1316,34 +1329,68 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             }
         }
 
-        // Resolve tablespace name to UUID, polling until available or interrupted
+        // Resolve the tablespace name to a UUID (the engine's storage namespace).
         String tablespaceName = config.getString(IndexingServerConfiguration.PROPERTY_TABLESPACE_NAME,
                 IndexingServerConfiguration.PROPERTY_TABLESPACE_NAME_DEFAULT);
-        long pollIntervalMs = config.getLong(IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS,
-                IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS_DEFAULT);
-        long tablespaceWaitTimeoutMs = config.getLong(
-                IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS,
-                IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS_DEFAULT);
-        long deadline = System.currentTimeMillis() + tablespaceWaitTimeoutMs;
-        LOGGER.log(Level.INFO, "Waiting up to {0}ms for tablespace ''{1}'' to become available...",
-                new Object[]{tablespaceWaitTimeoutMs, tablespaceName});
-        TableSpace tableSpace = null;
-        while (true) {
-            tableSpace = metadataStorageManager.describeTableSpace(tablespaceName);
+        String configuredTableSpaceUuid = config.getString(
+                IndexingServerConfiguration.PROPERTY_TABLESPACE_UUID,
+                IndexingServerConfiguration.PROPERTY_TABLESPACE_UUID_DEFAULT);
+        if (!configuredTableSpaceUuid.isEmpty()) {
+            // Explicit override — also lets push-mode siblings and the index
+            // optimizer be pinned to one storage namespace from config.
+            this.tableSpaceUUID = configuredTableSpaceUuid;
+            LOGGER.log(Level.INFO,
+                    "Using explicitly configured tablespace UUID ''{0}'' for tablespace ''{1}''",
+                    new Object[]{tableSpaceUUID, tablespaceName});
+        } else if (isPushModeConfigured()) {
+            // Push mode (testing only): there may be no HerdDB server to
+            // register the tablespace in the metadata store, so do NOT block
+            // for up to 30 minutes. Try a single lookup; if the tablespace is
+            // absent, derive a deterministic UUID from its name so restarts
+            // and sibling instances resolve the same storage namespace.
+            TableSpace tableSpace = metadataStorageManager.describeTableSpace(tablespaceName);
             if (tableSpace != null) {
-                break;
+                this.tableSpaceUUID = tableSpace.uuid;
+                LOGGER.log(Level.INFO,
+                        "Push mode: resolved tablespace ''{0}'' to UUID ''{1}'' from metadata",
+                        new Object[]{tablespaceName, tableSpaceUUID});
+            } else {
+                this.tableSpaceUUID = deterministicTableSpaceUuid(tablespaceName);
+                LOGGER.log(Level.INFO,
+                        "Push mode: tablespace ''{0}'' is not registered in the metadata store; "
+                                + "using UUID ''{1}'' derived from the tablespace name",
+                        new Object[]{tablespaceName, tableSpaceUUID});
             }
-            if (System.currentTimeMillis() > deadline) {
-                throw new RuntimeException("Timed out after " + tablespaceWaitTimeoutMs + "ms waiting for tablespace '"
-                        + tablespaceName + "' to become available");
+        } else {
+            // file / bookkeeper mode: a HerdDB server owns the tablespace.
+            // Poll until it becomes available or the timeout expires.
+            long pollIntervalMs = config.getLong(
+                    IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS,
+                    IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_POLL_INTERVAL_MS_DEFAULT);
+            long tablespaceWaitTimeoutMs = config.getLong(
+                    IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS,
+                    IndexingServerConfiguration.PROPERTY_TABLESPACE_WAIT_TIMEOUT_MS_DEFAULT);
+            long deadline = System.currentTimeMillis() + tablespaceWaitTimeoutMs;
+            LOGGER.log(Level.INFO, "Waiting up to {0}ms for tablespace ''{1}'' to become available...",
+                    new Object[]{tablespaceWaitTimeoutMs, tablespaceName});
+            TableSpace tableSpace = null;
+            while (true) {
+                tableSpace = metadataStorageManager.describeTableSpace(tablespaceName);
+                if (tableSpace != null) {
+                    break;
+                }
+                if (System.currentTimeMillis() > deadline) {
+                    throw new RuntimeException("Timed out after " + tablespaceWaitTimeoutMs
+                            + "ms waiting for tablespace '" + tablespaceName + "' to become available");
+                }
+                LOGGER.log(Level.INFO, "Tablespace ''{0}'' not yet available, retrying in {1}ms...",
+                        new Object[]{tablespaceName, pollIntervalMs});
+                Thread.sleep(pollIntervalMs);
             }
-            LOGGER.log(Level.INFO, "Tablespace ''{0}'' not yet available, retrying in {1}ms...",
-                    new Object[]{tablespaceName, pollIntervalMs});
-            Thread.sleep(pollIntervalMs);
+            this.tableSpaceUUID = tableSpace.uuid;
+            LOGGER.log(Level.INFO, "Resolved tablespace name ''{0}'' to UUID ''{1}''",
+                    new Object[]{tablespaceName, tableSpaceUUID});
         }
-        this.tableSpaceUUID = tableSpace.uuid;
-        LOGGER.log(Level.INFO, "Resolved tablespace name ''{0}'' to UUID ''{1}''",
-                new Object[]{tablespaceName, tableSpaceUUID});
 
         // Allow external components (IndexingServer) to bootstrap state from
         // remote storage now that we know the tablespace UUID — this is where

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -152,6 +152,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     private CommitLogTailing tailer;
     private Thread tailerThread;
 
+    /**
+     * Non-null only when {@code indexing.log.type=push}: the testing-only
+     * tailer fed by the {@code PushEntries} gRPC RPC. Held with a typed
+     * reference (in addition to {@link #tailer}) so {@link IndexingServiceImpl}
+     * can enqueue client-pushed entries into its bounded buffer.
+     */
+    private volatile PushCommitLogTailer pushTailer;
+
     private volatile LogSequenceNumber lastProcessedLsn;
     /**
      * Wall-clock timestamp (epoch ms) of the {@link LogEntry} at
@@ -1476,6 +1484,25 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             java.util.Properties bkClientProps = config.asProperties();
             tailer = new BookKeeperCommitLogTailer(zkAddress, zkSessionTimeout, zkPath,
                     bkLedgersPath, tableSpaceUUID, tailerStart, this::processEntry, bkClientProps);
+        } else if (IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH.equals(logType)) {
+            // Testing-only push mode: entries arrive over the PushEntries gRPC
+            // RPC instead of a file/BookKeeper log, so no HerdDB server and no
+            // materialised commit log are required. Recovery is otherwise
+            // unchanged — checkpointed segments and the schema snapshot are
+            // reloaded above, tailerStart is the durable watermark, and the
+            // push tailer simply resumes from there (skipping any re-pushed
+            // stale entries).
+            int pushBufferCapacity = config.getInt(
+                    IndexingServerConfiguration.PROPERTY_LOG_PUSH_BUFFER_CAPACITY,
+                    IndexingServerConfiguration.PROPERTY_LOG_PUSH_BUFFER_CAPACITY_DEFAULT);
+            LOGGER.log(Level.INFO,
+                    "Creating PushCommitLogTailer (testing-only push mode), "
+                            + "bufferCapacity={0}, tailerStart={1}",
+                    new Object[]{pushBufferCapacity, tailerStart});
+            PushCommitLogTailer push = new PushCommitLogTailer(
+                    pushBufferCapacity, tailerStart, this::processEntry);
+            this.pushTailer = push;
+            tailer = push;
         } else {
             tailer = new FileCommitLogTailer(logDirectory, tableSpaceUUID, tailerStart, this::processEntry);
         }
@@ -1508,6 +1535,16 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
 
     public String getTableSpaceUUID() {
         return tableSpaceUUID;
+    }
+
+    /**
+     * Returns the push-mode tailer when the engine is running with
+     * {@code indexing.log.type=push}, or {@code null} otherwise. Used by the
+     * {@code PushEntries} gRPC handler to enqueue client-pushed entries into
+     * the bounded buffer.
+     */
+    public PushCommitLogTailer getPushTailer() {
+        return pushTailer;
     }
 
     /**

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1548,6 +1548,20 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
     }
 
     /**
+     * Returns {@code true} when this engine is configured for push mode
+     * ({@code indexing.log.type=push}), regardless of whether {@link #start()}
+     * has completed. Lets the {@code PushEntries} gRPC handler distinguish
+     * "still starting" (retryable) from "not a push-mode service" (permanent):
+     * the gRPC server binds before {@link #start()} assigns {@link #pushTailer},
+     * so {@link #getPushTailer()} can be {@code null} during a normal boot.
+     */
+    public boolean isPushModeConfigured() {
+        return IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH.equals(
+                config.getString(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
+                        IndexingServerConfiguration.PROPERTY_LOG_TYPE_DEFAULT));
+    }
+
+    /**
      * Issue #491: returns the segmented-v2 ZK registry handle wired during
      * {@link #start()}, or {@code null} when {@link IndexingServerConfiguration#PROPERTY_INDEX_OPTIMIZER_ENABLED}
      * was unset / false at startup OR when the metadata storage manager was

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -41,16 +41,21 @@ import herddb.indexing.proto.ListPrimaryKeysRequest;
 import herddb.indexing.proto.MetricEntry;
 import herddb.indexing.proto.MetricValue;
 import herddb.indexing.proto.PrimaryKeysChunk;
+import herddb.indexing.proto.PushEntriesRequest;
+import herddb.indexing.proto.PushEntriesResponse;
+import herddb.indexing.proto.PushedLogEntry;
 import herddb.indexing.proto.SearchRequest;
 import herddb.indexing.proto.SearchResponse;
 import herddb.indexing.proto.SearchResult;
 import herddb.indexing.proto.WaitForCheckpointRequest;
 import herddb.indexing.proto.WaitForCheckpointResponse;
+import herddb.log.LogEntry;
 import herddb.log.LogSequenceNumber;
 import herddb.utils.Bytes;
 import herddb.utils.VectorSearchRequestContext;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.io.EOFException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -667,6 +672,68 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
             LOGGER.log(Level.SEVERE, "DropIndex RPC failed for index " + indexName, e);
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription(e.getMessage())
+                    .withCause(e)
+                    .asRuntimeException());
+        }
+    }
+
+    /**
+     * Push-based indexing (TESTING ONLY). Deserializes each pushed
+     * {@code LogEntry} and enqueues it into the {@link PushCommitLogTailer}'s
+     * bounded buffer; the call blocks until every entry has been accepted (the
+     * buffer fills during checkpoint/compaction back-pressure, so clients must
+     * use an infinite deadline).
+     *
+     * <p>Fails with {@code FAILED_PRECONDITION} when the engine is not running
+     * in push mode ({@code indexing.log.type=push}), and with
+     * {@code INVALID_ARGUMENT} when an entry blob cannot be deserialized.
+     */
+    @Override
+    public void pushEntries(PushEntriesRequest request,
+                            StreamObserver<PushEntriesResponse> responseObserver) {
+        PushCommitLogTailer pushTailer = engine.getPushTailer();
+        if (pushTailer == null) {
+            responseObserver.onError(Status.FAILED_PRECONDITION
+                    .withDescription("indexing service is not running in push mode "
+                            + "(indexing.log.type=push); PushEntries is not available")
+                    .asRuntimeException());
+            return;
+        }
+        try {
+            long accepted = 0;
+            for (PushedLogEntry pushed : request.getEntriesList()) {
+                LogEntry entry;
+                try {
+                    entry = LogEntry.deserialize(pushed.getEntry().toByteArray());
+                } catch (EOFException | RuntimeException e) {
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                            .withDescription("malformed LogEntry at batch index "
+                                    + accepted + ": " + e)
+                            .asRuntimeException());
+                    return;
+                }
+                LogSequenceNumber lsn = new LogSequenceNumber(
+                        pushed.getLsnLedger(), pushed.getLsnOffset());
+                // Blocks while the bounded buffer is full.
+                pushTailer.push(lsn, entry);
+                accepted++;
+            }
+            LogSequenceNumber watermark = pushTailer.getWatermark();
+            responseObserver.onNext(PushEntriesResponse.newBuilder()
+                    .setAcceptedCount(accepted)
+                    .setWatermarkLedger(watermark.ledgerId)
+                    .setWatermarkOffset(watermark.offset)
+                    .build());
+            responseObserver.onCompleted();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            responseObserver.onError(Status.CANCELLED
+                    .withDescription("interrupted while enqueueing pushed entries")
+                    .asRuntimeException());
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "PushEntries failed", e);
             responseObserver.onError(Status.INTERNAL
                     .withDescription(e.getMessage())
                     .withCause(e)

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -686,43 +686,58 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
      * buffer fills during checkpoint/compaction back-pressure, so clients must
      * use an infinite deadline).
      *
-     * <p>Fails with {@code FAILED_PRECONDITION} when the engine is not running
-     * in push mode ({@code indexing.log.type=push}), and with
-     * {@code INVALID_ARGUMENT} when an entry blob cannot be deserialized.
+     * <p>Fails with {@code FAILED_PRECONDITION} when the service is not
+     * configured for push mode ({@code indexing.log.type=push}), with
+     * {@code UNAVAILABLE} (retryable) when it is but the engine has not
+     * finished starting, and with {@code INVALID_ARGUMENT} when an entry blob
+     * cannot be deserialized — in which case the whole batch is rejected
+     * atomically, with no prefix of it enqueued.
      */
     @Override
     public void pushEntries(PushEntriesRequest request,
                             StreamObserver<PushEntriesResponse> responseObserver) {
         PushCommitLogTailer pushTailer = engine.getPushTailer();
         if (pushTailer == null) {
-            responseObserver.onError(Status.FAILED_PRECONDITION
-                    .withDescription("indexing service is not running in push mode "
-                            + "(indexing.log.type=push); PushEntries is not available")
-                    .asRuntimeException());
+            if (engine.isPushModeConfigured()) {
+                // Configured for push mode but the engine has not finished
+                // start() yet — the gRPC server binds before engine.start()
+                // assigns the tailer. Retryable; NOT a permanent mismatch.
+                responseObserver.onError(Status.UNAVAILABLE
+                        .withDescription("indexing engine is still starting; retry PushEntries")
+                        .asRuntimeException());
+            } else {
+                responseObserver.onError(Status.FAILED_PRECONDITION
+                        .withDescription("indexing service is not running in push mode "
+                                + "(indexing.log.type=push); PushEntries is not available")
+                        .asRuntimeException());
+            }
             return;
         }
+        // Deserialize the whole batch up-front so a malformed entry rejects the
+        // batch atomically — no prefix of it is enqueued.
+        List<LogEntry> entries = new ArrayList<>(request.getEntriesCount());
+        List<LogSequenceNumber> lsns = new ArrayList<>(request.getEntriesCount());
+        int index = 0;
+        for (PushedLogEntry pushed : request.getEntriesList()) {
+            try {
+                entries.add(LogEntry.deserialize(pushed.getEntry().toByteArray()));
+            } catch (EOFException | RuntimeException e) {
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                        .withDescription("malformed LogEntry at batch index " + index + ": " + e)
+                        .asRuntimeException());
+                return;
+            }
+            lsns.add(new LogSequenceNumber(pushed.getLsnLedger(), pushed.getLsnOffset()));
+            index++;
+        }
         try {
-            long accepted = 0;
-            for (PushedLogEntry pushed : request.getEntriesList()) {
-                LogEntry entry;
-                try {
-                    entry = LogEntry.deserialize(pushed.getEntry().toByteArray());
-                } catch (EOFException | RuntimeException e) {
-                    responseObserver.onError(Status.INVALID_ARGUMENT
-                            .withDescription("malformed LogEntry at batch index "
-                                    + accepted + ": " + e)
-                            .asRuntimeException());
-                    return;
-                }
-                LogSequenceNumber lsn = new LogSequenceNumber(
-                        pushed.getLsnLedger(), pushed.getLsnOffset());
+            for (int i = 0; i < entries.size(); i++) {
                 // Blocks while the bounded buffer is full.
-                pushTailer.push(lsn, entry);
-                accepted++;
+                pushTailer.push(lsns.get(i), entries.get(i));
             }
             LogSequenceNumber watermark = pushTailer.getWatermark();
             responseObserver.onNext(PushEntriesResponse.newBuilder()
-                    .setAcceptedCount(accepted)
+                    .setAcceptedCount(entries.size())
                     .setWatermarkLedger(watermark.ledgerId)
                     .setWatermarkOffset(watermark.offset)
                     .build());

--- a/herddb-indexing-service/src/main/java/herddb/indexing/PushCommitLogTailer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/PushCommitLogTailer.java
@@ -165,6 +165,9 @@ public class PushCommitLogTailer implements CommitLogTailing {
                 // keeps a pathological consumer error from killing the tailer.
                 LOGGER.log(Level.SEVERE, "Error dispatching pushed entry at " + pushed.lsn, e);
             }
+            // Advance the watermark unconditionally after dispatch — mirrors
+            // FileCommitLogTailer.drainReader(); a dispatched entry is always
+            // treated as consumed.
             watermark = pushed.lsn;
             entriesProcessed++;
         }
@@ -200,5 +203,16 @@ public class PushCommitLogTailer implements CommitLogTailing {
     @Override
     public void close() {
         running = false;
+        // Entries still buffered when the tailer stops are dropped (the engine
+        // does not drain on shutdown). They were already acknowledged to the
+        // client, so surface the loss — a restart resumes at the durable
+        // watermark and the client is expected to re-push from there.
+        int undispatched = buffer.size();
+        if (undispatched > 0) {
+            LOGGER.log(Level.WARNING,
+                    "PushCommitLogTailer closed with ~{0} undispatched buffered "
+                            + "entr(ies); they are dropped and must be re-pushed after restart",
+                    undispatched);
+        }
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/PushCommitLogTailer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/PushCommitLogTailer.java
@@ -77,8 +77,13 @@ public class PushCommitLogTailer implements CommitLogTailing {
 
     private volatile LogSequenceNumber watermark;
     private volatile boolean running = true;
-    /** Written only by the tailer thread; {@code volatile} for remote reads. */
-    private volatile long entriesProcessed;
+    /**
+     * Number of entries dispatched to the consumer. Written only by the single
+     * tailer thread; a plain {@code long} (not {@code volatile}) — matching
+     * {@code FileCommitLogTailer} and the {@link CommitLogTailing} counter
+     * contract, under which a cross-thread read may lag by one increment.
+     */
+    private long entriesProcessed;
 
     /** Immutable (LSN, entry) pair held in the bounded buffer. */
     private static final class PushedEntry {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/PushCommitLogTailer.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/PushCommitLogTailer.java
@@ -1,0 +1,204 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import herddb.log.CommitLogTailing;
+import herddb.log.LogEntry;
+import herddb.log.LogSequenceNumber;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Testing-only {@link CommitLogTailing} implementation whose entries are
+ * <em>pushed</em> in over the {@code PushEntries} gRPC RPC instead of being
+ * tailed from a file or BookKeeper ledger.
+ *
+ * <p>Selected via {@code indexing.log.type=push}. In this mode the indexing
+ * service needs neither a HerdDB server nor a materialised commit log: a test
+ * client serializes {@link LogEntry} objects and pushes them straight into the
+ * fixed-size in-memory buffer maintained here.
+ *
+ * <p>Threading model — identical contract to the other tailers:
+ * <ul>
+ *   <li>gRPC handler threads call {@link #push(LogSequenceNumber, LogEntry)},
+ *       which blocks on the bounded buffer when it is full. This is the
+ *       ingestion back-pressure: while the engine is stalled in a
+ *       checkpoint/compaction the tailer thread stops draining, the buffer
+ *       fills, and {@code push} parks the caller.</li>
+ *   <li>A single tailer thread runs {@link #run()}, draining the buffer and
+ *       dispatching each entry to the {@link EntryConsumer} (the engine's
+ *       {@code processEntry}) — so the consumer keeps its single-threaded
+ *       invariant, exactly as with {@code FileCommitLogTailer}.</li>
+ * </ul>
+ *
+ * <p>Entries pushed at or before the current watermark are skipped, mirroring
+ * {@code FileCommitLogTailer}: after a restart the tailer resumes at the
+ * durable watermark and a client re-pushing already-applied entries is a safe
+ * idempotent no-op. The client owns LSN assignment and is expected to push
+ * entries in strictly increasing LSN order.
+ *
+ * @author enrico.olivelli
+ */
+public class PushCommitLogTailer implements CommitLogTailing {
+
+    private static final Logger LOGGER = Logger.getLogger(PushCommitLogTailer.class.getName());
+
+    /**
+     * Poll granularity (ms) used on both the drain side ({@link #run()}) and
+     * the push side ({@link #push}) so that {@link #close()} is observed
+     * promptly without an unbounded park.
+     */
+    private static final long POLL_INTERVAL_MS = 200L;
+
+    private final BlockingQueue<PushedEntry> buffer;
+    private final EntryConsumer consumer;
+    private final int bufferCapacity;
+
+    private volatile LogSequenceNumber watermark;
+    private volatile boolean running = true;
+    /** Written only by the tailer thread; {@code volatile} for remote reads. */
+    private volatile long entriesProcessed;
+
+    /** Immutable (LSN, entry) pair held in the bounded buffer. */
+    private static final class PushedEntry {
+        final LogSequenceNumber lsn;
+        final LogEntry entry;
+
+        PushedEntry(LogSequenceNumber lsn, LogEntry entry) {
+            this.lsn = lsn;
+            this.entry = entry;
+        }
+    }
+
+    /**
+     * @param bufferCapacity fixed capacity of the in-memory buffer, in entries
+     * @param startFrom      initial watermark — {@code START_OF_TIME} for a
+     *                       fresh engine, or the durable recovery LSN after a
+     *                       restart
+     * @param consumer       the entry sink (the engine's {@code processEntry})
+     */
+    public PushCommitLogTailer(int bufferCapacity, LogSequenceNumber startFrom, EntryConsumer consumer) {
+        if (bufferCapacity < 1) {
+            throw new IllegalArgumentException("bufferCapacity must be >= 1, got " + bufferCapacity);
+        }
+        if (consumer == null) {
+            throw new IllegalArgumentException("consumer must not be null");
+        }
+        this.bufferCapacity = bufferCapacity;
+        this.buffer = new ArrayBlockingQueue<>(bufferCapacity);
+        this.watermark = startFrom != null ? startFrom : LogSequenceNumber.START_OF_TIME;
+        this.consumer = consumer;
+    }
+
+    /**
+     * Enqueues one entry, blocking while the fixed-size buffer is full. Called
+     * by gRPC handler threads serving {@code PushEntries}; entries larger than
+     * a single batch still drain safely because each entry is offered
+     * individually.
+     *
+     * @throws InterruptedException  if the calling thread is interrupted while
+     *                               parked on a full buffer
+     * @throws IllegalStateException if the tailer has been closed
+     */
+    public void push(LogSequenceNumber lsn, LogEntry entry) throws InterruptedException {
+        if (lsn == null || entry == null) {
+            throw new IllegalArgumentException("lsn and entry must not be null");
+        }
+        PushedEntry pushed = new PushedEntry(lsn, entry);
+        while (running) {
+            if (buffer.offer(pushed, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS)) {
+                return;
+            }
+        }
+        throw new IllegalStateException(
+                "PushCommitLogTailer is closed; entry at " + lsn + " rejected");
+    }
+
+    @Override
+    public void run() {
+        LOGGER.log(Level.INFO, "PushCommitLogTailer starting, watermark={0}, bufferCapacity={1}",
+                new Object[]{watermark, bufferCapacity});
+        while (running) {
+            PushedEntry pushed;
+            try {
+                pushed = buffer.poll(POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            if (pushed == null) {
+                continue;
+            }
+            // Idempotent skip: after a restart the tailer resumes at the
+            // durable watermark and the client may re-push already-applied
+            // entries. Mirrors FileCommitLogTailer.drainReader().
+            if (!watermark.isStartOfTime() && !pushed.lsn.after(watermark)) {
+                LOGGER.log(Level.FINE, "skipping pushed entry {0} at or before watermark {1}",
+                        new Object[]{pushed.lsn, watermark});
+                continue;
+            }
+            try {
+                consumer.accept(pushed.lsn, pushed.entry);
+            } catch (RuntimeException e) {
+                // processEntry already swallows its own failures; this guard
+                // keeps a pathological consumer error from killing the tailer.
+                LOGGER.log(Level.SEVERE, "Error dispatching pushed entry at " + pushed.lsn, e);
+            }
+            watermark = pushed.lsn;
+            entriesProcessed++;
+        }
+        LOGGER.log(Level.INFO, "PushCommitLogTailer stopped, watermark={0}, entriesProcessed={1}",
+                new Object[]{watermark, entriesProcessed});
+    }
+
+    /** Number of entries currently buffered but not yet dispatched. */
+    public int getBufferedCount() {
+        return buffer.size();
+    }
+
+    /** Fixed capacity of the in-memory buffer, in entries. */
+    public int getBufferCapacity() {
+        return bufferCapacity;
+    }
+
+    @Override
+    public LogSequenceNumber getWatermark() {
+        return watermark;
+    }
+
+    @Override
+    public long getEntriesProcessed() {
+        return entriesProcessed;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public void close() {
+        running = false;
+    }
+}

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -50,6 +50,20 @@ service IndexingService {
     // this RPC return UNIMPLEMENTED, which the client treats as a warning.
     // The commit-log tailer path remains the authoritative cleanup fallback.
     rpc DropIndex (DropIndexRequest) returns (DropIndexResponse);
+
+    // Push-based indexing (TESTING ONLY). When the indexing service runs with
+    // indexing.log.type=push it does NOT tail a file/BookKeeper commit log;
+    // instead a client serializes herddb.log.LogEntry objects and pushes them
+    // straight into a bounded in-memory buffer via this RPC. No HerdDB server
+    // and no commit log are required.
+    //
+    // The call blocks server-side until every entry in the batch has been
+    // accepted into the buffer — while a checkpoint/compaction stalls the
+    // tailer the buffer fills and the call parks. Clients MUST therefore use
+    // an infinite deadline. The client owns LSN assignment and MUST send
+    // entries in strictly increasing LSN order (and, when feeding multiple
+    // indexing-service instances, identically to every instance).
+    rpc PushEntries (PushEntriesRequest) returns (PushEntriesResponse);
 }
 
 message SearchRequest {
@@ -347,4 +361,28 @@ message DropIndexRequest {
 // Intentionally empty: the IS begins cleanup asynchronously and returns as
 // soon as the in-memory store has been removed from its tracking map.
 message DropIndexResponse {
+}
+
+// ---- Push-based indexing RPC (testing only — see rpc PushEntries) ----
+
+// One commit-log entry to push, with its client-assigned LSN.
+message PushedLogEntry {
+    // Log sequence number assigned by the client (ledgerId, offset).
+    int64 lsn_ledger = 1;
+    int64 lsn_offset = 2;
+    // A single serialized herddb.log.LogEntry (LogEntry.serialize()).
+    bytes entry = 3;
+}
+
+message PushEntriesRequest {
+    // Entries to enqueue, in strictly increasing LSN order.
+    repeated PushedLogEntry entries = 1;
+}
+
+message PushEntriesResponse {
+    // Number of entries this call accepted into the push buffer.
+    int64 accepted_count = 1;
+    // Tailer watermark (last applied LSN) at the moment the call returned.
+    int64 watermark_ledger = 2;
+    int64 watermark_offset = 3;
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServicePushGrpcTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServicePushGrpcTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import herddb.codec.RecordSerializer;
+import herddb.indexing.proto.PushEntriesRequest;
 import herddb.indexing.proto.PushEntriesResponse;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
@@ -36,12 +37,15 @@ import herddb.model.Record;
 import herddb.model.Table;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,8 +56,8 @@ import org.junit.rules.Timeout;
  * End-to-end coverage of the push-based indexing gRPC API: pushing serialized
  * {@code LogEntry} objects into an indexing service running with
  * {@code indexing.log.type=push} builds the vector index without a HerdDB
- * server or a commit log, and the API is rejected when the service is not in
- * push mode.
+ * server or a commit log; malformed batches are rejected atomically; and the
+ * API distinguishes "not a push service" from "engine still starting".
  */
 public class IndexingServicePushGrpcTest {
 
@@ -79,13 +83,17 @@ public class IndexingServicePushGrpcTest {
     private EmbeddedIndexingService startService(String logType) throws Exception {
         Path logDir = folder.newFolder("log").toPath();
         Path dataDir = folder.newFolder("data").toPath();
+        EmbeddedIndexingService svc = new EmbeddedIndexingService(
+                logDir, dataDir, pushConfig(logType));
+        svc.start();
+        return svc;
+    }
+
+    private static IndexingServerConfiguration pushConfig(String logType) {
         Properties props = new Properties();
         props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
         props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE, logType);
-        EmbeddedIndexingService svc = new EmbeddedIndexingService(
-                logDir, dataDir, new IndexingServerConfiguration(props));
-        svc.start();
-        return svc;
+        return new IndexingServerConfiguration(props);
     }
 
     private static Table vectorTable() {
@@ -200,11 +208,52 @@ public class IndexingServicePushGrpcTest {
         assertEquals(7L, resp.getAcceptedCount());
 
         awaitVectorCount(5, 40_000);
+        service.getEngine().awaitPendingWorkForTest();
+        List<?> hits = service.getEngine().search("default", "vectable", "vidx",
+                new float[]{0f, 0f, 0f}, 100);
+        assertEquals("every committed transactional vector must be searchable", 5, hits.size());
+    }
+
+    @Test
+    public void pushBatchWithAMalformedEntryIsRejectedAtomically() throws Exception {
+        service = startService(IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        pushClient = new IndexingPushClient(service.getAddress());
+
+        Table table = vectorTable();
+        push(1, 1, Arrays.asList(
+                LogEntryFactory.createTable(table, null),
+                LogEntryFactory.createIndex(vectorIndex(), null)));
+
+        // Batch: valid INSERT, garbage, valid INSERT. The garbage entry must
+        // reject the whole batch — neither valid INSERT may be applied.
+        Record r0 = RecordSerializer.makeRecord(table, "pk", "ok0", "vec", new float[]{1, 1, 1});
+        Record r2 = RecordSerializer.makeRecord(table, "pk", "ok2", "vec", new float[]{2, 2, 2});
+        List<LogSequenceNumber> lsns = Arrays.asList(
+                new LogSequenceNumber(1, 3),
+                new LogSequenceNumber(1, 4),
+                new LogSequenceNumber(1, 5));
+        List<ByteBuf> bufs = Arrays.asList(
+                LogEntryFactory.insert(table, r0.key, r0.value, null).serializeAsByteBuf(),
+                Unpooled.wrappedBuffer(new byte[]{1, 2, 3}),
+                LogEntryFactory.insert(table, r2.key, r2.value, null).serializeAsByteBuf());
+        try {
+            pushClient.pushEntries(lsns, bufs);
+            fail("a malformed entry must reject the whole batch");
+        } catch (StatusRuntimeException e) {
+            assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+        } finally {
+            for (ByteBuf b : bufs) {
+                b.release();
+            }
+        }
+        // All-or-nothing: neither valid INSERT in the rejected batch was applied.
+        Thread.sleep(500);
+        assertEquals("no entry from a rejected batch may be applied", 0L, indexedVectorCount());
     }
 
     @Test
     public void pushEntriesIsRejectedWhenNotInPushMode() throws Exception {
-        // Default "file" tailer mode — PushEntries must fail fast.
+        // Default "file" tailer mode — PushEntries must fail fast (permanent).
         service = startService(IndexingServerConfiguration.PROPERTY_LOG_TYPE_DEFAULT);
         assertNull("engine must not run a push tailer in file mode",
                 service.getEngine().getPushTailer());
@@ -214,6 +263,48 @@ public class IndexingServicePushGrpcTest {
             fail("PushEntries must be rejected when not in push mode");
         } catch (StatusRuntimeException e) {
             assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+        }
+    }
+
+    @Test
+    public void pushEntriesDuringEngineStartupIsRetryable() throws Exception {
+        // An engine configured for push mode but not yet started has no tailer
+        // (the gRPC server binds before engine.start() assigns it). The handler
+        // must return a retryable UNAVAILABLE, not the permanent-looking
+        // FAILED_PRECONDITION a correct client treats as fatal.
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+        IndexingServiceEngine engine = new IndexingServiceEngine(logDir, dataDir,
+                pushConfig(IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH));
+        assertNull("an unstarted engine has no push tailer yet", engine.getPushTailer());
+
+        IndexingServiceImpl impl = new IndexingServiceImpl(engine, NullStatsLogger.INSTANCE);
+        CapturingObserver<PushEntriesResponse> observer = new CapturingObserver<>();
+        impl.pushEntries(PushEntriesRequest.newBuilder().build(), observer);
+
+        assertNotNull("a still-starting engine must report an error", observer.error);
+        assertEquals(Status.Code.UNAVAILABLE,
+                ((StatusRuntimeException) observer.error).getStatus().getCode());
+    }
+
+    /** Minimal {@link StreamObserver} that records the terminal error for assertions. */
+    private static final class CapturingObserver<T> implements StreamObserver<T> {
+
+        private volatile Throwable error;
+
+        @Override
+        public void onNext(T value) {
+            // not exercised — this observer is used only for the error path
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+        }
+
+        @Override
+        public void onCompleted() {
+            // not exercised — this observer is used only for the error path
         }
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServicePushGrpcTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServicePushGrpcTest.java
@@ -1,0 +1,219 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import herddb.codec.RecordSerializer;
+import herddb.indexing.proto.PushEntriesResponse;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogEntryType;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.netty.buffer.ByteBuf;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+
+/**
+ * End-to-end coverage of the push-based indexing gRPC API: pushing serialized
+ * {@code LogEntry} objects into an indexing service running with
+ * {@code indexing.log.type=push} builds the vector index without a HerdDB
+ * server or a commit log, and the API is rejected when the service is not in
+ * push mode.
+ */
+public class IndexingServicePushGrpcTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60);
+
+    private EmbeddedIndexingService service;
+    private IndexingPushClient pushClient;
+
+    @After
+    public void tearDown() throws Exception {
+        if (pushClient != null) {
+            pushClient.close();
+        }
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private EmbeddedIndexingService startService(String logType) throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE, logType);
+        EmbeddedIndexingService svc = new EmbeddedIndexingService(
+                logDir, dataDir, new IndexingServerConfiguration(props));
+        svc.start();
+        return svc;
+    }
+
+    private static Table vectorTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private static Index vectorIndex() {
+        return Index.builder()
+                .name("vidx")
+                .table("vectable")
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    /**
+     * Serializes the entries to pooled direct ByteBufs, pushes them as one
+     * batch starting at {@code (ledger, firstOffset)}, and releases the
+     * buffers afterwards — mirroring how {@code VectorBench} drives the API.
+     */
+    private PushEntriesResponse push(long ledger, long firstOffset, List<LogEntry> entries) {
+        List<LogSequenceNumber> lsns = new ArrayList<>();
+        List<ByteBuf> bufs = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            lsns.add(new LogSequenceNumber(ledger, firstOffset + i));
+            bufs.add(entries.get(i).serializeAsByteBuf());
+        }
+        try {
+            return pushClient.pushEntries(lsns, bufs);
+        } finally {
+            for (ByteBuf b : bufs) {
+                b.release();
+            }
+        }
+    }
+
+    private long indexedVectorCount() {
+        return pushClient.getIndexStatus("default", "vectable", "vidx").getVectorCount();
+    }
+
+    private void awaitVectorCount(long expected, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        long last = -1;
+        while (System.currentTimeMillis() < deadline) {
+            last = indexedVectorCount();
+            if (last >= expected) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        fail("indexed vector count did not reach " + expected + " (last=" + last + ")");
+    }
+
+    @Test
+    public void pushedEntriesBuildTheVectorIndex() throws Exception {
+        service = startService(IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        assertNotNull("engine must run a push tailer", service.getEngine().getPushTailer());
+        pushClient = new IndexingPushClient(service.getAddress());
+
+        Table table = vectorTable();
+        // DDL batch: CREATE TABLE + CREATE VECTOR INDEX.
+        push(1, 1, Arrays.asList(
+                LogEntryFactory.createTable(table, null),
+                LogEntryFactory.createIndex(vectorIndex(), null)));
+
+        // 20 non-transactional INSERTs.
+        List<LogEntry> inserts = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Record r = RecordSerializer.makeRecord(table,
+                    "pk", "key" + i, "vec", new float[]{i, i + 1f, i + 2f});
+            inserts.add(LogEntryFactory.insert(table, r.key, r.value, null));
+        }
+        PushEntriesResponse resp = push(1, 3, inserts);
+        assertEquals("server must acknowledge every pushed entry", 20L, resp.getAcceptedCount());
+
+        awaitVectorCount(20, 40_000);
+        service.getEngine().awaitPendingWorkForTest();
+        List<?> hits = service.getEngine().search("default", "vectable", "vidx",
+                new float[]{0f, 1f, 2f}, 100);
+        assertEquals("every pushed vector must be searchable", 20, hits.size());
+    }
+
+    @Test
+    public void pushedEntriesWithinATransactionAreAppliedAtCommit() throws Exception {
+        service = startService(IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        pushClient = new IndexingPushClient(service.getAddress());
+
+        Table table = vectorTable();
+        push(1, 1, Arrays.asList(
+                LogEntryFactory.createTable(table, null),
+                LogEntryFactory.createIndex(vectorIndex(), null)));
+
+        // BEGIN + 5 INSERTs (carrying the transaction id) + COMMIT.
+        long txId = 7L;
+        List<LogEntry> txBatch = new ArrayList<>();
+        txBatch.add(LogEntryFactory.beginTransaction(txId));
+        for (int i = 0; i < 5; i++) {
+            Record r = RecordSerializer.makeRecord(table,
+                    "pk", "tx" + i, "vec", new float[]{i, i, i});
+            txBatch.add(new LogEntry(System.currentTimeMillis(), LogEntryType.INSERT,
+                    txId, table.tableId, r.key, r.value));
+        }
+        txBatch.add(LogEntryFactory.commitTransaction(txId));
+        PushEntriesResponse resp = push(1, 3, txBatch);
+        assertEquals(7L, resp.getAcceptedCount());
+
+        awaitVectorCount(5, 40_000);
+    }
+
+    @Test
+    public void pushEntriesIsRejectedWhenNotInPushMode() throws Exception {
+        // Default "file" tailer mode — PushEntries must fail fast.
+        service = startService(IndexingServerConfiguration.PROPERTY_LOG_TYPE_DEFAULT);
+        assertNull("engine must not run a push tailer in file mode",
+                service.getEngine().getPushTailer());
+        pushClient = new IndexingPushClient(service.getAddress());
+        try {
+            push(1, 1, Arrays.asList(LogEntryFactory.noop()));
+            fail("PushEntries must be rejected when not in push mode");
+        } catch (StatusRuntimeException e) {
+            assertEquals(Status.Code.FAILED_PRECONDITION, e.getStatus().getCode());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PushCommitLogTailerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PushCommitLogTailerTest.java
@@ -34,14 +34,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
 /**
  * Unit tests for {@link PushCommitLogTailer}: in-order dispatch, the bounded
- * buffer's blocking back-pressure, idempotent skipping of stale (re-pushed)
- * entries on restart, and lifecycle.
+ * buffer's blocking back-pressure, idempotent skipping of stale or
+ * out-of-order (re-pushed) entries, and lifecycle including the drop of
+ * still-buffered entries on {@code close()}.
  */
 public class PushCommitLogTailerTest {
 
@@ -54,9 +56,14 @@ public class PushCommitLogTailerTest {
     }
 
     private static void awaitSize(List<?> list, int target, long timeoutMs) throws InterruptedException {
+        awaitCondition(() -> list.size() >= target, timeoutMs);
+    }
+
+    private static void awaitCondition(BooleanSupplier condition, long timeoutMs)
+            throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;
-        while (list.size() < target && System.currentTimeMillis() < deadline) {
-            Thread.sleep(20);
+        while (!condition.getAsBoolean() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
         }
     }
 
@@ -120,13 +127,13 @@ public class PushCommitLogTailerTest {
         }, "test-pusher");
         pusher.start();
         try {
-            // Give the pusher time to fill the buffer and block.
-            Thread.sleep(500);
+            // Wait until the buffer is full and the pusher is parked on it.
+            awaitCondition(() -> tailer.getBufferedCount() == tailer.getBufferCapacity(), 5000);
+            assertEquals("buffer must be full", tailer.getBufferCapacity(),
+                    tailer.getBufferedCount());
             assertTrue("pusher must still be blocked on a full buffer", pusher.isAlive());
             assertTrue("no entry can be dispatched while the consumer is gated",
                     consumed.isEmpty());
-            assertEquals("buffer must be full", tailer.getBufferCapacity(),
-                    tailer.getBufferedCount());
 
             // Release the consumer: the buffer drains and the pusher completes.
             release.countDown();
@@ -170,6 +177,78 @@ public class PushCommitLogTailerTest {
         assertEquals(new LogSequenceNumber(6, 1), consumed.get(1));
         assertEquals(2L, tailer.getEntriesProcessed());
         assertEquals(new LogSequenceNumber(6, 1), tailer.getWatermark());
+    }
+
+    @Test
+    public void outOfOrderPushAfterAdvanceIsSkipped() throws Exception {
+        // A client that violates the strictly-increasing-LSN contract by
+        // pushing a regressing LSN gets that entry silently skipped (it is at
+        // or before the already-advanced watermark) — the watermark and the
+        // processed count, which the PushEntries response relies on, do not
+        // move backwards.
+        List<LogSequenceNumber> consumed = Collections.synchronizedList(new ArrayList<>());
+        PushCommitLogTailer tailer = new PushCommitLogTailer(128, LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> consumed.add(lsn));
+        Thread t = new Thread(tailer, "test-push-tailer");
+        t.start();
+        try {
+            tailer.push(new LogSequenceNumber(1, 1), anEntry());
+            tailer.push(new LogSequenceNumber(1, 2), anEntry());
+            tailer.push(new LogSequenceNumber(1, 3), anEntry());
+            awaitSize(consumed, 3, 5000);
+            assertEquals(new LogSequenceNumber(1, 3), tailer.getWatermark());
+
+            // Regressing LSN — must be skipped.
+            tailer.push(new LogSequenceNumber(1, 2), anEntry());
+            Thread.sleep(300);
+        } finally {
+            tailer.close();
+            t.join(5000);
+        }
+        assertEquals("the out-of-order entry must not be dispatched", 3, consumed.size());
+        assertEquals(3L, tailer.getEntriesProcessed());
+        assertEquals(new LogSequenceNumber(1, 3), tailer.getWatermark());
+    }
+
+    @Test
+    public void closeWithBufferedEntriesDropsThem() throws Exception {
+        // close() drops entries still in the buffer (the engine does not drain
+        // on shutdown). Only the entry already in-flight in the consumer when
+        // close() is called is dispatched.
+        CountDownLatch gate = new CountDownLatch(1);
+        List<LogSequenceNumber> consumed = Collections.synchronizedList(new ArrayList<>());
+        PushCommitLogTailer tailer = new PushCommitLogTailer(8, LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> {
+                    try {
+                        gate.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    consumed.add(lsn);
+                });
+        Thread t = new Thread(tailer, "test-push-tailer");
+        t.start();
+        try {
+            // Entry 1 is taken and parks the tailer in the gated consumer;
+            // entries 2 and 3 sit undispatched in the buffer.
+            tailer.push(new LogSequenceNumber(1, 1), anEntry());
+            tailer.push(new LogSequenceNumber(1, 2), anEntry());
+            tailer.push(new LogSequenceNumber(1, 3), anEntry());
+            awaitCondition(() -> tailer.getBufferedCount() == 2, 5000);
+            assertEquals("two entries must be buffered before close()", 2,
+                    tailer.getBufferedCount());
+
+            tailer.close();
+        } finally {
+            gate.countDown();
+            t.join(5000);
+        }
+        // Only entry 1 (already in-flight at close) was dispatched; 2 and 3 dropped.
+        assertEquals(1L, tailer.getEntriesProcessed());
+        assertEquals(1, consumed.size());
+        assertEquals("dropped entries are left undispatched in the buffer",
+                2, tailer.getBufferedCount());
     }
 
     @Test

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PushCommitLogTailerTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PushCommitLogTailerTest.java
@@ -1,0 +1,217 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.log.CommitLogTailing;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+/**
+ * Unit tests for {@link PushCommitLogTailer}: in-order dispatch, the bounded
+ * buffer's blocking back-pressure, idempotent skipping of stale (re-pushed)
+ * entries on restart, and lifecycle.
+ */
+public class PushCommitLogTailerTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
+
+    /** A throwaway entry — the tailer never interprets the payload. */
+    private static LogEntry anEntry() {
+        return LogEntryFactory.noop();
+    }
+
+    private static void awaitSize(List<?> list, int target, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (list.size() < target && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20);
+        }
+    }
+
+    @Test
+    public void entriesAreDispatchedInPushOrder() throws Exception {
+        List<LogSequenceNumber> consumed = Collections.synchronizedList(new ArrayList<>());
+        PushCommitLogTailer tailer = new PushCommitLogTailer(128, LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> consumed.add(lsn));
+        Thread t = new Thread(tailer, "test-push-tailer");
+        t.start();
+        try {
+            for (int i = 1; i <= 50; i++) {
+                tailer.push(new LogSequenceNumber(1, i), anEntry());
+            }
+            awaitSize(consumed, 50, 5000);
+        } finally {
+            tailer.close();
+            t.join(5000);
+        }
+        assertEquals(50, consumed.size());
+        for (int i = 0; i < 50; i++) {
+            assertEquals(1, consumed.get(i).ledgerId);
+            assertEquals(i + 1, consumed.get(i).offset);
+        }
+        assertEquals(50L, tailer.getEntriesProcessed());
+        assertEquals(new LogSequenceNumber(1, 50), tailer.getWatermark());
+    }
+
+    @Test
+    public void pushBlocksWhenBufferIsFullAndResumesWhenDrained() throws Exception {
+        // Capacity 2: with the consumer gated, the tailer thread parks holding
+        // one entry, two more fill the buffer, and the next push must block.
+        CountDownLatch release = new CountDownLatch(1);
+        List<LogSequenceNumber> consumed = Collections.synchronizedList(new ArrayList<>());
+        PushCommitLogTailer tailer = new PushCommitLogTailer(2, LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> {
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    consumed.add(lsn);
+                });
+        Thread tailerThread = new Thread(tailer, "test-push-tailer");
+        tailerThread.start();
+
+        final int total = 10;
+        AtomicReference<Throwable> pushFailure = new AtomicReference<>();
+        Thread pusher = new Thread(() -> {
+            try {
+                for (int i = 1; i <= total; i++) {
+                    tailer.push(new LogSequenceNumber(1, i), anEntry());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                pushFailure.set(e);
+            } catch (RuntimeException e) {
+                pushFailure.set(e);
+            }
+        }, "test-pusher");
+        pusher.start();
+        try {
+            // Give the pusher time to fill the buffer and block.
+            Thread.sleep(500);
+            assertTrue("pusher must still be blocked on a full buffer", pusher.isAlive());
+            assertTrue("no entry can be dispatched while the consumer is gated",
+                    consumed.isEmpty());
+            assertEquals("buffer must be full", tailer.getBufferCapacity(),
+                    tailer.getBufferedCount());
+
+            // Release the consumer: the buffer drains and the pusher completes.
+            release.countDown();
+            pusher.join(5000);
+            assertFalse("pusher must finish once the buffer drains", pusher.isAlive());
+            awaitSize(consumed, total, 5000);
+            assertEquals(total, consumed.size());
+        } finally {
+            release.countDown();
+            tailer.close();
+            tailerThread.join(5000);
+            pusher.join(5000);
+        }
+        assertNull("push must not fail", pushFailure.get());
+    }
+
+    @Test
+    public void entriesAtOrBeforeWatermarkAreSkipped() throws Exception {
+        // Restart semantics: a tailer resuming at a durable watermark must
+        // drop re-pushed entries that have already been applied.
+        LogSequenceNumber watermark = new LogSequenceNumber(5, 10);
+        List<LogSequenceNumber> consumed = Collections.synchronizedList(new ArrayList<>());
+        PushCommitLogTailer tailer = new PushCommitLogTailer(128, watermark,
+                (lsn, entry) -> consumed.add(lsn));
+        Thread t = new Thread(tailer, "test-push-tailer");
+        t.start();
+        try {
+            tailer.push(new LogSequenceNumber(5, 8), anEntry());   // stale
+            tailer.push(new LogSequenceNumber(5, 10), anEntry());  // == watermark
+            tailer.push(new LogSequenceNumber(5, 11), anEntry());  // new
+            tailer.push(new LogSequenceNumber(6, 1), anEntry());   // new
+            awaitSize(consumed, 2, 5000);
+            // Give any erroneously-accepted stale entry time to slip through.
+            Thread.sleep(300);
+        } finally {
+            tailer.close();
+            t.join(5000);
+        }
+        assertEquals(2, consumed.size());
+        assertEquals(new LogSequenceNumber(5, 11), consumed.get(0));
+        assertEquals(new LogSequenceNumber(6, 1), consumed.get(1));
+        assertEquals(2L, tailer.getEntriesProcessed());
+        assertEquals(new LogSequenceNumber(6, 1), tailer.getWatermark());
+    }
+
+    @Test
+    public void closeStopsTheTailerThread() throws Exception {
+        PushCommitLogTailer tailer = new PushCommitLogTailer(8, LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> { });
+        Thread t = new Thread(tailer, "test-push-tailer");
+        t.start();
+        assertTrue(tailer.isRunning());
+        tailer.close();
+        t.join(5000);
+        assertFalse("tailer thread must exit after close()", t.isAlive());
+        assertFalse(tailer.isRunning());
+    }
+
+    @Test
+    public void pushAfterCloseIsRejected() throws Exception {
+        PushCommitLogTailer tailer = new PushCommitLogTailer(8, LogSequenceNumber.START_OF_TIME,
+                (lsn, entry) -> { });
+        tailer.close();
+        try {
+            tailer.push(new LogSequenceNumber(1, 1), anEntry());
+            fail("push after close must be rejected");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("closed"));
+        }
+    }
+
+    @Test
+    public void constructorRejectsInvalidArguments() {
+        CommitLogTailing.EntryConsumer noop = (lsn, entry) -> { };
+        try {
+            new PushCommitLogTailer(0, LogSequenceNumber.START_OF_TIME, noop);
+            fail("zero capacity must be rejected");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+        try {
+            new PushCommitLogTailer(8, LogSequenceNumber.START_OF_TIME, null);
+            fail("null consumer must be rejected");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PushModeRestartTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PushModeRestartTest.java
@@ -1,0 +1,315 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.codec.RecordSerializer;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import io.netty.buffer.ByteBuf;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+
+/**
+ * Restart / recovery coverage for push mode. In push mode there is no commit
+ * log to replay, but the indexing service still reloads its checkpointed
+ * segments and restores the table/index schema from the persisted watermark
+ * snapshot, and the {@link PushCommitLogTailer} resumes from the durable LSN.
+ * It also resolves a stable tablespace UUID without a HerdDB server.
+ */
+public class PushModeRestartTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(120);
+
+    private static Table vectorTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("pk", ColumnTypes.STRING)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("pk")
+                .build();
+    }
+
+    private static Index vectorIndex() {
+        return Index.builder()
+                .name("vidx")
+                .table("vectable")
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    private static float[] vec(int seed, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = seed + i;
+        }
+        return v;
+    }
+
+    /**
+     * Starts a push-mode service with an <em>empty</em> metadata store (no
+     * HerdDB server registered the tablespace), so the engine must resolve the
+     * tablespace UUID by deterministic derivation.
+     */
+    private EmbeddedIndexingService startPushService(Path logDir, Path dataDir, String storageType)
+            throws Exception {
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, storageType);
+        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
+                IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        // Keep the persistent store path simple and deterministic for a tiny
+        // test dataset — recovery of the watermark/schema/segments is what is
+        // under test, not FusedPQ.
+        props.setProperty(IndexingServerConfiguration.PROPERTY_VECTOR_FUSED_PQ, "false");
+        EmbeddedIndexingService svc = new EmbeddedIndexingService(
+                logDir, dataDir, new IndexingServerConfiguration(props));
+        MemoryMetadataStorageManager meta = new MemoryMetadataStorageManager();
+        meta.start();
+        // Deliberately NO ensureDefaultTableSpace(): push mode must work
+        // without a server having registered the tablespace.
+        svc.setMetadataStorageManager(meta);
+        svc.start();
+        return svc;
+    }
+
+    private static void push(IndexingPushClient client, long ledger, long firstOffset,
+                             List<LogEntry> entries) {
+        List<LogSequenceNumber> lsns = new ArrayList<>();
+        List<ByteBuf> bufs = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            lsns.add(new LogSequenceNumber(ledger, firstOffset + i));
+            bufs.add(entries.get(i).serializeAsByteBuf());
+        }
+        try {
+            client.pushEntries(lsns, bufs);
+        } finally {
+            for (ByteBuf b : bufs) {
+                b.release();
+            }
+        }
+    }
+
+    private static long vectorCount(IndexingPushClient client) {
+        return client.getIndexStatus("default", "vectable", "vidx").getVectorCount();
+    }
+
+    private static void awaitVectorCount(IndexingPushClient client, long expected, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        long last = -1;
+        while (System.currentTimeMillis() < deadline) {
+            last = vectorCount(client);
+            if (last >= expected) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        fail("indexed vector count did not reach " + expected + " (last=" + last + ")");
+    }
+
+    @Test
+    public void pushModeDerivesAStableTableSpaceUuidAcrossRestarts() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        String firstUuid;
+        EmbeddedIndexingService svc = startPushService(logDir, dataDir, "memory");
+        try {
+            firstUuid = svc.getEngine().getTableSpaceUUID();
+            assertNotNull("a tablespace UUID must be resolved without a server", firstUuid);
+            assertTrue("derived UUID must be non-empty", !firstUuid.isEmpty());
+        } finally {
+            svc.close();
+        }
+        // A fresh engine with a fresh empty metadata store must derive the
+        // exact same UUID, so it addresses the same storage namespace.
+        svc = startPushService(logDir, dataDir, "memory");
+        try {
+            assertEquals("tablespace UUID must be stable across restarts",
+                    firstUuid, svc.getEngine().getTableSpaceUUID());
+        } finally {
+            svc.close();
+        }
+    }
+
+    @Test
+    public void pushTailerResumesFromThePersistedWatermarkSnapshot() throws Exception {
+        // Inject a watermark snapshot that already carries the schema and a
+        // non-START_OF_TIME LSN — the engine restores the schema, the push
+        // tailer resumes from that LSN, and re-pushed stale entries are
+        // skipped while genuinely new ones are applied.
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+
+        Table table = vectorTable();
+        LogSequenceNumber durable = new LogSequenceNumber(5, 100);
+        WatermarkSnapshot snapshot = new WatermarkSnapshot(durable, 1, 0L,
+                Collections.singletonList(table),
+                Collections.singletonList(vectorIndex()));
+
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
+                IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        EmbeddedIndexingService svc = new EmbeddedIndexingService(
+                logDir, dataDir, new IndexingServerConfiguration(props));
+        MemoryMetadataStorageManager meta = new MemoryMetadataStorageManager();
+        meta.start();
+        svc.setMetadataStorageManager(meta);
+        svc.setWatermarkStore(new InMemoryWatermarkStore(snapshot));
+        svc.start();
+        IndexingPushClient client = new IndexingPushClient(svc.getAddress());
+        try {
+            // The push tailer resumed at the durable LSN, not START_OF_TIME.
+            assertEquals(durable, svc.getEngine().getPushTailer().getWatermark());
+            // Schema was restored from the snapshot — the index exists.
+            assertEquals(0L, vectorCount(client));
+
+            // A re-pushed entry at/before the watermark is skipped.
+            Record stale = RecordSerializer.makeRecord(table, "pk", "stale", "vec", vec(1, 8));
+            push(client, 5, 100, Collections.singletonList(
+                    LogEntryFactory.insert(table, stale.key, stale.value, null)));
+            Thread.sleep(500);
+            assertEquals("re-pushed stale entry must be skipped", 0L, vectorCount(client));
+
+            // A genuinely new entry (LSN > watermark) is applied.
+            Record fresh = RecordSerializer.makeRecord(table, "pk", "fresh", "vec", vec(2, 8));
+            push(client, 5, 101, Collections.singletonList(
+                    LogEntryFactory.insert(table, fresh.key, fresh.value, null)));
+            awaitVectorCount(client, 1, 20_000);
+        } finally {
+            client.close();
+            svc.close();
+        }
+    }
+
+    @Test
+    public void pushModeReloadsCheckpointedSegmentsAfterRestart() throws Exception {
+        Path logDir = folder.newFolder("log").toPath();
+        Path dataDir = folder.newFolder("data").toPath();
+        Table table = vectorTable();
+        final int dim = 8;
+        final int rows = 40;
+
+        String tableSpaceUuid;
+        LogSequenceNumber durable;
+
+        // --- first run: push, checkpoint, capture the durable watermark ---
+        EmbeddedIndexingService svc = startPushService(logDir, dataDir, "file");
+        IndexingPushClient client = new IndexingPushClient(svc.getAddress());
+        try {
+            tableSpaceUuid = svc.getEngine().getTableSpaceUUID();
+            push(client, 1, 1, Arrays.asList(
+                    LogEntryFactory.createTable(table, null),
+                    LogEntryFactory.createIndex(vectorIndex(), null)));
+            List<LogEntry> inserts = new ArrayList<>();
+            for (int i = 0; i < rows; i++) {
+                Record r = RecordSerializer.makeRecord(table, "pk", "key" + i, "vec", vec(i, dim));
+                inserts.add(LogEntryFactory.insert(table, r.key, r.value, null));
+            }
+            push(client, 1, 3, inserts);
+            awaitVectorCount(client, rows, 60_000);
+
+            // Force a checkpoint: segments + watermark + schema become durable.
+            svc.getEngine().forceCheckpointAndSaveWatermark();
+            durable = svc.getEngine().getLastDurableLsn();
+            assertEquals("durable watermark must be the last pushed LSN",
+                    new LogSequenceNumber(1, 2 + rows), durable);
+        } finally {
+            client.close();
+            svc.close();
+        }
+
+        // --- restart: same directories, fresh empty metadata store ---
+        svc = startPushService(logDir, dataDir, "file");
+        client = new IndexingPushClient(svc.getAddress());
+        try {
+            assertEquals("tablespace UUID must be stable across restarts",
+                    tableSpaceUuid, svc.getEngine().getTableSpaceUUID());
+            // Checkpointed segments are reloaded with no commit-log replay.
+            awaitVectorCount(client, rows, 60_000);
+            // The push tailer resumed from the durable watermark.
+            assertEquals(durable, svc.getEngine().getPushTailer().getWatermark());
+
+            // A re-pushed stale entry (LSN <= watermark) is skipped.
+            Record stale = RecordSerializer.makeRecord(table, "pk", "key0", "vec", vec(0, dim));
+            push(client, 1, 2 + rows, Collections.singletonList(
+                    LogEntryFactory.insert(table, stale.key, stale.value, null)));
+            Thread.sleep(500);
+            assertEquals("re-pushed stale entry must not change the count",
+                    (long) rows, vectorCount(client));
+
+            // A new entry past the watermark is applied on top of the
+            // recovered state.
+            Record fresh = RecordSerializer.makeRecord(table, "pk", "afterRestart", "vec", vec(99, dim));
+            push(client, 1, 3 + rows, Collections.singletonList(
+                    LogEntryFactory.insert(table, fresh.key, fresh.value, null)));
+            awaitVectorCount(client, rows + 1, 60_000);
+        } finally {
+            client.close();
+            svc.close();
+        }
+    }
+
+    /** In-memory {@link WatermarkStore} preloaded with one snapshot. */
+    private static final class InMemoryWatermarkStore implements WatermarkStore {
+
+        private WatermarkSnapshot snapshot;
+
+        InMemoryWatermarkStore(WatermarkSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public WatermarkSnapshot load() {
+            return snapshot;
+        }
+
+        @Override
+        public void save(WatermarkSnapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-pdb.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.bookkeeper.enabled .Values.bookkeeper.pdb.enabled -}}
+{{- /* Push-indexing mode scales BookKeeper to 0 replicas; a PDB selecting an
+       empty workload would be unsatisfiable, so it is not rendered. */ -}}
+{{- if and .Values.bookkeeper.enabled .Values.bookkeeper.pdb.enabled (not .Values.pushIndexingMode.enabled) -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/bookkeeper-statefulset.yaml
@@ -8,7 +8,8 @@ metadata:
     app.kubernetes.io/component: bookkeeper
 spec:
   serviceName: {{ include "herddb.fullname" . }}-bookkeeper
-  replicas: {{ .Values.bookkeeper.replicaCount }}
+  # Push-indexing mode uses no commit log, so BookKeeper scales to 0.
+  replicas: {{ if .Values.pushIndexingMode.enabled }}0{{ else }}{{ .Values.bookkeeper.replicaCount }}{{ end }}
   selector:
     matchLabels:
       {{- include "herddb.selectorLabels" . | nindent 6 }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/indexing-service-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/indexing-service-configmap.yaml
@@ -19,8 +19,16 @@ data:
     server.zookeeper.address={{ include "herddb.zkAddress" . }}
     server.zookeeper.path=/herd
     server.zookeeper.session.timeout={{ .Values.indexingService.zkSessionTimeout }}
+    {{- if .Values.pushIndexingMode.enabled }}
+    # Push mode (testing only): commit-log entries are pushed straight in over
+    # the PushEntries gRPC RPC, so no HerdDB server, BookKeeper or commit log is
+    # used. ZooKeeper stays in the picture for file-server discovery and the
+    # index optimizer.
+    indexing.log.type=push
+    {{- else }}
     indexing.log.type=bookkeeper
     server.bookkeeper.ledgers.path=/ledgers
+    {{- end }}
     {{- end }}
     {{- if .Values.indexOptimizer.enabled }}
     # Issue #491: when the external index-optimizer service is enabled, the IS

--- a/herddb-kubernetes/src/main/helm/herddb/templates/server-pdb.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/server-pdb.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.server.pdb.enabled -}}
+{{- /* Push-indexing mode scales the server to 0 replicas; a PDB selecting an
+       empty workload would be unsatisfiable, so it is not rendered. */ -}}
+{{- if and .Values.server.pdb.enabled (not .Values.pushIndexingMode.enabled) -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
@@ -7,7 +7,9 @@ metadata:
     app.kubernetes.io/component: server
 spec:
   serviceName: {{ include "herddb.fullname" . }}-server
-  replicas: {{ .Values.server.replicaCount }}
+  # Push-indexing mode runs with no HerdDB server (entries are pushed straight
+  # into the indexing service over gRPC), so the server scales to 0.
+  replicas: {{ if .Values.pushIndexingMode.enabled }}0{{ else }}{{ .Values.server.replicaCount }}{{ end }}
   selector:
     matchLabels:
       {{- include "herddb.selectorLabels" . | nindent 6 }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/server-statefulset.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.pushIndexingMode.enabled (ne .Values.server.mode "cluster") }}
+{{- fail "pushIndexingMode.enabled=true requires server.mode=cluster (push mode is a cluster-mode deployment: ZooKeeper, the file server and the index optimizer remain up)" }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-pdb_test.yaml
@@ -50,3 +50,15 @@ tests:
       - equal:
           path: spec.minAvailable
           value: 2
+
+  # Push-indexing mode scales BookKeeper to 0 replicas, so its PDB (which
+  # would otherwise select an empty workload) must not be rendered.
+  - it: should not render in push-indexing mode even when bookkeeper.pdb.enabled is true
+    set:
+      server.mode: cluster
+      bookkeeper.enabled: true
+      bookkeeper.pdb.enabled: true
+      pushIndexingMode.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/bookkeeper-statefulset_test.yaml
@@ -14,3 +14,27 @@ tests:
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: ^[a-f0-9]{64}$
+
+  # Push-indexing mode uses no commit log, so BookKeeper scales to 0 replicas.
+  - it: should render 0 replicas when pushIndexingMode is enabled
+    template: templates/bookkeeper-statefulset.yaml
+    set:
+      server.mode: cluster
+      bookkeeper.enabled: true
+      bookkeeper.replicaCount: 3
+      pushIndexingMode.enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: should render the configured replicas when pushIndexingMode is disabled
+    template: templates/bookkeeper-statefulset.yaml
+    set:
+      server.mode: cluster
+      bookkeeper.enabled: true
+      bookkeeper.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-configmap_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-configmap_test.yaml
@@ -51,6 +51,10 @@ tests:
       - notMatchRegex:
           path: data["indexingservice.properties"]
           pattern: "indexing\\.log\\.type=bookkeeper"
+      # Push mode drops the bookkeeper ledgers path entirely.
+      - notMatchRegex:
+          path: data["indexingservice.properties"]
+          pattern: "server\\.bookkeeper\\.ledgers\\.path"
 
   - it: should emit indexing.log.type=bookkeeper in cluster mode when pushIndexingMode is disabled
     set:
@@ -61,3 +65,6 @@ tests:
       - matchRegex:
           path: data["indexingservice.properties"]
           pattern: "indexing\\.log\\.type=bookkeeper"
+      - notMatchRegex:
+          path: data["indexingservice.properties"]
+          pattern: "indexing\\.log\\.type=push"

--- a/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-configmap_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/indexing-service-configmap_test.yaml
@@ -36,3 +36,28 @@ tests:
       - matchRegex:
           path: data["indexingservice.properties"]
           pattern: "indexing\\.optimizer\\.enabled=true"
+
+  # Push mode: the IS configmap must emit indexing.log.type=push (not
+  # bookkeeper) so the indexing service tails no commit log.
+  - it: should emit indexing.log.type=push when pushIndexingMode is enabled
+    set:
+      indexingService.enabled: true
+      server.mode: cluster
+      pushIndexingMode.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["indexingservice.properties"]
+          pattern: "indexing\\.log\\.type=push"
+      - notMatchRegex:
+          path: data["indexingservice.properties"]
+          pattern: "indexing\\.log\\.type=bookkeeper"
+
+  - it: should emit indexing.log.type=bookkeeper in cluster mode when pushIndexingMode is disabled
+    set:
+      indexingService.enabled: true
+      server.mode: cluster
+      pushIndexingMode.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["indexingservice.properties"]
+          pattern: "indexing\\.log\\.type=bookkeeper"

--- a/herddb-kubernetes/src/main/helm/herddb/tests/server-pdb_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/server-pdb_test.yaml
@@ -41,3 +41,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # Push-indexing mode scales the server to 0 replicas, so its PDB (which
+  # would otherwise select an empty workload) must not be rendered.
+  - it: should not render in push-indexing mode even when server.pdb.enabled is true
+    set:
+      server.mode: cluster
+      server.pdb.enabled: true
+      pushIndexingMode.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
@@ -160,3 +160,15 @@ tests:
       - notEqual:
           path: spec.template.metadata.annotations["checksum/config"]
           value: e03e1ab6bd1f6b88466ef23b2b312809927b3b628dd1ff9f59737e6e3a8cdfd0
+
+  # Push-indexing mode runs with no HerdDB server, so it scales to 0 replicas.
+  - it: should render 0 replicas when pushIndexingMode is enabled
+    template: templates/server-statefulset.yaml
+    set:
+      server.mode: cluster
+      server.replicaCount: 2
+      pushIndexingMode.enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0

--- a/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/tests/server-statefulset_test.yaml
@@ -172,3 +172,14 @@ tests:
       - equal:
           path: spec.replicas
           value: 0
+
+  - it: should render the configured replicas in cluster mode when pushIndexingMode is disabled
+    template: templates/server-statefulset.yaml
+    set:
+      server.mode: cluster
+      server.replicaCount: 2
+      pushIndexingMode.enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -16,6 +16,20 @@ serviceAccount:
   # Override the generated name
   name: ""
 
+# Push-based indexing mode (TESTING ONLY).
+#
+# When enabled the HerdDB server and BookKeeper StatefulSets are rendered with
+# 0 replicas, and the indexing service is configured with
+# indexing.log.type=push: a client (e.g. VectorBench --protocol grpc) pushes
+# commit-log entries straight into the indexing service over the PushEntries
+# gRPC RPC, so neither a HerdDB server nor a commit log is needed. ZooKeeper,
+# the file server, the index optimizer, MinIO and the tools pod are left
+# untouched and stay up.
+#
+# Requires server.mode=cluster and indexingService.enabled=true.
+pushIndexingMode:
+  enabled: false
+
 # HerdDB server (JDBC endpoint + metadata)
 server:
   # Server mode: "standalone" or "cluster"

--- a/herddb-services/test-start-indexing-service-push.sh
+++ b/herddb-services/test-start-indexing-service-push.sh
@@ -1,0 +1,70 @@
+#/bin/bash
+# Licensed to Diennea S.r.l. under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. Diennea S.r.l. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Starts a single HerdDB Indexing Service locally, on this host, in PUSH mode
+# (indexing.log.type=push) -- testing only.
+#
+# In push mode the indexing service does NOT tail a commit log: a client
+# (e.g. VectorBench with --protocol grpc) pushes commit-log entries straight
+# in over the PushEntries gRPC RPC. No HerdDB server, no BookKeeper and no
+# ZooKeeper are started or needed -- this is the cheapest way to exercise the
+# indexing service.
+#
+# Once it is up (gRPC on localhost:9850), drive ingestion with:
+#   vector-testings/run.sh --protocol grpc --grpc-endpoint localhost:9850 \
+#       --dataset sift1m --rows 100000
+#
+# Heap can be overridden with the ISHEAP env var (default 4g).
+
+set -x
+
+BASEDIR=${HERDDB_TESTS_HOME:-target}
+ISDIR=$(realpath $BASEDIR/indexing-push)
+ZIP=$(ls target/herddb-service*zip)
+
+echo "Installing $ZIP"
+rm -Rf $ISDIR
+
+echo "Unzipping Indexing Service in $ISDIR"
+TMPUNZIP=$(mktemp -d)
+unzip -q $ZIP -d $TMPUNZIP
+mv $TMPUNZIP/herddb* $ISDIR
+rmdir $TMPUNZIP
+
+cd $ISDIR
+mkdir -p tmp
+
+# Configure the indexing service for standalone PUSH mode. A fresh unzip means
+# these lines are appended exactly once per run.
+INDEXING_CONFIGFILE=conf/indexingservice.properties
+echo ""                                    >> $INDEXING_CONFIGFILE
+echo "# --- push mode (test-start-indexing-service-push.sh) ---" >> $INDEXING_CONFIGFILE
+echo "indexing.log.type=push"              >> $INDEXING_CONFIGFILE
+echo "indexing.storage.type=file"          >> $INDEXING_CONFIGFILE
+echo "indexing.data.dir=dbdata/indexdata"  >> $INDEXING_CONFIGFILE
+echo "server.mode=standalone"              >> $INDEXING_CONFIGFILE
+
+export JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Djava.net.preferIPv4Stack=true -Xmx${ISHEAP:-4g} -Xms${ISHEAP:-4g} -Djava.awt.headless=true -Djava.util.logging.config.file=conf/logging.properties -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$ISDIR/indexingservice-heapdump.hprof --add-modules jdk.incubator.vector -Djava.io.tmpdir=$(pwd)/tmp"
+bin/service indexing-service start
+
+sleep 2
+
+echo "Indexing Service started in PUSH mode (gRPC on localhost:9850)."
+echo "No HerdDB server / BookKeeper / ZooKeeper is required."
+echo "Drive ingestion with:"
+echo "  vector-testings/run.sh --protocol grpc --grpc-endpoint localhost:9850 --dataset sift1m --rows 100000"

--- a/vector-testings/pom.xml
+++ b/vector-testings/pom.xml
@@ -45,6 +45,21 @@
             <version>${project.version}</version>
             <classifier>uber</classifier>
         </dependency>
+        <!--
+            herddb-core supplies LogEntry / Table / Index / RecordSerializer,
+            which the gRPC protocol mode serializes by hand; herddb-indexing-service
+            supplies the PushEntries gRPC stubs and the IndexingPushClient helper.
+        -->
+        <dependency>
+            <groupId>org.herddb</groupId>
+            <artifactId>herddb-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.herddb</groupId>
+            <artifactId>herddb-indexing-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
@@ -100,6 +115,14 @@
             <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
+        <!-- EmbeddedIndexingService, for the gRPC protocol integration test. -->
+        <dependency>
+            <groupId>org.herddb</groupId>
+            <artifactId>herddb-indexing-service</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -127,6 +150,14 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>herddb.vectortesting.VectorBench</mainClass>
                                 </transformer>
+                                <!--
+                                  Merge META-INF/services/* so the gRPC
+                                  ServiceLoader providers (channel / name
+                                  resolver) survive shading — without this the
+                                  grpc client fails with "no functional channel
+                                  service provider found".
+                                -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>

--- a/vector-testings/run.sh
+++ b/vector-testings/run.sh
@@ -16,6 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# Runs the VectorBench tool; all arguments are forwarded to it. Examples:
+#   ./run.sh --dataset sift1m --rows 100000                   (default --protocol jdbc)
+#   ./run.sh --protocol grpc --grpc-endpoint localhost:9850 --dataset sift1m --rows 100000
+# With --protocol grpc the bench pushes serialized commit-log entries straight
+# into a single indexing service (indexing.log.type=push) — ingestion only,
+# no HerdDB server required.
+#
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -35,6 +35,12 @@ public class Config {
         JSON
     }
 
+    /** Wire protocol used by the benchmark. */
+    public enum Protocol {
+        JDBC,
+        GRPC
+    }
+
     String jdbcUrl = "jdbc:herddb:server:localhost:7000";
     String username = "sa";
     String password = "hdb";
@@ -101,6 +107,18 @@ public class Config {
     int waitForIndexesTimeoutSeconds = 600;
     boolean noProgress = false;
     OutputFormat outputFormat = OutputFormat.TEXT;
+    /**
+     * Wire protocol: {@link Protocol#JDBC} (default) drives the benchmark
+     * through a HerdDB server; {@link Protocol#GRPC} pushes serialized
+     * {@code LogEntry} objects straight into a single indexing service
+     * ({@code indexing.log.type=push}) — ingestion only.
+     */
+    Protocol protocol = Protocol.JDBC;
+    /**
+     * Indexing-service gRPC endpoint ({@code host:port}) used when
+     * {@link #protocol} is {@link Protocol#GRPC}.
+     */
+    String grpcEndpoint = "localhost:9850";
     /**
      * Interval in seconds between periodic {@code [status]} dumps during ingestion.
      * A dedicated JDBC connection queries {@code syslogstatus}, {@code systablestats} and
@@ -193,6 +211,12 @@ public class Config {
         opts.addOption(null, "run-queries-during-ingestion-period", true,
                 "Seconds between consecutive query rounds when --run-queries-during-ingestion is "
                         + "active (default: 30, minimum: 1)");
+        opts.addOption(null, "protocol", true,
+                "Wire protocol: jdbc (default) or grpc. grpc pushes serialized LogEntries "
+                        + "straight into a single indexing service (ingestion only).");
+        opts.addOption(null, "grpc-endpoint", true,
+                "Indexing-service gRPC endpoint host:port for --protocol grpc "
+                        + "(default: localhost:9850)");
         opts.addOption(null, "config", true, "Path to properties file");
         opts.addOption("h", "help", false, "Show help");
         return opts;
@@ -223,6 +247,12 @@ public class Config {
         // CLI overrides
         if (cmd.hasOption("url")) {
             cfg.jdbcUrl = cmd.getOptionValue("url");
+        }
+        if (cmd.hasOption("protocol")) {
+            cfg.protocol = parseProtocol(cmd.getOptionValue("protocol"));
+        }
+        if (cmd.hasOption("grpc-endpoint")) {
+            cfg.grpcEndpoint = cmd.getOptionValue("grpc-endpoint");
         }
         if (cmd.hasOption("user")) {
             cfg.username = cmd.getOptionValue("user");
@@ -383,6 +413,12 @@ public class Config {
         if (props.containsKey("url")) {
             jdbcUrl = props.getProperty("url");
         }
+        if (props.containsKey("protocol")) {
+            protocol = parseProtocol(props.getProperty("protocol"));
+        }
+        if (props.containsKey("grpc-endpoint")) {
+            grpcEndpoint = props.getProperty("grpc-endpoint");
+        }
         if (props.containsKey("user")) {
             username = props.getProperty("user");
         }
@@ -519,6 +555,18 @@ public class Config {
             case "json", "ndjson" -> OutputFormat.JSON;
             default -> throw new IllegalArgumentException("Unknown output-format: " + raw
                     + ". Supported: text, json");
+        };
+    }
+
+    private static Protocol parseProtocol(String raw) {
+        if (raw == null) {
+            throw new IllegalArgumentException("protocol cannot be null");
+        }
+        return switch (raw.toLowerCase()) {
+            case "jdbc" -> Protocol.JDBC;
+            case "grpc" -> Protocol.GRPC;
+            default -> throw new IllegalArgumentException("Unknown protocol: " + raw
+                    + ". Supported: jdbc, grpc");
         };
     }
 

--- a/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
@@ -1,0 +1,271 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import herddb.codec.RecordSerializer;
+import herddb.index.vector.VectorIndexManager;
+import herddb.indexing.IndexingPushClient;
+import herddb.indexing.proto.PushEntriesResponse;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogEntryType;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.model.TableSpace;
+import io.netty.buffer.ByteBuf;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * The {@code --protocol grpc} ingestion path of VectorBench.
+ *
+ * <p>Instead of going through JDBC and a HerdDB server, this mode talks
+ * straight to a single indexing service running with
+ * {@code indexing.log.type=push}: it serializes HerdDB {@link LogEntry}
+ * objects itself (CREATE_TABLE, CREATE_INDEX, BEGIN/INSERT/COMMIT) and pushes
+ * them over the {@code PushEntries} gRPC RPC. No HerdDB server, BookKeeper or
+ * commit log is involved.
+ *
+ * <p>It is ingestion-only: a transaction wraps each batch of inserts, the
+ * entries are serialized into pooled direct {@link ByteBuf}s to keep the
+ * client's memory footprint low, and a single thread issues every push so the
+ * indexing service sees a strictly increasing LSN stream. Verification polls
+ * the index status over gRPC and checks the indexed vector count.
+ */
+public final class GrpcBench {
+
+    /** Fixed ledger component of the synthetic LSN stream; offsets are monotonic. */
+    private static final String INDEX_NAME = "vidx";
+
+    private GrpcBench() {
+    }
+
+    /**
+     * Entry point for {@code --protocol grpc}. Loads the dataset, opens the
+     * gRPC client and drives ingestion, then exits the JVM (mirroring the JDBC
+     * path's terminal {@code System.exit(0)}).
+     */
+    static void run(Config config, BenchOutput out, long benchmarkStartNs) throws Exception {
+        out.header("=== gRPC PUSH MODE (indexing service " + config.grpcEndpoint + ") ===");
+        out.info("Loading dataset...");
+        DatasetLoader loader = new DatasetLoader(config.datasetDir, config.dataset, config.datasetUrl);
+        loader.ensureDataset();
+
+        long toIngest = Math.max(0L, config.numRows - config.resumeFrom);
+        try (IndexingPushClient client = new IndexingPushClient(config.grpcEndpoint);
+                DatasetLoader.VectorStream stream = loader.streamBaseVectors(config.resumeFrom, toIngest)) {
+            long pushed = ingest(client, config, out, stream.iterator(), config.resumeFrom, toIngest);
+            double totalSecs = (System.nanoTime() - benchmarkStartNs) / 1e9;
+            LinkedHashMap<String, Object> summary = new LinkedHashMap<>();
+            summary.put("protocol", "grpc");
+            summary.put("endpoint", config.grpcEndpoint);
+            summary.put("dataset", config.dataset.name());
+            summary.put("rows", pushed);
+            summary.put("total_wall_time_s", Math.round(totalSecs * 10.0) / 10.0);
+            out.summary(summary);
+        }
+        out.done();
+        System.exit(0);
+    }
+
+    /**
+     * Pushes the schema (CREATE_TABLE + CREATE_INDEX) and then streams
+     * {@code totalRows} INSERTs from {@code vectors}, one transaction per
+     * {@code config.batchSize} rows, and finally verifies the indexed vector
+     * count over gRPC.
+     *
+     * <p>Package-private and free of {@code System.exit} so integration tests
+     * can drive it directly with a synthetic vector source.
+     *
+     * @return the number of vector rows pushed
+     */
+    static long ingest(IndexingPushClient client, Config config, BenchOutput out,
+                       Iterator<float[]> vectors, long firstRowId, long totalRows) throws Exception {
+        Table table = buildTable(config);
+        Index index = buildIndex(config);
+
+        // The client owns LSN assignment. A fresh ledger id per run keeps the
+        // stream strictly after any watermark a reused indexing service may
+        // already hold; offsets are monotonic within the run.
+        long ledgerId = System.currentTimeMillis();
+        long[] offset = {1L};
+
+        out.phaseStart("schema");
+        out.info("Pushing CREATE TABLE " + config.tableName + " + CREATE VECTOR INDEX " + INDEX_NAME);
+        pushBatch(client, ledgerId, offset, Arrays.asList(
+                LogEntryFactory.createTable(table, null),
+                LogEntryFactory.createIndex(index, null)));
+        // Baseline so verification works even against a non-fresh service.
+        long baseline = client.getIndexStatus(TableSpace.DEFAULT, config.tableName, INDEX_NAME)
+                .getVectorCount();
+        out.phaseDone("schema", 0.0);
+
+        out.header("=== INGESTION PHASE (gRPC push) ===");
+        out.phaseStart("ingest");
+        long ingestStart = System.nanoTime();
+        long rowId = firstRowId;
+        long pushed = 0;
+        long pushCalls = 0;
+        long txId = 1;
+        long lastProgressNs = ingestStart;
+
+        while (vectors.hasNext()) {
+            // One transaction per push batch: BEGIN + N INSERTs + COMMIT.
+            List<LogEntry> batch = new ArrayList<>(config.batchSize + 2);
+            batch.add(LogEntryFactory.beginTransaction(txId));
+            int n = 0;
+            while (n < config.batchSize && vectors.hasNext()) {
+                float[] v = vectors.next();
+                Record record = RecordSerializer.makeRecord(table, "id", (int) rowId, "vec", v);
+                batch.add(new LogEntry(System.currentTimeMillis(), LogEntryType.INSERT,
+                        txId, table.tableId, record.key, record.value));
+                rowId++;
+                n++;
+            }
+            batch.add(LogEntryFactory.commitTransaction(txId));
+            txId++;
+
+            PushEntriesResponse resp = pushBatch(client, ledgerId, offset, batch);
+            pushed += n;
+            pushCalls++;
+            if (resp.getAcceptedCount() != batch.size()) {
+                throw new IllegalStateException("indexing service accepted "
+                        + resp.getAcceptedCount() + " of " + batch.size() + " pushed entries");
+            }
+
+            long now = System.nanoTime();
+            if (now - lastProgressNs > 1_000_000_000L || !vectors.hasNext()) {
+                lastProgressNs = now;
+                double elapsed = (now - ingestStart) / 1e9;
+                double opsPerSec = elapsed > 0 ? pushed / elapsed : 0.0;
+                LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+                fields.put("rows", pushed);
+                fields.put("total", totalRows);
+                fields.put("push_calls", pushCalls);
+                fields.put("ops_per_sec", opsPerSec);
+                out.progress("ingest", elapsed, String.format(
+                        "pushed %d/%d rows | %.0f ops/s | %d push calls",
+                        pushed, totalRows, opsPerSec, pushCalls), fields);
+            }
+        }
+
+        double ingestSecs = (System.nanoTime() - ingestStart) / 1e9;
+        out.phaseDone("ingest", ingestSecs);
+        out.info(String.format("Pushed %d rows in %d transactions over %.1fs (%.0f ops/s)",
+                pushed, pushCalls, ingestSecs, ingestSecs > 0 ? pushed / ingestSecs : 0.0));
+
+        if (config.skipVerify) {
+            out.info("Skipping vector-count verification (--skip-verify).");
+        } else {
+            verifyVectorCount(client, config, out, baseline + pushed);
+        }
+        return pushed;
+    }
+
+    /**
+     * Polls {@code GetIndexStatus} until the indexed vector count reaches
+     * {@code expected}. The indexing service applies pushed entries
+     * asynchronously and may pause for a checkpoint/compaction, so this waits
+     * with a generous deadline rather than asserting immediately.
+     */
+    private static void verifyVectorCount(IndexingPushClient client, Config config,
+                                          BenchOutput out, long expected) throws InterruptedException {
+        out.phaseStart("verification");
+        long verifyStart = System.nanoTime();
+        long deadlineMs = System.currentTimeMillis() + 3_600_000L;
+        long last = -1;
+        while (System.currentTimeMillis() < deadlineMs) {
+            last = client.getIndexStatus(TableSpace.DEFAULT, config.tableName, INDEX_NAME)
+                    .getVectorCount();
+            if (last >= expected) {
+                out.phaseDone("verification", (System.nanoTime() - verifyStart) / 1e9);
+                out.info("Verification OK: index '" + INDEX_NAME + "' reports " + last + " vectors");
+                return;
+            }
+            double elapsed = (System.nanoTime() - verifyStart) / 1e9;
+            LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+            fields.put("vector_count", last);
+            fields.put("expected", expected);
+            out.progress("verification", elapsed,
+                    "indexed " + last + "/" + expected + " vectors", fields);
+            Thread.sleep(1000);
+        }
+        throw new IllegalStateException("index vector count reached only " + last
+                + " of the expected " + expected + " within the verification timeout");
+    }
+
+    /**
+     * Serializes each entry into a pooled direct {@link ByteBuf}, assigns it
+     * the next LSN, pushes the batch, and releases the buffers once the
+     * (zero-copy) RPC has returned.
+     */
+    private static PushEntriesResponse pushBatch(IndexingPushClient client, long ledgerId,
+                                                 long[] offset, List<LogEntry> entries) {
+        List<LogSequenceNumber> lsns = new ArrayList<>(entries.size());
+        List<ByteBuf> bufs = new ArrayList<>(entries.size());
+        for (LogEntry entry : entries) {
+            lsns.add(new LogSequenceNumber(ledgerId, offset[0]++));
+            bufs.add(entry.serializeAsByteBuf());
+        }
+        try {
+            return client.pushEntries(lsns, bufs);
+        } finally {
+            for (ByteBuf buf : bufs) {
+                buf.release();
+            }
+        }
+    }
+
+    private static Table buildTable(Config config) {
+        return Table.builder()
+                .name(config.tableName)
+                .tablespace(TableSpace.DEFAULT)
+                .column("id", ColumnTypes.INTEGER)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("id")
+                .build();
+    }
+
+    private static Index buildIndex(Config config) {
+        Index.Builder builder = Index.builder()
+                .name(INDEX_NAME)
+                .table(config.tableName)
+                .tablespace(TableSpace.DEFAULT)
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .property(VectorIndexManager.PROP_M, String.valueOf(config.indexM))
+                .property(VectorIndexManager.PROP_BEAM_WIDTH, String.valueOf(config.indexBeamWidth))
+                .property(VectorIndexManager.PROP_SIMILARITY, config.effectiveSimilarity())
+                .property(VectorIndexManager.PROP_FUSED_PQ, "true")
+                .property(VectorIndexManager.PROP_NEIGHBOR_OVERFLOW,
+                        String.valueOf(config.indexNeighborOverflow))
+                .property(VectorIndexManager.PROP_ALPHA, String.valueOf(config.indexAlpha));
+        if (config.indexNumShards > 1) {
+            builder.property(VectorIndexManager.PROP_NUM_SHARDS, String.valueOf(config.indexNumShards));
+        }
+        return builder.build();
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * The {@code --protocol grpc} ingestion path of VectorBench.
@@ -57,7 +58,7 @@ import java.util.List;
  */
 public final class GrpcBench {
 
-    /** Fixed ledger component of the synthetic LSN stream; offsets are monotonic. */
+    /** Name of the vector index this mode creates, populates and verifies. */
     private static final String INDEX_NAME = "vidx";
 
     private GrpcBench() {
@@ -70,6 +71,10 @@ public final class GrpcBench {
      */
     static void run(Config config, BenchOutput out, long benchmarkStartNs) throws Exception {
         out.header("=== gRPC PUSH MODE (indexing service " + config.grpcEndpoint + ") ===");
+        if (config.resumeFromAuto) {
+            out.info("WARNING: --resume-from auto is not supported with --protocol grpc; "
+                    + "ingestion starts at row " + config.resumeFrom + ".");
+        }
         out.info("Loading dataset...");
         DatasetLoader loader = new DatasetLoader(config.datasetDir, config.dataset, config.datasetUrl);
         loader.ensureDataset();
@@ -115,9 +120,13 @@ public final class GrpcBench {
 
         out.phaseStart("schema");
         out.info("Pushing CREATE TABLE " + config.tableName + " + CREATE VECTOR INDEX " + INDEX_NAME);
-        pushBatch(client, ledgerId, offset, Arrays.asList(
+        PushEntriesResponse schemaResp = pushBatch(client, ledgerId, offset, Arrays.asList(
                 LogEntryFactory.createTable(table, null),
                 LogEntryFactory.createIndex(index, null)));
+        if (schemaResp.getAcceptedCount() != 2) {
+            throw new IllegalStateException("indexing service accepted "
+                    + schemaResp.getAcceptedCount() + " of 2 schema entries");
+        }
         // Baseline so verification works even against a non-fresh service.
         long baseline = client.getIndexStatus(TableSpace.DEFAULT, config.tableName, INDEX_NAME)
                 .getVectorCount();
@@ -139,7 +148,7 @@ public final class GrpcBench {
             int n = 0;
             while (n < config.batchSize && vectors.hasNext()) {
                 float[] v = vectors.next();
-                Record record = RecordSerializer.makeRecord(table, "id", (int) rowId, "vec", v);
+                Record record = RecordSerializer.makeRecord(table, "id", rowId, "vec", v);
                 batch.add(new LogEntry(System.currentTimeMillis(), LogEntryType.INSERT,
                         txId, table.tableId, record.key, record.value));
                 rowId++;
@@ -218,19 +227,33 @@ public final class GrpcBench {
     }
 
     /**
-     * Serializes each entry into a pooled direct {@link ByteBuf}, assigns it
-     * the next LSN, pushes the batch, and releases the buffers once the
-     * (zero-copy) RPC has returned.
+     * Pushes a batch, serializing each entry with
+     * {@link LogEntry#serializeAsByteBuf()}.
      */
     private static PushEntriesResponse pushBatch(IndexingPushClient client, long ledgerId,
                                                  long[] offset, List<LogEntry> entries) {
+        return pushBatch(client, ledgerId, offset, entries, LogEntry::serializeAsByteBuf);
+    }
+
+    /**
+     * Serializes each entry into a pooled direct {@link ByteBuf} with
+     * {@code serializer}, assigns it the next LSN, pushes the batch, and
+     * releases <em>every</em> buffer once the (zero-copy) RPC has returned —
+     * including when serializing a later entry throws mid-batch.
+     *
+     * <p>The serializer is a parameter so tests can exercise that buffer
+     * lifecycle without a live indexing service.
+     */
+    static PushEntriesResponse pushBatch(IndexingPushClient client, long ledgerId, long[] offset,
+                                         List<LogEntry> entries,
+                                         Function<LogEntry, ByteBuf> serializer) {
         List<LogSequenceNumber> lsns = new ArrayList<>(entries.size());
         List<ByteBuf> bufs = new ArrayList<>(entries.size());
-        for (LogEntry entry : entries) {
-            lsns.add(new LogSequenceNumber(ledgerId, offset[0]++));
-            bufs.add(entry.serializeAsByteBuf());
-        }
         try {
+            for (LogEntry entry : entries) {
+                lsns.add(new LogSequenceNumber(ledgerId, offset[0]++));
+                bufs.add(serializer.apply(entry));
+            }
             return client.pushEntries(lsns, bufs);
         } finally {
             for (ByteBuf buf : bufs) {
@@ -243,7 +266,9 @@ public final class GrpcBench {
         return Table.builder()
                 .name(config.tableName)
                 .tablespace(TableSpace.DEFAULT)
-                .column("id", ColumnTypes.INTEGER)
+                // LONG, not INTEGER: a bench may ingest more than 2^31 rows and
+                // the primary key must stay unique.
+                .column("id", ColumnTypes.LONG)
                 .column("vec", ColumnTypes.FLOATARRAY)
                 .primaryKey("id")
                 .build();

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -186,6 +186,13 @@ public class VectorBench {
     private static void runBenchmark(Config config, BenchOutput out, long benchmarkStartNs, BenchRuntime runtime) throws Exception {
         out.config(config);
 
+        // gRPC push mode: ingestion straight into a single indexing service,
+        // with no HerdDB server. Entirely separate from the JDBC path below.
+        if (config.protocol == Config.Protocol.GRPC) {
+            GrpcBench.run(config, out, benchmarkStartNs);
+            return;
+        }
+
         // Summary accumulators
         double ingestionWallSecs = -1, indexWallSecs = -1, queryWallSecs = -1;
         double checkpointPostIngestSecs = -1, checkpointPostIndexSecs = -1;

--- a/vector-testings/src/test/java/herddb/vectortesting/ConfigProtocolTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/ConfigProtocolTest.java
@@ -1,0 +1,70 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+/** Parsing of the {@code --protocol} / {@code --grpc-endpoint} options. */
+class ConfigProtocolTest {
+
+    @Test
+    void defaultsToJdbc() throws Exception {
+        Config cfg = Config.parse(new String[]{});
+        assertEquals(Config.Protocol.JDBC, cfg.protocol);
+        assertEquals("localhost:9850", cfg.grpcEndpoint);
+    }
+
+    @Test
+    void grpcProtocolAndEndpointAreParsed() throws Exception {
+        Config cfg = Config.parse(new String[]{
+                "--protocol", "grpc", "--grpc-endpoint", "indexer-host:9999"});
+        assertEquals(Config.Protocol.GRPC, cfg.protocol);
+        assertEquals("indexer-host:9999", cfg.grpcEndpoint);
+    }
+
+    @Test
+    void protocolIsCaseInsensitive() throws Exception {
+        assertEquals(Config.Protocol.GRPC,
+                Config.parse(new String[]{"--protocol", "GRPC"}).protocol);
+        assertEquals(Config.Protocol.JDBC,
+                Config.parse(new String[]{"--protocol", "Jdbc"}).protocol);
+    }
+
+    @Test
+    void unknownProtocolIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Config.parse(new String[]{"--protocol", "thrift"}));
+    }
+
+    @Test
+    void protocolCanBeSetFromAPropertiesFile() throws Exception {
+        java.io.File props = java.io.File.createTempFile("vectorbench", ".properties");
+        props.deleteOnExit();
+        try (java.io.FileWriter w = new java.io.FileWriter(props)) {
+            w.write("protocol=grpc\n");
+            w.write("grpc-endpoint=cfg-host:7777\n");
+        }
+        Config cfg = Config.parse(new String[]{"--config", props.getAbsolutePath()});
+        assertEquals(Config.Protocol.GRPC, cfg.protocol);
+        assertEquals("cfg-host:7777", cfg.grpcEndpoint);
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
@@ -23,8 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import herddb.indexing.EmbeddedIndexingService;
 import herddb.indexing.IndexingPushClient;
 import herddb.indexing.IndexingServerConfiguration;
+import herddb.model.TableSpace;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Properties;
@@ -33,15 +35,37 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * End-to-end test of the VectorBench {@code --protocol grpc} ingestion path:
- * {@link GrpcBench#ingest} pushes the schema and a batch of transactional
- * INSERTs straight into an embedded indexing service running in push mode, and
- * the indexed vector count is verified over gRPC.
+ * End-to-end tests of the VectorBench {@code --protocol grpc} ingestion path:
+ * {@link GrpcBench#ingest} pushes the schema and transactional INSERTs straight
+ * into an embedded indexing service running in push mode, and the indexed
+ * vector count is verified over gRPC.
  */
 class GrpcBenchIntegrationTest {
 
     @TempDir
     Path tempDir;
+
+    private EmbeddedIndexingService startPushService() throws Exception {
+        Path logDir = Files.createDirectories(tempDir.resolve("log"));
+        Path dataDir = Files.createDirectories(tempDir.resolve("data"));
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
+                IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        EmbeddedIndexingService service = new EmbeddedIndexingService(
+                logDir, dataDir, new IndexingServerConfiguration(props));
+        service.start();
+        return service;
+    }
+
+    private static Config grpcConfig(String tableName) {
+        Config config = new Config();
+        config.protocol = Config.Protocol.GRPC;
+        config.tableName = tableName;
+        config.batchSize = 64;
+        config.noProgress = true;
+        return config;
+    }
 
     /** Deterministic synthetic base vectors — no dataset download needed. */
     private static Iterator<float[]> syntheticVectors(int count, int dim) {
@@ -71,33 +95,51 @@ class GrpcBenchIntegrationTest {
     @Test
     @Timeout(120)
     void grpcIngestPushesSchemaAndVectorsAndVerifies() throws Exception {
-        Path logDir = Files.createDirectories(tempDir.resolve("log"));
-        Path dataDir = Files.createDirectories(tempDir.resolve("data"));
-        Properties props = new Properties();
-        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
-        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
-                IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
-        EmbeddedIndexingService service = new EmbeddedIndexingService(
-                logDir, dataDir, new IndexingServerConfiguration(props));
-        service.start();
+        EmbeddedIndexingService service = startPushService();
         try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
-            Config config = new Config();
-            config.protocol = Config.Protocol.GRPC;
-            config.tableName = "grpc_bench";
-            config.batchSize = 64;
-            config.noProgress = true;
-
-            BenchOutput out = BenchOutput.create(config);
+            Config config = grpcConfig("grpc_bench");
             int rows = 300;
             // ingest() pushes CREATE TABLE + CREATE VECTOR INDEX, then the rows
             // in 64-row transactions, and polls GetIndexStatus until the count
-            // matches — it would throw if verification failed.
-            long pushed = GrpcBench.ingest(client, config, out,
+            // matches — it throws if verification fails.
+            long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
                     syntheticVectors(rows, 16), 0L, rows);
             assertEquals(rows, pushed);
+            assertEquals(rows,
+                    client.getIndexStatus(TableSpace.DEFAULT, "grpc_bench", "vidx").getVectorCount(),
+                    "every pushed vector must be indexed");
+        } finally {
+            service.close();
+        }
+    }
 
-            long indexed = client.getIndexStatus("herd", "grpc_bench", "vidx").getVectorCount();
-            assertEquals(rows, indexed, "every pushed vector must be indexed");
+    @Test
+    @Timeout(120)
+    void grpcIngestWithZeroRowsPushesSchemaOnly() throws Exception {
+        EmbeddedIndexingService service = startPushService();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = grpcConfig("grpc_empty");
+            long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
+                    Collections.<float[]>emptyIterator(), 0L, 0L);
+            assertEquals(0, pushed);
+            // The schema is still pushed: the index exists and reports 0 vectors.
+            assertEquals(0,
+                    client.getIndexStatus(TableSpace.DEFAULT, "grpc_empty", "vidx").getVectorCount());
+        } finally {
+            service.close();
+        }
+    }
+
+    @Test
+    @Timeout(120)
+    void grpcIngestWithSkipVerifyReturnsThePushedCount() throws Exception {
+        EmbeddedIndexingService service = startPushService();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = grpcConfig("grpc_skipverify");
+            config.skipVerify = true;
+            long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
+                    syntheticVectors(128, 16), 0L, 128);
+            assertEquals(128, pushed);
         } finally {
             service.close();
         }

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import herddb.indexing.EmbeddedIndexingService;
+import herddb.indexing.IndexingPushClient;
+import herddb.indexing.IndexingServerConfiguration;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end test of the VectorBench {@code --protocol grpc} ingestion path:
+ * {@link GrpcBench#ingest} pushes the schema and a batch of transactional
+ * INSERTs straight into an embedded indexing service running in push mode, and
+ * the indexed vector count is verified over gRPC.
+ */
+class GrpcBenchIntegrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    /** Deterministic synthetic base vectors — no dataset download needed. */
+    private static Iterator<float[]> syntheticVectors(int count, int dim) {
+        return new Iterator<>() {
+            private int produced;
+
+            @Override
+            public boolean hasNext() {
+                return produced < count;
+            }
+
+            @Override
+            public float[] next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                float[] v = new float[dim];
+                for (int j = 0; j < dim; j++) {
+                    v[j] = (produced % 97) + j * 0.5f;
+                }
+                produced++;
+                return v;
+            }
+        };
+    }
+
+    @Test
+    @Timeout(120)
+    void grpcIngestPushesSchemaAndVectorsAndVerifies() throws Exception {
+        Path logDir = Files.createDirectories(tempDir.resolve("log"));
+        Path dataDir = Files.createDirectories(tempDir.resolve("data"));
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
+                IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        EmbeddedIndexingService service = new EmbeddedIndexingService(
+                logDir, dataDir, new IndexingServerConfiguration(props));
+        service.start();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = new Config();
+            config.protocol = Config.Protocol.GRPC;
+            config.tableName = "grpc_bench";
+            config.batchSize = 64;
+            config.noProgress = true;
+
+            BenchOutput out = BenchOutput.create(config);
+            int rows = 300;
+            // ingest() pushes CREATE TABLE + CREATE VECTOR INDEX, then the rows
+            // in 64-row transactions, and polls GetIndexStatus until the count
+            // matches — it would throw if verification failed.
+            long pushed = GrpcBench.ingest(client, config, out,
+                    syntheticVectors(rows, 16), 0L, rows);
+            assertEquals(rows, pushed);
+
+            long indexed = client.getIndexStatus("herd", "grpc_bench", "vidx").getVectorCount();
+            assertEquals(rows, indexed, "every pushed vector must be indexed");
+        } finally {
+            service.close();
+        }
+    }
+}

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchTest.java
@@ -1,0 +1,66 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.vectortesting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link GrpcBench} internals. */
+class GrpcBenchTest {
+
+    @Test
+    void pushBatchReleasesBuffersWhenSerializationFailsMidBatch() {
+        // A serializer that hands out two pooled direct buffers, then throws on
+        // the third entry — simulating LogEntry.serializeAsByteBuf() failing
+        // mid-batch. pushBatch must release the two already-allocated buffers
+        // rather than leak them.
+        List<ByteBuf> handed = new ArrayList<>();
+        Function<LogEntry, ByteBuf> serializer = entry -> {
+            if (handed.size() == 2) {
+                throw new IllegalStateException("simulated serialization failure");
+            }
+            ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(16);
+            handed.add(buf);
+            return buf;
+        };
+        List<LogEntry> entries = Arrays.asList(
+                LogEntryFactory.noop(), LogEntryFactory.noop(),
+                LogEntryFactory.noop(), LogEntryFactory.noop());
+
+        // The client is never reached: serialization fails before pushEntries().
+        assertThrows(IllegalStateException.class, () ->
+                GrpcBench.pushBatch(null, 1L, new long[]{1L}, entries, serializer));
+
+        assertEquals(2, handed.size(), "the serializer should have produced two buffers");
+        for (ByteBuf buf : handed) {
+            assertEquals(0, buf.refCnt(),
+                    "every allocated buffer must be released after a mid-batch failure");
+        }
+    }
+}


### PR DESCRIPTION
# Push-based indexing: gRPC ingestion for the indexing service (testing only)

## Context & motivation

The HerdDB **indexing service** builds vector indexes by *pulling* commit-log
entries through the `CommitLogTailing` interface. Two tailer modes exist
today, selected by `indexing.log.type`:

- `file` → `FileCommitLogTailer` (polls local `.txlog` files)
- `bookkeeper` → `BookKeeperCommitLogTailer` (follows BookKeeper ledgers)

Both require a **running HerdDB server** that materialises every mutation into
a durable commit log. For *testing* the indexing service that is pure
overhead — a full server + BookKeeper + a write-amplified commit log, just to
feed entries the test already holds in memory.

This PR adds a third, **testing-only** mode — `indexing.log.type=push` — where
commit-log entries are *pushed* straight into the indexing service over a new
gRPC API into a fixed-size in-memory buffer. No HerdDB server, no BookKeeper,
no commit log → far cheaper test/benchmark runs. It is mutually exclusive with
`file`/`bookkeeper`, enabled explicitly, and works in cluster mode (ZooKeeper),
with the file server (including S3/object storage), and with the index
optimizer.

## Design

```
VectorBench (--protocol grpc)                Indexing Service (indexing.log.type=push)
  build LogEntry (CREATE_TABLE,                ┌───────────────────────────────────┐
  CREATE_INDEX, BEGIN/INSERT/COMMIT)           │ IndexingServiceImpl.pushEntries()  │ gRPC handler threads
  serialize → pooled direct ByteBuf            │        │ deserialize LogEntry      │
  single ordered "pusher" thread               │        ▼                          │
        │  PushEntries(repeated{lsn,bytes})    │ PushCommitLogTailer.push(lsn,e) ───┼─► ArrayBlockingQueue
        └────────────────────────────────────►│        (blocks when buffer full)   │   (fixed capacity)
                                               │        ▼                          │
   verify: GetIndexStatus.vector_count          │ tailer thread: take() → consumer  │
                                               │   = IndexingServiceEngine          │
                                               │       .processEntry(lsn, entry)    │
                                               └───────────────────────────────────┘
```

Key design decisions:

- **Batched unary RPC.** `PushEntries` carries a list of `(LSN, serialized
  LogEntry)` pairs. The call blocks server-side until every entry has been
  accepted into the bounded buffer — when a checkpoint/compaction stalls the
  tailer the buffer fills and `push` parks. Clients therefore use an
  **infinite gRPC deadline**.
- **Single-threaded consumer contract preserved.** gRPC handler threads only
  *enqueue*; one dedicated tailer thread drains the buffer into the engine's
  `processEntry`, exactly like the file/BookKeeper tailers.
- **Back-pressure.** The bounded `ArrayBlockingQueue` is the ingestion
  back-pressure: a full buffer blocks `push`, which blocks the client.
- **Recovery is unchanged.** A checkpoint already persists the watermark plus
  a schema snapshot (issue #368). On restart the engine reloads its
  checkpointed segments, restores the schema, and the push tailer resumes
  from the durable watermark — re-pushed stale entries (`lsn ≤ watermark`)
  are skipped idempotently. The only push-mode addition is resolving the
  tablespace UUID without a server.
- **Client owns the LSN stream.** The client assigns strictly increasing
  LSNs and, for multiple indexing-service instances, pushes the identical
  ordered stream to every instance.

## Step breakdown

Implemented as 5 reviewed steps; each step has its own commit(s), its own
tests, and a `pr-reviewer` agent pass.

### Step 1 — Push gRPC API + `PushCommitLogTailer` (`15d805ad`, `63c8beea`)

- `indexing_service.proto`: new `PushEntries` RPC + `PushedLogEntry` /
  `PushEntriesRequest` / `PushEntriesResponse` messages.
- `PushCommitLogTailer`: `CommitLogTailing` backed by a bounded
  `ArrayBlockingQueue`; idempotent skip of entries at/before the watermark.
- `IndexingServiceEngine.start()`: third branch of the log-type switch;
  `getPushTailer()` / `isPushModeConfigured()` accessors.
- `IndexingServiceImpl.pushEntries()`: deserializes the whole batch up-front
  (so a malformed entry rejects the batch atomically), enqueues it;
  `FAILED_PRECONDITION` when not a push-mode service, retryable `UNAVAILABLE`
  while the engine is still starting, `INVALID_ARGUMENT` on a malformed entry.
- `IndexingServer`: configurable gRPC `maxInboundMessageSize` (default 64 MiB).
- `IndexingPushClient`: thin gRPC client — no deadline, zero-copy `ByteBuf`
  wrapping.

### Step 2 — Push-mode restart/recovery + standalone startup (`316e93c4`)

- `IndexingServiceEngine.start()`: tablespace resolution no longer blocks for
  up to 30 minutes waiting for a server. With `indexing.tablespace.uuid` set
  it is used verbatim; otherwise push mode does a single metadata lookup and,
  if the tablespace is absent, derives a deterministic UUID from the
  tablespace name (stable across restarts and sibling instances). `file` /
  `bookkeeper` mode keeps the poll-until-available behaviour.
- `herddb-services/test-start-indexing-service-push.sh`: launches a single
  indexing service locally in standalone push mode (no server / BookKeeper /
  ZooKeeper).

### Step 3 — VectorBench `--protocol grpc` ingestion mode (`fa92e343`, `015acc42`)

- `Config`: `--protocol jdbc|grpc` (default `jdbc`) and `--grpc-endpoint
  host:port`.
- `GrpcBench`: serializes HerdDB `LogEntry` objects by hand (CREATE_TABLE,
  CREATE_INDEX, BEGIN + INSERTs + COMMIT per batch) into pooled direct
  `ByteBuf`s, pushes them via `IndexingPushClient` on a single ordered
  thread, and verifies by polling `GetIndexStatus`. Ingestion only.
- `vector-testings` depends on `herddb-core` + `herddb-indexing-service`; the
  shade plugin gains a `ServicesResourceTransformer` so the gRPC ServiceLoader
  providers survive shading.
- `run.sh` documents `--protocol` / `--grpc-endpoint`.

### Step 4 — Helm zero-replica push-indexing mode (`e3c9def5`, `0da274af`)

- `values.yaml`: new `pushIndexingMode.enabled` toggle.
- When enabled: the `server` and `bookkeeper` StatefulSets render at 0
  replicas, the indexing-service ConfigMap emits `indexing.log.type=push`,
  and the now-empty server/bookkeeper PodDisruptionBudgets are suppressed.
  ZooKeeper, file server, index optimizer, MinIO and tools stay up.
- A `fail` guard rejects `pushIndexingMode.enabled=true` with
  `server.mode != cluster`.

### Step 5 — Agent documentation (`80dea8bb`)

- `herddb-k3s-bench` and `herddb-local-bench` agent definitions gain a "gRPC
  push mode" section describing the no-server topology and the exact commands.

## Test coverage

**`herddb-indexing-service`** (16 new tests):

- `PushCommitLogTailerTest` — in-order dispatch, blocking back-pressure
  (buffer-full → `push` parks → drains), idempotent stale-skip, out-of-order
  skip, `close()` dropping still-buffered entries, lifecycle, constructor
  validation.
- `IndexingServicePushGrpcTest` — end-to-end DDL + INSERT push, transactional
  push applied at COMMIT, atomic rejection of a malformed batch,
  `FAILED_PRECONDITION` when not in push mode, retryable `UNAVAILABLE` during
  engine startup.
- `PushModeRestartTest` — stable derived tablespace UUID across restarts,
  push tailer resuming from a persisted watermark snapshot, and an
  end-to-end file-backed checkpoint + restart that reloads segments and
  schema with no commit-log replay.

**`vector-testings`** (9 new tests):

- `ConfigProtocolTest` — `--protocol` / `--grpc-endpoint` parsing,
  case-insensitivity, validation, properties-file source.
- `GrpcBenchTest` — `pushBatch` releases every pooled buffer on a mid-batch
  serialization failure (no leak).
- `GrpcBenchIntegrationTest` — `GrpcBench.ingest` end-to-end against an
  embedded push-mode indexing service, zero-row schema-only ingest, and the
  `--skip-verify` path.

**`herddb-kubernetes`** (9 new helm-unittest cases, 189 total):

- server / bookkeeper StatefulSet 0-replica rendering in push mode and the
  configured count when off; server / bookkeeper PDB suppression in push
  mode; IS ConfigMap `indexing.log.type=push` (and `bookkeeper` when off,
  with `server.bookkeeper.ledgers.path` asserted absent in push mode).

## Quality gates

Each step passed, before its commit: module compilation, its own new tests
plus a regression sweep of the nearby existing tests, a strict `pr-reviewer`
agent pass (Steps 1, 3 and 4 returned `REQUEST_CHANGES`; every finding was
fixed in a follow-up `... review fixes` commit and re-verified), and Spotless
formatting. The Helm step additionally passes the full `helm unittest` suite
and a hand-verified `helm template` render of the push topology. Before this
PR the whole repository passes the CI gate: `spotless:check`,
`apache-rat:check`, `spotbugs:check` and `install` under the `-Pci` profile.

## Trying it

Locally, with no HerdDB server:

```
herddb-services/test-start-indexing-service-push.sh
vector-testings/run.sh --protocol grpc --grpc-endpoint localhost:9850 \
    --dataset sift1m --rows 100000
```

On Kubernetes: `helm install ... --set pushIndexingMode.enabled=true` scales
the server and BookKeeper to 0 replicas; drive ingestion with VectorBench
`--protocol grpc` against an indexing-service pod.

## Scope

Push mode is **testing-only** and must be enabled explicitly. It does not
change the `file` / `bookkeeper` tailer paths, the on-disk format, the
checkpoint pipeline, or any production hot path — all push-mode code is gated
behind `indexing.log.type=push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
