### PR TITLE
issue #587: cap input segments per vector-index compaction cycle

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -587,6 +587,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     public static final long DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES = 1000L;
 
+    /**
+     * Default hard cap on the number of input segments a single compaction
+     * cycle may merge (issue #587). The downstream PQ-retraining step samples
+     * training vectors per input segment with random remote-storage reads, so
+     * its I/O cost scales with the input count; an unbounded selection of small
+     * segments (53 in the incident) could stall a cycle for hours. The cap
+     * bounds per-cycle I/O — leftover segments are merged by later cycles.
+     * Configurable in production via {@code vector.index.compaction.maxInputs};
+     * {@code 0} disables the cap.
+     */
+    public static final int DEFAULT_VECTOR_INDEX_COMPACTION_MAX_INPUTS = 16;
+
     /** Compaction policy knobs — defaults match IndexingServerConfiguration. */
     private volatile long vectorIndexCompactionIntervalMs = 5L * 60_000L;
     private volatile long vectorIndexCompactionMinBytes = 256L * 1024 * 1024;
@@ -607,6 +619,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     private volatile long vectorIndexCompactionMicroSegmentMaxNodes =
             DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES;
+    /**
+     * Hard cap on the number of input segments per compaction cycle (issue
+     * #587). Not scaled by the tiered multiplier — bounding worst-case
+     * per-cycle PQ-retraining I/O is the entire point of the cap. {@code 0}
+     * disables it. Pre-normalised by {@link #setCompactionMaxInputs}.
+     */
+    private volatile int vectorIndexCompactionMaxInputs =
+            DEFAULT_VECTOR_INDEX_COMPACTION_MAX_INPUTS;
     private volatile long vectorIndexCompactionRetentionMs = 10L * 60_000L;
     /**
      * When {@code true} (the default), the per-cycle byte cap and segment
@@ -1952,6 +1972,31 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
+     * Sets the hard cap on the number of input segments a single compaction
+     * cycle may merge (issue #587). A compaction cycle still fires on the same
+     * triggers, but merges at most {@code maxInputs} segments per cycle
+     * (smallest-first); any remaining segments are merged by subsequent cycles.
+     * This bounds the per-cycle remote I/O of the downstream PQ-retraining
+     * step, whose cost scales with the number of input segments.
+     *
+     * <p>The value is normalised via {@link VectorIndexCompactor#clampMaxInputs}:
+     * {@code 0} (or negative) disables the cap; {@code 1} is clamped up to 2.
+     * Can be called at any time to re-tune a running store.
+     */
+    public void setCompactionMaxInputs(int maxInputs) {
+        this.vectorIndexCompactionMaxInputs =
+                VectorIndexCompactor.clampMaxInputs(maxInputs);
+    }
+
+    /**
+     * Returns the current compaction input cap (issue #587); {@code 0} means
+     * the cap is disabled.
+     */
+    public int getCompactionMaxInputs() {
+        return vectorIndexCompactionMaxInputs;
+    }
+
+    /**
      * Sets the segment-count back-pressure threshold (issue #354).
      * {@link #addVectorInternal} will block when {@code segments.size()}
      * exceeds this value, waking the compaction thread first.
@@ -2411,7 +2456,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     vectorIndexCompactionMinBytes,
                     effectiveMaxBytes,
                     effectiveMaxCount,
-                    vectorIndexCompactionMicroSegmentMaxNodes);
+                    vectorIndexCompactionMicroSegmentMaxNodes,
+                    // Issue #587: hard cap on input segments per cycle. Deliberately
+                    // NOT tier-scaled — bounding worst-case PQ-retraining I/O is the
+                    // point of the cap, so it stays flat regardless of accumulation.
+                    vectorIndexCompactionMaxInputs);
             if (candidates.isEmpty()) {
                 if (snapshot.size() >= COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD) {
                     LOGGER.log(Level.WARNING,

--- a/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
+++ b/herddb-core/src/main/java/herddb/index/vector/PersistentVectorStore.java
@@ -620,10 +620,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private volatile long vectorIndexCompactionMicroSegmentMaxNodes =
             DEFAULT_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES;
     /**
-     * Hard cap on the number of input segments per compaction cycle (issue
-     * #587). Not scaled by the tiered multiplier — bounding worst-case
-     * per-cycle PQ-retraining I/O is the entire point of the cap. {@code 0}
-     * disables it. Pre-normalised by {@link #setCompactionMaxInputs}.
+     * Base hard cap on the number of input segments per compaction cycle
+     * (issue #587). When tiered compaction is enabled this base value is
+     * tier-scaled (2×/4×/8×) per cycle by {@link VectorIndexCompactor#computeTieredMaxInputs}
+     * so the per-cycle drain rate keeps pace with the backlog and the cap
+     * cannot starve the tailer. {@code 0} disables the cap. Pre-normalised by
+     * {@link #setCompactionMaxInputs}.
      */
     private volatile int vectorIndexCompactionMaxInputs =
             DEFAULT_VECTOR_INDEX_COMPACTION_MAX_INPUTS;
