### PR TITLE
issue #609: wire direct object-storage access for the index optimizer

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/IndexOptimizerMain.java
@@ -24,6 +24,9 @@ import herddb.indexing.segment.SegmentRegistryClient;
 import herddb.metadata.MetadataStorageManagerException;
 import herddb.metadata.ServiceDiscoveryListener;
 import herddb.model.TableSpace;
+import herddb.remote.RemoteFileDataStorageManager;
+import herddb.remote.storage.ObjectStorage;
+import herddb.remote.storage.S3ObjectStorage;
 import herddb.server.RemoteFileClient;
 import herddb.server.RemoteFileServiceFactory;
 import herddb.server.ServerConfiguration;
@@ -31,6 +34,7 @@ import herddb.storage.DataStorageManager;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -55,6 +59,15 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 
 /**
  * Bootstrap entry point for the index-optimizer service. Loaded by the
@@ -1231,6 +1244,15 @@ public final class IndexOptimizerMain {
         this.mergerDataStorageManager = factory.createDataStorageManager(
                 metaDir, remoteTmp, Integer.MAX_VALUE, mergerFileClient);
 
+        // Issue #609: when indexoptimizer.s3.direct.enabled=true, attach a direct
+        // ObjectStorage client so RemoteSegmentGraphMerger's downloadGraphFile/
+        // downloadMapFile fast path runs against the object store rather than
+        // routing every block through the gRPC file-server. Mirrors the IS-side
+        // wiring in IndexingServer.buildDataStorageManager. Pulled into a helper
+        // so the env-var-validation + S3 client construction can be unit-tested
+        // in isolation.
+        maybeEnableDirectS3(this.mergerDataStorageManager, configuration);
+
         // Build the config provider that reads per-index jvector build parameters
         // directly from the checkpoint metadata on the remote file server (issue #516).
         // This avoids any dependency on IS liveness — the remote file server is
@@ -1242,6 +1264,134 @@ public final class IndexOptimizerMain {
                 "index merge config provider: RemoteMetadataIndexMergeConfigProvider"
                 + " (tablespaceUuid={0})", tablespaceUuid);
         return new RemoteSegmentMerger(mergerDataStorageManager, tmpDir, configProvider);
+    }
+
+    /**
+     * Issue #609: optionally wire a direct {@link ObjectStorage} client onto
+     * the optimizer's {@link RemoteFileDataStorageManager} so streaming
+     * compaction reads input segments directly from S3/GCS instead of routing
+     * every block through the gRPC file-server. Mirrors
+     * {@code IndexingServer.buildDataStorageManager}'s wiring for the IS pod.
+     *
+     * <p>Behaviour:
+     * <ul>
+     *   <li>When {@code indexoptimizer.s3.direct.enabled=false} (the default),
+     *       this is a strict no-op — no env-var lookup happens.</li>
+     *   <li>When the flag is {@code true} but the DSM is not a
+     *       {@link RemoteFileDataStorageManager} (e.g. unit-test fallbacks),
+     *       a {@link Level#WARNING} is logged and the optimizer continues
+     *       without direct S3. This matches the IS-side behaviour and keeps
+     *       the pod startable in degraded environments.</li>
+     *   <li>When the flag is {@code true} and the DSM is correct, the
+     *       {@code S3_ACCESS_KEY} and {@code S3_SECRET_KEY} environment
+     *       variables MUST be set; a missing or empty value surfaces as an
+     *       {@link IOException} (fast-fail).</li>
+     * </ul>
+     *
+     * <p>Package-private for unit-test access.
+     */
+    static void maybeEnableDirectS3(DataStorageManager dsm,
+            OptimizerConfiguration configuration) throws IOException {
+        boolean enabled = configuration.getBoolean(
+                OptimizerConfiguration.PROPERTY_S3_DIRECT_ENABLED,
+                OptimizerConfiguration.PROPERTY_S3_DIRECT_ENABLED_DEFAULT);
+        if (!enabled) {
+            return;
+        }
+        if (!(dsm instanceof RemoteFileDataStorageManager)) {
+            LOGGER.log(Level.WARNING,
+                    "indexoptimizer.s3.direct.enabled=true but the data storage manager"
+                            + " ({0}) is not a RemoteFileDataStorageManager — direct S3"
+                            + " download will NOT be active",
+                    dsm.getClass().getSimpleName());
+            return;
+        }
+        // Keys are injected exclusively via environment variables so they
+        // never appear in ConfigMaps, properties files, or log output.
+        String accessKey = System.getenv("S3_ACCESS_KEY");
+        String secretKey = System.getenv("S3_SECRET_KEY");
+        ObjectStorage directStorage = buildDirectS3ObjectStorage(
+                configuration, accessKey, secretKey);
+        ((RemoteFileDataStorageManager) dsm).setDirectObjectStorage(directStorage);
+        LOGGER.log(Level.INFO,
+                "Direct S3 download enabled for streaming compaction input segments"
+                        + " (issue #609)");
+    }
+
+    /**
+     * Builds an {@link ObjectStorage} that connects directly to S3/GCS for
+     * streaming-compaction segment downloads (issue #609). Pure function: takes
+     * credentials as parameters so the env-var-validation half of the public
+     * surface can be unit-tested independently of S3 client construction.
+     *
+     * <p>Throws {@link IOException} when either credential is {@code null} or
+     * empty so the optimizer fails fast at startup with a clear message instead
+     * of surfacing the misconfiguration as a cryptic AWS SDK error on the first
+     * merge.
+     *
+     * <p>Package-private for unit-test access.
+     */
+    static ObjectStorage buildDirectS3ObjectStorage(OptimizerConfiguration configuration,
+            String accessKey, String secretKey) throws IOException {
+        if (accessKey == null || accessKey.isEmpty()) {
+            throw new IOException(
+                    "S3_ACCESS_KEY environment variable must be set when "
+                            + OptimizerConfiguration.PROPERTY_S3_DIRECT_ENABLED + "=true");
+        }
+        if (secretKey == null || secretKey.isEmpty()) {
+            throw new IOException(
+                    "S3_SECRET_KEY environment variable must be set when "
+                            + OptimizerConfiguration.PROPERTY_S3_DIRECT_ENABLED + "=true");
+        }
+        String bucket = configuration.getString(
+                OptimizerConfiguration.PROPERTY_S3_BUCKET,
+                OptimizerConfiguration.PROPERTY_S3_BUCKET_DEFAULT);
+        String region = configuration.getString(
+                OptimizerConfiguration.PROPERTY_S3_REGION,
+                OptimizerConfiguration.PROPERTY_S3_REGION_DEFAULT);
+        String endpoint = configuration.getString(
+                OptimizerConfiguration.PROPERTY_S3_ENDPOINT,
+                OptimizerConfiguration.PROPERTY_S3_ENDPOINT_DEFAULT);
+        String s3Prefix = configuration.getString(
+                OptimizerConfiguration.PROPERTY_S3_PREFIX,
+                OptimizerConfiguration.PROPERTY_S3_PREFIX_DEFAULT);
+        boolean gcsCompatibility = configuration.getBoolean(
+                OptimizerConfiguration.PROPERTY_S3_GCS_COMPATIBILITY,
+                OptimizerConfiguration.PROPERTY_S3_GCS_COMPATIBILITY_DEFAULT);
+
+        S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .httpClientBuilder(AwsCrtAsyncHttpClient.builder());
+
+        if (gcsCompatibility) {
+            LOGGER.log(Level.INFO,
+                    "Direct S3 client (GCS compatibility): path-style addressing, "
+                            + "SDK checksums WHEN_REQUIRED");
+            clientBuilder
+                    .serviceConfiguration(S3Configuration.builder()
+                            .pathStyleAccessEnabled(true)
+                            .build())
+                    .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                    .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+        } else {
+            LOGGER.log(Level.INFO,
+                    "Direct S3 client (AWS mode): virtual-hosted-style, "
+                            + "SDK default checksums");
+        }
+        if (!endpoint.isEmpty()) {
+            clientBuilder.endpointOverride(URI.create(endpoint));
+        }
+
+        S3AsyncClient s3Client = clientBuilder.build();
+        LOGGER.log(Level.INFO,
+                "Direct S3 client built for streaming compaction segment downloads:"
+                        + " bucket={0}, region={1}, prefix={2}",
+                new Object[]{bucket, region, s3Prefix});
+        // No StatsLogger here: the optimizer's stats provider may not be ready
+        // when this is invoked during startup.
+        return new S3ObjectStorage(s3Client, bucket, s3Prefix);
     }
 
     private Path resolveTmpDirectory() throws IOException {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/optimizer/OptimizerConfiguration.java
@@ -202,6 +202,67 @@ public final class OptimizerConfiguration {
     public static final long PROPERTY_REMOTE_FILE_MAX_INFLIGHT_WRITE_BYTES_DEFAULT = 256L * 1024L * 1024L;
 
     // -------------------------------------------------------------------------
+    // Direct S3 access for streaming compaction (issue #609)
+    //
+    // Mirrors the IndexingServerConfiguration S3 block (issue #381). When
+    // {@code indexoptimizer.s3.direct.enabled=true} the optimizer pod attaches
+    // an {@link herddb.remote.storage.ObjectStorage} client to its
+    // {@link herddb.remote.RemoteFileDataStorageManager} so the
+    // {@code RemoteSegmentGraphMerger} downloads input segment graph/map
+    // files directly from object storage instead of routing them through the
+    // gRPC file-server. This is the optimizer-side counterpart of the
+    // streaming-compaction eager-download fast path: it eliminates wire-level
+    // contention against the file-server's bounded {@code max.inflight.read.bytes}
+    // semaphore and lifts merge throughput on large segments.
+    //
+    // Access/secret keys are read at runtime from the {@code S3_ACCESS_KEY} and
+    // {@code S3_SECRET_KEY} environment variables (never from the properties
+    // file) so they are not visible in ConfigMaps or log output.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Enable direct object-storage download for streaming compaction input
+     * segments. Default {@code false}.
+     *
+     * <p>When {@code true}, the optimizer opens an S3/GCS client and downloads
+     * input segment graph/map files for streaming compaction directly from
+     * the bucket, bypassing the gRPC file-server. Requires the optimizer to
+     * be wired against a {@link herddb.remote.RemoteFileDataStorageManager}
+     * — when the DSM is anything else (e.g. test fallbacks) a WARNING is
+     * logged and the flag is silently ignored.
+     *
+     * <p><strong>Note:</strong> the configured bucket ({@link #PROPERTY_S3_BUCKET})
+     * is assumed to be pre-provisioned and accessible at startup. A missing
+     * bucket surfaces as a storage error on the first merge attempt.
+     */
+    public static final String PROPERTY_S3_DIRECT_ENABLED = "indexoptimizer.s3.direct.enabled";
+    public static final boolean PROPERTY_S3_DIRECT_ENABLED_DEFAULT = false;
+
+    /** S3 endpoint URL override. Leave empty for native AWS S3; set for GCS or MinIO. */
+    public static final String PROPERTY_S3_ENDPOINT = "indexoptimizer.s3.endpoint";
+    public static final String PROPERTY_S3_ENDPOINT_DEFAULT = "";
+
+    /** S3 bucket name containing the segment data. */
+    public static final String PROPERTY_S3_BUCKET = "indexoptimizer.s3.bucket";
+    public static final String PROPERTY_S3_BUCKET_DEFAULT = "";
+
+    /** AWS region. Used for native AWS S3; typically {@code "auto"} for GCS. */
+    public static final String PROPERTY_S3_REGION = "indexoptimizer.s3.region";
+    public static final String PROPERTY_S3_REGION_DEFAULT = "us-east-1";
+
+    /** Optional key prefix within the bucket (e.g. {@code "herddb/"}). */
+    public static final String PROPERTY_S3_PREFIX = "indexoptimizer.s3.prefix";
+    public static final String PROPERTY_S3_PREFIX_DEFAULT = "";
+
+    /**
+     * Enable GCS-compatibility mode on the S3 client:
+     * path-style addressing + SDK checksums WHEN_REQUIRED.
+     * Required for GCS and MinIO. Default {@code false}.
+     */
+    public static final String PROPERTY_S3_GCS_COMPATIBILITY = "indexoptimizer.s3.gcs.compatibility";
+    public static final boolean PROPERTY_S3_GCS_COMPATIBILITY_DEFAULT = false;
+
+    // -------------------------------------------------------------------------
     // K-way single-pass merge (issue #524)
     // -------------------------------------------------------------------------
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainDirectS3Test.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainDirectS3Test.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
-import java.util.concurrent.CompletableFuture;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -256,16 +255,31 @@ public class IndexOptimizerMainDirectS3Test {
         OptimizerConfiguration cfg = configWith(p);
         ObjectStorage storage = IndexOptimizerMain.buildDirectS3ObjectStorage(
                 cfg, "ak", "sk");
-
         DummyRemoteFileDsm dsm = newRemoteFileDsm();
-        assertFalse(dsm.supportsDirectMultipartDownload());
+        try {
+            assertFalse(dsm.supportsDirectMultipartDownload());
 
-        dsm.setDirectObjectStorage(storage);
+            dsm.setDirectObjectStorage(storage);
 
-        assertTrue("setDirectObjectStorage(...) must flip the support flag",
-                dsm.supportsDirectMultipartDownload());
-        assertSame("DummyRemoteFileDsm must record the attached storage",
-                storage, dsm.lastAttachedStorage);
+            assertTrue("setDirectObjectStorage(...) must flip the support flag",
+                    dsm.supportsDirectMultipartDownload());
+            assertSame("DummyRemoteFileDsm must record the attached storage",
+                    storage, dsm.lastAttachedStorage);
+        } finally {
+            // Release the SDK S3AsyncClient + CRT HTTP client owned by the
+            // S3ObjectStorage so the per-test class doesn't leak SDK threads
+            // and direct-memory arenas. dsm.close() chains through to the
+            // attached ObjectStorage so we don't need to close `storage`
+            // explicitly. Broad catch is required: close paths on the SDK and
+            // on RemoteFileDataStorageManager can raise both IOException and
+            // RuntimeException (e.g. IllegalStateException when an arena is
+            // already released); test cleanup must not propagate those.
+            try {
+                dsm.close();
+            } catch (Exception ignored) {
+                // best-effort
+            }
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -316,13 +330,4 @@ public class IndexOptimizerMainDirectS3Test {
             // No close() — nothing to do.
         }
     }
-
-    /**
-     * Compile-time guard: a no-op reference to {@link CompletableFuture} keeps
-     * the AWS-SDK transitive deps in the resolved set even when test pruning
-     * (e.g. {@code -Dmaven.test.skip}) trims unused classes. Harmless at run
-     * time.
-     */
-    @SuppressWarnings("unused")
-    private static final Class<?> KEEP_DEP_RESOLVED = CompletableFuture.class;
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainDirectS3Test.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/optimizer/IndexOptimizerMainDirectS3Test.java
@@ -1,0 +1,328 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.optimizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.remote.RemoteFileDataStorageManager;
+import herddb.remote.storage.ObjectStorage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the direct-S3 wiring added in issue #609 to
+ * {@link IndexOptimizerMain}. Exercises the two package-private helpers in
+ * isolation so the env-var validation, the {@link ObjectStorage}
+ * construction, and the
+ * {@link RemoteFileDataStorageManager#setDirectObjectStorage} hand-off are
+ * all covered without standing up a real ZooKeeper / file-server / S3
+ * backend.
+ */
+public class IndexOptimizerMainDirectS3Test {
+
+    private Path tmpRoot;
+
+    @Before
+    public void setUp() throws IOException {
+        tmpRoot = Files.createTempDirectory("optimizer-direct-s3-test-");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (tmpRoot != null) {
+            FileUtils.deleteDirectory(tmpRoot.toFile());
+        }
+    }
+
+    private static OptimizerConfiguration configWith(Properties extra) {
+        Properties p = new Properties();
+        // Provide a tablespace name so the constructor doesn't trip on
+        // required-field validation in unrelated paths. The S3 helpers
+        // under test only consume the S3 keys.
+        p.setProperty(OptimizerConfiguration.PROPERTY_TABLESPACE_NAME, "ts");
+        p.putAll(extra);
+        return new OptimizerConfiguration(p);
+    }
+
+    /**
+     * When {@code indexoptimizer.s3.direct.enabled=false} (the default),
+     * {@link IndexOptimizerMain#maybeEnableDirectS3} is a strict no-op:
+     * no env-var lookup happens, no setter is called on the DSM. We verify
+     * the no-op contract by passing a DSM that would never have direct
+     * download support and asserting it stays that way.
+     */
+    @Test
+    public void maybeEnableDirectS3_flagFalse_isStrictNoop() throws Exception {
+        OptimizerConfiguration cfg = configWith(new Properties());
+        // Default = false; do not even set the property.
+        DummyRemoteFileDsm dsm = newRemoteFileDsm();
+        assertFalse("precondition: direct download not yet wired",
+                dsm.supportsDirectMultipartDownload());
+
+        IndexOptimizerMain.maybeEnableDirectS3(dsm, cfg);
+
+        assertFalse("flag=false must leave direct download disabled",
+                dsm.supportsDirectMultipartDownload());
+        assertEquals("flag=false must not invoke the setter", 0, dsm.setterCalls);
+    }
+
+    /**
+     * When the flag is enabled but the DSM is not a
+     * {@link RemoteFileDataStorageManager} (e.g. unit-test fallbacks that
+     * use the in-memory DSM, or a future plugin DSM), the wiring must log
+     * a WARNING and continue — never throw. The optimizer pod must remain
+     * startable in degraded environments rather than crashing on a
+     * misconfiguration that has zero impact on correctness.
+     */
+    @Test
+    public void maybeEnableDirectS3_flagTrueWithNonRemoteDsm_logsAndSkips()
+            throws Exception {
+        Properties p = new Properties();
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_DIRECT_ENABLED, "true");
+        OptimizerConfiguration cfg = configWith(p);
+
+        // No env vars set; the helper must short-circuit on the DSM type check
+        // before it ever consults S3_ACCESS_KEY / S3_SECRET_KEY.
+        IndexOptimizerMain.maybeEnableDirectS3(new MemoryDataStorageManager(), cfg);
+        // Reaching this line proves the helper neither threw nor required env vars.
+    }
+
+    /**
+     * {@code buildDirectS3ObjectStorage} fast-fails when the access key is
+     * absent: the helper throws {@link IOException} with a message that names
+     * the missing env var and the optimizer property. This keeps a
+     * misconfigured pod from limping into the first merge attempt and then
+     * surfacing the failure as a cryptic AWS SDK auth error.
+     */
+    @Test
+    public void buildDirectS3_emptyAccessKey_throws() {
+        OptimizerConfiguration cfg = configWith(new Properties());
+        try {
+            IndexOptimizerMain.buildDirectS3ObjectStorage(cfg, "", "sk");
+            fail("expected IOException for empty access key");
+        } catch (IOException expected) {
+            assertTrue("error message must reference S3_ACCESS_KEY: "
+                            + expected.getMessage(),
+                    expected.getMessage().contains("S3_ACCESS_KEY"));
+            assertTrue("error message must reference the property name: "
+                            + expected.getMessage(),
+                    expected.getMessage().contains(
+                            OptimizerConfiguration.PROPERTY_S3_DIRECT_ENABLED));
+        }
+    }
+
+    /**
+     * Same as above but with a null access key — the env-var case (the
+     * variable being unset returns {@code null} from {@code System.getenv},
+     * not an empty string).
+     */
+    @Test
+    public void buildDirectS3_nullAccessKey_throws() {
+        OptimizerConfiguration cfg = configWith(new Properties());
+        try {
+            IndexOptimizerMain.buildDirectS3ObjectStorage(cfg, null, "sk");
+            fail("expected IOException for null access key");
+        } catch (IOException expected) {
+            assertTrue(expected.getMessage().contains("S3_ACCESS_KEY"));
+        }
+    }
+
+    /**
+     * Symmetric to {@link #buildDirectS3_emptyAccessKey_throws}: an empty
+     * secret key surfaces with a {@code S3_SECRET_KEY}-named error.
+     */
+    @Test
+    public void buildDirectS3_emptySecretKey_throws() {
+        OptimizerConfiguration cfg = configWith(new Properties());
+        try {
+            IndexOptimizerMain.buildDirectS3ObjectStorage(cfg, "ak", "");
+            fail("expected IOException for empty secret key");
+        } catch (IOException expected) {
+            assertTrue("error message must reference S3_SECRET_KEY: "
+                            + expected.getMessage(),
+                    expected.getMessage().contains("S3_SECRET_KEY"));
+        }
+    }
+
+    /**
+     * Null secret key: same fast-fail path as empty.
+     */
+    @Test
+    public void buildDirectS3_nullSecretKey_throws() {
+        OptimizerConfiguration cfg = configWith(new Properties());
+        try {
+            IndexOptimizerMain.buildDirectS3ObjectStorage(cfg, "ak", null);
+            fail("expected IOException for null secret key");
+        } catch (IOException expected) {
+            assertTrue(expected.getMessage().contains("S3_SECRET_KEY"));
+        }
+    }
+
+    /**
+     * Happy path for the pure builder: with valid creds and a typical
+     * GCS-compatible configuration (path-style addressing, WHEN_REQUIRED
+     * checksums) it returns a non-null {@link ObjectStorage} without
+     * connecting anywhere. The AWS SDK's {@code S3AsyncClient} construction
+     * is lazy — no network traffic is generated.
+     */
+    @Test
+    public void buildDirectS3_gcsCompatibilityConfig_returnsObjectStorage()
+            throws Exception {
+        Properties p = new Properties();
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_ENDPOINT,
+                "https://storage.googleapis.com");
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_BUCKET, "test-bucket");
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_REGION, "auto");
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_PREFIX, "herddb/");
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_GCS_COMPATIBILITY, "true");
+        OptimizerConfiguration cfg = configWith(p);
+
+        ObjectStorage storage = IndexOptimizerMain.buildDirectS3ObjectStorage(
+                cfg, "ak", "sk");
+        try {
+            assertNotNull("builder must return a non-null ObjectStorage", storage);
+        } finally {
+            // Defensive: ObjectStorage is Closeable in some impls; S3ObjectStorage
+            // exposes close-through to the underlying client. Silently best-effort.
+            tryClose(storage);
+        }
+    }
+
+    /**
+     * AWS-mode happy path (no GCS compatibility, no endpoint override).
+     * Default region is used. Same construction is non-throwing and yields
+     * a non-null storage.
+     */
+    @Test
+    public void buildDirectS3_awsModeMinimalConfig_returnsObjectStorage()
+            throws Exception {
+        Properties p = new Properties();
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_BUCKET, "test-bucket-aws");
+        // Leave region/prefix/gcsCompatibility at defaults.
+        OptimizerConfiguration cfg = configWith(p);
+
+        ObjectStorage storage = IndexOptimizerMain.buildDirectS3ObjectStorage(
+                cfg, "ak", "sk");
+        try {
+            assertNotNull(storage);
+        } finally {
+            tryClose(storage);
+        }
+    }
+
+    /**
+     * End-to-end through {@link IndexOptimizerMain#maybeEnableDirectS3}
+     * using a fake env source: we bypass {@code System.getenv} by directly
+     * exercising the pure builder, then verify that
+     * {@link RemoteFileDataStorageManager#setDirectObjectStorage} actually
+     * flips {@code supportsDirectMultipartDownload()} from {@code false} to
+     * {@code true}. This is the contract that
+     * {@link IndexOptimizerMain#buildRemoteSegmentMerger} relies on.
+     */
+    @Test
+    public void buildDirectS3_andAttach_flipsSupportsDirectMultipartDownload()
+            throws Exception {
+        Properties p = new Properties();
+        p.setProperty(OptimizerConfiguration.PROPERTY_S3_BUCKET, "b");
+        OptimizerConfiguration cfg = configWith(p);
+        ObjectStorage storage = IndexOptimizerMain.buildDirectS3ObjectStorage(
+                cfg, "ak", "sk");
+
+        DummyRemoteFileDsm dsm = newRemoteFileDsm();
+        assertFalse(dsm.supportsDirectMultipartDownload());
+
+        dsm.setDirectObjectStorage(storage);
+
+        assertTrue("setDirectObjectStorage(...) must flip the support flag",
+                dsm.supportsDirectMultipartDownload());
+        assertSame("DummyRemoteFileDsm must record the attached storage",
+                storage, dsm.lastAttachedStorage);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------------
+
+    private DummyRemoteFileDsm newRemoteFileDsm() throws IOException {
+        Path metaDir = Files.createDirectories(tmpRoot.resolve("meta"));
+        Path remoteTmp = Files.createDirectories(tmpRoot.resolve("remote-tmp"));
+        // Construct with a null RemoteFileServiceClient: the helpers under test
+        // never invoke any client method, and only setDirectObjectStorage /
+        // supportsDirectMultipartDownload are exercised on this instance.
+        return new DummyRemoteFileDsm(metaDir, remoteTmp);
+    }
+
+    /**
+     * {@link RemoteFileDataStorageManager} subclass that records direct-storage
+     * attach calls so the test can assert on the wiring contract without
+     * depending on a real S3 backend.
+     */
+    private static final class DummyRemoteFileDsm extends RemoteFileDataStorageManager {
+
+        volatile ObjectStorage lastAttachedStorage;
+        volatile int setterCalls;
+
+        DummyRemoteFileDsm(Path metaDir, Path remoteTmp) {
+            super(metaDir, remoteTmp, Integer.MAX_VALUE, /* client */ null);
+        }
+
+        @Override
+        public void setDirectObjectStorage(ObjectStorage storage) {
+            this.lastAttachedStorage = storage;
+            this.setterCalls++;
+            super.setDirectObjectStorage(storage);
+        }
+    }
+
+    private static void tryClose(Object o) {
+        // S3ObjectStorage doesn't expose Closeable directly; use reflection so
+        // we don't tie the test to its concrete signature. Best-effort cleanup —
+        // any failure is ignored so the assertion path isn't masked.
+        if (o == null) {
+            return;
+        }
+        try {
+            o.getClass().getMethod("close").invoke(o);
+        } catch (ReflectiveOperationException ignored) {
+            // No close() — nothing to do.
+        }
+    }
+
+    /**
+     * Compile-time guard: a no-op reference to {@link CompletableFuture} keeps
+     * the AWS-SDK transitive deps in the resolved set even when test pruning
+     * (e.g. {@code -Dmaven.test.skip}) trims unused classes. Harmless at run
+     * time.
+     */
+    @SuppressWarnings("unused")
+    private static final Class<?> KEEP_DEP_RESOLVED = CompletableFuture.class;
+}

