### PR TITLE
issue #614: Phase B observability + regression tests for local-scope and delete safety

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -6024,6 +6024,25 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
         long phaseBStartMs = System.currentTimeMillis();
 
+        // Heap snapshot at Phase B entry. Phase B duration is provably
+        // O(N_live_shards) in this implementation (each shard is written from
+        // its already-built per-shard OnHeapGraphIndex with no global-graph
+        // search — see writeShardAsFusedPQSegment), so an unusually slow
+        // Phase B is almost always GC-pressure driven, not algorithmic
+        // (issue #614). Logging the heap utilisation at start and end makes
+        // such events unambiguous in the logs without needing a heap dump.
+        Runtime rt = Runtime.getRuntime();
+        long heapUsedAtStart = rt.totalMemory() - rt.freeMemory();
+        long heapMaxAtStart = rt.maxMemory();
+        long heapPctAtStart = heapMaxAtStart > 0
+                ? (heapUsedAtStart * 100L / heapMaxAtStart) : -1L;
+        LOGGER.log(Level.INFO,
+                "checkpoint {0} Phase B: starting ({1} shards, heap used={2} MB / max={3} MB = {4}%)",
+                new Object[]{indexName, snapshotShards.size(),
+                        heapUsedAtStart / (1024L * 1024L),
+                        heapMaxAtStart / (1024L * 1024L),
+                        heapPctAtStart});
+
         // Cleanup all shard builders first (finalizes HNSW diversity/refine)
         for (LiveGraphShard shard : snapshotShards) {
             if (shard.builder != null) {
@@ -6116,10 +6135,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
             bytesWritten += r.graphFileSize + r.mapFileSize;
         }
         lastPhaseBBytesWritten.set(bytesWritten);
+        long heapUsedAtEnd = rt.totalMemory() - rt.freeMemory();
+        long heapMaxAtEnd = rt.maxMemory();
+        long heapPctAtEnd = heapMaxAtEnd > 0
+                ? (heapUsedAtEnd * 100L / heapMaxAtEnd) : -1L;
         LOGGER.log(Level.INFO,
-                "checkpoint {0} Phase B: completed in {1} ms ({2} shard segments, {3} total vectors, {4} bytes)",
+                "checkpoint {0} Phase B: completed in {1} ms ({2} shard segments, {3} total vectors, {4} bytes;"
+                        + " heap used={5} MB / max={6} MB = {7}%, delta {8}%)",
                 new Object[]{indexName, phaseBElapsedMs, newSegmentResults.size(),
-                        totalShardVectors, bytesWritten});
+                        totalShardVectors, bytesWritten,
+                        heapUsedAtEnd / (1024L * 1024L),
+                        heapMaxAtEnd / (1024L * 1024L),
+                        heapPctAtEnd,
+                        heapPctAtEnd - heapPctAtStart});
 
         // Order the results by segmentId so that the persisted IndexStatus and
         // the in-memory segment list are both deterministic.
@@ -6591,6 +6619,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // Update compaction metrics for this shard
         compactionNodesTotal.addAndGet(shardSize);
 
+        // Per-step timing for the four sub-phases of a shard write
+        // (issue #614 observability). Initialised to start so a thrown
+        // exception leaves them as a deterministic "0 ms for everything
+        // after the throw" view in any future telemetry that consumes them.
+        long shardStartNanos = System.nanoTime();
+        long pqDoneNanos = shardStartNanos;
+        long graphWriteDoneNanos = shardStartNanos;
+        long graphUploadDoneNanos = shardStartNanos;
+
         writingGraphActive.incrementAndGet();
         try {
             // Get the shard's already-built OnHeapGraphIndex (no rebuild!)
@@ -6626,6 +6663,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             ProductQuantization pq = useFusedPQForShard
                     ? getOrTrainPQ(shardView, pqSubspaces) : null;
             PQVectors pqv = (pq != null) ? pq.encodeAll(shardView, PhysicalCoreExecutor.pool()) : null;
+            pqDoneNanos = System.nanoTime();
 
             // Write graph + features to temp file, streaming via suppliers
             Path tempFile = Files.createTempFile(
@@ -6658,6 +6696,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     writtenFeatureIds = RemoteSegmentGraphMerger.featureSetToStringList(suppliers.keySet());
                 }
                 success = true;
+                graphWriteDoneNanos = System.nanoTime();
 
                 // Upload graph file
                 long graphSize = Files.size(tempFile);
@@ -6674,6 +6713,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     uploadingActive.decrementAndGet();
                 }
                 trackProvisionalMultipartFile(segUuid, "graph");