@@ -2435,6 +2437,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // throughput stays proportional to the ingest rate.
             long effectiveMaxBytes = vectorIndexCompactionMaxBytes;
             int effectiveMaxCount = vectorIndexCompactionMaxCount;
+            // Issue #587: the input-segment cap is tier-scaled together with the
+            // byte/count caps so the per-cycle drain rate rises with the backlog
+            // — that is what keeps the flat cap from starving the tailer.
+            int effectiveMaxInputs = vectorIndexCompactionMaxInputs;
             if (vectorIndexCompactionTieredEnabled) {
                 int tier = VectorIndexCompactor.tieredMultiplier(snapshot.size());
                 if (tier > 1) {
@@ -2442,11 +2448,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             snapshot.size(), vectorIndexCompactionMaxBytes);
                     effectiveMaxCount = VectorIndexCompactor.computeTieredMaxCount(
                             snapshot.size(), vectorIndexCompactionMaxCount);
+                    effectiveMaxInputs = VectorIndexCompactor.computeTieredMaxInputs(
+                            snapshot.size(), vectorIndexCompactionMaxInputs);
                     LOGGER.log(Level.INFO,
                             "vector store {0}: tiered compaction — {1} segments → "
-                                    + "effective maxBytes={2} ({3}×), effective maxCount={4} ({3}×)",
+                                    + "effective maxBytes={2} ({3}×), effective maxCount={4} ({3}×),"
+                                    + " effective maxInputs={5} ({3}×)",
                             new Object[]{indexName, snapshot.size(),
-                                    effectiveMaxBytes, tier, effectiveMaxCount});
+                                    effectiveMaxBytes, tier, effectiveMaxCount,
+                                    effectiveMaxInputs});
                 }
             }
 
@@ -2457,10 +2467,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     effectiveMaxBytes,
                     effectiveMaxCount,
                     vectorIndexCompactionMicroSegmentMaxNodes,
