### PR TITLE
issue #592: exclude BLink from estimatedInMemoryBytes() to fix spurious back-pressure

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -409,12 +409,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * <p>Each segment's contribution is captured as a snapshot at registration
      * time and stored on the segment in
      * {@link VectorSegment#cachedEstimatedInMemoryBytes}, so the same value can
-     * later be subtracted on unregistration even if the segment's underlying
-     * BLink page-cache or pkData arrays have shifted in between.  Subsequent
-     * BLink page loads/evictions are not reflected in this counter; the BLink
-     * page-cache footprint is bounded by the {@link MemoryManager}'s global
-     * index-page replacement policy budget, which the back-pressure code
-     * already enforces independently.
+     * later be subtracted on unregistration.  The snapshot covers only the
+     * pkData / pkOffsets / pkLengths heap arrays (≈16 B/vector for BIGINT PKs);
+     * the BLink pk-to-ordinal tree is intentionally excluded because its
+     * loaded-page footprint is already bounded by the {@link MemoryManager}'s
+     * global index-page replacement policy budget, which the back-pressure code
+     * enforces independently (issue #592).
      */
     private final AtomicLong onDiskSegmentsEstimatedMemoryBytes = new AtomicLong(0);
 
@@ -4686,22 +4686,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
      *   <li>pkToNode + nodeToPk ConcurrentHashMap entries (~100 bytes per entry × 2)</li>
      *   <li>Bytes PK objects (~50 bytes average)</li>
      *   <li>On-disk segments' in-memory footprint (pkData / pkOffsets / pkLengths
-     *       arrays plus the BLink pk-to-ordinal tree, issue #360) — read in
-     *       O(1) from {@link #onDiskSegmentsEstimatedMemoryBytes}, an
-     *       incrementally-maintained counter populated by
+     *       arrays only, ≈16 B/vector for BIGINT PKs) — read in O(1) from
+     *       {@link #onDiskSegmentsEstimatedMemoryBytes}, an incrementally-
+     *       maintained counter populated by
      *       {@link #registerSegmentMemoryEstimate} at every mutation of
-     *       {@link #segments} (issue #455).</li>
+     *       {@link #segments} (issue #455).  The BLink pk-to-ordinal tree is
+     *       intentionally excluded: its page-cache footprint is bounded by the
+     *       {@link MemoryManager}'s index-page replacement policy independently,
+     *       and including it caused permanent over-counting that triggered
+     *       spurious back-pressure stalls (issue #592).</li>
      * </ul>
-     *
-     * <p><strong>Snapshot semantics for the on-disk-segment portion.</strong>
-     * Each segment's contribution is captured as a snapshot at registration
-     * time, so subsequent BLink page-cache loads/evictions on already-
-     * registered segments are not reflected here.  Callers using this value
-     * for diagnostics should be aware that it tracks the static pkData /
-     * pkOffsets / pkLengths arrays exactly but only the registration-time
-     * snapshot of the dynamic BLink page-cache footprint; the live BLink
-     * footprint is bounded independently by the {@link MemoryManager} index
-     * page-replacement policy.
      */
     @Override
     public long estimatedMemoryUsageBytes() {
@@ -4729,7 +4723,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
     /**
      * Returns the estimated heap footprint of the in-memory HNSW shards only —
      * the live, frozen, and deferred {@link LiveGraphShard} graphs — excluding
-     * the on-disk segment pkData/pkOffsets/pkLengths/BLink contribution that
+     * the on-disk segment pkData/pkOffsets/pkLengths contribution that
      * {@link #estimatedMemoryUsageBytes()} additionally counts.
      *
      * <p>Issue #563: this is the figure that genuinely shrinks when a
@@ -4765,8 +4759,8 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     /**
      * Returns the in-memory footprint of all currently registered on-disk
-     * {@link VectorSegment} objects (pkData/pkOffsets/pkLengths arrays plus
-     * the BLink pk-to-ordinal tree, snapshotted at segment registration time).
+     * {@link VectorSegment} objects (pkData/pkOffsets/pkLengths arrays only,
+     * ≈16 B/vector for BIGINT PKs; BLink is excluded — see issue #592).
      *
      * <p>Exposed for testing so that tests can assert the on-disk segment
      * contribution separately from the live-shard contribution, which is
@@ -4801,10 +4795,11 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * on the segment in {@link VectorSegment#cachedEstimatedInMemoryBytes},
      * marks {@link VectorSegment#registeredInMemoryCounter}, and adds the
      * snapshot to {@link #onDiskSegmentsEstimatedMemoryBytes}.  Must be called
-     * exactly once per segment, after pkData/pkOffsets/pkLengths and the BLink
-     * have been populated (i.e. after {@code loadFusedPQSegment}), while the
-     * caller holds {@code stateLock.writeLock()} (or, for the load path, while
-     * no other thread can observe the store yet).
+     * exactly once per segment, after pkData/pkOffsets/pkLengths have been
+     * populated (i.e. after {@code loadFusedPQSegment}), while the caller
+     * holds {@code stateLock.writeLock()} (or, for the load path, while no
+     * other thread can observe the store yet).  The snapshot covers only
+     * pkData/pkOffsets/pkLengths; BLink is excluded (issue #592).
      *
      * <p>If the segment is already registered the call is a no-op so retry
      * paths cannot double-count.  The {@code registeredInMemoryCounter} flag
@@ -4859,13 +4854,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * counter is compared (issue #455 — a missed register/unregister at any
      * future mutation site would cause the two values to diverge).
      *
-     * <p>The values may differ if the BLink page cache of an already-
-     * registered segment has loaded or evicted pages since registration; the
-     * tests only invoke this at clean lifecycle points where no such drift
-     * can occur (immediately after {@code start}, after a {@code checkpoint},
-     * after {@code runCompactionCycle}, after {@code reloadFromStatus}, and
-     * after the all-deleted checkpoint that resets {@code segments} to
-     * empty).
+     * <p>Since BLink is intentionally excluded from
+     * {@link VectorSegment#estimatedInMemoryBytes()} (issue #592), the counter
+     * and the iterated sum are always consistent: both count only the stable
+     * pkData/pkOffsets/pkLengths arrays, which do not change after registration.
      *
      * @return iterated sum of {@code seg.estimatedInMemoryBytes()} across
      *         the current segment list

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -5853,9 +5853,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
             //
             // Capture snapshots BEFORE publishing newSegments: if any
             // estimatedInMemoryBytes() call were ever to throw (e.g. an
-            // unforeseen failure inside BLink.getUsedMemory()), unwinding
-            // before the publish leaves both this.segments and the counter
-            // consistent — no half-updated-counter window.
+            // unforeseen runtime failure), unwinding before the publish
+            // leaves both this.segments and the counter consistent —
+            // no half-updated-counter window.
             //
             // Issue #538 pr-reviewer pass-4: ordering is now `reapply →
             // register → publish`, so a throw in the reapply above also

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorSegment.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorSegment.java
@@ -423,7 +423,8 @@ class VectorSegment implements Closeable {
      * (e.g. before the segment is fully loaded) contribute 0.
      *
      * @return estimated bytes of heap occupied by this segment's pkData /
-     *         pkOffsets / pkLengths arrays (~16 B/vector for BIGINT PKs)
+     *         pkOffsets / pkLengths arrays (~12 B/vector for 4-byte INT PKs,
+     *         ~16 B/vector for 8-byte BIGINT PKs)
      */
     long estimatedInMemoryBytes() {
         long bytes = 0;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorSegment.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorSegment.java
@@ -394,29 +394,36 @@ class VectorSegment implements Closeable {
     /**
      * Estimates the heap memory currently held by this on-disk segment.
      *
-     * <p>Accounts for three components that are completely absent from the
+     * <p>Accounts for the two components that are completely absent from the
      * live-shard estimate in {@code PersistentVectorStore.estimatedMemoryUsageBytes()}:
      * <ol>
      *   <li>{@link #pkData} — byte array with all PKs packed end-to-end.</li>
      *   <li>{@link #pkOffsets} / {@link #pkLengths} — parallel {@code int[]}
      *       arrays mapping ordinal → offset/length inside {@code pkData}.</li>
-     *   <li>{@link #onDiskPkToNode} — pk-to-ordinal {@link BLink} tree whose
-     *       internal BLink Node structures are the single largest contributor
-     *       to the unaccounted heap gap (issue #360).  BLink already tracks
-     *       its loaded-page memory in {@link BLink#getUsedMemory()}.</li>
      * </ol>
      *
-     * <p>Note: {@link #onDiskGraph} upper HNSW layers are intentionally excluded.
-     * {@code OnDiskGraphIndex.ramBytesUsed()} iterates the in-memory neighbor maps
-     * with no result caching; including it would add O(segments × upper-layer-nodes)
-     * work to every {@code addVector} call via the back-pressure hot path.
-     * The three components above (pkData + BLink) already account for the primary
-     * 5–6 GiB unaccounted gap observed in the GKE BIGANN benchmark.
+     * <p>{@link #onDiskPkToNode} (BLink pk-to-ordinal tree) is intentionally
+     * excluded.  Its loaded-page footprint is already bounded by the
+     * {@link herddb.core.MemoryManager}'s global index-page replacement policy
+     * budget, which the back-pressure code enforces independently.  Including
+     * BLink's {@code getUsedMemory()} here would double-count its contribution:
+     * the snapshot taken at segment registration remains at the peak value
+     * (all pages loaded) while the MemoryManager freely evicts pages afterwards,
+     * causing {@code onDiskSegmentsEstimatedMemoryBytes} to be permanently
+     * over-stated by ≈128 B/vector and triggering spurious back-pressure stalls
+     * well below the true memory limit (issue #592).
+     *
+     * <p>Note: {@link #onDiskGraph} upper HNSW layers are also intentionally
+     * excluded. {@code OnDiskGraphIndex.ramBytesUsed()} iterates the in-memory
+     * neighbor maps with no result caching; including it would add
+     * O(segments × upper-layer-nodes) work to every {@code addVector} call via
+     * the back-pressure hot path.
      *
      * <p>Each field is null-guarded: fields that have not yet been populated
      * (e.g. before the segment is fully loaded) contribute 0.
      *
-     * @return estimated bytes of heap occupied by this segment's in-memory state
+     * @return estimated bytes of heap occupied by this segment's pkData /
+     *         pkOffsets / pkLengths arrays (~16 B/vector for BIGINT PKs)
      */
     long estimatedInMemoryBytes() {
         long bytes = 0;
@@ -432,10 +439,7 @@ class VectorSegment implements Closeable {
         if (pl != null) {
             bytes += (long) pl.length * Integer.BYTES;
         }
-        BLink<Bytes, Long> p2n = this.onDiskPkToNode;
-        if (p2n != null) {
-            bytes += p2n.getUsedMemory();
-        }
+        // BLink (onDiskPkToNode) intentionally excluded — see Javadoc above.
         return bytes;
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreBackpressureLivelockTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreBackpressureLivelockTest.java
@@ -116,17 +116,19 @@ public class PersistentVectorStoreBackpressureLivelockTest {
         MemoryDataStorageManager dsm = new MemoryDataStorageManager();
         MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
 
-        // Memory limit calibrated for the post-fix accounting that now includes
-        // on-disk VectorSegment memory (pkData/pkOffsets/pkLengths + BLink tree).
+        // Memory limit calibrated for the corrected on-disk accounting (issue #592:
+        // BLink is excluded from VectorSegment.estimatedInMemoryBytes(), so the
+        // on-disk cost drops from ~120 B/vector to ~12 B/vector for INT keys).
         //
         // The limit must satisfy two constraints:
         //   (a) > max total with all 2000 vectors on-disk + empty live shard, so
         //       back-pressure always releases after a checkpoint.
         //       Upper bound: ~200 KB (OnHeapGraphIndex.CompletionTracker[50000])
-        //                   + ~240 KB (2000 vectors × ~120B on-disk estimate)
-        //                   = ~440 KB  →  use 512 KB for headroom.
+        //                   + ~24 KB (2000 vectors × ~12B on-disk estimate, BLink-free)
+        //                   = ~224 KB  →  512 KB gives comfortable headroom.
         //   (b) < peak estimate with 2000 vectors filling the live shard, so
         //       back-pressure fires at least once during ingestion (~1.1 MB peak).
+        //       1.1 MB >> 512 KB, so back-pressure still fires as expected.
         //
         // With this limit back-pressure fires ~3-5 times during the run, which is
         // sufficient to exercise the livelock-prevention code.

--- a/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreEstimatedMemoryCounterTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/PersistentVectorStoreEstimatedMemoryCounterTest.java
@@ -55,12 +55,11 @@ import org.junit.rules.TemporaryFolder;
  * to diverge and the assertion to fail — which is the test contract this
  * class enforces.
  *
- * <p>The cross-check is invoked only at "clean" lifecycle points where no
- * BLink page-cache activity can have shifted a registered segment's
- * {@code estimatedInMemoryBytes()} since registration: immediately after
- * {@code start()}, after each {@code checkpoint()}, after
- * {@code runCompactionCycle()}, after {@code reloadFromStatus()}, and after
- * the all-deleted checkpoint that clears the segment list.
+ * <p>Because BLink is intentionally excluded from
+ * {@code VectorSegment.estimatedInMemoryBytes()} (issue #592), the counter
+ * and the iterated sum always agree: both count only the stable
+ * pkData/pkOffsets/pkLengths arrays.  The cross-check is therefore valid at
+ * any point in the lifecycle, not just at "quiescent BLink" moments.
  */
 public class PersistentVectorStoreEstimatedMemoryCounterTest {
 
@@ -123,8 +122,8 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
 
     /**
      * After a single checkpoint the counter must become non-zero (segments
-     * exist now and each one's pkData/pkOffsets/pkLengths arrays plus its
-     * BLink contribute), the live iterated sum must agree exactly, and
+     * exist now and each one's pkData/pkOffsets/pkLengths arrays contribute),
+     * the live iterated sum must agree exactly, and
      * {@code estimatedMemoryUsageBytes()} must be at least the on-disk
      * portion (plus whatever live-shard overhead the empty post-checkpoint
      * shards still report).
@@ -477,6 +476,73 @@ public class PersistentVectorStoreEstimatedMemoryCounterTest {
             assertEquals("shadow segment count must match leader post-compaction",
                     leaderSegmentsPost, shadow.getSegmentCount());
             assertCounterMatchesIteration(shadow, "shadow after second reload");
+        }
+    }
+
+    /**
+     * Regression test for issue #592: verifies that the on-disk memory counter
+     * excludes the BLink pk-to-ordinal tree.
+     *
+     * <p>Before the fix, {@code VectorSegment.estimatedInMemoryBytes()} included
+     * {@code onDiskPkToNode.getUsedMemory()}, which added ≈128 B/vector of phantom
+     * cost (BLink entry overhead for a 4-byte INT key).  The total estimated cost
+     * was ≈140 B/vector instead of the true ≈12 B/vector (pkData 4 B + pkOffsets
+     * 4 B + pkLengths 4 B for INT keys), causing {@code waitForMemoryPressureRelief}
+     * to stall ingestion workers far below the actual memory limit.
+     *
+     * <p>After the fix only the heap arrays are counted.  This test inserts
+     * {@code numVectors} vectors, checkpoints, and then asserts that the per-vector
+     * on-disk cost is between the theoretical minimum (raw array bytes) and 48
+     * bytes — a threshold that is comfortably below the BLink contribution of
+     * ≈128 B/vector.
+     */
+    @Test
+    public void testOnDiskCounterExcludesBLinkPageCache() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("counter-no-blink").toPath();
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(128 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        int numVectors = 400;
+        int dim = 16;
+        // INT keys (Bytes.from_int): 4 bytes per PK, so raw array cost is:
+        //   pkData:    4 B/vector
+        //   pkOffsets: 4 B/vector
+        //   pkLengths: 4 B/vector
+        //   ────────────────────
+        //   total:    12 B/vector  →  4800 B for 400 vectors
+        //
+        // BLink contribution (ENTRY_CONSTANT_SIZE + Bytes + Long) ≈ 128 B/vector.
+        // If BLink were still included the counter would be ≈ 140 B/vector = 56 000 B.
+        long pkArraysLowerBound = (long) numVectors * Integer.BYTES * 3; // 4800 B
+        // Upper bound: 48 B/vector leaves generous room for array header overhead
+        // while remaining clearly below the BLink contribution of 128 B/vector.
+        long blinkFreeUpperBound = (long) numVectors * 48;               // 19 200 B
+
+        Random rng = new Random(592);
+
+        try (PersistentVectorStore store = createStore(tmpDir, dsm, mm, "uuid-no-blink")) {
+            store.start();
+
+            for (int i = 0; i < numVectors; i++) {
+                store.addVector(Bytes.from_int(i), randomVector(rng, dim));
+            }
+            store.checkpoint();
+
+            assertTrue("checkpoint must have produced at least one segment",
+                    store.getSegmentCount() > 0);
+
+            long onDisk = store.getOnDiskSegmentsEstimatedMemoryBytes();
+
+            assertTrue("on-disk counter must be >= pkArray lower bound ("
+                    + pkArraysLowerBound + " B), got " + onDisk,
+                    onDisk >= pkArraysLowerBound);
+            assertTrue("on-disk counter must be < BLink-free upper bound of "
+                    + blinkFreeUpperBound + " B (≈48 B/vector); got " + onDisk
+                    + " B — if this fails, BLink.getUsedMemory() was re-introduced"
+                    + " into VectorSegment.estimatedInMemoryBytes() (issue #592)",
+                    onDisk <= blinkFreeUpperBound);
+
+            assertCounterMatchesIteration(store, "after checkpoint (BLink-free)");
         }
     }
 }


### PR DESCRIPTION
Fixes #592.

## Root Cause

`VectorSegment.estimatedInMemoryBytes()` included `onDiskPkToNode.getUsedMemory()` — a snapshot of the BLink pk-to-ordinal tree's loaded-page memory taken once at segment registration (when all BLink pages are fully in-memory after a checkpoint flush). The MemoryManager independently evicts BLink pages afterward but the snapshot in `onDiskSegmentsEstimatedMemoryBytes` is never decremented. This causes a ~128 B/vector permanent phantom cost that makes `waitForMemoryPressureRelief()` stall all apply workers at ~14M vectors under default settings (33% × 8 GiB = 2.64 GiB limit).

## Changes

- **`VectorSegment.java`**: Removed `p2n.getUsedMemory()` from `estimatedInMemoryBytes()`. Updated Javadoc to explain that BLink is intentionally excluded (managed by MemoryManager independently; including it was double-counting that caused issue #592).
- **`PersistentVectorStore.java`**: Updated 6 comments that mentioned BLink being included in the on-disk segment estimate (`onDiskSegmentsEstimatedMemoryBytes` field, `estimatedMemoryUsageBytes()`, `getLiveShardMemoryBytes()`, `getOnDiskSegmentsEstimatedMemoryBytes()`, `registerSegmentMemoryEstimate()`, `sumOnDiskSegmentMemoryBytesByIterationForTesting()`).

## Tests

- **`PersistentVectorStoreEstimatedMemoryCounterTest#testOnDiskCounterExcludesBLinkPageCache`** (new): inserts 400 vectors, checkpoints, and asserts that `getOnDiskSegmentsEstimatedMemoryBytes()` is ≥ raw array lower bound (12 B/vector) and ≤ 48 B/vector — a threshold comfortably below the BLink contribution of 128 B/vector. If BLink is re-introduced, this test fails immediately.
- **`PersistentVectorStoreEstimatedMemoryCounterTest`**: all 8 existing tests still pass; updated class/method Javadoc to reflect that the "clean lifecycle point" caveat is now moot (BLink is no longer counted so no drift can occur).
- **`PersistentVectorStoreBackpressureLivelockTest`**: both existing tests pass unchanged; updated calibration comment in `testIngestionCompletesUnderMemoryPressure` to reflect the corrected on-disk estimate (~12 B/vector instead of ~120 B/vector).

## Impact

Per-vector on-disk estimate: **~144 B → ~16 B** (for BIGINT PKs). The global back-pressure limit is now accurate across the full 50M-vector range without requiring `indexing.memory.vector.percentage` workaround bumps.

🤖 Implemented by the `pr-worker` agent.