### PR TITLE
issue #608: stabilise SegmentOwnershipTransferTest waitFor deadline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,14 +56,23 @@ Never push commits directly to the `master` branch. Always create a feature bran
 open a pull request so that CI runs and changes can be reviewed before merging.
 
 ## Before Sending a PR
+Spotless replaced Maven Checkstyle in issue #544 / PR #554 — **do not invoke
+`mvn checkstyle:check` directly**; with no project-level configuration the
+plugin falls back to the Sun defaults and reports thousands of bogus
+violations. Use Spotless instead.
+
 First auto-fix formatting (unused imports, trailing whitespace, trailing
 newline, tabs → spaces) with Spotless, then run the code validation checks
 locally before opening a pull request:
 ```
 mvn -B spotless:apply -DskipTests
-mvn -B spotless:check apache-rat:check spotbugs:check install -DskipTests -Pci
+mvn -B spotless:check apache-rat:check install -DskipTests spotbugs:check -Pci
 ```
-This matches what `.github/workflows/ci.yml` runs in CI (spotless, Apache RAT license headers, SpotBugs).
+This matches what `.github/workflows/ci.yml` runs in CI (spotless, Apache RAT
+license headers, SpotBugs). The goal order is significant: `spotbugs:check`
+must run **after** `install` because it analyses the freshly-compiled `.class`
+files that `install` writes — running spotbugs first leaves it inspecting
+stale classes (or no classes at all on a clean checkout).
 
 For any change related to indexes, checkpoints, or concurrency, also run every
 subclass of `DirectMultipleConcurrentUpdatesSuite` (in

--- a/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentOwnershipTransferTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentOwnershipTransferTest.java
@@ -126,15 +126,30 @@ public class SegmentOwnershipTransferTest {
         }
     }
 
-    private static void waitFor(java.util.function.BooleanSupplier predicate) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + 10_000L;
+    /**
+     * Polls {@code predicate} until it becomes true or the deadline elapses.
+     *
+     * <p>The deadline is generous (30s) because the watcher's single-thread
+     * dispatch executor must process several ZK watcher fires (children +
+     * per-segment data) and re-list the index between each transition, and
+     * on a contended CI runner those round-trips occasionally exceed a tighter
+     * deadline — see issue #608. A healthy run completes in milliseconds, so
+     * a 30s exhaustion still signals a real regression.
+     *
+     * <p>{@code desc} is included in the failure message so the test reports
+     * exactly which predicate did not stabilise (mirrors the helper in
+     * {@code SegmentTransferCrashRecoveryTest}).
+     */
+    private static void waitFor(java.util.function.BooleanSupplier predicate, String desc)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 30_000L;
         while (System.currentTimeMillis() < deadline) {
             if (predicate.getAsBoolean()) {
                 return;
             }
             Thread.sleep(20);
         }
-        fail("predicate did not become true within 10s");
+        fail("predicate did not become true within 30s: " + desc);
     }
 
     @Test
@@ -143,7 +158,8 @@ public class SegmentOwnershipTransferTest {
         RecordingListener l0 = new RecordingListener();
         try (SegmentAssignmentWatcher w0 = new SegmentAssignmentWatcher(registry, 0, l0)) {
             w0.watchIndex(TS_UUID, IDX_UUID);
-            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID));
+            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID),
+                    "instance 0 sees initial ASSIGNED");
         }
         assertEquals(Collections.singletonList("ASSIGNED:" + SEG_UUID), l0.snapshot());
     }
@@ -158,7 +174,8 @@ public class SegmentOwnershipTransferTest {
              SegmentAssignmentWatcher w1 = new SegmentAssignmentWatcher(registry, 1, l1)) {
             w0.watchIndex(TS_UUID, IDX_UUID);
             w1.watchIndex(TS_UUID, IDX_UUID);
-            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID));
+            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID),
+                    "instance 0 sees initial ASSIGNED");
 
             // 1) Optimizer initiates transfer to instance 1.
             VersionedSegmentMetadata v0 = registry.getSegment(TS_UUID, IDX_UUID, SEG_UUID).orElseThrow();
