### PR TITLE
issue #586: add periodic channelIdle() heartbeat to HDBClient

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -127,6 +127,16 @@ public class ClientConfiguration {
     public static final String PROPERTY_ALLOW_READS_FROM_FOLLOWERS = "client.allowReadsFromFollowers";
     public static final boolean PROPERTY_ALLOW_READS_FROM_FOLLOWERS_DEFAULT = false;
 
+    /**
+     * Interval (in milliseconds) between successive {@code channelIdle()} heartbeat ticks.
+     * Each tick scans every open channel for expired per-request deadlines registered by
+     * {@code sendRequestWithAsyncReply} and fails them with IOException, preventing a
+     * silently-dead TCP connection from hanging {@code executeUpdateAsync} /
+     * {@code executeUpdatesAsync} calls forever (issue #586).
+     */
+    public static final String PROPERTY_IDLE_CHECK_INTERVAL_MS = "client.idle.check.interval.ms";
+    public static final long PROPERTY_IDLE_CHECK_INTERVAL_MS_DEFAULT = 30_000L;
+
 
     public ClientConfiguration(Properties properties) {
         this.properties = new Properties();

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -41,8 +41,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -68,6 +71,7 @@ public class HDBClient implements AutoCloseable {
     private final boolean allowReadsFromFollowers;
     private volatile OidcTokenProvider oidcTokenProvider;
     private final Object oidcTokenProviderLock = new Object();
+    private final ScheduledExecutorService idleCheckScheduler;
 
     public HDBClient(ClientConfiguration configuration) {
         this(configuration, NullStatsLogger.INSTANCE);
@@ -130,6 +134,25 @@ public class HDBClient implements AutoCloseable {
             default:
                 throw new IllegalStateException(mode);
         }
+
+        // Schedule a periodic channelIdle() heartbeat so that per-request deadlines
+        // registered by sendRequestWithAsyncReply are actually checked.  Without this
+        // heartbeat, AbstractChannel.processPendingReplyMessagesDeadline() is never
+        // invoked and a silently-dead TCP channel hangs every in-flight CompletableFuture
+        // returned by executeUpdateAsync / executeUpdatesAsync forever (issue #586).
+        long idleCheckIntervalMs = configuration.getLong(
+                ClientConfiguration.PROPERTY_IDLE_CHECK_INTERVAL_MS,
+                ClientConfiguration.PROPERTY_IDLE_CHECK_INTERVAL_MS_DEFAULT);
+        ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1, r -> {
+            Thread t = new Thread(r, "hdb-client-idle-check");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.setRemoveOnCancelPolicy(true);
+        this.idleCheckScheduler = scheduler;
+        this.idleCheckScheduler.scheduleAtFixedRate(
+                this::tickAllConnections,
+                idleCheckIntervalMs, idleCheckIntervalMs, TimeUnit.MILLISECONDS);
     }
 
     private static MultithreadEventLoopGroup buildNetworkGroup(boolean connectRemoteServers) {
@@ -171,6 +194,7 @@ public class HDBClient implements AutoCloseable {
 
     @Override
     public void close() {
+        idleCheckScheduler.shutdown();
         List<HDBConnection> connectionsAtClose = new ArrayList<>(this.connections.values());
         for (HDBConnection connection : connectionsAtClose) {
             connection.close();
@@ -180,6 +204,33 @@ public class HDBClient implements AutoCloseable {
         }
         if (thredpool != null) {
             thredpool.shutdown();
+        }
+    }
+
+    /**
+     * Periodic heartbeat task: calls {@code channelIdle()} on every open channel owned by
+     * every open {@link HDBConnection}.  This activates
+     * {@code AbstractChannel.processPendingReplyMessagesDeadline()}, which scans
+     * {@code pendingReplyMessagesDeadline} and fails expired async-reply callbacks with
+     * IOException, preventing a silently-dead TCP channel from permanently hanging
+     * {@code executeUpdateAsync} / {@code executeUpdatesAsync} futures (issue #586).
+     *
+     * <p>The method catches {@link RuntimeException} broadly so that one misbehaving
+     * {@code channelIdle()} call cannot permanently cancel the
+     * {@code scheduleAtFixedRate} heartbeat.
+     */
+    private void tickAllConnections() {
+        try {
+            for (HDBConnection conn : connections.values()) {
+                conn.tickChannels();
+            }
+        } catch (RuntimeException e) {
+            // Catching RuntimeException broadly: if this runnable throws, scheduleAtFixedRate
+            // cancels the recurring task permanently.  Log and swallow so the heartbeat
+            // survives any single misbehaving channelIdle() invocation.
+            LOG.log(Level.WARNING,
+                    "tickAllConnections: unexpected error during idle-check tick "
+                            + "(skipping this tick; heartbeat continues on next interval)", e);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -106,6 +106,23 @@ public class HDBConnection implements AutoCloseable {
 
     private static final Logger LOGGER = Logger.getLogger(HDBConnection.class.getName());
 
+    /**
+     * Called by {@link HDBClient#tickAllConnections()} on every heartbeat tick.
+     * Invokes {@code channelIdle()} on every open channel so that
+     * {@code AbstractChannel.processPendingReplyMessagesDeadline()} scans for expired
+     * async-reply callbacks and fails them with IOException (issue #586).
+     */
+    void tickChannels() {
+        for (ClientSideConnectionPeer[] peers : routes.values()) {
+            for (ClientSideConnectionPeer peer : peers) {
+                herddb.network.Channel ch = peer.getChannel();
+                if (ch != null) {
+                    ch.channelIdle();
+                }
+            }
+        }
+    }
+
     public boolean waitForTableSpace(String tableSpace, int timeout) throws HDBException, ClientSideMetadataProviderException {
         long start = System.currentTimeMillis();
         while (!closed) {

--- a/herddb-core/src/test/java/herddb/client/HDBClientIdleCheckHeartbeatTest.java
+++ b/herddb-core/src/test/java/herddb/client/HDBClientIdleCheckHeartbeatTest.java
@@ -1,0 +1,125 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.client;
+
+import static herddb.core.TestUtils.newServerConfigurationWithAutoPort;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.model.TableSpace;
+import herddb.network.Channel;
+import herddb.proto.PduCodec;
+import herddb.server.Server;
+import herddb.server.StaticClientSideMetadataProvider;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #586: verifies that {@link HDBClient} periodically calls
+ * {@link Channel#channelIdle()} on every open channel so that expired per-request
+ * deadlines registered by {@code sendRequestWithAsyncReply} are detected and their
+ * callbacks are completed with {@link IOException} rather than hanging forever.
+ *
+ * <p>Strategy: connect to a real HerdDB server (so SASL auth succeeds), then inject
+ * a "phantom" pending callback directly onto the underlying channel via
+ * {@link Channel#sendRequestWithAsyncReply} with a fake PDU that the server will
+ * silently discard (a {@code FLAGS_ISRESPONSE} AckResponse frame whose message-id
+ * the server has no pending callback for).  The client's callback is left pending
+ * with a 2-second deadline.  With {@code PROPERTY_IDLE_CHECK_INTERVAL_MS=300 ms},
+ * the periodic heartbeat detects the expired deadline in ≈ 2.3 s and fires the
+ * callback with {@link IOException}.
+ */
+public class HDBClientIdleCheckHeartbeatTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Verifies that the periodic idle-check heartbeat detects and fails an expired
+     * async-reply callback on an otherwise-healthy channel.
+     */
+    @Test(timeout = 30_000)
+    public void testExpiredCallbackFiredByHeartbeat() throws Exception {
+        Path baseDir = folder.newFolder().toPath();
+        try (Server server = new Server(newServerConfigurationWithAutoPort(baseDir))) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            // HDBClient with a short heartbeat interval and per-request timeout.
+            ClientConfiguration config = new ClientConfiguration(folder.newFolder().toPath());
+            config.set(ClientConfiguration.PROPERTY_IDLE_CHECK_INTERVAL_MS, 300L);
+            // PROPERTY_TIMEOUT is used as the per-request deadline passed to
+            // sendRequestWithAsyncReply; 2 000 ms keeps the test fast.
+            config.set(ClientConfiguration.PROPERTY_TIMEOUT, 2_000);
+
+            try (HDBClient client = new HDBClient(config);
+                 HDBConnection connection = client.openConnection()) {
+
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+                assertTrue(connection.waitForTableSpace(TableSpace.DEFAULT, 10_000));
+
+                // Obtain and open the underlying channel.
+                ClientSideConnectionPeer peer = connection.getRouteToTableSpace(TableSpace.DEFAULT);
+                Channel channel = peer.ensureOpen();
+                assertNotNull("channel must be open after waitForTableSpace", channel);
+
+                AtomicReference<Throwable> callbackError = new AtomicReference<>();
+                CountDownLatch latch = new CountDownLatch(1);
+
+                // Craft a PDU that the SERVER will silently discard:
+                // AckResponse has FLAGS_ISRESPONSE set (not FLAGS_ISREQUEST), so
+                // AbstractChannel.processPduResponse() on the server side will look up
+                // a callback for this message-id, find none, and return without closing
+                // the channel.  The client-side sendRequestWithAsyncReply call registers
+                // the callback with key fakeRequestId, which is what the heartbeat will scan.
+                long fakeRequestId = 99_999_888L;
+                ByteBuf fakePdu = PduCodec.AckResponse.write(fakeRequestId);
+                long deadlineMs = 2_000L; // same as PROPERTY_TIMEOUT above
+
+                channel.sendRequestWithAsyncReply(fakeRequestId, fakePdu, deadlineMs, (pdu, error) -> {
+                    if (pdu != null) {
+                        pdu.close();
+                    }
+                    callbackError.set(error);
+                    latch.countDown();
+                });
+
+                // Wait for the heartbeat to detect the expired deadline.
+                // With interval=300ms and deadline=2000ms, the heartbeat fires at
+                // ~2100ms → callback should complete well within 8 s.
+                boolean fired = latch.await(8, TimeUnit.SECONDS);
+                assertTrue("idle-check heartbeat must fire the expired callback within 8 s "
+                        + "(PROPERTY_IDLE_CHECK_INTERVAL_MS=300 ms, deadline=2 s)", fired);
+
+                Throwable err = callbackError.get();
+                assertNotNull("callback must have been invoked with an error", err);
+                assertTrue("error must be an IOException (from processPendingReplyMessagesDeadline), "
+                        + "got: " + err.getClass().getName() + ": " + err.getMessage(),
+                        err instanceof IOException);
+            }
+        }
+    }
+}

--- a/herddb-net/src/test/java/herddb/network/netty/AbstractChannelIdleCheckTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/AbstractChannelIdleCheckTest.java
@@ -1,0 +1,171 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.network.netty;
+
+import static herddb.network.netty.Utils.buildAckRequest;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnection;
+import herddb.proto.Pdu;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * Regression test for issue #586: proves that {@link AbstractChannel#channelIdle()} scans
+ * {@code pendingReplyMessagesDeadline} and fires expired async-reply callbacks with
+ * {@link IOException}.
+ *
+ * <p>A "no-reply" server accepts TCP connections and reads incoming PDUs, but
+ * never sends any response.  The client registers an async-reply callback with a
+ * short deadline via {@link Channel#sendRequestWithAsyncReply}; after the deadline
+ * expires the test manually calls {@link Channel#channelIdle()}, which must invoke
+ * {@code processPendingReplyMessagesDeadline()} and complete the callback exceptionally.
+ *
+ * <p>This is the foundational unit test for the {@code channelIdle()} mechanism that
+ * both {@link herddb.remote.RemoteFileServiceClient} (issue #584) and
+ * {@link herddb.client.HDBClient} (issue #586) rely on.
+ */
+public class AbstractChannelIdleCheckTest {
+
+    @Test(timeout = 15_000)
+    public void testChannelIdleFiresExpiredCallback() throws Exception {
+        // Server that accepts connections but never sends replies.
+        try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor(
+                "localhost", NetworkUtils.assignFirstFreePort(), true)) {
+            acceptor.setAcceptor(channel -> {
+                channel.setMessagesReceiver(new ChannelEventListener() {
+                    @Override
+                    public void requestReceived(Pdu message, Channel channel) {
+                        // Discard the PDU — no reply sent.  Channel stays open.
+                        message.close();
+                    }
+
+                    @Override
+                    public void channelClosed(Channel channel) {
+                        // nothing to do
+                    }
+                });
+                return (ServerSideConnection) () -> new Random().nextLong();
+            });
+            acceptor.start();
+
+            ExecutorService executor = Executors.newCachedThreadPool();
+            try (Channel client = NettyConnector.connect(
+                    acceptor.getHost(), acceptor.getPort(), true, 0, 0,
+                    new ChannelEventListener() {
+                        @Override
+                        public void channelClosed(Channel channel) {
+                            // nothing to do
+                        }
+                    }, executor, null)) {
+
+                AtomicReference<Throwable> callbackError = new AtomicReference<>();
+                CountDownLatch latch = new CountDownLatch(1);
+
+                long requestId = 42L;
+                long timeoutMs = 100L; // very short deadline
+                ByteBuf request = buildAckRequest((int) requestId);
+                client.sendRequestWithAsyncReply(requestId, request, timeoutMs, (pdu, error) -> {
+                    callbackError.set(error);
+                    latch.countDown();
+                });
+
+                // Let the deadline expire before triggering the idle check.
+                Thread.sleep(200);
+
+                // Manually trigger the idle check — this is what the HDBClient
+                // heartbeat scheduler calls periodically (issue #586).
+                client.channelIdle();
+
+                assertTrue("expired async-reply callback must fire within 1 s of channelIdle()",
+                        latch.await(1, TimeUnit.SECONDS));
+                Throwable err = callbackError.get();
+                assertNotNull("callback must have been called with an error", err);
+                assertTrue("root cause must be an IOException, got: " + err.getClass().getName(),
+                        err instanceof IOException);
+            } finally {
+                executor.shutdown();
+            }
+        }
+    }
+
+    /**
+     * Verifies that a callback whose deadline has NOT yet expired is NOT fired by
+     * {@code channelIdle()}.
+     */
+    @Test(timeout = 15_000)
+    public void testChannelIdleDoesNotFireNonExpiredCallback() throws Exception {
+        try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor(
+                "localhost", NetworkUtils.assignFirstFreePort(), true)) {
+            acceptor.setAcceptor(channel -> {
+                channel.setMessagesReceiver(new ChannelEventListener() {
+                    @Override
+                    public void requestReceived(Pdu message, Channel channel) {
+                        message.close(); // no reply
+                    }
+
+                    @Override
+                    public void channelClosed(Channel channel) {
+                    }
+                });
+                return (ServerSideConnection) () -> new Random().nextLong();
+            });
+            acceptor.start();
+
+            ExecutorService executor = Executors.newCachedThreadPool();
+            try (Channel client = NettyConnector.connect(
+                    acceptor.getHost(), acceptor.getPort(), true, 0, 0,
+                    new ChannelEventListener() {
+                        @Override
+                        public void channelClosed(Channel channel) {
+                        }
+                    }, executor, null)) {
+
+                CountDownLatch latch = new CountDownLatch(1);
+
+                long requestId = 99L;
+                long timeoutMs = 60_000L; // far-future deadline — must NOT fire
+                ByteBuf request = buildAckRequest((int) requestId);
+                client.sendRequestWithAsyncReply(requestId, request, timeoutMs, (pdu, error) -> {
+                    latch.countDown();
+                });
+
+                // Trigger the idle check immediately — deadline has not expired yet.
+                client.channelIdle();
+
+                // The callback must NOT have been invoked.
+                boolean firedPrematurely = latch.await(300, TimeUnit.MILLISECONDS);
+                assertTrue("channelIdle() must NOT fire callbacks whose deadline has not expired",
+                        !firedPrematurely);
+            } finally {
+                executor.shutdown();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #586.

## Changes

- **`ClientConfiguration.java`**: add `PROPERTY_IDLE_CHECK_INTERVAL_MS` (default 30 000 ms) — the interval between successive `channelIdle()` heartbeat ticks.
- **`HDBClient.java`**: in the constructor, create a single-threaded daemon `ScheduledExecutorService` and schedule `tickAllConnections()` at the configured interval. In `close()`, shut it down. `tickAllConnections()` has a broad `RuntimeException` catch with a comment explaining why — `scheduleAtFixedRate` permanently cancels a recurring task on any unchecked exception, so we must swallow and log.
- **`HDBConnection.java`**: add package-private `tickChannels()` that iterates `routes.values()` and calls `channelIdle()` on every non-null `Channel`. This is the method that reaches `AbstractChannel.processPendingReplyMessagesDeadline()` and fails expired async-reply callbacks with IOException.

## Tests

- **`AbstractChannelIdleCheckTest`** (`herddb-net`): pure unit test — no-reply server, client registers async callback with 100 ms deadline, manually calls `channelIdle()` after 200 ms, verifies IOException. A second test verifies that non-expired callbacks are NOT fired.
- **`HDBClientIdleCheckHeartbeatTest`** (`herddb-core`): integration test against a real HerdDB server — injects a phantom pending callback (fake `AckResponse` PDU the server silently discards, so the callback stays pending), then waits for the 300 ms heartbeat to detect the expired 2 s deadline and fire the callback with IOException within 8 s.

🤖 Implemented by the `pr-worker` agent.