--- a/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/examples/gke/values.yaml
@@ -535,6 +535,27 @@ indexOptimizer:
     # 512 MiB write buffer — matches the IS write cap and ensures the optimizer
     # doesn't stall on gRPC back-pressure when uploading large merged graphs.
     maxInflightWriteBytes: "536870912"   # 512 MiB
+  # Direct GCS download for streaming-compaction input segments (issue #609).
+  # Mirrors the indexing-service S3 block above. With this enabled the optimizer
+  # downloads input segment graph/map files directly from GCS instead of
+  # routing every block through the gRPC file-server — same wire-throughput
+  # win that direct S3 gives the IS for cold-start recovery, applied to merge
+  # I/O. Required when the optimizer drives steady-state compaction on a
+  # bucket with thousands of segments.
+  s3:
+    directEnabled: true
+    # GCS S3-compatible endpoint — same as fileServer.s3.endpoint and
+    # indexingService.s3.endpoint.
+    endpoint: "https://storage.googleapis.com"
+    region: "auto"
+    # Must match fileServer.s3.bucket (override with --set on install).
+    bucket: "herddb-pages"
+    # Enable GCS-compatibility tweaks on the S3 client
+    # (path-style addressing + WHEN_REQUIRED SDK checksums) — required for GCS.
+    gcsCompatibility: true
+    # Reuse the same Kubernetes Secret as the file server and the IS
+    # (S3_ACCESS_KEY / S3_SECRET_KEY).
+    credentialsSecret: "herddb-gcs-credentials"
   # JVM budget matched to the indexing-service budget (same node class, same
   # memory envelope).
   #   -Xms28g -Xmx28g: same heap as the IS — large enough for PQ codebook

