### PR TITLE
issue #578: bounded pinned frontier region in SegmentBlockCache

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -33,6 +33,7 @@ import herddb.utils.ByteBufDataOutput;
 import herddb.utils.Bytes;
 import herddb.utils.VectorSearchRequestContext;
 import herddb.utils.VisibleByteArrayOutputStream;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
@@ -64,10 +65,12 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.AbstractMap;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -5164,7 +5167,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * @param approxBytesPerNode estimated bytes per graph node, used to cap the BFS
      * @param pinBytesPerSegment frontier budget; nodes visited = min(size, budget / bpn)
      */
-    private void pinSegmentBfs(VectorSegment seg, OnDiskGraphIndex odg,
+    void pinSegmentBfs(VectorSegment seg, OnDiskGraphIndex odg,
                                long approxBytesPerNode, long pinBytesPerSegment) {
         io.github.jbellis.jvector.disk.ReaderSupplier rs = seg.onDiskReaderSupplier;
         if (!(rs instanceof PinModeReaderSupplier)) {
@@ -5176,18 +5179,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // Frontier region not configured: skip (no benefit, avoid wasted reads).
             return;
         }
-        io.github.jbellis.jvector.disk.ReaderSupplier pinSupplier = pinCapable.withPinMode();
+        ReaderSupplier pinSupplier = pinCapable.withPinMode();
         int idUpperBound = odg.getIdUpperBound();
         int nodeLimit = (int) Math.min(
                 idUpperBound,
                 Math.max(1L, pinBytesPerSegment / approxBytesPerNode));
         try {
-            io.github.jbellis.jvector.disk.RandomAccessReader pinReader = pinSupplier.get();
+            RandomAccessReader pinReader = pinSupplier.get();
             OnDiskGraphIndex.View pinView = odg.new View(pinReader);
             try {
                 ImmutableGraphIndex.NodeAtLevel entry = pinView.entryNode();
-                java.util.Set<Integer> visited = new java.util.HashSet<>();
-                java.util.ArrayDeque<Integer> queue = new java.util.ArrayDeque<>();
+                Set<Integer> visited = new HashSet<>();
+                ArrayDeque<Integer> queue = new ArrayDeque<>();
                 queue.add(entry.node);
                 visited.add(entry.node);
                 while (!queue.isEmpty() && visited.size() < nodeLimit) {
@@ -5212,7 +5215,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             LOGGER.log(Level.WARNING,
                     "pinSegmentBfs {0}: I/O error pinning segment {1}: {2}",
                     new Object[]{indexName, seg.segmentId, e.getMessage()});
-        } catch (java.io.UncheckedIOException e) {
+        } catch (UncheckedIOException e) {
             LOGGER.log(Level.WARNING,
                     "pinSegmentBfs {0}: I/O error pinning segment {1}: {2}",
                     new Object[]{indexName, seg.segmentId,

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -4950,6 +4950,25 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
+     * Per-segment byte budget for the frontier (pinned) region BFS pass
+     * (issue #578). When {@code -1} (the default) the budget mirrors
+     * {@link #warmupBytesPerSegment}. When {@code 0} or negative (and not
+     * {@code -1}) the pin BFS is disabled. Set via
+     * {@link #setPinBytesPerSegment(long)}.
+     */
+    private volatile long pinBytesPerSegment = -1;
+
+    /**
+     * Sets the per-segment byte budget for the frontier-warmup BFS pass
+     * (issue #578). A value of {@code 0} disables pin-warmup. A value of
+     * {@code -1} (the default) makes the pin budget mirror
+     * {@link #warmupBytesPerSegment}.
+     */
+    public void setPinBytesPerSegment(long pinBytesPerSegment) {
+        this.pinBytesPerSegment = pinBytesPerSegment;
+    }
+
+    /**
      * Total number of segments actually BFS-warmed by this store since start
      * (issue #569). Exposed for tests and Prometheus exporters.
      */
@@ -5009,6 +5028,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         if (nodesVisited > 0) {
             seg.warmedUp = true;
             warmedSegmentsTotal.incrementAndGet();
+            // After the main warm pass, run the pin BFS to promote
+            // entry-frontier blocks into the eviction-resistant frontier region.
+            long pinBudget = this.pinBytesPerSegment;
+            if (pinBudget == -1) {
+                pinBudget = bytesPerSegment;
+            }
+            if (pinBudget > 0) {
+                pinSegmentBfs(seg, odg, approxBytesPerNode, pinBudget);
+            }
             return nodesVisited;
         }
         // nodesVisited == 0 means warmUpSegmentBfs hit an I/O error (it
@@ -5106,6 +5134,95 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     "warmUpBlockCache " + indexName + ": unexpected error warming segment "
                             + seg.segmentId, e);
             return 0;
+        }
+    }
+
+    /**
+     * Performs a secondary BFS over Layer 0 of {@code seg} using a
+     * <em>pin-mode</em> reader so that every accessed block is inserted into
+     * the frontier (pinned) region of the {@link herddb.remote.SegmentBlockCache}
+     * instead of the ordinary evictable region (issue #578).
+     *
+     * <p>The pin BFS is only possible when:
+     * <ol>
+     *   <li>The segment's {@code onDiskReaderSupplier} is a
+     *       {@link RemoteRandomAccessReader.Supplier} (not a local-disk supplier).</li>
+     *   <li>The supplier's block cache has a frontier region configured
+     *       ({@link RemoteRandomAccessReader.Supplier#hasFrontierCacheActive()}).</li>
+     * </ol>
+     * When either condition is not met, this method returns silently — the ordinary
+     * warm pass (which already loaded the blocks into the main cache) is
+     * sufficient.
+     *
+     * <p>Upper-layer HNSW data is heap-resident after
+     * {@code OnDiskGraphIndex.loadInMemoryLayers} so only Level-0 reads actually
+     * go through the remote reader — meaning only Layer-0 blocks end up pinned,
+     * which is exactly the right set (entry-frontier blocks).
+     *
+     * @param seg              segment whose frontier region is being warmed
+     * @param odg              the already-open {@link OnDiskGraphIndex} for that segment
+     * @param approxBytesPerNode estimated bytes per graph node, used to cap the BFS
+     * @param pinBytesPerSegment frontier budget; nodes visited = min(size, budget / bpn)
+     */
+    private void pinSegmentBfs(VectorSegment seg, OnDiskGraphIndex odg,
+                               long approxBytesPerNode, long pinBytesPerSegment) {
+        io.github.jbellis.jvector.disk.ReaderSupplier rs = seg.onDiskReaderSupplier;
+        if (!(rs instanceof PinModeReaderSupplier)) {
+            // Not a pin-capable reader supplier (e.g. local disk in unit tests): skip.
+            return;
+        }
+        PinModeReaderSupplier pinCapable = (PinModeReaderSupplier) rs;
+        if (!pinCapable.hasFrontierCacheActive()) {
+            // Frontier region not configured: skip (no benefit, avoid wasted reads).
+            return;
+        }
+        io.github.jbellis.jvector.disk.ReaderSupplier pinSupplier = pinCapable.withPinMode();
+        int idUpperBound = odg.getIdUpperBound();
+        int nodeLimit = (int) Math.min(
+                idUpperBound,
+                Math.max(1L, pinBytesPerSegment / approxBytesPerNode));
+        try {
+            io.github.jbellis.jvector.disk.RandomAccessReader pinReader = pinSupplier.get();
+            OnDiskGraphIndex.View pinView = odg.new View(pinReader);
+            try {
+                ImmutableGraphIndex.NodeAtLevel entry = pinView.entryNode();
+                java.util.Set<Integer> visited = new java.util.HashSet<>();
+                java.util.ArrayDeque<Integer> queue = new java.util.ArrayDeque<>();
+                queue.add(entry.node);
+                visited.add(entry.node);
+                while (!queue.isEmpty() && visited.size() < nodeLimit) {
+                    int node = queue.poll();
+                    // Level-0 read: routes through pin-mode RemoteRandomAccessReader
+                    // → SegmentBlockCache.pinBlock → frontier cache
+                    NodesIterator neighbors = pinView.getNeighborsIterator(0, node);
+                    while (neighbors.hasNext() && visited.size() < nodeLimit) {
+                        int neighbor = neighbors.nextInt();
+                        if (visited.add(neighbor)) {
+                            queue.add(neighbor);
+                        }
+                    }
+                }
+                LOGGER.log(Level.FINE,
+                        "pinSegmentBfs {0}: pinned {1} frontier nodes for segment {2}",
+                        new Object[]{indexName, visited.size(), seg.segmentId});
+            } finally {
+                pinView.close();
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING,
+                    "pinSegmentBfs {0}: I/O error pinning segment {1}: {2}",
+                    new Object[]{indexName, seg.segmentId, e.getMessage()});
+        } catch (java.io.UncheckedIOException e) {
+            LOGGER.log(Level.WARNING,
+                    "pinSegmentBfs {0}: I/O error pinning segment {1}: {2}",
+                    new Object[]{indexName, seg.segmentId,
+                            e.getCause() != null ? e.getCause().getMessage() : e.getMessage()});
+        } catch (Exception e) {
+            // Broad catch: pin BFS is best-effort; any unexpected failure from
+            // an unknown ReaderSupplier implementation must not abort warmup.
+            LOGGER.log(Level.WARNING,
+                    "pinSegmentBfs " + indexName + ": unexpected error pinning segment "
+                            + seg.segmentId, e);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/index/vector/PinModeReaderSupplier.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PinModeReaderSupplier.java
@@ -1,0 +1,62 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.vector;
+
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+
+/**
+ * Extension mixin for {@link ReaderSupplier} implementations that support
+ * a pin-mode variant (issue #578).
+ *
+ * <p>A <em>pin-mode</em> supplier produces readers that insert every loaded
+ * block into the frontier (eviction-resistant pinned) region of the
+ * {@code SegmentBlockCache} rather than the ordinary evictable main cache.
+ * This allows the warmup BFS to mark entry-frontier HNSW Layer-0 blocks as
+ * high-value without touching the broader eviction policy.
+ *
+ * <p>Implementations that do not back a remote block cache (e.g. local-file
+ * suppliers used in unit tests) need not implement this interface; callers
+ * check for it with {@code instanceof} before invoking.
+ *
+ * @author enrico.olivelli
+ */
+public interface PinModeReaderSupplier {
+
+    /**
+     * Returns {@code true} when the underlying block cache has a configured
+     * frontier (pinned) region with a positive byte budget. Callers skip the
+     * pin BFS when this returns {@code false} — there is no benefit to calling
+     * {@link #withPinMode()} if nowhere to put pinned blocks.
+     */
+    boolean hasFrontierCacheActive();
+
+    /**
+     * Returns a new {@link ReaderSupplier} whose readers use {@code pinMode=true}.
+     * Every block loaded by a reader from the returned supplier is placed into
+     * the frontier (pinned) region of the block cache instead of the main
+     * evictable cache.
+     *
+     * <p>The returned supplier shares the same underlying block cache and
+     * stats logger as this supplier; pinned blocks are immediately visible to
+     * normal readers.
+     */
+    ReaderSupplier withPinMode();
+}

--- a/herddb-core/src/test/java/herddb/index/vector/PinSegmentBfsTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/PinSegmentBfsTest.java
@@ -1,0 +1,169 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for {@link PersistentVectorStore#pinSegmentBfs} (package-private).
+ * Verifies the three negative guard paths:
+ * <ol>
+ *   <li>Non-{@link PinModeReaderSupplier} supplier → method is a no-op.</li>
+ *   <li>{@link PinModeReaderSupplier} with {@code hasFrontierCacheActive() == false} → no-op.</li>
+ *   <li>Null supplier → no-op (instanceof null = false).</li>
+ * </ol>
+ * The positive path (frontier actually populated) is covered by
+ * {@code RemoteRandomAccessReaderPinModeTest} which tests the full
+ * supplier → pinBlock → frontier-cache pipeline end-to-end.
+ */
+public class PinSegmentBfsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore(
+                "testidx", "testtable", "tstblspace", "vector_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+    }
+
+    /**
+     * A {@link ReaderSupplier} that does NOT implement {@link PinModeReaderSupplier}.
+     * Tracks whether {@code get()} was ever called.
+     */
+    private static class PlainReaderSupplier implements ReaderSupplier {
+        boolean getCalled = false;
+
+        @Override
+        public RandomAccessReader get() throws IOException {
+            getCalled = true;
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    /**
+     * A stub {@link PinModeReaderSupplier} whose frontier cache is disabled
+     * ({@code hasFrontierCacheActive() == false}).
+     */
+    private static class DisabledFrontierSupplier implements ReaderSupplier, PinModeReaderSupplier {
+        boolean withPinModeCalled = false;
+
+        @Override
+        public boolean hasFrontierCacheActive() {
+            return false;
+        }
+
+        @Override
+        public ReaderSupplier withPinMode() {
+            withPinModeCalled = true;
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public RandomAccessReader get() throws IOException {
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    @Test
+    public void pinSegmentBfsIsNoOpWhenSupplierIsNotPinModeReaderSupplier() throws Exception {
+        try (PersistentVectorStore store = createStore(folder.newFolder("store").toPath())) {
+            VectorSegment seg = new VectorSegment(1);
+            PlainReaderSupplier plain = new PlainReaderSupplier();
+            seg.onDiskReaderSupplier = plain;
+
+            // onDiskGraph = null → the method must return early after the instanceof check.
+            // Passing null for odg is safe because pinSegmentBfs returns before any
+            // ODG access when the supplier is not a PinModeReaderSupplier.
+            store.pinSegmentBfs(seg, null, 1L, 1_000_000L);
+
+            assertFalse("get() must not be called on a non-PinModeReaderSupplier",
+                    plain.getCalled);
+        }
+    }
+
+    @Test
+    public void pinSegmentBfsIsNoOpWhenNullSupplier() throws Exception {
+        try (PersistentVectorStore store = createStore(folder.newFolder("store").toPath())) {
+            VectorSegment seg = new VectorSegment(2);
+            seg.onDiskReaderSupplier = null;
+
+            // null instanceof PinModeReaderSupplier = false → must return immediately.
+            store.pinSegmentBfs(seg, null, 1L, 1_000_000L);
+            // No exception = pass.
+        }
+    }
+
+    @Test
+    public void pinSegmentBfsIsNoOpWhenFrontierCacheInactive() throws Exception {
+        try (PersistentVectorStore store = createStore(folder.newFolder("store").toPath())) {
+            VectorSegment seg = new VectorSegment(3);
+            DisabledFrontierSupplier disabled = new DisabledFrontierSupplier();
+            seg.onDiskReaderSupplier = disabled;
+
+            store.pinSegmentBfs(seg, null, 1L, 1_000_000L);
+
+            assertFalse("withPinMode() must not be called when hasFrontierCacheActive() == false",
+                    disabled.withPinModeCalled);
+        }
+    }
+
+    @Test
+    public void pinModeReaderSupplierNegativeInstanceofDoesNotRequirePinInterface() {
+        // Confirm the interface hierarchy: a plain ReaderSupplier is not a PinModeReaderSupplier.
+        PlainReaderSupplier plain = new PlainReaderSupplier();
+        assertFalse("plain ReaderSupplier must not implement PinModeReaderSupplier",
+                plain instanceof PinModeReaderSupplier);
+    }
+
+    @Test
+    public void setPinBytesPerSegmentDefaultIsMirrorOfWarmup() throws Exception {
+        // Default -1 means "mirror warmup budget". Explicitly setting 0 disables pin BFS.
+        try (PersistentVectorStore store = createStore(folder.newFolder("store").toPath())) {
+            // Setting 0 should disable pin BFS — no exception expected.
+            store.setPinBytesPerSegment(0L);
+            store.setPinBytesPerSegment(-1L);
+            store.setPinBytesPerSegment(1_000_000L);
+            // All above are set-only operations; the test verifies no NPE/ISE thrown.
+            assertTrue("setter accepted all values without error", true);
+        }
+    }
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -211,6 +211,30 @@ public final class IndexingServerConfiguration {
     /** Hard-coded default: async warmup is enabled. */
     public static final boolean PROPERTY_VECTOR_SEGMENT_CACHE_WARMUP_ASYNC_DEFAULT = true;
 
+    /**
+     * Byte budget for the frontier (pinned) region of the
+     * {@link herddb.remote.SegmentBlockCache} (issue #578).
+     *
+     * <p>When the frontier region is enabled, the post-warmup BFS pass
+     * (triggered after the main warmup BFS) inserts entry-frontier Layer-0
+     * blocks into a second Caffeine cache with its own independent byte budget.
+     * Blocks in the frontier region are evicted only when the frontier budget
+     * overflows — never by pressure from the much larger main cache — so they
+     * act as "soft-pinned" entries for the HNSW entry-point neighbourhood.
+     *
+     * <p>Default: {@code 0} = auto-size as 10% of
+     * {@link #PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_MAX_BYTES} (after auto-sizing
+     * of the main cache budget, if needed). Set to a negative value to disable
+     * the frontier region entirely; set to a positive value to override.
+     */
+    public static final String PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_FRONTIER_MAX_BYTES =
+            "indexing.vector.segmentPageCacheFrontierMaxBytes";
+    /**
+     * {@code 0} → auto-size as 10 % of the main cache budget.
+     * Negative → disabled.
+     */
+    public static final long PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_FRONTIER_MAX_BYTES_DEFAULT = 0;
+
     // Compaction (checkpoint driver — existing)
     public static final String PROPERTY_COMPACTION_INTERVAL = "indexing.compaction.interval";
     public static final long PROPERTY_COMPACTION_INTERVAL_DEFAULT = 60000L;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -965,12 +965,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 // start(); the factory lambda runs later (tailer-driven), so the
                 // field is always populated by the time this executes.
                 store.setWarmupBytesPerSegment(this.warmupBytesPerSegment);
-                // Issue #578: set the frontier-pin budget for the secondary BFS
-                // pass that inserts entry-frontier Layer-0 blocks into the
-                // eviction-resistant frontier region after warmup. A value of -1
-                // (the PersistentVectorStore default) means "use the same budget as
-                // warmupBytesPerSegment"; we pass the actual frontier budget so the
-                // store can cap the pin BFS to the frontier budget independently.
+                // Issue #578: set the frontier-pin BFS budget:
+                //   -1  = mirror warmupBytesPerSegment (the default sentinel in
+                //         PersistentVectorStore); used when the frontier region is
+                //         active so the pin BFS covers the same number of nodes as
+                //         the main warmup BFS.
+                //    0  = disable pin BFS entirely; used when no frontier budget
+                //         has been allocated (finalFrontierMaxBytes <= 0).
                 store.setPinBytesPerSegment(finalFrontierMaxBytes > 0 ? -1L : 0L);
                 // Issue #491: when the external index-optimizer is enabled cluster-wide
                 // (indexing.optimizer.enabled=true) AND the metadata storage manager is

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -875,12 +875,25 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                                 source
                         });
             }
+            // Frontier (pinned) region budget (issue #578).
+            // Default 0 → auto-size as 10% of the main cache budget.
+            long frontierMaxBytes = config.getLong(
+                    IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_FRONTIER_MAX_BYTES,
+                    IndexingServerConfiguration.PROPERTY_VECTOR_SEGMENT_PAGE_CACHE_FRONTIER_MAX_BYTES_DEFAULT);
+            if (frontierMaxBytes == 0 && segmentPageCacheMaxBytes > 0) {
+                frontierMaxBytes = segmentPageCacheMaxBytes / 10;
+            }
+            if (frontierMaxBytes < 0) {
+                frontierMaxBytes = 0; // explicit disable
+            }
             this.segmentBlockCache = segmentPageCacheMaxBytes > 0
-                    ? new SegmentBlockCache(segmentPageCacheMaxBytes)
+                    ? new SegmentBlockCache(segmentPageCacheMaxBytes, frontierMaxBytes)
                     : SegmentBlockCache.disabled();
             LOGGER.log(Level.INFO,
-                    "vector index segmentPageCacheMaxBytes: {0} (active={1})",
-                    new Object[]{segmentPageCacheMaxBytes, segmentBlockCache.isActive()});
+                    "vector index segmentPageCacheMaxBytes: {0} (active={1}), "
+                            + "frontierMaxBytes: {2} (active={3})",
+                    new Object[]{segmentPageCacheMaxBytes, segmentBlockCache.isActive(),
+                            frontierMaxBytes, segmentBlockCache.isFrontierCacheActive()});
             // Install the cache + stats logger on the remote DSM so that every
             // multipartIndexReaderSupplier it builds routes reads through it.
             // Stats logger may still be null at this point (set later by
@@ -902,6 +915,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             final long vectorMemLimit = maxVectorMemoryBytes;
             final VectorMemoryBudget budget = this;
             final long finalSegmentPageCacheMaxBytes = segmentPageCacheMaxBytes;
+            final long finalFrontierMaxBytes = frontierMaxBytes;
             int configuredSearchParallelism = config.getInt(
                     IndexingServerConfiguration.PROPERTY_VECTOR_SEARCH_PARALLELISM,
                     IndexingServerConfiguration.PROPERTY_VECTOR_SEARCH_PARALLELISM_DEFAULT);
@@ -951,6 +965,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 // start(); the factory lambda runs later (tailer-driven), so the
                 // field is always populated by the time this executes.
                 store.setWarmupBytesPerSegment(this.warmupBytesPerSegment);
+                // Issue #578: set the frontier-pin budget for the secondary BFS
+                // pass that inserts entry-frontier Layer-0 blocks into the
+                // eviction-resistant frontier region after warmup. A value of -1
+                // (the PersistentVectorStore default) means "use the same budget as
+                // warmupBytesPerSegment"; we pass the actual frontier budget so the
+                // store can cap the pin BFS to the frontier budget independently.
+                store.setPinBytesPerSegment(finalFrontierMaxBytes > 0 ? -1L : 0L);
                 // Issue #491: when the external index-optimizer is enabled cluster-wide
                 // (indexing.optimizer.enabled=true) AND the metadata storage manager is
                 // ZK-backed, attach a SegmentRegistryPublisher BEFORE start() so that:
@@ -5039,6 +5060,84 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
 
             @Override public Long getSample() {
                 return cache.maxBytes();
+            }
+        });
+
+        // --- Frontier (pinned) region metrics ---
+        // Same shape as the main cache metrics so the Grafana dashboard can
+        // use the same panel templates with a "frontier" label filter.
+        // All return 0 when the frontier region is disabled.
+        StatsLogger frontier = scope.scope("frontier");
+        frontier.registerGauge("hits", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierHitCount();
+            }
+        });
+        frontier.registerGauge("evictions", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierEvictionCount();
+            }
+        });
+        frontier.registerGauge("load_success", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierLoadSuccessCount();
+            }
+        });
+        frontier.registerGauge("load_failure", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierLoadFailureCount();
+            }
+        });
+        frontier.registerGauge("load_time_nanos_total", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierTotalLoadTimeNanos();
+            }
+        });
+        frontier.registerGauge("size_entries", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierEstimatedSize();
+            }
+        });
+        frontier.registerGauge("size_bytes", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.frontierWeightedSize();
+            }
+        });
+        frontier.registerGauge("max_bytes", new Gauge<Long>() {
+            @Override public Long getDefaultValue() {
+                return 0L;
+            }
+
+            @Override public Long getSample() {
+                return cache.maxFrontierBytes();
             }
         });
     }

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -4543,6 +4543,186 @@
       "panels": [
         {
           "datasource": "Prometheus",
+          "fill": 1,
+          "id": 450,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "indexing_segment_block_cache_frontier_size_bytes{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "used [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "indexing_segment_block_cache_frontier_max_bytes{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "max [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "seriesOverrides": [
+            {
+              "alias": "/max/",
+              "fill": 0,
+              "dashes": true
+            }
+          ],
+          "title": "Frontier Cache (Pinned Region) — Size (bytes)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "bytes", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 451,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "indexing_segment_block_cache_frontier_size_entries{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "entries [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Frontier Cache (Pinned Region) — Entries",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "short", "decimals": 0, "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 452,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_frontier_hits{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "hits/s [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Frontier Cache (Pinned Region) — Hits (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 453,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_frontier_evictions{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "evictions/s [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Frontier Cache (Pinned Region) — Evictions (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 454,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_frontier_load_time_nanos_total{job=\"indexing-service\",instance=~\"$instance\"}[1m]) / clamp_min(rate(indexing_segment_block_cache_frontier_load_success{job=\"indexing-service\",instance=~\"$instance\"}[1m]) + rate(indexing_segment_block_cache_frontier_load_failure{job=\"indexing-service\",instance=~\"$instance\"}[1m]), 1)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg pin load ns [{{instance}}]",
+              "refId": "A"
+            }
+          ],
+          "title": "Frontier Cache (Pinned Region) — Average Pin Load Latency",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ns", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 455,
+          "legend": {"avg": true, "current": true, "max": true, "min": false, "show": true, "total": false, "values": true},
+          "lines": true,
+          "linewidth": 1,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rate(indexing_segment_block_cache_frontier_load_success{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "load_success/s [{{instance}}]",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(indexing_segment_block_cache_frontier_load_failure{job=\"indexing-service\",instance=~\"$instance\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "load_failure/s [{{instance}}]",
+              "refId": "B"
+            }
+          ],
+          "title": "Frontier Cache (Pinned Region) — Pin Loads / Failures (1m)",
+          "type": "graph",
+          "xaxis": {"mode": "time", "show": true},
+          "yaxes": [
+            {"format": "ops", "logBase": 1, "min": 0, "show": true},
+            {"format": "short", "logBase": 1, "show": false}
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Frontier Cache — Entry-Frontier Pinned Region (issue #578)",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "datasource": "Prometheus",
           "id": 500,
           "span": 3,
           "targets": [

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -21,6 +21,7 @@
 package herddb.remote;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import herddb.index.vector.PinModeReaderSupplier;
 import herddb.utils.VectorSearchRequestContext;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
@@ -69,6 +70,15 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     private final Counter clientReadBytes;
     private final Counter clientReadRequests;
     private final SegmentBlockCache blockCache;
+    /**
+     * When {@code true}, every block loaded by {@link #ensureBlockLoaded} is
+     * inserted into the frontier (pinned) region of the {@link SegmentBlockCache}
+     * via {@link SegmentBlockCache#pinBlock} instead of the ordinary
+     * {@link SegmentBlockCache#getBlock}. Used by the warmup BFS pass so that
+     * entry-frontier Layer-0 blocks survive main-cache eviction pressure.
+     * Set to {@code false} on all normal (non-warmup) readers.
+     */
+    private final boolean pinMode;
 
     private long position;
     /**
@@ -106,6 +116,21 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
                                     long totalSize, int writeBlockSize, int bufferSize,
                                     StatsLogger statsLogger,
                                     SegmentBlockCache blockCache) {
+        this(client, path, totalSize, writeBlockSize, bufferSize, statsLogger, blockCache, false);
+    }
+
+    /**
+     * Full constructor. All public convenience constructors delegate here.
+     *
+     * @param pinMode when {@code true} blocks are inserted into the frontier
+     *     (pinned) region via {@link SegmentBlockCache#pinBlock}; when
+     *     {@code false} blocks use normal eviction via
+     *     {@link SegmentBlockCache#getBlock}
+     */
+    RemoteRandomAccessReader(RemoteFileServiceClient client, String path,
+                             long totalSize, int writeBlockSize, int bufferSize,
+                             StatsLogger statsLogger,
+                             SegmentBlockCache blockCache, boolean pinMode) {
         Objects.requireNonNull(statsLogger, "statsLogger (use NullStatsLogger.INSTANCE to disable)");
         Objects.requireNonNull(blockCache, "blockCache (use SegmentBlockCache.disabled() to disable)");
         if (writeBlockSize <= 0) {
@@ -126,6 +151,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         this.writeBlockSize = writeBlockSize;
         this.bufferSize = effective;
         this.blockCache = blockCache;
+        this.pinMode = pinMode;
 
         StatsLogger clientScope = statsLogger.scope("rfs").scope("client");
         this.clientReadLatency = clientScope.getOpStatsLogger("read_latency");
@@ -523,8 +549,15 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         long startNanos = System.nanoTime();
         ByteBuf data;
         try {
-            data = blockCache.getBlock(path, bufferOffset, bufferSize,
-                    (p, off, len) -> fetchBlockFromRemote(p, off, len, bufferIndex));
+            if (pinMode) {
+                // Pin-warmup BFS: insert this block into the frontier region so it
+                // survives eviction pressure from the much larger main cache.
+                data = blockCache.pinBlock(path, bufferOffset, bufferSize,
+                        (p, off, len) -> fetchBlockFromRemote(p, off, len, bufferIndex));
+            } else {
+                data = blockCache.getBlock(path, bufferOffset, bufferSize,
+                        (p, off, len) -> fetchBlockFromRemote(p, off, len, bufferIndex));
+            }
         } catch (IOException e) {
             if (ctx != null && !wasCached) {
                 ctx.recordCacheMiss();
@@ -591,8 +624,14 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
     /**
      * A {@link ReaderSupplier} that creates {@link RemoteRandomAccessReader} instances
      * for concurrent searcher threads (jvector calls {@code get()} per search thread).
+     *
+     * <p>To obtain a pin-mode supplier for the frontier-warmup BFS pass, call
+     * {@link #withPinMode()}. The returned supplier creates readers that insert
+     * every loaded block into the frontier (pinned) region of the block cache so
+     * that entry-frontier Layer-0 blocks survive eviction pressure from the main
+     * cache.
      */
-    public static class Supplier implements ReaderSupplier {
+    public static class Supplier implements ReaderSupplier, PinModeReaderSupplier {
 
         private final RemoteFileServiceClient client;
         private final String path;
@@ -601,11 +640,23 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
         private final int bufferSize;
         private final StatsLogger statsLogger;
         private final SegmentBlockCache blockCache;
+        /**
+         * When {@code true}, {@link #get()} returns a pin-mode reader that
+         * routes block loads through {@link SegmentBlockCache#pinBlock}.
+         */
+        private final boolean pinMode;
 
         public Supplier(RemoteFileServiceClient client, String path,
                         long totalSize, int writeBlockSize, int bufferSize,
                         StatsLogger statsLogger,
                         SegmentBlockCache blockCache) {
+            this(client, path, totalSize, writeBlockSize, bufferSize, statsLogger, blockCache, false);
+        }
+
+        private Supplier(RemoteFileServiceClient client, String path,
+                         long totalSize, int writeBlockSize, int bufferSize,
+                         StatsLogger statsLogger,
+                         SegmentBlockCache blockCache, boolean pinMode) {
             this.client = client;
             this.path = path;
             this.totalSize = totalSize;
@@ -615,6 +666,7 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
                     "statsLogger (use NullStatsLogger.INSTANCE to disable)");
             this.blockCache = Objects.requireNonNull(blockCache,
                     "blockCache (use SegmentBlockCache.disabled() to disable)");
+            this.pinMode = pinMode;
         }
 
         /**
@@ -651,10 +703,37 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
                     NullStatsLogger.INSTANCE, SegmentBlockCache.disabled());
         }
 
+        /**
+         * Returns a new {@link Supplier} with the same configuration but with
+         * {@code pinMode=true}. Readers produced by the returned supplier route
+         * every block load through {@link SegmentBlockCache#pinBlock}, placing
+         * the block into the frontier (pinned) region of the cache. Use this
+         * for the one-time warmup BFS pass so that entry-frontier Layer-0 blocks
+         * are eviction-resistant during subsequent searches.
+         *
+         * <p>Note: the returned supplier still targets the same
+         * {@link SegmentBlockCache}, so pinned blocks are immediately visible to
+         * all normal readers sharing the same cache instance.
+         */
+        public Supplier withPinMode() {
+            return new Supplier(client, path, totalSize, writeBlockSize, bufferSize,
+                    statsLogger, blockCache, true);
+        }
+
+        /**
+         * Returns {@code true} when the underlying {@link SegmentBlockCache}
+         * has a frontier (pinned) region configured. Callers can skip the
+         * {@link #withPinMode()} BFS pass when this returns {@code false} (no
+         * frontier budget has been allocated).
+         */
+        public boolean hasFrontierCacheActive() {
+            return blockCache.isFrontierCacheActive();
+        }
+
         @Override
         public RandomAccessReader get() throws IOException {
             return new RemoteRandomAccessReader(client, path, totalSize,
-                    writeBlockSize, bufferSize, statsLogger, blockCache);
+                    writeBlockSize, bufferSize, statsLogger, blockCache, pinMode);
         }
 
         @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -55,6 +55,18 @@ import java.util.concurrent.atomic.AtomicLong;
  * Callers always hold a non-null {@code SegmentBlockCache} — the disabled
  * instance is interchangeable with a real one and eliminates null checks.
  *
+ * <h3>Frontier (pinned) region</h3>
+ * <p>When a non-zero {@code frontierMaxBytes} budget is supplied, a second
+ * Caffeine cache — the <em>frontier region</em> — is created alongside the
+ * main eviction region. Blocks inserted via {@link #pinBlock} are placed into
+ * the frontier region and are served back by {@link #getBlock} /
+ * {@link #getBlockAsync} <em>before</em> the main cache is consulted.
+ * Because the frontier region has its own independent byte budget, its blocks
+ * are only evicted when the frontier budget overflows (LRU within the frontier
+ * region), never by pressure from the much larger main cache. This makes hot
+ * entry-frontier HNSW Layer-0 blocks effectively pinned regardless of overall
+ * access patterns (issue #578).
+ *
  * @author enrico.olivelli
  */
 public final class SegmentBlockCache {
@@ -105,11 +117,37 @@ public final class SegmentBlockCache {
      * when the load completes.
      */
     private final ConcurrentHashMap<BlockKey, InFlightLoad> inFlightAsync;
+
+    /**
+     * Byte budget for the frontier region. {@code 0} means no frontier region.
+     * Set once at construction; see {@link #SegmentBlockCache(long, long)}.
+     */
+    private final long frontierMaxBytes;
+
+    /**
+     * Second, independently-budgeted Caffeine cache for blocks that the warmup
+     * BFS has explicitly promoted as high-value entry-frontier Layer-0 blocks
+     * (issue #578). Non-null only when {@link #frontierMaxBytes} &gt; 0.
+     *
+     * <p>Blocks inserted via {@link #pinBlock} land here. {@link #getBlock} and
+     * {@link #getBlockAsync} check this cache <em>before</em> the main
+     * {@link #cache}, so a frontier-pinned block is always served from the
+     * frontier region regardless of whether the main cache also holds a copy.
+     *
+     * <p>When the frontier budget overflows, Caffeine evicts only the
+     * coldest block within the frontier — never an unpinned hot block from
+     * the main cache. This gives the entry-frontier a bounded, predictable
+     * memory footprint across arbitrarily many loaded segments.
+     */
+    private final Cache<BlockKey, ByteBuf> frontierCache;
+
     // We track hit/miss/load stats ourselves because the only way to do an
     // atomic retain-under-lock is via asMap().compute(), and Caffeine's
     // recordStats() does not count compute() invocations as gets. Keeping our
     // own counters is also what makes the stats meaningful for the Grafana
     // panels and the per-request cache_hits_per_request histogram.
+
+    // --- Main cache stats ---
     private final AtomicLong hits = new AtomicLong();
     private final AtomicLong misses = new AtomicLong();
     private final AtomicLong evictions = new AtomicLong();
@@ -117,11 +155,47 @@ public final class SegmentBlockCache {
     private final AtomicLong loadFailure = new AtomicLong();
     private final AtomicLong loadTimeNanos = new AtomicLong();
 
+    // --- Frontier (pinned) region stats — same shape as main cache stats ---
+    private final AtomicLong frontierHits = new AtomicLong();
+    private final AtomicLong frontierEvictions = new AtomicLong();
+    private final AtomicLong frontierLoadSuccess = new AtomicLong();
+    private final AtomicLong frontierLoadFailure = new AtomicLong();
+    private final AtomicLong frontierLoadTimeNanos = new AtomicLong();
+
+    /**
+     * Creates a cache with a main eviction region and no frontier (pinned) region.
+     * Equivalent to {@code SegmentBlockCache(maxBytes, 0)}.
+     *
+     * @param maxBytes byte budget for the main (evictable) region;
+     *     {@code <= 0} disables caching entirely
+     */
     public SegmentBlockCache(long maxBytes) {
+        this(maxBytes, 0L);
+    }
+
+    /**
+     * Creates a cache with a main eviction region and an optional frontier
+     * (pinned) region (issue #578).
+     *
+     * <p>The frontier region is a second Caffeine cache with its own
+     * {@code maximumWeight(frontierMaxBytes)} budget. Blocks inserted via
+     * {@link #pinBlock} land here and are evicted only when the frontier budget
+     * itself overflows (LRU within the frontier region). {@link #getBlock} and
+     * {@link #getBlockAsync} check the frontier region first, so a pinned block
+     * is always served even if the main cache has already evicted its copy.
+     *
+     * @param maxBytes         byte budget for the main (evictable) region;
+     *     {@code <= 0} disables caching entirely (including the frontier region)
+     * @param frontierMaxBytes byte budget for the frontier (pinned) region;
+     *     {@code <= 0} disables pinning (no second cache is created)
+     */
+    public SegmentBlockCache(long maxBytes, long frontierMaxBytes) {
         this.maxBytes = maxBytes;
+        this.frontierMaxBytes = frontierMaxBytes;
         if (maxBytes <= 0) {
             this.cache = null;
             this.inFlightAsync = null;
+            this.frontierCache = null;
         } else {
             this.cache = Caffeine.newBuilder()
                     .maximumWeight(maxBytes)
@@ -147,6 +221,21 @@ public final class SegmentBlockCache {
                     })
                     .build();
             this.inFlightAsync = new ConcurrentHashMap<>();
+            if (frontierMaxBytes > 0) {
+                this.frontierCache = Caffeine.newBuilder()
+                        .maximumWeight(frontierMaxBytes)
+                        .weigher((BlockKey k, ByteBuf v) -> v == null ? 0 : v.capacity())
+                        .executor(Runnable::run)
+                        .removalListener((BlockKey k, ByteBuf v, RemovalCause cause) -> {
+                            if (cause != null && cause.wasEvicted()) {
+                                frontierEvictions.incrementAndGet();
+                            }
+                            ReferenceCountUtil.safeRelease(v);
+                        })
+                        .build();
+            } else {
+                this.frontierCache = null;
+            }
         }
     }
 
@@ -155,8 +244,25 @@ public final class SegmentBlockCache {
         return cache != null;
     }
 
+    /**
+     * Returns {@code true} when the frontier (pinned) region is enabled. Callers
+     * can use this to skip the warmup BFS pin pass when no frontier budget has
+     * been allocated (e.g. when running with a 0-budget testing configuration).
+     */
+    public boolean isFrontierCacheActive() {
+        return frontierCache != null;
+    }
+
     public long maxBytes() {
         return maxBytes;
+    }
+
+    /**
+     * Returns the configured byte budget for the frontier (pinned) region.
+     * Returns {@code 0} when the frontier region is disabled.
+     */
+    public long maxFrontierBytes() {
+        return frontierMaxBytes;
     }
 
     /**
@@ -165,6 +271,11 @@ public final class SegmentBlockCache {
      * a multiple of {@code length} — this is the natural alignment used by
      * {@link RemoteRandomAccessReader}, where the read window is a fixed-size
      * sliding buffer.
+     *
+     * <p>The frontier (pinned) region is checked <em>before</em> the main
+     * eviction cache. If the block was previously promoted via
+     * {@link #pinBlock}, it is returned from the frontier region regardless of
+     * whether it is also present in the main cache.
      *
      * <p><b>Ownership</b>: the returned {@link ByteBuf} is a caller-owned
      * retained slice; the caller MUST release it exactly once. The underlying
@@ -199,6 +310,28 @@ public final class SegmentBlockCache {
         }
         long blockIndex = offset / length;
         BlockKey key = new BlockKey(path, blockIndex);
+
+        // Fast path: check the frontier (pinned) region first. A block that
+        // was explicitly pinned via pinBlock() is served from here regardless
+        // of whether the main cache also holds a copy. This prevents eviction
+        // pressure in the much larger main cache from displacing entry-frontier
+        // Layer-0 blocks.
+        if (frontierCache != null) {
+            ByteBuf[] frontierRetained = new ByteBuf[1];
+            frontierCache.asMap().computeIfPresent(key, (k, existing) -> {
+                frontierHits.incrementAndGet();
+                existing.retain();
+                frontierRetained[0] = existing;
+                return existing;
+            });
+            if (frontierRetained[0] != null) {
+                try {
+                    return frontierRetained[0].retainedSlice(0, frontierRetained[0].readableBytes());
+                } finally {
+                    frontierRetained[0].release();
+                }
+            }
+        }
 
         // Everything happens inside a single asMap().compute() call so that
         // the retain is atomic with the entry-present check — no window for
@@ -264,12 +397,100 @@ public final class SegmentBlockCache {
     }
 
     /**
+     * Loads the block at {@code (path, offset, length)} into the frontier
+     * (pinned) region, giving it eviction-resistant treatment (issue #578).
+     *
+     * <p>The frontier region has its own byte budget ({@code frontierMaxBytes}).
+     * Blocks here are evicted only when the frontier budget overflows — never by
+     * eviction pressure in the much larger main cache. On a subsequent
+     * {@link #getBlock} or {@link #getBlockAsync} call the frontier region is
+     * checked first, so pinned blocks are served from the frontier regardless of
+     * main-cache state.
+     *
+     * <p>When no frontier budget has been allocated ({@code !isFrontierCacheActive()})
+     * this method falls through to {@link #getBlock}, so callers never need to
+     * guard against a null frontier.
+     *
+     * <p><b>Ownership</b>: identical to {@link #getBlock} — the returned
+     * {@link ByteBuf} is a caller-owned retained slice; the caller MUST release
+     * it exactly once.
+     *
+     * @param path   logical multipart path
+     * @param offset block start, must be a multiple of {@code length}
+     * @param length block length in bytes (&gt; 0)
+     * @param loader invoked at most once per key on miss in the frontier region
+     */
+    public ByteBuf pinBlock(String path, long offset, int length, BlockLoader loader)
+            throws IOException {
+        Objects.requireNonNull(path, "path");
+        Objects.requireNonNull(loader, "loader");
+        if (length <= 0) {
+            throw new IllegalArgumentException("length must be > 0, got " + length);
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be >= 0, got " + offset);
+        }
+        if (frontierCache == null) {
+            // No frontier budget: degrade gracefully to normal caching so the
+            // call is never a no-op even when pinning is disabled.
+            return getBlock(path, offset, length, loader);
+        }
+        long blockIndex = offset / length;
+        BlockKey key = new BlockKey(path, blockIndex);
+
+        // Same atomic retain-under-lock pattern as getBlock: the compute()
+        // serialises the retain with the removal listener so we can never
+        // hand out a slice of an already-released buffer.
+        ByteBuf retained;
+        try {
+            retained = frontierCache.asMap().compute(key, (k, existing) -> {
+                if (existing != null) {
+                    frontierHits.incrementAndGet();
+                    existing.retain();
+                    return existing;
+                }
+                long startNanos = System.nanoTime();
+                ByteBuf loaded;
+                try {
+                    loaded = loader.load(path, offset, length);
+                } catch (IOException ioe) {
+                    frontierLoadFailure.incrementAndGet();
+                    frontierLoadTimeNanos.addAndGet(System.nanoTime() - startNanos);
+                    throw new CacheLoadException(ioe);
+                }
+                frontierLoadTimeNanos.addAndGet(System.nanoTime() - startNanos);
+                if (loaded == null) {
+                    frontierLoadFailure.incrementAndGet();
+                    throw new CacheLoadException(new IOException(
+                            "loader returned null for " + path + "@" + offset));
+                }
+                frontierLoadSuccess.incrementAndGet();
+                loaded.retain();
+                return loaded;
+            });
+        } catch (CacheLoadException e) {
+            throw (IOException) e.getCause();
+        }
+        if (retained == null) {
+            return invokeLoader(loader, path, offset, length);
+        }
+        try {
+            return retained.retainedSlice(0, retained.readableBytes());
+        } finally {
+            retained.release();
+        }
+    }
+
+    /**
      * Async sibling of {@link #getBlock}: fetches the block at
      * {@code (path, offset, length)} and returns a {@link CompletableFuture}
      * that completes with a <em>caller-owned retained slice</em> of the cached
      * buffer. Ownership rules are identical to those of {@link #getBlock}:
      * the caller MUST release the returned {@link ByteBuf} exactly once; the
      * cache's own reference is released on eviction.
+     *
+     * <p>The frontier (pinned) region is checked first, before the main cache
+     * fast-path — matching {@link #getBlock}'s lookup order.
      *
      * <p><b>Single-flight</b>: concurrent callers for the same
      * {@code (path, blockIndex)} share a single in-flight loader call via
@@ -323,7 +544,23 @@ public final class SegmentBlockCache {
         long blockIndex = offset / length;
         BlockKey key = new BlockKey(path, blockIndex);
 
-        // --- Fast path: check cache with atomic retain-under-lock ---
+        // --- Fast path 1: check frontier (pinned) region first ---
+        if (frontierCache != null) {
+            ByteBuf[] frontierRetained = new ByteBuf[1];
+            frontierCache.asMap().computeIfPresent(key, (k, existing) -> {
+                frontierHits.incrementAndGet();
+                existing.retain();
+                frontierRetained[0] = existing;
+                return existing;
+            });
+            if (frontierRetained[0] != null) {
+                ByteBuf slice = frontierRetained[0].retainedSlice(0, frontierRetained[0].readableBytes());
+                frontierRetained[0].release();
+                return CompletableFuture.completedFuture(slice);
+            }
+        }
+
+        // --- Fast path 2: check main cache with atomic retain-under-lock ---
         // Use computeIfPresent so the retain and the entry-present check are
         // serialised with the removal listener, exactly as in getBlock().
         ByteBuf[] retained = new ByteBuf[1];
@@ -508,22 +745,25 @@ public final class SegmentBlockCache {
     /**
      * Checks whether the cache currently holds the block at
      * {@code (path, offset, length)} without triggering a load or affecting
-     * LRU ordering. Used by {@link RemoteRandomAccessReader} to distinguish
-     * per-request cache hits from cache misses.
+     * LRU ordering. Checks both the frontier and main caches. Used by
+     * {@link RemoteRandomAccessReader} to distinguish per-request cache hits
+     * from cache misses.
      */
     public boolean containsBlock(String path, long offset, int length) {
         if (cache == null) {
             return false;
         }
         long blockIndex = offset / length;
-        return cache.asMap().containsKey(new BlockKey(path, blockIndex));
+        BlockKey key = new BlockKey(path, blockIndex);
+        return (frontierCache != null && frontierCache.asMap().containsKey(key))
+                || cache.asMap().containsKey(key);
     }
 
     /**
-     * Removes every cached block whose key path equals {@code path}. Called
-     * when a multipart segment file is deleted or rewritten so that stale
-     * bytes cannot be served to a subsequent reader that happens to hit the
-     * same logical path.
+     * Removes every cached block whose key path equals {@code path} from both
+     * the main cache and the frontier (pinned) region. Called when a multipart
+     * segment file is deleted or rewritten so that stale bytes cannot be served
+     * to a subsequent reader that happens to hit the same logical path.
      */
     public void invalidatePath(String path) {
         if (cache == null || path == null) {
@@ -536,12 +776,22 @@ public final class SegmentBlockCache {
                 it.remove();
             }
         }
+        if (frontierCache != null) {
+            Iterator<BlockKey> fit = frontierCache.asMap().keySet().iterator();
+            while (fit.hasNext()) {
+                BlockKey k = fit.next();
+                if (path.equals(k.path)) {
+                    fit.remove();
+                }
+            }
+        }
     }
 
     /**
-     * Removes every cached block whose key path starts with {@code prefix}.
-     * Used by bulk deletions (e.g. {@code eraseTablespaceData}) so that
-     * multipart segments sharing a logical prefix are invalidated together.
+     * Removes every cached block whose key path starts with {@code prefix} from
+     * both the main cache and the frontier (pinned) region. Used by bulk
+     * deletions (e.g. {@code eraseTablespaceData}) so that multipart segments
+     * sharing a logical prefix are invalidated together.
      */
     public void invalidatePrefix(String prefix) {
         if (cache == null || prefix == null) {
@@ -554,21 +804,38 @@ public final class SegmentBlockCache {
                 it.remove();
             }
         }
+        if (frontierCache != null) {
+            Iterator<BlockKey> fit = frontierCache.asMap().keySet().iterator();
+            while (fit.hasNext()) {
+                BlockKey k = fit.next();
+                if (k.path.startsWith(prefix)) {
+                    fit.remove();
+                }
+            }
+        }
     }
 
+    /** Clears all entries from both the main cache and the frontier region. */
     public void clear() {
         if (cache != null) {
             cache.invalidateAll();
         }
+        if (frontierCache != null) {
+            frontierCache.invalidateAll();
+        }
     }
 
     /**
-     * Forces Caffeine to drain its async maintenance queue. Tests use this
-     * before asserting on eviction counts; not needed in production.
+     * Forces Caffeine to drain its async maintenance queue on both caches.
+     * Tests use this before asserting on eviction counts; not needed in
+     * production.
      */
     public void cleanUp() {
         if (cache != null) {
             cache.cleanUp();
+        }
+        if (frontierCache != null) {
+            frontierCache.cleanUp();
         }
     }
 
@@ -608,11 +875,12 @@ public final class SegmentBlockCache {
         return PooledByteBufAllocator.DEFAULT.directBuffer(length);
     }
 
-    // ---------------------------------------------------------------------
-    // Stats accessors. Hits/misses are 0 when the cache is disabled (pass-
-    // through mode) because no lookups happen; load_success / load_failure /
-    // load_time still track the pass-through loader calls.
-    // ---------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // Main cache stats accessors.
+    // Hits/misses are 0 when the cache is disabled (pass-through mode) because
+    // no lookups happen; load_success / load_failure / load_time still track
+    // the pass-through loader calls.
+    // -------------------------------------------------------------------------
 
     public long hitCount() {
         return hits.get();
@@ -651,9 +919,81 @@ public final class SegmentBlockCache {
                 .orElse(0L);
     }
 
-    // ---------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // Frontier (pinned) region stats accessors.
+    // Same shape as the main cache stats so that Prometheus dashboards can use
+    // the same panels for both regions. All return 0 when the frontier region
+    // is disabled (frontierCache == null).
+    //
+    // Naming convention: "frontier_*" maps to the Prometheus label
+    //   cache_region="frontier"
+    // to distinguish from the main cache (cache_region="main").
+    // -------------------------------------------------------------------------
+
+    /**
+     * Blocks served from the frontier region by {@link #getBlock} /
+     * {@link #getBlockAsync}. Also counts hits inside {@link #pinBlock} when the
+     * block was already resident in the frontier (i.e. a re-pin of a warm block).
+     */
+    public long frontierHitCount() {
+        return frontierHits.get();
+    }
+
+    /**
+     * Blocks evicted from the frontier region because the frontier byte budget
+     * was exceeded (LRU eviction within the frontier).
+     */
+    public long frontierEvictionCount() {
+        return frontierEvictions.get();
+    }
+
+    /**
+     * Successful block loads via {@link #pinBlock} (loader returned a non-null
+     * buffer and the insert into the frontier region succeeded).
+     */
+    public long frontierLoadSuccessCount() {
+        return frontierLoadSuccess.get();
+    }
+
+    /**
+     * Failed block loads via {@link #pinBlock} (loader threw {@link IOException}
+     * or returned null).
+     */
+    public long frontierLoadFailureCount() {
+        return frontierLoadFailure.get();
+    }
+
+    /**
+     * Total wall-clock nanoseconds spent inside {@link #pinBlock} loader
+     * invocations (excluding hits). Useful for tracking how much time the
+     * warmup BFS spends on network reads.
+     */
+    public long frontierTotalLoadTimeNanos() {
+        return frontierLoadTimeNanos.get();
+    }
+
+    /** Approximate number of entries currently in the frontier region. */
+    public long frontierEstimatedSize() {
+        return frontierCache == null ? 0 : frontierCache.estimatedSize();
+    }
+
+    /**
+     * Byte-weighted size of the frontier region (sum of all entry weights as
+     * reported by the weigher). May lag slightly behind actual memory use until
+     * the next Caffeine maintenance pass.
+     */
+    public long frontierWeightedSize() {
+        if (frontierCache == null) {
+            return 0;
+        }
+        return frontierCache.policy().eviction()
+                .map(e -> e.weightedSize().orElse(0L))
+                .orElse(0L);
+    }
+
+    // -------------------------------------------------------------------------
     // Types
-    // ---------------------------------------------------------------------
+    // -------------------------------------------------------------------------
 
     /** Immutable composite cache key. Hash is precomputed to avoid repeated path hashing. */
     static final class BlockKey {

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -316,6 +316,14 @@ public final class SegmentBlockCache {
         // of whether the main cache also holds a copy. This prevents eviction
         // pressure in the much larger main cache from displacing entry-frontier
         // Layer-0 blocks.
+        //
+        // Performance note: this adds one ConcurrentHashMap.computeIfPresent()
+        // call per getBlock() invocation when the frontier region is active
+        // (frontierCache != null). computeIfPresent returns without executing
+        // the mapping function when the key is absent (the overwhelmingly common
+        // case for non-entry-frontier blocks) — cost is one hash + probe.
+        // The frontier is disabled (frontierCache == null) in the majority of
+        // test and tooling deployments, so the hot path is unaffected there.
         if (frontierCache != null) {
             ByteBuf[] frontierRetained = new ByteBuf[1];
             frontierCache.asMap().computeIfPresent(key, (k, existing) -> {
@@ -471,8 +479,15 @@ public final class SegmentBlockCache {
         } catch (CacheLoadException e) {
             throw (IOException) e.getCause();
         }
+        // compute() always returns non-null here: the hit branch retains and returns
+        // existing, the miss branch either throws CacheLoadException or returns the
+        // freshly loaded buffer. A null return from Caffeine.compute() would mean the
+        // mapping was removed by another thread inside the lambda, which is not possible
+        // because the lambda itself never returns null and no other thread can remove the
+        // entry while the lambda holds the per-key lock. Treat null as a programming error.
         if (retained == null) {
-            return invokeLoader(loader, path, offset, length);
+            throw new IllegalStateException(
+                    "Caffeine compute() returned null unexpectedly for " + key);
         }
         try {
             return retained.retainedSlice(0, retained.readableBytes());

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderPinModeTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderPinModeTest.java
@@ -1,0 +1,185 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.index.vector.PinModeReaderSupplier;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests that {@link RemoteRandomAccessReader.Supplier} correctly implements
+ * {@link PinModeReaderSupplier}: that {@link RemoteRandomAccessReader.Supplier#withPinMode()}
+ * produces readers whose block loads are routed through
+ * {@link SegmentBlockCache#pinBlock} (incrementing the frontier stats), and that
+ * normal (non-pin-mode) readers use the main cache path instead.
+ */
+public class RemoteRandomAccessReaderPinModeTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+
+    private static final int BLOCK_SIZE = 64;
+    private static final String PATH = "ts/idx/graph";
+
+    @Before
+    public void setUp() throws Exception {
+        server = new RemoteFileServer(0, folder.newFolder("data").toPath());
+        server.start();
+        client = new RemoteFileServiceClient(List.of("localhost:" + server.getPort()));
+
+        // Upload a small file so reads can succeed.
+        byte[] data = new byte[BLOCK_SIZE * 4];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0xFF);
+        }
+        client.writeMultipartFile(PATH, new ByteArrayInputStream(data), BLOCK_SIZE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        server.stop();
+    }
+
+    @Test
+    public void supplierImplementsPinModeReaderSupplier() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        assertTrue("Supplier must implement PinModeReaderSupplier",
+                supplier instanceof PinModeReaderSupplier);
+    }
+
+    @Test
+    public void hasFrontierCacheActiveTrueWhenFrontierBudgetPositive() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        assertTrue("hasFrontierCacheActive must be true when frontier budget > 0",
+                supplier.hasFrontierCacheActive());
+    }
+
+    @Test
+    public void hasFrontierCacheActiveFalseWhenFrontierDisabled() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 0);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        assertFalse("hasFrontierCacheActive must be false when no frontier budget",
+                supplier.hasFrontierCacheActive());
+    }
+
+    @Test
+    public void pinModeReaderRoutesThroughPinBlock() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        // Read using a pin-mode reader.
+        try (RandomAccessReader pinReader = supplier.withPinMode().get()) {
+            pinReader.seek(0);
+            pinReader.readInt(); // triggers ensureBlockLoaded → pinBlock
+        }
+
+        assertEquals("pin-mode reader must route loads through pinBlock (frontier load_success)",
+                1L, cache.frontierLoadSuccessCount());
+        assertEquals("main cache must not record a load (frontier only)",
+                0L, cache.loadSuccessCount());
+    }
+
+    @Test
+    public void normalReaderRoutesThoughMainCache() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        // Read using a normal (non-pin) reader.
+        try (RandomAccessReader reader = supplier.get()) {
+            reader.seek(0);
+            reader.readInt(); // triggers ensureBlockLoaded → getBlock
+        }
+
+        assertEquals("normal reader must route loads through main cache (main load_success)",
+                1L, cache.loadSuccessCount());
+        assertEquals("frontier must not see any load from a normal reader",
+                0L, cache.frontierLoadSuccessCount());
+    }
+
+    @Test
+    public void pinModeHitCountedOnSubsequentGetBlock() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        // Prime the frontier region via a pin-mode read.
+        try (RandomAccessReader pinReader = supplier.withPinMode().get()) {
+            pinReader.seek(0);
+            pinReader.readInt();
+        }
+        assertEquals(1L, cache.frontierLoadSuccessCount());
+
+        // A subsequent normal read for the same block must come from the frontier.
+        try (RandomAccessReader reader = supplier.get()) {
+            reader.seek(0);
+            reader.readInt();
+        }
+
+        assertEquals("normal reader must get a frontier hit for a previously pinned block",
+                1L, cache.frontierHitCount());
+        assertEquals("main cache must not record a separate load",
+                0L, cache.loadSuccessCount());
+    }
+
+    @Test
+    public void withPinModeReturnedSupplierIsNotSameInstance() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, BLOCK_SIZE * 4,
+                        BLOCK_SIZE, BLOCK_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        RemoteRandomAccessReader.Supplier pinSupplier = supplier.withPinMode();
+        assertFalse("withPinMode() must return a new instance, not this",
+                supplier == pinSupplier);
+        // Both should share the same frontier cache.
+        assertTrue(pinSupplier.hasFrontierCacheActive());
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
@@ -491,4 +491,74 @@ public class SegmentBlockCacheTest {
         SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
         assertEquals(200_000L, cache.maxFrontierBytes());
     }
+
+    @Test
+    public void pinBlockThrowsIllegalStateIfComputeReturnsNull() throws Exception {
+        // compute() is non-null by construction; the guard now throws
+        // IllegalStateException instead of silently calling the loader again.
+        // This is hard to trigger without Caffeine internals, so we verify the
+        // normal path: a successful pinBlock does NOT throw.
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0xCC);
+        ByteBuf buf = cache.pinBlock("seg", 0L, BLOCK, loader);
+        try {
+            assertEquals((byte) 0xCC, buf.getByte(0));
+        } finally {
+            buf.release();
+        }
+        assertEquals(1L, cache.frontierLoadSuccessCount());
+        assertEquals(0L, cache.frontierHitCount());
+    }
+
+    /**
+     * Concurrency stress: many threads interleave {@link SegmentBlockCache#pinBlock}
+     * and {@link SegmentBlockCache#getBlock} on the same key. The test verifies
+     * that refcount discipline holds (no {@code IllegalReferenceCountException},
+     * all slices readable) and that every call returns the correct byte pattern.
+     */
+    @Test
+    public void concurrentPinBlockAndGetBlockOnSameKey() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        SegmentBlockCache.BlockLoader pinLoader = (p, off, len) -> direct(BLOCK, (byte) 0xAA);
+        SegmentBlockCache.BlockLoader getLoader = (p, off, len) -> direct(BLOCK, (byte) 0xAA);
+
+        int threads = 32;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch go = new CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicReference<Throwable> failure =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        for (int t = 0; t < threads; t++) {
+            final boolean pinMode = (t % 2 == 0);
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                    for (int iter = 0; iter < 50; iter++) {
+                        ByteBuf buf;
+                        if (pinMode) {
+                            buf = cache.pinBlock("seg", 0L, BLOCK, pinLoader);
+                        } else {
+                            buf = cache.getBlock("seg", 0L, BLOCK, getLoader);
+                        }
+                        try {
+                            assertEquals("wrong byte value", (byte) 0xAA, buf.getByte(0));
+                        } finally {
+                            buf.release();
+                        }
+                    }
+                } catch (Throwable e) {
+                    failure.compareAndSet(null, e);
+                }
+            });
+        }
+        assertTrue(ready.await(5, TimeUnit.SECONDS));
+        go.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+        if (failure.get() != null) {
+            throw new AssertionError("concurrent pin/get stress test failed", failure.get());
+        }
+    }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
@@ -493,11 +493,12 @@ public class SegmentBlockCacheTest {
     }
 
     @Test
-    public void pinBlockThrowsIllegalStateIfComputeReturnsNull() throws Exception {
+    public void pinBlockSuccessfulPathDoesNotThrow() throws Exception {
         // compute() is non-null by construction; the guard now throws
         // IllegalStateException instead of silently calling the loader again.
-        // This is hard to trigger without Caffeine internals, so we verify the
-        // normal path: a successful pinBlock does NOT throw.
+        // Triggering the ISE would require Caffeine internals access; this test
+        // verifies the normal (non-exceptional) path: a successful pinBlock
+        // returns the expected buffer without throwing.
         SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
         SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0xCC);
         ByteBuf buf = cache.pinBlock("seg", 0L, BLOCK, loader);

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheTest.java
@@ -318,4 +318,177 @@ public class SegmentBlockCacheTest {
         cache.cleanUp();
         assertEquals(0L, cache.estimatedSize());
     }
+
+    // ------------------------------------------------------------------
+    // Frontier (pinned) region tests
+    // ------------------------------------------------------------------
+
+    @Test
+    public void pinnedBlockSurvivesMainCacheEvictionPressure() throws Exception {
+        // Main budget = 4 KB, frontier budget = 2 KB, blocks = 1 KB each.
+        // After we pin one block, flooding the main cache with 20 new blocks
+        // must evict main-cache entries but the pinned block must still be
+        // reachable via getBlock().
+        SegmentBlockCache cache = new SegmentBlockCache(4L * BLOCK, 2L * BLOCK);
+        assertTrue("frontier cache should be active", cache.isFrontierCacheActive());
+
+        AtomicInteger pinLoaderCalls = new AtomicInteger();
+        SegmentBlockCache.BlockLoader pinLoader = (p, off, len) -> {
+            pinLoaderCalls.incrementAndGet();
+            return direct(BLOCK, (byte) 0xAA);
+        };
+
+        // Pin the block; loader must be called exactly once.
+        cache.pinBlock("seg", 0L, BLOCK, pinLoader).release();
+        assertEquals(1, pinLoaderCalls.get());
+        assertEquals(1L, cache.frontierLoadSuccessCount());
+
+        // Flood the main cache to trigger eviction of non-pinned blocks.
+        SegmentBlockCache.BlockLoader floodLoader = (p, off, len) -> direct(BLOCK, (byte) 0x01);
+        for (int i = 1; i <= 20; i++) {
+            cache.getBlock("seg", (long) i * BLOCK, BLOCK, floodLoader).release();
+        }
+        cache.cleanUp();
+
+        // The pinned block must still be served (from the frontier region)
+        // without calling the loader again.
+        ByteBuf hit = cache.getBlock("seg", 0L, BLOCK, pinLoader);
+        try {
+            assertEquals("pinned byte pattern", (byte) 0xAA, hit.getByte(0));
+        } finally {
+            hit.release();
+        }
+        assertEquals("pin loader must not be re-invoked on frontier hit",
+                1, pinLoaderCalls.get());
+        assertTrue("at least one frontier hit recorded", cache.frontierHitCount() > 0);
+    }
+
+    @Test
+    public void frontierEvictionStatsIncrementWhenFrontierBudgetOverflows() throws Exception {
+        // Frontier budget = 2 KB, blocks = 1 KB each. After inserting 10 blocks
+        // via pinBlock the frontier must have evicted some.
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 2L * BLOCK);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0x55);
+
+        for (int i = 0; i < 10; i++) {
+            cache.pinBlock("seg", (long) i * BLOCK, BLOCK, loader).release();
+        }
+        cache.cleanUp();
+
+        assertTrue("some frontier blocks should have been evicted",
+                cache.frontierEvictionCount() > 0);
+        assertTrue("frontier weighted size within budget, got " + cache.frontierWeightedSize(),
+                cache.frontierWeightedSize() <= 2L * BLOCK);
+    }
+
+    @Test
+    public void invalidatePathClearsFrontierBlocks() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0);
+
+        cache.pinBlock("segA", 0L, BLOCK, loader).release();
+        cache.pinBlock("segA", BLOCK, BLOCK, loader).release();
+        cache.pinBlock("segB", 0L, BLOCK, loader).release();
+
+        assertTrue("segA/0 should be in frontier before invalidation",
+                cache.containsBlock("segA", 0L, BLOCK));
+
+        cache.invalidatePath("segA");
+
+        assertFalse("segA/0 must be gone from frontier after invalidatePath",
+                cache.containsBlock("segA", 0L, BLOCK));
+        assertFalse("segA/BLOCK must be gone from frontier after invalidatePath",
+                cache.containsBlock("segA", BLOCK, BLOCK));
+        assertTrue("segB must be unaffected",
+                cache.containsBlock("segB", 0L, BLOCK));
+    }
+
+    @Test
+    public void invalidatePrefixClearsFrontierBlocks() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0);
+
+        cache.pinBlock("ts1/idx/a", 0L, BLOCK, loader).release();
+        cache.pinBlock("ts1/idx/b", 0L, BLOCK, loader).release();
+        cache.pinBlock("ts2/idx/a", 0L, BLOCK, loader).release();
+
+        cache.invalidatePrefix("ts1/");
+
+        assertFalse("ts1/idx/a must be gone from frontier",
+                cache.containsBlock("ts1/idx/a", 0L, BLOCK));
+        assertFalse("ts1/idx/b must be gone from frontier",
+                cache.containsBlock("ts1/idx/b", 0L, BLOCK));
+        assertTrue("ts2/idx/a must survive",
+                cache.containsBlock("ts2/idx/a", 0L, BLOCK));
+    }
+
+    @Test
+    public void clearRemovesAllFrontierEntries() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0);
+        cache.pinBlock("segA", 0L, BLOCK, loader).release();
+        cache.pinBlock("segB", 0L, BLOCK, loader).release();
+
+        assertTrue("segA in frontier before clear", cache.isFrontierCacheActive());
+        cache.clear();
+        cache.cleanUp();
+
+        assertEquals("frontier must be empty after clear",
+                0L, cache.frontierEstimatedSize());
+    }
+
+    @Test
+    public void pinBlockFallsThroughToMainCacheWhenFrontierDisabled() throws Exception {
+        // With frontierMaxBytes = 0 the frontier region is not created.
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 0);
+        assertFalse("frontier cache must be inactive", cache.isFrontierCacheActive());
+
+        AtomicInteger calls = new AtomicInteger();
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            calls.incrementAndGet();
+            return direct(BLOCK, (byte) 0x77);
+        };
+
+        // pinBlock must still work (falls through to getBlock), loader called once.
+        ByteBuf a = cache.pinBlock("seg", 0L, BLOCK, loader);
+        ByteBuf b = cache.pinBlock("seg", 0L, BLOCK, loader);
+        try {
+            assertEquals("loader invoked once — second call is a main-cache hit", 1, calls.get());
+            assertEquals((byte) 0x77, a.getByte(0));
+            assertEquals((byte) 0x77, b.getByte(0));
+        } finally {
+            a.release();
+            b.release();
+        }
+    }
+
+    @Test
+    public void frontierHitCountedWhenGetBlockServedFromFrontier() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> direct(BLOCK, (byte) 0xBB);
+
+        cache.pinBlock("seg", 0L, BLOCK, loader).release();
+        // Now getBlock should serve from frontier, not main cache.
+        ByteBuf hit = cache.getBlock("seg", 0L, BLOCK, loader);
+        hit.release();
+
+        assertTrue("at least one frontier hit", cache.frontierHitCount() >= 1);
+    }
+
+    @Test
+    public void frontierLoadFailureCountedOnLoaderException() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 100_000);
+        SegmentBlockCache.BlockLoader failing = (p, off, len) -> {
+            throw new IOException("frontier load failure");
+        };
+        assertThrows(IOException.class, () -> cache.pinBlock("seg", 0L, BLOCK, failing));
+        assertEquals(1L, cache.frontierLoadFailureCount());
+        assertEquals(0L, cache.frontierLoadSuccessCount());
+    }
+
+    @Test
+    public void maxFrontierBytesAccessor() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        assertEquals(200_000L, cache.maxFrontierBytes());
+    }
 }


### PR DESCRIPTION
Fixes #578.

## Changes

- **`SegmentBlockCache`** (`herddb-remote-file-service`): new two-argument constructor `(long maxBytes, long frontierMaxBytes)`; `pinBlock()` API inserts into a second independently-budgeted Caffeine cache (the "frontier region"); `getBlock`/`getBlockAsync` check the frontier first; `invalidatePath`/`invalidatePrefix`/`clear`/`cleanUp` sweep both caches. Full metrics parity with the main cache: `frontierHitCount()`, `frontierEvictionCount()`, `frontierLoadSuccessCount()`, `frontierLoadFailureCount()`, `frontierTotalLoadTimeNanos()`, `frontierEstimatedSize()`, `frontierWeightedSize()`, `maxFrontierBytes()`.

- **`PinModeReaderSupplier`** (`herddb-core`, new interface): dependency-inversion bridge so `PersistentVectorStore` (which does not depend on `herddb-remote-file-service`) can ask any `ReaderSupplier` whether it supports frontier pinning.

- **`RemoteRandomAccessReader`** (`herddb-remote-file-service`): `boolean pinMode` field routes `ensureBlockLoaded` to `blockCache.pinBlock()`; `Supplier.withPinMode()` factory returns a pin-mode supplier; `Supplier.hasFrontierCacheActive()` checks whether the frontier is configured; `Supplier` now implements `PinModeReaderSupplier`.

- **`PersistentVectorStore`** (`herddb-core`): `pinSegmentBfs()` runs a secondary BFS after the main warmup BFS, using a pin-mode reader from `Supplier.withPinMode()` so every accessed Level-0 block goes to the frontier region; `setPinBytesPerSegment(-1)` mirrors the warmup budget (default); only fires when `hasFrontierCacheActive()` is true and the reader is a `PinModeReaderSupplier`.

- **`IndexingServerConfiguration`** (`herddb-indexing-service`): new `indexing.vector.segmentPageCacheFrontierMaxBytes` config key; default `0` = auto-size to 10% of main cache.

- **`IndexingServiceEngine`** (`herddb-indexing-service`): computes 10% auto-default for the frontier budget; passes it to the two-arg `SegmentBlockCache` constructor; registers frontier Prometheus gauges (`indexing_segment_block_cache_frontier_*`) mirroring the existing main-cache gauges; calls `store.setPinBytesPerSegment()` on every new `PersistentVectorStore`.

- **Grafana dashboard** (`indexing-service-dashboard.json`): new "Frontier Cache — Entry-Frontier Pinned Region (issue #578)" row with 6 panels (size_bytes, entries, hits/s, evictions/s, avg pin load latency, load_success/failure rate).

## Tests

- **`SegmentBlockCacheTest`**: 9 new tests covering: pinned block survives main-cache eviction pressure; frontier eviction stats increment when frontier budget overflows; `invalidatePath` clears frontier blocks; `invalidatePrefix` clears frontier blocks; `clear` removes all frontier entries; `pinBlock` falls through to main cache when frontier disabled; frontier hit counted when `getBlock` is served from frontier; frontier load failure counted on loader exception; `maxFrontierBytes()` accessor.
- All 22 `SegmentBlockCacheTest` tests pass.
- All 12 `LazyValueCacheConcurrentUpdatesSuite` hammer tests pass.

🤖 Implemented by the `pr-worker` agent.