+                graphUploadDoneNanos = System.nanoTime();
 
                 ConcurrentHashMap<Integer, Bytes> ordinalToPk = buildOrdinalToPk(shard);
                 Path mapFile = writeFusedPQMapDataToTempFile(shardView, ordinalToPk);
@@ -6702,6 +6742,23 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     // writtenFeatureIds was derived from suppliers.keySet() inside the
                     // writer block so it cannot drift if future code adds/removes features.
                     swr.jvectorFeatureIds = writtenFeatureIds;
+                    // Per-step timing breakdown for the shard write (issue #614).
+                    // Helps distinguish CPU-bound work (PQ train/encode, graph build)
+                    // from I/O-bound work (uploads) when a Phase B runs unusually
+                    // long. All four sub-steps are local to this shard — none of
+                    // them touch the global on-disk graph.
+                    long mapWriteUploadDoneNanos = System.nanoTime();
+                    long pqMs = (pqDoneNanos - shardStartNanos) / 1_000_000L;
+                    long graphWriteMs = (graphWriteDoneNanos - pqDoneNanos) / 1_000_000L;
+                    long graphUploadMs = (graphUploadDoneNanos - graphWriteDoneNanos) / 1_000_000L;
+                    long mapMs = (mapWriteUploadDoneNanos - graphUploadDoneNanos) / 1_000_000L;
+                    long totalMs = (mapWriteUploadDoneNanos - shardStartNanos) / 1_000_000L;
+                    LOGGER.log(Level.INFO,
+                            "checkpoint {0} Phase B: shard segment {1} ({2} vectors) written —"
+                                    + " pq={3} ms, graph-write={4} ms, graph-upload={5} ms,"
+                                    + " map-write+upload={6} ms, total={7} ms",
+                            new Object[]{indexName, segmentId, shardSize,
+                                    pqMs, graphWriteMs, graphUploadMs, mapMs, totalMs});
                     return swr;
                 } finally {
                     Files.deleteIfExists(mapFile);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCheckpointPhaseBDeleteRecallTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCheckpointPhaseBDeleteRecallTest.java
@@ -1,0 +1,196 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #614: locks the two invariants the issue author
+ * explicitly asked us to guard when changing Phase B —
+ *
+ * <ol>
+ *   <li><b>Deletes must remain effective across a checkpoint.</b> A PK deleted
+ *       in the live shards before checkpoint must not reappear in search
+ *       results after Phase B has flushed those shards to disk.</li>
+ *   <li><b>Recall on surviving keys must not degrade catastrophically.</b>
+ *       Surviving PKs must still be findable; specifically, the original
+ *       vector of a surviving PK must self-match (i.e. its own PK is the
+ *       top-1 result, and it appears within the top-K).</li>
+ * </ol>
+ *
+ * <p>This test does NOT measure absolute recall against a ground truth — that
+ * is the job of {@code PersistentVectorStoreRecallTest}. Its purpose is to
+ * fail loudly if a Phase B refactor either (a) drops surviving vectors from
+ * the persisted graph or (b) leaks tombstoned PKs back into search results.
+ */
+public class PersistentVectorStoreCheckpointPhaseBDeleteRecallTest {
+
+    /** Total vectors inserted before any deletion. */
+    private static final int N = 1000;
+
+    /** Vector dimension. */
+    private static final int DIM = 32;
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE);
+    }
+
+    private float[] randomVector(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void deletesSurviveCheckpointAndSurvivorsRemainRecallable() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            Random rng = new Random(6140);
+
+            // Keep a copy of the original vectors so we can replay each as
+            // a query post-checkpoint. Without this we cannot tell whether
+            // a missing PK is a delete-leak (good) or a graph-loss (bad).
+            List<float[]> originalVectors = new ArrayList<>(N);
+            for (int i = 0; i < N; i++) {
+                float[] v = randomVector(rng);
+                originalVectors.add(v);
+                store.addVector(Bytes.from_int(i), v);
+            }
+            assertEquals(N, store.size());
+
+            // Delete every even-indexed PK (500 deletions) BEFORE the
+            // checkpoint, so Phase B sees a frozen shard with active
+            // tombstones — the exact configuration where a buggy graph
+            // serializer could leak deleted ordinals.
+            Set<Integer> deleted = new HashSet<>();
+            for (int i = 0; i < N; i += 2) {
+                store.removeVector(Bytes.from_int(i));
+                deleted.add(i);
+            }
+            assertEquals(N - deleted.size(), store.size());
+
+            // Run the checkpoint that flushes live shards (with the deletes
+            // applied) to a brand-new on-disk segment. This is the exact
+            // doCheckpointFusedPQPhaseB → writeShardAsFusedPQSegment path
+            // that issue #614 is concerned with.
+            store.checkpoint();
+            assertEquals(N - deleted.size(), store.size());
+
+            // ----- Invariant 1: deleted PKs do not reappear. -----
+            // Replay each deleted vector as a query — if the post-Phase-B
+            // segment still indexes a tombstoned ordinal, the deleted PK
+            // will surface here.
+            int deletedLeaks = 0;
+            for (int i : deleted) {
+                List<Map.Entry<Bytes, Float>> results =
+                        store.search(originalVectors.get(i), 10);
+                for (Map.Entry<Bytes, Float> e : results) {
+                    if (e.getKey().equals(Bytes.from_int(i))) {
+                        deletedLeaks++;
+                        break;
+                    }
+                }
+            }
+            assertEquals(
+                    "Deleted PKs must not reappear in search results after Phase B"
+                            + " has flushed the live shard to disk. Leaks=" + deletedLeaks,
+                    0, deletedLeaks);
+
+            // ----- Invariant 2: surviving PKs are still recallable. -----
+            // For every surviving PK, query its OWN original vector. The
+            // graph + PQ are noisy approximations, so we tolerate a small
+            // fraction of misses (HNSW with these parameters and random
+            // 32-d vectors hits >97% in practice). The point is to catch
+            // a graph-loss regression — if Phase B silently drops nodes,
+            // the miss rate jumps to large fractions, not a few percent.
+            int top1Self = 0;
+            int topKContains = 0;
+            int topK = 10;
+            for (int i = 1; i < N; i += 2) {
+                List<Map.Entry<Bytes, Float>> results =
+                        store.search(originalVectors.get(i), topK);
+                Bytes self = Bytes.from_int(i);
+                if (!results.isEmpty() && results.get(0).getKey().equals(self)) {
+                    top1Self++;
+                }
+                for (Map.Entry<Bytes, Float> e : results) {
+                    if (e.getKey().equals(self)) {
+                        topKContains++;
+                        break;
+                    }
+                }
+
+                // Per-query: deleted PKs must not appear in any survivor
+                // query either. Tightens invariant 1 across the survivor
+                // search space too.
+                for (Map.Entry<Bytes, Float> e : results) {
+                    int rk = e.getKey().to_int();
+                    assertFalse(
+                            "Survivor query for PK=" + i + " returned tombstoned PK=" + rk,
+                            deleted.contains(rk));
+                }
+            }
+            int survivors = N - deleted.size();
+            double top1Rate = top1Self / (double) survivors;
+            double topKRate = topKContains / (double) survivors;
+            System.out.printf(
+                    "Phase B delete-recall: survivors=%d, self-match top1=%.4f, in-topK=%.4f%n",
+                    survivors, top1Rate, topKRate);
+            assertTrue(
+                    "Surviving PKs must self-match in top-" + topK + " for at least 95% of"
+                            + " queries (was " + topKRate + "); a lower rate indicates Phase B"
+                            + " is losing nodes from the persisted graph.",
+                    topKRate >= 0.95);
+            assertTrue(
+                    "Surviving PKs must self-match in top-1 for at least 90% of queries"
+                            + " (was " + top1Rate + "); a lower rate indicates the persisted"
+                            + " graph is materially degraded.",
+                    top1Rate >= 0.90);
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCheckpointPhaseBLocalScopeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCheckpointPhaseBLocalScopeTest.java
@@ -1,0 +1,160 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #614: locks the invariant that Phase B duration
+ * scales with the size of the snapshotted live shards, not with the size of
+ * the on-disk index.
+ *
+ * <p>The test inserts {@code BATCH_SIZE} vectors three times in a row, running
+ * a checkpoint after each batch, and asserts that Phase B for batches 2 and 3
+ * is not dramatically slower than batch 1 — even though batches 2 and 3 run
+ * with progressively more on-disk vectors already persisted.
+ *
+ * <p>If a future change introduces a Phase B code path that consults the
+ * global on-disk graph (e.g. inter-segment edge building, full-graph PQ
+ * retraining over previously-written segments), Phase B duration would start
+ * growing with the on-disk vector count and this test would fail. That is
+ * exactly the regression vector this test is designed to catch — see
+ * {@code writeShardAsFusedPQSegment} in {@link PersistentVectorStore}, which
+ * by construction only references the per-shard {@code OnHeapGraphIndex}.
+ */
+public class PersistentVectorStoreCheckpointPhaseBLocalScopeTest {
+
+    /** Vectors inserted per batch. Three batches → three Phase B measurements. */
+    private static final int BATCH_SIZE = 500;
+
+    /** Vector dimension; kept small so each per-shard write is fast. */
+    private static final int DIM = 32;
+
+    /**
+     * Slack ratio: later Phase B may be up to {@code RATIO_LIMIT}× slower than
+     * the first one before the test fails. The expected ratio is ~1.0 — Phase
+     * B is purely per-shard. The slack absorbs JVM warmup, GC, and noise on
+     * the very first run.
+     */
+    private static final double RATIO_LIMIT = 5.0;
+
+    /**
+     * Absolute floor (ms): when the first Phase B is very short (single-digit
+     * ms), small absolute jitter would otherwise blow the ratio. Below this
+     * floor the test ignores the ratio and only asserts an upper-bound on the
+     * later duration.
+     */
+    private static final long ABSOLUTE_FLOOR_MS = 200L;
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("testidx", "testtable", "tstblspace",
+                "vector_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE); // compaction disabled — keeps Phase B the only
+                                 // code path that writes on-disk segments, so
+                                 // any regression has nowhere to hide.
+    }
+
+    private float[] randomVector(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private void insertBatch(PersistentVectorStore store, Random rng, int base) {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            store.addVector(Bytes.from_int(base + i), randomVector(rng));
+        }
+    }
+
+    @Test
+    public void phaseBDurationDoesNotGrowWithOnDiskSize() throws Exception {
+        Path tmpDir = tmpFolder.newFolder().toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            Random rng = new Random(614);
+
+            // --- Batch 1: 500 vectors → 1 segment on disk after checkpoint.
+            insertBatch(store, rng, 0);
+            store.checkpoint();
+            long phaseB1Ms = store.getLastCheckpointPhaseBDurationMs();
+
+            // --- Batch 2: another 500. Now Phase B writes 500 fresh live
+            // vectors WHILE 500 already exist on disk. Local-scope Phase B
+            // should not care.
+            insertBatch(store, rng, BATCH_SIZE);
+            store.checkpoint();
+            long phaseB2Ms = store.getLastCheckpointPhaseBDurationMs();
+
+            // --- Batch 3: another 500. 1000 already on disk. Same story.
+            insertBatch(store, rng, 2 * BATCH_SIZE);
+            store.checkpoint();
+            long phaseB3Ms = store.getLastCheckpointPhaseBDurationMs();
+
+            System.out.printf(
+                    "PhaseB durations (ms): batch1=%d batch2=%d batch3=%d%n",
+                    phaseB1Ms, phaseB2Ms, phaseB3Ms);
+
+            // Sanity check: all three checkpoints actually ran Phase B.
+            assertTrue("Phase B #1 should report a non-negative duration, was " + phaseB1Ms,
+                    phaseB1Ms >= 0);
+            assertTrue("Phase B #2 should report a non-negative duration, was " + phaseB2Ms,
+                    phaseB2Ms >= 0);
+            assertTrue("Phase B #3 should report a non-negative duration, was " + phaseB3Ms,
+                    phaseB3Ms >= 0);
+
+            // Core invariant: Phase B for batches 2 and 3 must not balloon
+            // relative to batch 1. We allow up to RATIO_LIMIT× when batch 1
+            // is above ABSOLUTE_FLOOR_MS; below the floor, the ratio is
+            // dominated by noise so we only assert an absolute upper bound.
+            long ratioBaselineMs = Math.max(phaseB1Ms, ABSOLUTE_FLOOR_MS);
+            long allowedMs = (long) Math.ceil(ratioBaselineMs * RATIO_LIMIT);
+            assertTrue(
+                    "Phase B #2 (" + phaseB2Ms + " ms) must not exceed "
+                            + allowedMs + " ms (= " + RATIO_LIMIT + "× baseline of "
+                            + ratioBaselineMs + " ms) — Phase B appears to scale with"
+                            + " on-disk size, which is the issue #614 regression.",
+                    phaseB2Ms <= allowedMs);
+            assertTrue(
+                    "Phase B #3 (" + phaseB3Ms + " ms) must not exceed "
+                            + allowedMs + " ms (= " + RATIO_LIMIT + "× baseline of "
+                            + ratioBaselineMs + " ms) — Phase B appears to scale with"
+                            + " on-disk size, which is the issue #614 regression.",
+                    phaseB3Ms <= allowedMs);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #614 (defensively — see analysis below).

## Background

Issue #614 reports that `doCheckpointFusedPQPhaseB` builds the new on-disk
segment by searching the global graph, making Phase B O(N_total) instead of
O(N_live_shards). Code inspection on master (`b7855a2f`) shows this is **not**
what happens today:

* `doCheckpointFusedPQPhaseB` (`PersistentVectorStore.java:6017`) iterates the
  frozen `LiveGraphShard`s and calls `writeShardAsFusedPQSegment` for each.
* `writeShardAsFusedPQSegment` serializes the shard's *already-built*
  `OnHeapGraphIndex` (built incrementally during `addVector` against a
  `BuildScoreProvider` that sees only the per-shard `VectorStorage`) and
  PQ-encodes the shard's vectors. No `OnDiskGraphIndexCompactor`, no global
  graph reader, no inter-segment edges.

The 35-minute Phase B observed in the issue (checkpoint #131) ran while the
JVM was at 99.5% heap, which the issue itself acknowledges. The
`Compaction I/O progress` log lines quoted in the issue come from jvector's
`OnDiskGraphIndexCompactor`, invoked only from `runCompactionCycle` /
`RemoteSegmentGraphMerger` (background compaction) — confirmed by a test
run on this branch where those log lines appear under
`PersistentVectorStoreCompactionDeletePkRaceTest`, never under Phase B.

So there is no algorithmic bug to fix. This PR locks the invariants in place
with two regression tests and adds the observability that would have made
the original incident easier to diagnose.

## Changes

* `PersistentVectorStore.java`
  - `doCheckpointFusedPQPhaseB`: log JVM heap utilisation at start, append
    heap + delta to the existing completion line.
  - `writeShardAsFusedPQSegment`: record and log per-step timings (PQ train
    + encode, graph-file write, graph upload, map write + upload) at INFO.
* `PersistentVectorStoreCheckpointPhaseBLocalScopeTest` (new): three
  500-vector batches, checkpoint after each, assert Phase B durations for
  batches 2 and 3 stay within 5× of batch 1. A regression that re-introduces
  global-graph work would scale with on-disk size and fail this bound.
* `PersistentVectorStoreCheckpointPhaseBDeleteRecallTest` (new): insert 1000,
  delete every even PK, checkpoint, then verify (i) deleted PKs do not
  reappear in search results and (ii) surviving PKs self-match in top-1 ≥ 0.90
  and in-topK ≥ 0.95.

## Tests

```
mvn -pl herddb-indexing-service \
    -Dtest='PersistentVectorStoreCheckpointPhaseBLocalScopeTest,PersistentVectorStoreCheckpointPhaseBDeleteRecallTest' \
    test
```
→ green (Tests run: 2, Failures: 0, Errors: 0, Skipped: 0).

A wider sweep of related tests (parallel Phase B, concurrent checkpoint,
delete + Phase C race, compaction delete race, recall, checkpoint pool, plain
delete) — 28 tests — was also run on this branch and stays green.

Sample log output from the new local-scope test, showing the new lines:

```
Phase B: starting (1 shards, heap used=22 MB / max=2,048 MB = 1%)
Phase B: shard segment 0 (500 vectors) written —
    pq=358 ms, graph-write=104 ms, graph-upload=11 ms, map-write+upload=16 ms, total=490 ms
Phase B: completed in 510 ms (1 shard segments, 500 total vectors, 302,532 bytes;
    heap used=77 MB / max=2,048 MB = 3%, delta 2%)
```

The local-scope test produces:
```
PhaseB durations (ms): batch1=510 batch2=110 batch3=31
```
batches 2 and 3 are faster than batch 1, as expected when Phase B is local —
no work scaling with the 500 / 1000 on-disk vectors.

🤖 Implemented by the `pr-worker` agent.