--- a/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-configmap.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-configmap.yaml
@@ -69,6 +69,27 @@ data:
     indexoptimizer.remote.file.client.max.inflight.write.bytes={{ .maxInflightWriteBytes | default 268435456 | int64 }}
     {{- end }}
     {{- end }}
+    {{- if and .Values.indexOptimizer.s3 .Values.indexOptimizer.s3.directEnabled }}
+    # Direct S3/GCS access for streaming compaction (issue #609). When
+    # enabled, the optimizer downloads input segment graph/map files
+    # directly from object storage instead of routing every block through
+    # the gRPC file-server. S3_ACCESS_KEY / S3_SECRET_KEY env vars are
+    # injected by the StatefulSet from .Values.indexOptimizer.s3.credentialsSecret.
+    indexoptimizer.s3.direct.enabled=true
+    {{- if .Values.indexOptimizer.s3.endpoint }}
+    indexoptimizer.s3.endpoint={{ .Values.indexOptimizer.s3.endpoint }}
+    {{- end }}
+    {{- if .Values.indexOptimizer.s3.bucket }}
+    indexoptimizer.s3.bucket={{ .Values.indexOptimizer.s3.bucket }}
+    {{- end }}
+    indexoptimizer.s3.region={{ .Values.indexOptimizer.s3.region | default "us-east-1" }}
+    {{- if .Values.indexOptimizer.s3.prefix }}
+    indexoptimizer.s3.prefix={{ .Values.indexOptimizer.s3.prefix }}
+    {{- end }}
+    {{- if .Values.indexOptimizer.s3.gcsCompatibility }}
+    indexoptimizer.s3.gcs.compatibility=true
+    {{- end }}
+    {{- end }}
     {{- range $k, $v := .Values.indexOptimizer.extraConfig }}
     {{ $k }}={{ $v }}
     {{- end }}