@@ -167,7 +184,8 @@ public class SegmentOwnershipTransferTest {
             assertEquals(1, transferring.metadata().getPendingOwnerInstanceId());
 
             // 2) Watcher 1 sees the pending assignment.
-            waitFor(() -> l1.events.contains("PENDING:" + SEG_UUID));
+            waitFor(() -> l1.events.contains("PENDING:" + SEG_UUID),
+                    "instance 1 sees PENDING after initiate");
 
             // 3) New owner finishes opening locally and CAS-completes the transfer.
             VersionedSegmentMetadata afterComplete = OwnershipTransfer.complete(registry,
@@ -178,8 +196,10 @@ public class SegmentOwnershipTransferTest {
                     afterComplete.metadata().getPendingOwnerInstanceId());
 
             // 4) Watcher 1 now sees ASSIGNED, and watcher 0 sees RELEASED.
-            waitFor(() -> l1.events.contains("ASSIGNED:" + SEG_UUID));
-            waitFor(() -> l0.events.contains("RELEASED:" + SEG_UUID));
+            waitFor(() -> l1.events.contains("ASSIGNED:" + SEG_UUID),
+                    "instance 1 sees ASSIGNED after complete");
+            waitFor(() -> l0.events.contains("RELEASED:" + SEG_UUID),
+                    "instance 0 sees RELEASED after complete");
         }
 
         // Final trace: instance 0 went ASSIGNED → RELEASED; instance 1 went PENDING → ASSIGNED.
@@ -239,14 +259,16 @@ public class SegmentOwnershipTransferTest {
         RecordingListener l0 = new RecordingListener();
         try (SegmentAssignmentWatcher w0 = new SegmentAssignmentWatcher(registry, 0, l0)) {
             w0.watchIndex(TS_UUID, IDX_UUID);
-            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID));
+            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID),
+                    "instance 0 sees initial ASSIGNED");
 
             VersionedSegmentMetadata current = registry.getSegment(TS_UUID, IDX_UUID, SEG_UUID).orElseThrow();
             registry.casDeleteSegment(current);
             // The watcher passes the cached pre-deletion metadata (not null) so that
             // downstream listeners (e.g. IndexingServiceEngine) can identify which segment
             // was removed and call dropSegmentByUuid on it.
-            waitFor(() -> l0.events.contains("RELEASED:" + SEG_UUID));
+            waitFor(() -> l0.events.contains("RELEASED:" + SEG_UUID),
+                    "instance 0 sees RELEASED after delete");
         }
     }
 
@@ -271,7 +293,8 @@ public class SegmentOwnershipTransferTest {
             w0.watchIndex(TS_UUID, IDX_UUID);
             w1.watchIndex(TS_UUID, IDX_UUID);
             // Initial assignment to instance 0 — wait for it to land before starting cycles.
-            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID));
+            waitFor(() -> l0.events.contains("ASSIGNED:" + SEG_UUID),
+                    "instance 0 sees initial ASSIGNED before cycles");
 
             for (int i = 0; i < cycles; i++) {
                 int target = (i % 2 == 0) ? 1 : 0;
@@ -300,7 +323,9 @@ public class SegmentOwnershipTransferTest {
                     long releases = sourceL.events.stream()
                             .filter(e -> e.equals("RELEASED:" + SEG_UUID)).count();
                     return assigns == expectedAssignsTarget && releases == expectedReleasesSource;
-                });
+                }, "cycle " + i + ": target=" + t + " expects "
+                        + expectedAssignsTarget + " ASSIGNED, source=" + s + " expects "
+                        + expectedReleasesSource + " RELEASED");
             }
 
             // Final exact counts:


### PR DESCRIPTION
Fixes #608.

## Changes
- **`herddb-indexing-service/src/test/java/herddb/indexing/segment/SegmentOwnershipTransferTest.java`** — raise the deadline in the file-local `waitFor` helper from 10 s → 30 s and add a `String desc` parameter so a timeout failure identifies the exact predicate. The 10 s budget proved too tight on contended CI runners (observed in run 25856862885, PR #554) where the watcher's single-thread dispatch executor has to process several ZK watcher fires plus an index re-list per transition. 30 s matches the deadline used by comparable polling helpers elsewhere in the suite (`OptimizerMergeAdoptionRecallTest`, `IndexOptimizerSessionExpiredTest`, `OptimizerTaskRegistryIntegrationTest`). Healthy runs still complete each cycle in well under a second.
- **`CLAUDE.md`** (small unrelated doc fix surfaced while running pre-PR validation) — warn that `mvn checkstyle:check` must not be invoked directly (it falls back to Sun defaults and reports thousands of bogus violations since Spotless replaced Checkstyle in #544/#554), and reorder the pre-PR command so `spotbugs:check` runs **after** `install`, matching `.github/workflows/ci.yml`.

## Tests
- All 7 tests in `SegmentOwnershipTransferTest` pass locally with the new helper.
- `repeatedTransfersFireTerminalEventsExactlyOncePerCycle` run 3× in isolation: 3 / 3 green, ~0.83 s each.
- Pre-PR validation (`mvn -B spotless:check apache-rat:check install -DskipTests spotbugs:check -Pci`) green across all modules.

This change does not touch any production code path — it only relaxes a brittle test timing budget and improves the failure message — so no new test was added (a "should not flake" test on a healthy local box would always pass and provide no signal).

🤖 Implemented by the \`pr-worker\` agent.