### PR TITLE
issue #596: release ByteBuf in sendRequest when future.complete() returns false

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileServiceClient.java
@@ -1640,7 +1640,7 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
                     return;
                 }
                 T value = parser.parse(reply);
-                future.complete(value);
+                completeOrRelease(future, value);
             } catch (RuntimeException parseError) {
                 future.completeExceptionally(parseError);
             } finally {
@@ -1652,6 +1652,34 @@ public class RemoteFileServiceClient implements AutoCloseable, RemoteFileClient 
             }
         });
         return future;
+    }
+
+    /**
+     * Completes {@code future} with {@code value}. If the future is already
+     * done (cancelled or completed exceptionally by a concurrent timeout or
+     * channel-error callback), {@link CompletableFuture#complete} returns
+     * {@code false} and the value would be abandoned with refcount = 1. In
+     * that case this method calls {@link ReferenceCountUtil#safeRelease} to
+     * decrement the refcount of any {@link io.netty.util.ReferenceCounted}
+     * held by {@code value} (e.g. a pooled direct {@link ByteBuf} returned by
+     * {@link #parseReadFileRangeResponse} or {@link #parseReadFileResponse}).
+     * For non-ReferenceCounted types (e.g. {@code byte[]}) the call is a
+     * no-op, so this helper is safe for all {@link #sendRequest} callers.
+     *
+     * <p>This is the fix for issue #596: the "normal-path" ByteBuf leak that
+     * occurs when a successful {@code readFileRange} response arrives after the
+     * outer {@link CompletableFuture} has already been cancelled or timed out.
+     *
+     * <p>Package-private for direct unit testing (see
+     * {@code RemoteFileServiceClientReadFileRangeByteBufLeakTest}).
+     */
+    static <T> void completeOrRelease(CompletableFuture<T> future, T value) {
+        if (!future.complete(value)) {
+            // The future was already completed (cancelled or completed
+            // exceptionally by a concurrent timeout / channel-idle check).
+            // Release any ReferenceCounted resource so it is not leaked.
+            ReferenceCountUtil.safeRelease(value);
+        }
     }
 
     private static <T> CompletableFuture<T> failed(Throwable t) {

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientReadFileRangeByteBufLeakTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientReadFileRangeByteBufLeakTest.java
@@ -27,16 +27,31 @@ import static org.junit.Assert.fail;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.util.concurrent.CompletableFuture;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
 /**
- * Regression tests for issue #582:
+ * Regression tests for issue #582 and issue #596.
+ *
+ * <h3>Issue #582 — exception-path leak</h3>
  * {@link RemoteFileServiceClient#parseReadFileRangeResponse} and
  * {@link RemoteFileServiceClient#parseReadFileResponse} must release the
  * allocated direct {@code ByteBuf buf} when the PDU-content read throws
  * after the allocation but before returning the buffer to the caller.
+ *
+ * <h3>Issue #596 — normal-path leak (future-cancellation race)</h3>
+ * When the parser returns a {@code ByteBuf} successfully but
+ * {@code CompletableFuture.complete(value)} returns {@code false} — because
+ * the future was already cancelled or completed exceptionally by a concurrent
+ * timeout / channel-idle event — the {@code ByteBuf} is abandoned with
+ * refcount = 1. {@link RemoteFileServiceClient#completeOrRelease} fixes this
+ * by calling {@link io.netty.util.ReferenceCountUtil#safeRelease} whenever
+ * {@code complete()} returns {@code false}. Tests for this fix verify that
+ * pre-cancelled or already-exceptionally-completed futures cause the buffer
+ * to be released, while a normally-completing future leaves the buffer owned
+ * by the caller.
  *
  * <h3>How the leak is triggered</h3>
  * Both parsers follow the pattern:
@@ -324,6 +339,99 @@ public class RemoteFileServiceClientReadFileRangeByteBufLeakTest {
             }
             pdu.close();
         }
+        assertEquals("refCnt must drop to 0 after caller releases the buffer",
+                0, captured[0].refCnt());
+    }
+
+    // -------------------------------------------------------------------------
+    // completeOrRelease — issue #596: normal-path future-cancellation leak
+    // -------------------------------------------------------------------------
+
+    /**
+     * Regression test for issue #596 (primary scenario):
+     * {@link RemoteFileServiceClient#completeOrRelease} must release the
+     * {@code ByteBuf} when the target future is already cancelled.
+     *
+     * <p>This simulates the production race: the safety-net timeout in
+     * {@code getUnchecked()} cancels the outer {@link CompletableFuture}
+     * while the network response is in flight.  When the callback finally
+     * fires, {@code parser.parse()} allocates a {@code ByteBuf} successfully,
+     * but {@code future.complete(buf)} returns {@code false}.  Before the fix,
+     * {@code buf} was abandoned (refCnt = 1, never released).  The fix calls
+     * {@code ReferenceCountUtil.safeRelease(buf)}, dropping refCnt to 0.
+     */
+    @Test
+    public void testCompleteOrRelease_releasesWhenFutureCancelled() {
+        final ByteBuf[] captured = {null};
+        PooledByteBufAllocator spy = spyAllocator(captured);
+
+        ByteBuf buf = spy.directBuffer(16);
+        assertEquals("precondition: freshly allocated buffer must have refCnt == 1",
+                1, buf.refCnt());
+
+        CompletableFuture<ByteBuf> future = new CompletableFuture<>();
+        future.cancel(false);  // simulate safety-net timeout
+
+        RemoteFileServiceClient.completeOrRelease(future, buf);
+
+        assertEquals(
+                "completeOrRelease must release the ByteBuf when future.complete() returns false"
+                        + " due to cancellation (issue #596 regression)",
+                0, captured[0].refCnt());
+    }
+
+    /**
+     * Issue #596, error-race variant: {@code completeOrRelease} must release
+     * the {@code ByteBuf} when the future was already completed exceptionally
+     * (e.g., a concurrent channel-idle error completed it before the parsed
+     * response arrived).
+     */
+    @Test
+    public void testCompleteOrRelease_releasesWhenFutureAlreadyCompletedExceptionally() {
+        final ByteBuf[] captured = {null};
+        PooledByteBufAllocator spy = spyAllocator(captured);
+
+        ByteBuf buf = spy.directBuffer(16);
+        assertEquals("precondition: freshly allocated buffer must have refCnt == 1",
+                1, buf.refCnt());
+
+        CompletableFuture<ByteBuf> future = new CompletableFuture<>();
+        future.completeExceptionally(new java.io.IOException("channel closed"));
+
+        RemoteFileServiceClient.completeOrRelease(future, buf);
+
+        assertEquals(
+                "completeOrRelease must release the ByteBuf when future is already "
+                        + "completed exceptionally (issue #596 race variant)",
+                0, captured[0].refCnt());
+    }
+
+    /**
+     * Issue #596, normal-completion guard: {@code completeOrRelease} must NOT
+     * release the {@code ByteBuf} when the future accepts the value (i.e., when
+     * {@code future.complete(buf)} returns {@code true}).  The caller is then
+     * responsible for releasing the buffer, exactly as before.
+     */
+    @Test
+    public void testCompleteOrRelease_doesNotReleaseWhenFutureAcceptsValue() {
+        final ByteBuf[] captured = {null};
+        PooledByteBufAllocator spy = spyAllocator(captured);
+
+        ByteBuf buf = spy.directBuffer(16);
+
+        CompletableFuture<ByteBuf> future = new CompletableFuture<>();
+
+        RemoteFileServiceClient.completeOrRelease(future, buf);
+
+        // The buffer must still be alive — the caller (future's dependent) owns it.
+        assertEquals(
+                "completeOrRelease must NOT release the ByteBuf when future.complete() "
+                        + "returns true: caller now owns the refcount (issue #596 guard)",
+                1, captured[0].refCnt());
+        assertEquals("future must hold the buffer", buf, future.getNow(null));
+
+        // Cleanup — simulate the caller releasing the buffer.
+        future.getNow(null).release();
         assertEquals("refCnt must drop to 0 after caller releases the buffer",
                 0, captured[0].refCnt());
     }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientReadFileRangeByteBufLeakTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileServiceClientReadFileRangeByteBufLeakTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Rule;
 import org.junit.Test;
@@ -396,7 +397,7 @@ public class RemoteFileServiceClientReadFileRangeByteBufLeakTest {
                 1, buf.refCnt());
 
         CompletableFuture<ByteBuf> future = new CompletableFuture<>();
-        future.completeExceptionally(new java.io.IOException("channel closed"));
+        future.completeExceptionally(new IOException("channel closed"));
 
         RemoteFileServiceClient.completeOrRelease(future, buf);
 


### PR DESCRIPTION
Fixes #596.

## Root cause

`sendRequest`'s response callback calls `parser.parse(reply)` which (for the `readFileRange` path) calls `parseReadFileRangeResponse`, allocating a pooled direct `ByteBuf`. It then calls `future.complete(value)`. If the future was **already cancelled or completed exceptionally** — e.g., by the safety-net timeout in `getUnchecked()` racing with a late-arriving network response, or by a concurrent channel-idle error — `future.complete()` returns `false` and the `ByteBuf` is silently abandoned with refcount = 1. This is the *normal-path* leak: allocation and copy both succeeded, but the buffer was never transferred to a caller that could release it.

This is distinct from the exception-path leak fixed by #582 (where `writeBytes` threw inside the lambda). The #582 fix added the `boolean success + try/finally` guard in `parseReadFileRangeResponse`, but that only covers the case where the parser itself fails — not the case where the parser succeeds but the future rejects the result.

## Changes

- **`RemoteFileServiceClient.java`**: Extracted `completeOrRelease(CompletableFuture<T>, T)` — a package-private static helper that calls `future.complete(value)` and, when it returns `false`, calls `ReferenceCountUtil.safeRelease(value)` to release any `ReferenceCounted` resource (e.g., `ByteBuf`) that would otherwise be leaked. For non-`ReferenceCounted` types (e.g., `byte[]`) `safeRelease` is a no-op, making the helper safe for all `sendRequest` callers. Updated `sendRequest` to call `completeOrRelease(future, value)` instead of `future.complete(value)`.

## Tests

- **`testCompleteOrRelease_releasesWhenFutureCancelled`** (new): pre-cancels the future, calls `completeOrRelease`, asserts `refCnt == 0`. Primary regression for issue #596.
- **`testCompleteOrRelease_releasesWhenFutureAlreadyCompletedExceptionally`** (new): future already completed with an exception, calls `completeOrRelease`, asserts `refCnt == 0`. Covers the concurrent-channel-error race variant.
- **`testCompleteOrRelease_doesNotReleaseWhenFutureAcceptsValue`** (new): future not yet completed, calls `completeOrRelease`, asserts `refCnt == 1` (caller owns it). Guards against over-releasing.

🤖 Implemented by the `pr-worker` agent.