--- a/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-statefulset.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/templates/index-optimizer-statefulset.yaml
@@ -100,6 +100,23 @@ spec:
             - name: JAVA_OPTS_EXTRA
               value: {{ .Values.indexOptimizer.javaOptsExtra | quote }}
             {{- end }}
+            {{- if and .Values.indexOptimizer.s3 .Values.indexOptimizer.s3.credentialsSecret }}
+            # Issue #609: S3/GCS credentials for direct streaming-compaction
+            # downloads. Mirrors the indexing-service statefulset pattern.
+            # IndexOptimizerMain.maybeEnableDirectS3 reads these env vars only
+            # when indexoptimizer.s3.direct.enabled=true (rendered above in the
+            # configmap when .Values.indexOptimizer.s3.directEnabled is set).
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.indexOptimizer.s3.credentialsSecret }}
+                  key: S3_ACCESS_KEY
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.indexOptimizer.s3.credentialsSecret }}
+                  key: S3_SECRET_KEY
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.indexOptimizer.httpPort | default 9853 }}

--- a/herddb-kubernetes/src/main/helm/herddb/values.yaml
+++ b/herddb-kubernetes/src/main/helm/herddb/values.yaml
@@ -460,6 +460,29 @@ indexOptimizer:
     retries: 3
     maxInflightReadBytes: "268435456"   # 256 MiB
     maxInflightWriteBytes: "268435456"  # 256 MiB