-                    // Issue #587: hard cap on input segments per cycle. Deliberately
-                    // NOT tier-scaled — bounding worst-case PQ-retraining I/O is the
-                    // point of the cap, so it stays flat regardless of accumulation.
-                    vectorIndexCompactionMaxInputs);
+                    // Issue #587: hard cap on input segments per cycle, tier-scaled
+                    // above so the drain rate keeps pace with the backlog.
+                    effectiveMaxInputs);
             if (candidates.isEmpty()) {
                 if (snapshot.size() >= COMPACTION_SEGMENT_COUNT_WARN_THRESHOLD) {
                     LOGGER.log(Level.WARNING,

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -305,6 +305,78 @@ final class VectorIndexCompactor {
             long maxTotalBytes,
             int maxCount,
             long microSegmentMaxNodes) {
+        return chooseSegmentsToMerge(candidates, minCount, minTotalBytes,
+                maxTotalBytes, maxCount, microSegmentMaxNodes, /*maxInputs*/ 0);
+    }
+
+    /**
+     * Hard cap on the number of input segments per compaction (issue #587):
+     * value below which a positive {@code maxInputs} is clamped. A single-input
+     * "merge" is degenerate, so any enabled cap is forced to at least 2.
+     *
+     * <p>Package-private for unit tests.
+     */
+    static final int MIN_MAX_INPUTS = 2;
+
+    /**
+     * Normalises a configured {@code maxInputs} value: {@code <= 0} disables the
+     * cap (returns {@code 0}); {@code 1} is clamped up to {@link #MIN_MAX_INPUTS}
+     * because a one-segment merge does no useful work; any larger value is
+     * returned unchanged.
+     *
+     * <p>Package-private for unit tests.
+     */
+    static int clampMaxInputs(int maxInputs) {
+        if (maxInputs <= 0) {
+            return 0;
+        }
+        return Math.max(MIN_MAX_INPUTS, maxInputs);
+    }
+
+    /**
+     * Truncates {@code picked} to at most {@code maxInputs} segments when a
+     * positive cap is configured (issue #587). The list is already sorted
+     * smallest-bytes-first, so truncation keeps the smallest segments — which
+     * maximises the contraction ratio and bounds the per-cycle remote I/O of
+     * the downstream PQ-retraining step (whose cost scales with the number of
+     * input segments). A no-op when the cap is disabled or not exceeded.
+     *
+     * <p>Package-private for unit tests.
+     */
+    static List<VectorSegment> capInputs(List<VectorSegment> picked, int maxInputs) {
+        if (maxInputs > 0 && picked.size() > maxInputs) {
+            LOGGER.log(Level.INFO,
+                    "compaction: capping merge inputs from {0} to {1} segments "
+                            + "(vector.index.compaction.maxInputs); remaining segments "
+                            + "compact in subsequent cycles",
+                    new Object[]{picked.size(), maxInputs});
+            return new ArrayList<>(picked.subList(0, maxInputs));
+        }
+        return picked;
+    }
+
+    /**
+     * Full entry point adding a hard cap on the number of input segments per
+     * compaction cycle (issue #587). See the 6-arg overload for the trigger and
+     * micro-segment semantics — they are unchanged. The cap is applied
+     * <em>after</em> the fire/no-fire decision, so it never changes whether a
+     * cycle compacts, only how many segments a single cycle merges; the
+     * leftover segments are picked up by subsequent cycles.
+     *
+     * <p>Package-private for unit tests.
+     *
+     * @param maxInputs maximum number of input segments a single compaction
+     *     cycle may merge; {@code 0} (or negative) disables the cap. Values are
+     *     expected to be pre-normalised via {@link #clampMaxInputs}.
+     */
+    static List<VectorSegment> chooseSegmentsToMerge(
+            List<VectorSegment> candidates,
+            int minCount,
+            long minTotalBytes,
+            long maxTotalBytes,
+            int maxCount,
+            long microSegmentMaxNodes,
+            int maxInputs) {
         if (candidates == null || candidates.size() < minCount) {
             return new ArrayList<>();
         }
@@ -363,10 +435,10 @@ final class VectorIndexCompactor {
                 microTotal += seg.estimatedSizeBytes;
             }
             if (microPicked.size() >= 2) {
-                return microPicked;
+                return capInputs(microPicked, maxInputs);
             }
         }
-        return picked;
+        return capInputs(picked, maxInputs);
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
+++ b/herddb-core/src/main/java/herddb/index/vector/VectorIndexCompactor.java
@@ -363,11 +363,29 @@ final class VectorIndexCompactor {
      * cycle compacts, only how many segments a single cycle merges; the
      * leftover segments are picked up by subsequent cycles.
      *
+     * <p><b>The cap does NOT apply to the micro-segment fast path (#570).</b>
+     * The fast path exists to reclaim segment-count slots <em>quickly</em>
+     * under memory-pressure checkpoint storms; micro-segment merges are cheap
+     * by construction (bounded by {@code microSegmentMaxNodes} live nodes), so
+     * the PQ-retraining-I/O concern that motivates the cap does not apply to
+     * them, and capping the fast path would directly throttle the back-pressure
+     * relief valve. The cap therefore truncates only the normal byte-capped
+     * selection.
+     *
+     * <p><b>Starvation safety.</b> The caller
+     * ({@link PersistentVectorStore#runCompactionCycle}) tier-scales
+     * {@code maxInputs} via {@link #computeTieredMaxInputs} exactly as it scales
+     * {@code maxTotalBytes} and {@code maxCount} (issue #354), so the per-cycle
+     * drain rate rises with the backlog. A flat cap therefore cannot starve the
+     * tailer: by the time the segment count approaches the back-pressure
+     * threshold the effective cap has scaled up with it.
+     *
      * <p>Package-private for unit tests.
      *
      * @param maxInputs maximum number of input segments a single compaction
      *     cycle may merge; {@code 0} (or negative) disables the cap. Values are
-     *     expected to be pre-normalised via {@link #clampMaxInputs}.
+     *     expected to be pre-normalised via {@link #clampMaxInputs} and, where
+     *     tiered scaling is enabled, already tier-scaled by the caller.
      */
     static List<VectorSegment> chooseSegmentsToMerge(
             List<VectorSegment> candidates,
@@ -435,7 +453,10 @@ final class VectorIndexCompactor {
                 microTotal += seg.estimatedSizeBytes;
             }
             if (microPicked.size() >= 2) {
-                return capInputs(microPicked, maxInputs);
+                // Deliberately NOT capped — see method javadoc: the
+                // micro-segment fast path must stay a fast slot-reclaiming
+                // cycle (issue #570).
+                return microPicked;
             }
         }
         return capInputs(picked, maxInputs);
@@ -510,6 +531,37 @@ final class VectorIndexCompactor {
             return Integer.MAX_VALUE;
         }
         return baseMaxCount * multiplier;
+    }
+
+    /**
+     * Returns the effective per-cycle input-segment cap (issue #587) after
+     * applying the tiered scaling factor for {@code totalSegmentCount}.
+     *
+     * <p>Tier-scaling the cap is what makes it starvation-safe: the per-cycle
+     * drain rate rises with the backlog (2×/4×/8× at 100/300/500 segments),
+     * mirroring {@link #computeTieredMaxCount}, so the cap can never let the
+     * segment count grow unboundedly toward the back-pressure threshold while
+     * still bounding worst-case per-cycle PQ-retraining I/O at each tier.
+     *
+     * <p>A disabled cap ({@code baseMaxInputs <= 0}) is returned unchanged so
+     * it stays disabled. The result is capped at {@link Integer#MAX_VALUE} to
+     * avoid overflow.
+     *
+     * <p>Package-private for unit tests.
+     */
+    static int computeTieredMaxInputs(int totalSegmentCount, int baseMaxInputs) {
+        if (baseMaxInputs <= 0) {
+            return baseMaxInputs;
+        }
+        int multiplier = tieredMultiplier(totalSegmentCount);
+        if (multiplier == 1) {
+            return baseMaxInputs;
+        }
+        // Guard against overflow.
+        if (baseMaxInputs > Integer.MAX_VALUE / multiplier) {
+            return Integer.MAX_VALUE;
+        }
+        return baseMaxInputs * multiplier;
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/index/vector/Issue354TieredCompactionTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue354TieredCompactionTest.java
@@ -168,6 +168,10 @@ public class Issue354TieredCompactionTest {
         store.setTieredCompactionEnabled(true);
         // Disable backpressure so we can build lots of segments freely.
         store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+        // Disable the issue #587 input-count cap: it is orthogonal to tiered
+        // scaling, and this test verifies that tiered fan-in lets a cycle merge
+        // more than the un-tiered backlog in one shot.
+        store.setCompactionMaxInputs(0);
 
         try (store) {
             store.start();
@@ -246,6 +250,10 @@ public class Issue354TieredCompactionTest {
                 /*retentionMs*/ 0);
         store.setTieredCompactionEnabled(false);
         store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+        // Disable the issue #587 input-count cap so the whole backlog drains in
+        // one cycle, as this test's premise (below) requires. The cap is
+        // exercised separately by VectorIndexCompactorChooseTest.
+        store.setCompactionMaxInputs(0);
 
         try (store) {
             store.start();

--- a/herddb-core/src/test/java/herddb/index/vector/Issue354TieredCompactionTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue354TieredCompactionTest.java
@@ -125,6 +125,32 @@ public class Issue354TieredCompactionTest {
         assertEquals("should cap at Integer.MAX_VALUE on overflow", Integer.MAX_VALUE, result);
     }
 
+    @Test
+    public void tieredMaxInputsScalesCorrectly() {
+        // Issue #587: the input cap is tier-scaled like the byte/count caps so
+        // the per-cycle drain rate keeps pace with the backlog.
+        int base = 16;
+        assertEquals(base, VectorIndexCompactor.computeTieredMaxInputs(50, base));
+        assertEquals(base * 2, VectorIndexCompactor.computeTieredMaxInputs(100, base));
+        assertEquals(base * 4, VectorIndexCompactor.computeTieredMaxInputs(300, base));
+        assertEquals(base * 8, VectorIndexCompactor.computeTieredMaxInputs(500, base));
+    }
+
+    @Test
+    public void tieredMaxInputsDoesNotOverflow() {
+        int nearMax = Integer.MAX_VALUE / 8 + 1;
+        int result = VectorIndexCompactor.computeTieredMaxInputs(500, nearMax);
+        assertEquals("should cap at Integer.MAX_VALUE on overflow", Integer.MAX_VALUE, result);
+    }
+
+    @Test
+    public void tieredMaxInputsKeepsDisabledCapDisabled() {
+        // A disabled cap (0) must stay 0 at every tier — never scaled into a
+        // positive (active) cap.
+        assertEquals(0, VectorIndexCompactor.computeTieredMaxInputs(50, 0));
+        assertEquals(0, VectorIndexCompactor.computeTieredMaxInputs(500, 0));
+    }
+
     // -------------------------------------------------------------------------
     // Integration test: tiered compaction merges more segments when count is high
     // -------------------------------------------------------------------------

--- a/herddb-core/src/test/java/herddb/index/vector/Issue587CompactionInputCapTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/Issue587CompactionInputCapTest.java
@@ -1,0 +1,162 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.index.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end test for issue #587: the per-cycle input-segment cap must bound
+ * how many segments a single compaction cycle merges <em>without</em> starving
+ * compaction — successive cycles must keep draining the backlog until it
+ * converges.
+ *
+ * <p>This is the multi-cycle counterpart to {@link VectorIndexCompactorChooseTest},
+ * which only exercises the {@code chooseSegmentsToMerge} selection in isolation.
+ * Here the cap is left at its default-enabled value (16) and a real
+ * {@link PersistentVectorStore} drives several compaction cycles, proving that:
+ * <ul>
+ *   <li>every cycle merges at most the (tier-scaled) cap of input segments, and</li>
+ *   <li>the segment count strictly decreases on every compacting cycle and the
+ *       backlog converges — i.e. the cap cannot let the segment count grow
+ *       unboundedly toward the back-pressure threshold.</li>
+ * </ul>
+ */
+public class Issue587CompactionInputCapTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Before
+    public void disableDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreDeferral() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+    }
+
+    @Test
+    public void compactionDrainsBacklogAcrossCyclesWithCapEnabled() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("issue-587-cap").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        // Large cache to avoid the MemoryDataStorageManager namespace collision
+        // documented in Issue354TieredCompactionTest.
+        MemoryManager mm = new MemoryManager(2048L * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore store = new PersistentVectorStore(
+                "testidx587", "testtable", "tstblspace", "vec",
+                tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+        store.configureCompaction(
+                /*intervalMs*/ Long.MAX_VALUE,
+                /*minBytes*/ 1L,                  // byte trigger fires immediately
+                /*maxBytes*/ Long.MAX_VALUE,      // never byte-limited
+                /*minCount*/ 2,
+                /*maxCount*/ Integer.MAX_VALUE,   // isolate the byte trigger
+                /*retentionMs*/ 0);
+        store.setTieredCompactionEnabled(true);
+        // Disable backpressure so the backlog can be built freely; the test
+        // then proves the cap drains it without relying on back-pressure.
+        store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+        // Disable the micro-segment fast path: this test's tiny checkpoints
+        // would otherwise all be micro-segments and take the (uncapped, by
+        // design) #570 fast path. The incident in #587 merged large segments
+        // via the normal path, which is the path the cap targets.
+        store.setCompactionMicroSegmentMaxNodes(0);
+        // Leave the input cap at its default-enabled value — this is the whole
+        // point of the test.
+        assertEquals("cap must be enabled by default",
+                PersistentVectorStore.DEFAULT_VECTOR_INDEX_COMPACTION_MAX_INPUTS,
+                store.getCompactionMaxInputs());
+        final int cap = store.getCompactionMaxInputs();
+
+        try (store) {
+            store.start();
+            Random rng = new Random(587);
+            int dim = 8;
+
+            // Build 50 on-disk segments — well above the cap of 16, but below
+            // the tier-1 threshold (100) so the effective cap stays flat at 16
+            // and the test exercises the strict multi-cycle drain.
+            int numCheckpoints = 50;
+            for (int c = 0; c < numCheckpoints; c++) {
+                for (int i = 0; i < 5; i++) {
+                    float[] vec = new float[dim];
+                    for (int d = 0; d < dim; d++) {
+                        vec[d] = rng.nextFloat();
+                    }
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec);
+                }
+                store.checkpoint();
+            }
+
+            int segments = store.getSegmentCount();
+            assertTrue("expected a backlog well above the cap, got " + segments,
+                    segments > cap);
+
+            int compactingCycles = 0;
+            long successes = store.getCompactionSuccessesTotal();
+            // Drive cycles until the backlog is drained. The bound (60) is far
+            // above the ~4 cycles a correct implementation needs; exhausting it
+            // means the cap starved compaction — a test failure.
+            for (int cycle = 0; cycle < 60 && store.getSegmentCount() > 3; cycle++) {
+                int before = store.getSegmentCount();
+                store.runCompactionCycle();
+                int after = store.getSegmentCount();
+
+                long successesNow = store.getCompactionSuccessesTotal();
+                if (successesNow > successes) {
+                    // A compaction actually ran this cycle.
+                    successes = successesNow;
+                    compactingCycles++;
+                    long merged = store.getCompactionLastInputSegments();
+                    assertTrue("each cycle must merge at most the cap (" + cap
+                                    + ") input segments; merged=" + merged,
+                            merged <= cap);
+                    assertTrue("a compacting cycle must merge at least 2 inputs; merged="
+                                    + merged, merged >= 2);
+                    assertTrue("segment count must strictly decrease on a compacting "
+                                    + "cycle: " + before + " -> " + after,
+                            after < before);
+                }
+            }
+
+            assertTrue("backlog must converge below the cap; got "
+                            + store.getSegmentCount(),
+                    store.getSegmentCount() <= cap);
+            assertTrue("a >cap backlog must take several capped cycles to drain; "
+                            + "compactingCycles=" + compactingCycles,
+                    compactingCycles >= 2);
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorChooseTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorChooseTest.java
@@ -36,6 +36,12 @@ public class VectorIndexCompactorChooseTest {
         return s;
     }
 
+    private static VectorSegment seg(int id, long sizeBytes, int liveNodes) {
+        VectorSegment s = seg(id, sizeBytes);
+        s.liveCount.set(liveNodes);
+        return s;
+    }
+
     @Test
     public void belowMinCountYieldsEmpty() {
         List<VectorSegment> cand = new ArrayList<>();
@@ -179,5 +185,113 @@ public class VectorIndexCompactorChooseTest {
             assertTrue("no huge segment should be in the result",
                     s.estimatedSizeBytes <= 10L);
         }
+    }
+
+    // ---- Tests for the input-count cap (issue #587) ----
+
+    /**
+     * With a positive {@code maxInputs}, a picked set larger than the cap is
+     * truncated to exactly {@code maxInputs} segments, keeping the smallest
+     * (the list is sorted smallest-bytes-first).
+     */
+    @Test
+    public void maxInputsTruncatesPickedSmallestFirst() {
+        List<VectorSegment> cand = new ArrayList<>();
+        // 53 segments — the incident's candidate count. Size == id so the
+        // smallest-first sort yields ids 1..53 in ascending order.
+        for (int i = 1; i <= 53; i++) {
+            cand.add(seg(i, i));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 4, /*minBytes*/ 1L, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE, /*microSegmentMaxNodes*/ 0L,
+                /*maxInputs*/ 16);
+        assertEquals("picked set must be truncated to maxInputs", 16, picked.size());
+        for (int i = 0; i < 16; i++) {
+            assertEquals("must keep the 16 smallest segments, in order",
+                    i + 1, picked.get(i).segmentId);
+        }
+    }
+
+    /**
+     * {@code maxInputs == 0} disables the cap: the full byte-capped selection
+     * is returned even when it is very large.
+     */
+    @Test
+    public void maxInputsZeroDisablesCap() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 1; i <= 53; i++) {
+            cand.add(seg(i, i));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 4, /*minBytes*/ 1L, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE, /*microSegmentMaxNodes*/ 0L,
+                /*maxInputs*/ 0);
+        assertEquals("disabled cap must return the full selection", 53, picked.size());
+    }
+
+    /**
+     * The cap is applied AFTER the fire/no-fire decision: it never makes a
+     * non-compacting cycle compact, and never suppresses a cycle that the
+     * triggers would fire. Here the count trigger fires on 20 segments and the
+     * cap merely limits how many of them this cycle merges.
+     */
+    @Test
+    public void maxInputsDoesNotChangeTriggerDecision() {
+        // Below minCount: no trigger — cap must not resurrect the cycle.
+        List<VectorSegment> tooFew = new ArrayList<>();
+        tooFew.add(seg(1, 100L));
+        tooFew.add(seg(2, 100L));
+        assertTrue(VectorIndexCompactor.chooseSegmentsToMerge(
+                tooFew, /*minCount*/ 4, /*minBytes*/ 1L, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE, /*microSegmentMaxNodes*/ 0L,
+                /*maxInputs*/ 16).isEmpty());
+
+        // Count trigger fires (20 >= maxCount 10) although bytes are tiny;
+        // the cap then limits the merge to 16 of the 20 segments.
+        List<VectorSegment> many = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            many.add(seg(i, i));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                many, /*minCount*/ 2, /*minBytes*/ 1L * 1024 * 1024,
+                /*maxBytes*/ Long.MAX_VALUE, /*maxCount*/ 10,
+                /*microSegmentMaxNodes*/ 0L, /*maxInputs*/ 16);
+        assertEquals("count trigger fires, capped to maxInputs", 16, picked.size());
+    }
+
+    /**
+     * The cap also applies to the micro-segment fast-path result (issue #570):
+     * a large set of micro-segments is truncated to {@code maxInputs}.
+     */
+    @Test
+    public void maxInputsCapsMicroSegmentPath() {
+        List<VectorSegment> cand = new ArrayList<>();
+        // 30 micro-segments (liveCount 10 << microSegmentMaxNodes 1000).
+        for (int i = 1; i <= 30; i++) {
+            cand.add(seg(i, i, /*liveNodes*/ 10));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1L, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ 10, /*microSegmentMaxNodes*/ 1000L, /*maxInputs*/ 16);
+        assertEquals("micro-segment fast path result must also be capped",
+                16, picked.size());
+        for (VectorSegment s : picked) {
+            assertTrue("micro path must merge only micro-segments", s.size() < 1000L);
+        }
+    }
+
+    /**
+     * {@link VectorIndexCompactor#clampMaxInputs} normalises configured values:
+     * non-positive disables (0); 1 is clamped up to 2; larger values pass
+     * through.
+     */
+    @Test
+    public void clampMaxInputsBehaviour() {
+        assertEquals(0, VectorIndexCompactor.clampMaxInputs(0));
+        assertEquals(0, VectorIndexCompactor.clampMaxInputs(-5));
+        assertEquals(2, VectorIndexCompactor.clampMaxInputs(1));
+        assertEquals(2, VectorIndexCompactor.clampMaxInputs(2));
+        assertEquals(16, VectorIndexCompactor.clampMaxInputs(16));
     }
 }

--- a/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorChooseTest.java
+++ b/herddb-core/src/test/java/herddb/index/vector/VectorIndexCompactorChooseTest.java
@@ -261,11 +261,13 @@ public class VectorIndexCompactorChooseTest {
     }
 
     /**
-     * The cap also applies to the micro-segment fast-path result (issue #570):
-     * a large set of micro-segments is truncated to {@code maxInputs}.
+     * The cap deliberately does NOT apply to the micro-segment fast path
+     * (issue #570): that path must stay a fast slot-reclaiming cycle, so a
+     * large set of micro-segments is returned in full even when it exceeds
+     * {@code maxInputs}.
      */
     @Test
-    public void maxInputsCapsMicroSegmentPath() {
+    public void microSegmentPathIsNotCapped() {
         List<VectorSegment> cand = new ArrayList<>();
         // 30 micro-segments (liveCount 10 << microSegmentMaxNodes 1000).
         for (int i = 1; i <= 30; i++) {
@@ -274,11 +276,30 @@ public class VectorIndexCompactorChooseTest {
         List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
                 cand, /*minCount*/ 2, /*minBytes*/ 1L, /*maxBytes*/ Long.MAX_VALUE,
                 /*maxCount*/ 10, /*microSegmentMaxNodes*/ 1000L, /*maxInputs*/ 16);
-        assertEquals("micro-segment fast path result must also be capped",
-                16, picked.size());
+        assertEquals("micro-segment fast path must NOT be capped by maxInputs",
+                30, picked.size());
         for (VectorSegment s : picked) {
             assertTrue("micro path must merge only micro-segments", s.size() < 1000L);
         }
+    }
+
+    /**
+     * When the picked set is already at or below {@code maxInputs}, the cap is
+     * a no-op and the full selection is returned (covers the
+     * {@code maxInputs >= picked.size()} branch of {@code capInputs}).
+     */
+    @Test
+    public void maxInputsNoOpWhenPickedFitsUnderCap() {
+        List<VectorSegment> cand = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            cand.add(seg(i, i));
+        }
+        List<VectorSegment> picked = VectorIndexCompactor.chooseSegmentsToMerge(
+                cand, /*minCount*/ 2, /*minBytes*/ 1L, /*maxBytes*/ Long.MAX_VALUE,
+                /*maxCount*/ Integer.MAX_VALUE, /*microSegmentMaxNodes*/ 0L,
+                /*maxInputs*/ 16);
+        assertEquals("a picked set within the cap must be returned untruncated",
+                5, picked.size());
     }
 
     /**

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -297,9 +297,12 @@ public final class IndexingServerConfiguration {
      * cost scales with the input count — an unbounded selection of small
      * segments can stall a cycle for hours. Compaction still fires on the same
      * triggers; it merges at most this many segments per cycle (smallest-first)
-     * and the rest are merged by subsequent cycles. Unlike the byte/count caps,
-     * this cap is <em>not</em> tier-scaled — bounding worst-case per-cycle I/O
-     * is its purpose. Default is {@code 16}. Set to {@code 0} to disable.
+     * and the rest are merged by subsequent cycles. Like the byte/count caps,
+     * this base value is tier-scaled (2×/4×/8× at 100/300/500 segments) when
+     * tiered compaction is enabled, so the per-cycle drain rate keeps pace with
+     * the backlog and the cap cannot starve the tailer. The cap never applies
+     * to the micro-segment fast path. Default is {@code 16}. Set to {@code 0}
+     * to disable.
      */
     public static final String PROPERTY_VECTOR_INDEX_COMPACTION_MAX_INPUTS =
             "vector.index.compaction.maxInputs";

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -291,6 +291,21 @@ public final class IndexingServerConfiguration {
             1000L;
 
     /**
+     * Hard cap on the number of input segments a single compaction cycle may
+     * merge (issue #587). The downstream PQ-retraining step samples training
+     * vectors per input segment with random remote-storage reads, so its I/O
+     * cost scales with the input count — an unbounded selection of small
+     * segments can stall a cycle for hours. Compaction still fires on the same
+     * triggers; it merges at most this many segments per cycle (smallest-first)
+     * and the rest are merged by subsequent cycles. Unlike the byte/count caps,
+     * this cap is <em>not</em> tier-scaled — bounding worst-case per-cycle I/O
+     * is its purpose. Default is {@code 16}. Set to {@code 0} to disable.
+     */
+    public static final String PROPERTY_VECTOR_INDEX_COMPACTION_MAX_INPUTS =
+            "vector.index.compaction.maxInputs";
+    public static final int PROPERTY_VECTOR_INDEX_COMPACTION_MAX_INPUTS_DEFAULT = 16;
+
+    /**
      * How long old segment files remain on-disk after a compaction swap
      * before the reaper may physically delete them. Also gated by
      * {@code shadowAckedGeneration}: reclaim waits for the later of the

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -795,6 +795,10 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES,
                     IndexingServerConfiguration
                             .PROPERTY_VECTOR_INDEX_COMPACTION_MICROSEGMENT_MAX_NODES_DEFAULT);
+            // Hard cap on input segments per compaction cycle (issue #587).
+            final int vectorCompactionMaxInputs = config.getInt(
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MAX_INPUTS,
+                    IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_MAX_INPUTS_DEFAULT);
             final boolean vectorCompactionTieredEnabled = config.getBoolean(
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_TIERED_ENABLED,
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_TIERED_ENABLED_DEFAULT);
@@ -831,13 +835,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                     "vector index compaction: tieredEnabled={0}, backpressureSegments={1}, "
                             + "backpressureMaxWaitMs={2}, localKickFraction={3},"
                             + " localEnabledWithOptimizer={4}, streamingEnabled={5},"
-                            + " microSegmentMaxNodes={6}",
+                            + " microSegmentMaxNodes={6}, maxInputs={7}",
                     new Object[]{vectorCompactionTieredEnabled, vectorCompactionBackpressureSegments,
                             vectorCompactionBackpressureMaxWaitMs,
                             vectorCompactionLocalKickFraction,
                             vectorCompactionLocalEnabledWithOptimizer,
                             vectorCompactionStreamingEnabled,
-                            vectorCompactionMicroSegmentMaxNodes});
+                            vectorCompactionMicroSegmentMaxNodes,
+                            vectorCompactionMaxInputs});
             // Async IO pipeline for FusedPQ search (issue #547).
             // Config key takes precedence over the system property.
             final boolean vectorSearchAsyncPipelineEnabled = config.getBoolean(
@@ -950,6 +955,7 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                         vectorCompactionRetentionMs);
                 store.setTieredCompactionEnabled(vectorCompactionTieredEnabled);
                 store.setCompactionMicroSegmentMaxNodes(vectorCompactionMicroSegmentMaxNodes);
+                store.setCompactionMaxInputs(vectorCompactionMaxInputs);
                 store.setCompactionBackpressureThreshold(vectorCompactionBackpressureSegments);
                 store.setCompactionBackpressureMaxWaitMs(vectorCompactionBackpressureMaxWaitMs);
                 store.setLocalCompactionKickFraction(vectorCompactionLocalKickFraction);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/OptimizerMergeAdoptionRecallTest.java
@@ -312,12 +312,19 @@ public class OptimizerMergeAdoptionRecallTest {
                 // ---------------------------------------------------------------
                 // Wait for watcher events to propagate and the store to settle to
                 // exactly 1 on-disk segment (the merged output) with at least 1
-                // successful adoption. Both conditions must be met: just reaching
-                // count==1 via drops alone (e.g. 2 drops out of 3) is insufficient.
+                // successful adoption and all 3 deprecated segments dropped.
+                //
+                // The drops>=3 condition is required, not just count==1: the
+                // onSegmentReleased callback calls store.dropSegmentByUuid()
+                // (which decrements the on-disk count) BEFORE drops.incrementAndGet(),
+                // so on a slow runner this loop could otherwise observe count==1
+                // after the 3rd drop's dropSegmentByUuid() but before its counter
+                // increment, exit early, and fail the drops>=3 assertion.
                 // ---------------------------------------------------------------
                 long deadline = System.currentTimeMillis() + 30_000L;
                 while (System.currentTimeMillis() < deadline
-                        && (store.getOnDiskSegmentCount() != 1 || adoptions.get() < 1)) {
+                        && (store.getOnDiskSegmentCount() != 1 || adoptions.get() < 1
+                                || drops.get() < 3)) {
                     Thread.sleep(20);
                 }
 


### PR DESCRIPTION
Fixes #587.

A vector-index compaction cycle that selected **53 input segments** stalled the Indexing Service for 2+ hours. The downstream PQ-retraining step (jvector `PQRetrainer.extractVectorsSequential`) samples training vectors per input segment with random remote-storage reads, so its I/O cost scales with the number of input segments. `VectorIndexCompactor.chooseSegmentsToMerge` bounded the picked set only by a byte cap, which never bites when many segments are individually small — leaving the input count effectively unbounded.

This PR is the **HerdDB-side mitigation**. The complementary jvector-side fix (parallelizing the per-source extraction so the per-read latency is hidden) is in **eolivelli/jvector#12**. The two changes are independent — HerdDB CI builds jvector from `eolivelli/jvector` `main` and is unaffected by the jvector PR's merge state — but full latency relief needs both.

## Changes
- `VectorIndexCompactor` — new 7-arg `chooseSegmentsToMerge` overload with a `maxInputs` parameter (6-arg overload delegates with the cap disabled). After the fire/no-fire trigger decision, the normal byte-capped selection is truncated smallest-first to at most `maxInputs` segments, with an INFO log when truncation happens. The micro-segment fast path (#570) is **deliberately exempt** — those cycles must stay fast slot-reclaiming merges and the PQ-retraining-I/O concern does not apply to them. Added `clampMaxInputs` (`<=0` disables, `1`→`2`) and `computeTieredMaxInputs`.
- `PersistentVectorStore` — `DEFAULT_VECTOR_INDEX_COMPACTION_MAX_INPUTS = 16`, a `vectorIndexCompactionMaxInputs` field, `setCompactionMaxInputs`/`getCompactionMaxInputs`. The base cap is **tier-scaled** (2×/4×/8× at 100/300/500 segments) per cycle alongside the byte/count caps, so the per-cycle drain rate rises with the backlog and the cap cannot starve the tailer toward the back-pressure threshold. The cycle still fires on the same triggers and merges leftover segments in subsequent cycles.
- `IndexingServerConfiguration` / `IndexingServiceEngine` — new `vector.index.compaction.maxInputs` config key (default 16), wired into the store and the startup config log.

## Tests
- `VectorIndexCompactorChooseTest` — new cases: a 53-segment pick is truncated to the 16 smallest in order; `maxInputs=0` disables the cap; the cap never changes the fire/no-fire trigger decision; a picked set within the cap is returned untruncated; the micro-segment fast-path result is **not** capped; `clampMaxInputs` normalisation.
- `Issue587CompactionInputCapTest` — new end-to-end test: builds a 50-segment backlog with the cap enabled at its default, drives multiple compaction cycles, and asserts every cycle merges at most the cap and the segment count strictly converges (no starvation).
- `Issue354TieredCompactionTest` — new `computeTieredMaxInputs` unit tests (scaling, overflow, disabled-cap); the two end-to-end tiered tests disable the orthogonal input cap so their "drain the whole backlog in one cycle" premise still holds.
- Pre-PR validation green: `spotless:check apache-rat:check install -DskipTests spotbugs:check -Pci` (the exact CI gate).
- Hammer suite green (twice): `DirectMultipleConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test`, `BLinkConcurrentSearchInsertTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)