+  # Direct S3/GCS access for streaming compaction (issue #609). Mirrors
+  # indexingService.s3 above. When enabled, the optimizer downloads input
+  # segment graph/map files directly from object storage instead of routing
+  # every block through the gRPC file-server, lifting merge throughput on
+  # large segments and removing wire-level contention against the
+  # file-server's bounded max.inflight.read.bytes semaphore.
+  s3:
+    # Set to true to enable direct object-storage downloads during merges.
+    directEnabled: false
+    # S3 endpoint URL — leave empty for AWS S3, set for GCS or MinIO.
+    # When fileServer.storageMode=s3 this should match fileServer.s3.endpoint.
+    endpoint: ""
+    # Bucket containing the segment data. Should match fileServer.s3.bucket.
+    bucket: ""
+    region: "us-east-1"
+    # Optional key prefix within the bucket. Should match fileServer.s3.prefix.
+    prefix: ""
+    # Enable GCS-compatibility tweaks (path-style addressing, WHEN_REQUIRED checksums).
+    # Set to true for GCS and MinIO. Should match fileServer.s3.gcsCompatibility.
+    gcsCompatibility: false
+    # Name of a Kubernetes Secret with S3_ACCESS_KEY and S3_SECRET_KEY entries.
+    # When set, the env vars are injected into the optimizer pods from this secret.
+    credentialsSecret: ""
   zkSessionTimeout: 40000
   # JVM options for the optimizer process. The optimizer needs enough heap and
   # direct memory to execute PQ retraining + graph-merge in a single JVM:

--- a/herddb-kubernetes/src/test/java/herddb/kubernetes/IndexOptimizerHelmTemplateTest.java
+++ b/herddb-kubernetes/src/test/java/herddb/kubernetes/IndexOptimizerHelmTemplateTest.java
@@ -127,6 +127,77 @@ public class IndexOptimizerHelmTemplateTest {
         assertTrue(r.stdout.contains("storageClassName: \"fast-ssd\""));
     }
 
+    /**
+     * Issue #609: with the chart's default {@code indexOptimizer.s3.directEnabled=false}
+     * the configmap must NOT emit {@code indexoptimizer.s3.direct.enabled=true},
+     * and the statefulset must NOT mount {@code S3_ACCESS_KEY} /
+     * {@code S3_SECRET_KEY} env vars. This guards against an accidental regression
+     * where the helm template would unconditionally render those keys and force
+     * every deployment to ship a credentials Secret.
+     */
+    @Test
+    public void s3DirectDisabledByDefault_noS3KeysOrEnvVars() throws Exception {
+        ProcessResult r = runHelm("template", "test", chartDir.toString(),
+                "--set", "indexOptimizer.enabled=true",
+                "--set", "indexOptimizer.tablespaceName=herd");
+        assertEquals("helm template failed:\n" + r.stderr, 0, r.exitCode);
+        String yaml = r.stdout;
+        assertFalse("default render must not enable direct S3:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.direct.enabled=true"));
+        assertFalse("default render must not inject S3_ACCESS_KEY env var:\n" + yaml,
+                yaml.contains("name: S3_ACCESS_KEY"));
+        assertFalse("default render must not inject S3_SECRET_KEY env var:\n" + yaml,
+                yaml.contains("name: S3_SECRET_KEY"));
+    }
+
+    /**
+     * Issue #609: with {@code indexOptimizer.s3.directEnabled=true} plus a
+     * complete GCS-style configuration (endpoint + bucket + gcsCompatibility +
+     * credentialsSecret), the configmap must emit every
+     * {@code indexoptimizer.s3.*} property and the statefulset must inject the
+     * {@code S3_ACCESS_KEY} / {@code S3_SECRET_KEY} env vars sourced from the
+     * configured Secret. Mirrors the indexing-service direct-S3 contract from
+     * issue #381.
+     */
+    @Test
+    public void s3DirectEnabled_rendersPropertiesAndCredentialEnvVars()
+            throws Exception {
+        ProcessResult r = runHelm("template", "test", chartDir.toString(),
+                "--set", "indexOptimizer.enabled=true",
+                "--set", "indexOptimizer.tablespaceName=herd",
+                "--set", "indexOptimizer.s3.directEnabled=true",
+                "--set", "indexOptimizer.s3.endpoint=https://storage.googleapis.com",
+                "--set", "indexOptimizer.s3.bucket=test-bucket",
+                "--set", "indexOptimizer.s3.region=auto",
+                "--set", "indexOptimizer.s3.prefix=herddb/",
+                "--set", "indexOptimizer.s3.gcsCompatibility=true",
+                "--set", "indexOptimizer.s3.credentialsSecret=test-gcs-creds");
+        assertEquals("helm template failed:\n" + r.stderr, 0, r.exitCode);
+        String yaml = r.stdout;
+
+        // ConfigMap rendering.
+        assertTrue("missing indexoptimizer.s3.direct.enabled=true:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.direct.enabled=true"));
+        assertTrue("missing indexoptimizer.s3.endpoint:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.endpoint=https://storage.googleapis.com"));
+        assertTrue("missing indexoptimizer.s3.bucket:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.bucket=test-bucket"));
+        assertTrue("missing indexoptimizer.s3.region:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.region=auto"));
+        assertTrue("missing indexoptimizer.s3.prefix:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.prefix=herddb/"));
+        assertTrue("missing indexoptimizer.s3.gcs.compatibility=true:\n" + yaml,
+                yaml.contains("indexoptimizer.s3.gcs.compatibility=true"));
+
+        // StatefulSet env-var injection from the Secret.
+        assertTrue("S3_ACCESS_KEY env var must be injected:\n" + yaml,
+                yaml.contains("name: S3_ACCESS_KEY"));
+        assertTrue("S3_SECRET_KEY env var must be injected:\n" + yaml,
+                yaml.contains("name: S3_SECRET_KEY"));
+        assertTrue("S3 env vars must reference the credentials Secret name:\n" + yaml,
+                yaml.contains("name: test-gcs-creds"));
+    }
+
     /* ------------------- helpers ------------------- */
 
     private static boolean helmAvailable() {


### PR DESCRIPTION
Fixes #609 (extension of PR #603's eager-download fast path to the optimizer pod).

## Context

PR #603 added an eager-download path in `VectorIndexCompactor.rebuildSegmentStreaming` and `RemoteSegmentGraphMerger.downloadGraphFile`/`downloadMapFile` so streaming compaction downloads input segment graph/map files to local temp files before the merge starts. That path is gated on `DataStorageManager.supportsDirectMultipartDownload()`, which for `RemoteFileDataStorageManager` requires `setDirectObjectStorage(...)` to have been called with a real S3/GCS client.

The IS pod has had the wiring since issue #381 (`indexing.s3.direct.enabled`). The **optimizer pod has never had it** — `IndexOptimizerMain.buildRemoteSegmentMerger()` creates the DSM via `factory.createDataStorageManager(...)` and then proceeds without ever attaching an `ObjectStorage`. Result: every merge input segment is still pulled block-by-block over the gRPC file-server, regardless of how the IS is configured.

## Changes

- **`OptimizerConfiguration`**: 6 new constants under `indexoptimizer.s3.*` (`direct.enabled`, `endpoint`, `bucket`, `region`, `prefix`, `gcs.compatibility`), mirroring `IndexingServerConfiguration` line-for-line.

- **`IndexOptimizerMain`**: two package-private static helpers:
  - `maybeEnableDirectS3(DataStorageManager, OptimizerConfiguration)` — strict no-op when the flag is false (no env-var lookup), `WARNING` log + return when the DSM is not a `RemoteFileDataStorageManager`, fast-fail with `IOException` mentioning the missing env var when `S3_ACCESS_KEY` / `S3_SECRET_KEY` are unset, otherwise attaches the client via `setDirectObjectStorage`.
  - `buildDirectS3ObjectStorage(OptimizerConfiguration, accessKey, secretKey)` — pure function for unit-testability. Credentials taken as parameters so the env-var read happens in one specific call site (the wiring helper) and isn't entangled with S3 client construction.
  - `buildRemoteSegmentMerger` calls `maybeEnableDirectS3` immediately after `factory.createDataStorageManager(...)`.

- **Helm chart**:
  - `values.yaml`: new `indexOptimizer.s3` block adjacent to `indexOptimizer.remoteFileClient`, mirroring the structure of `indexingService.s3`.
  - `templates/index-optimizer-configmap.yaml`: renders `indexoptimizer.s3.*` properties under `{{- if and .Values.indexOptimizer.s3 .Values.indexOptimizer.s3.directEnabled }}`.
  - `templates/index-optimizer-statefulset.yaml`: injects `S3_ACCESS_KEY` / `S3_SECRET_KEY` from `.Values.indexOptimizer.s3.credentialsSecret` when set, alongside the existing `JAVA_OPTS` / `JAVA_OPTS_EXTRA` env-var stanza.

- **GKE example values**: `indexOptimizer.s3.directEnabled: true` with the same endpoint / bucket / `herddb-gcs-credentials` secret already used by the indexing service. Comment block explains the rationale (mirror of the IS-side direct-S3 win, applied to merge I/O).

## Tests

- **`IndexOptimizerMainDirectS3Test`** (new — 9 cases): flag-off strict no-op, non-`RemoteFileDataStorageManager` soft-skip, env-var fast-fail (both `null` and empty for each of `S3_ACCESS_KEY` and `S3_SECRET_KEY`), GCS-compat happy path, AWS-mode minimal config, end-to-end attach that flips `supportsDirectMultipartDownload()` from `false` to `true`.

- **`IndexOptimizerHelmTemplateTest`** (extended — 2 new cases): default render emits no `indexoptimizer.s3.direct.enabled=true` and no `S3_ACCESS_KEY` / `S3_SECRET_KEY` env vars; `directEnabled=true` render emits all six properties and the Secret-sourced env vars.

## Validation

- `mvn -pl herddb-indexing-service -Dtest='IndexOptimizerMainDirectS3Test'` — 9/9 pass.
- `mvn -pl herddb-indexing-service -Dtest='IndexOptimizerMainConfigTest,OptimizerMergerLateBindingTest,IndexOptimizerEventDrivenTest,IndexOptimizerSessionExpiredTest'` — 15/15 pass (regression gate).
- `mvn -pl herddb-kubernetes -Pkubernetes -Dtest='IndexOptimizerHelmTemplateTest'` — 7/7 pass.
- `mvn -B spotless:apply -DskipTests` — no formatting deltas.
- `mvn -B spotless:check apache-rat:check spotbugs:check install -DskipTests -Pci` — all 22 modules green.
- `helm template ... examples/gke/values.yaml` manually rendered — both IS and optimizer pods get direct-S3 properties and Secret-sourced env vars.

🤖 Implemented by the \`pr-worker\` agent.