### PR TITLE
issue #619: bulk-prefetch vector segment warmup via SegmentBlockCache.bulkInsert

### DIFF
--- a/herddb-core/src/main/java/herddb/index/vector/BulkPrefetchReaderSupplier.java
+++ b/herddb-core/src/main/java/herddb/index/vector/BulkPrefetchReaderSupplier.java
@@ -48,6 +48,18 @@ import java.io.IOException;
  * need not implement this interface; callers check for it with
  * {@code instanceof} and fall back to the default BFS path when it is absent.
  *
+ * <p><b>Layout assumption.</b> Callers using this interface for HNSW warmup
+ * (notably {@code PersistentVectorStore.bulkPrefetchSegmentIntoCache}) assume
+ * that the bytes the warmup BFS would have visited — the HNSW entry-frontier
+ * on Layer 0 — live in the file's leading prefix. This holds for the current
+ * jvector {@code OnDiskGraphIndex} layout where Layer 0 data dominates the
+ * file from a small header onwards. If a future jvector layout change moves
+ * the entry-frontier later in the file, the prefetch still populates the
+ * cache correctly but covers the wrong bytes; the subsequent BFS then degrades
+ * to pre-#619 per-node wire reads — no correctness impact, only a missed
+ * optimisation. Implementations therefore do not need to know about the HNSW
+ * layout; they just deliver the bytes requested.
+ *
  * @author enrico.olivelli
  */
 public interface BulkPrefetchReaderSupplier {

--- a/herddb-core/src/main/java/herddb/index/vector/BulkPrefetchReaderSupplier.java
+++ b/herddb-core/src/main/java/herddb/index/vector/BulkPrefetchReaderSupplier.java
@@ -1,0 +1,82 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.index.vector;
+
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import java.io.IOException;
+
+/**
+ * Extension mixin for {@link ReaderSupplier} implementations that can populate
+ * the local block cache in bulk via a small number of large I/O reads
+ * (issue #619).
+ *
+ * <p>The default warmup path executes a BFS over the HNSW Layer-0 graph and
+ * lets the per-thread {@link io.github.jbellis.jvector.disk.RandomAccessReader}
+ * pull one cache-block at a time. With a 32 MiB warmup budget and 16 KiB cache
+ * blocks that is up to ~2000 individual {@code readFileRange} round-trips per
+ * segment — fast on a local file system, but devastatingly slow when the
+ * indexing service is backed by the remote file server / S3 / GCS.
+ *
+ * <p>Suppliers that implement this mixin can short-circuit that BFS by reading
+ * a contiguous prefix of the segment file in a few large multipart-chunk-sized
+ * RPCs and bulk-inserting every covered block into the shared
+ * {@code SegmentBlockCache}. The subsequent BFS pass then hits the cache for
+ * every read — no wire I/O — preserving the per-segment "warmed" accounting
+ * and the pin BFS pass for the frontier region while removing the dominant
+ * latency.
+ *
+ * <p>Implementations that do not back a remote, network-bound storage (e.g.
+ * local-file suppliers used in unit tests, or pass-through in-memory readers)
+ * need not implement this interface; callers check for it with
+ * {@code instanceof} and fall back to the default BFS path when it is absent.
+ *
+ * @author enrico.olivelli
+ */
+public interface BulkPrefetchReaderSupplier {
+
+    /**
+     * Prefetches up to {@code maxBytes} bytes starting at {@code startOffset}
+     * from the underlying file into the local block cache.
+     *
+     * <p>The implementation issues a small number of large reads (one per
+     * underlying multipart chunk, executed in parallel) and bulk-inserts every
+     * covered cache-block into the {@code SegmentBlockCache}. After this
+     * method returns successfully every block in
+     * {@code [startOffset, startOffset + bytesCovered)} is resident in the
+     * main cache region; subsequent reads via a normal
+     * {@code RandomAccessReader} on the same {@code (path, blockSize)} hit the
+     * cache without wire I/O.
+     *
+     * <p>The method is best-effort and idempotent: a block that is already
+     * cached is left untouched (existing entries are never evicted by this
+     * call), and a partial read at end-of-file is allowed.
+     *
+     * @param startOffset starting byte offset within the file; must be
+     *     non-negative and aligned to the underlying multipart chunk size
+     * @param maxBytes    maximum number of bytes to read; the actual amount
+     *     read is clamped to {@code fileSize - startOffset}
+     * @return number of bytes actually transferred from storage into the
+     *     cache (may be less than {@code maxBytes} at end-of-file)
+     * @throws IOException if the storage backend fails; the caller must treat
+     *     this as best-effort and fall back to the per-block BFS path
+     */
+    long bulkPrefetchIntoCache(long startOffset, long maxBytes) throws IOException;
+}

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -100,6 +100,7 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import herddb.index.vector.BulkPrefetchReaderSupplier;
 import herddb.index.vector.PinModeReaderSupplier;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 
@@ -5179,6 +5180,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
         int nodeLimit = (int) Math.min(
                 idUpperBound,
                 Math.max(1L, bytesPerSegment / approxBytesPerNode));
+        // Bulk-prefetch shortcut (issue #619): when the segment's reader supplier
+        // supports bulk prefetch (i.e. it is backed by the remote file service),
+        // pull the warmup budget worth of bytes in a few large multipart-aligned
+        // reads and bulk-insert them into the SegmentBlockCache. The BFS below
+        // then runs entirely against a hot cache — no per-node wire round-trips.
+        // The prefetch is best-effort: any I/O failure is logged and the BFS
+        // path still runs as before, which means we never regress versus the
+        // pre-#619 behaviour even when the remote file service is degraded.
+        bulkPrefetchSegmentIntoCache(seg, bytesPerSegment);
         int nodesVisited = warmUpSegmentBfs(seg, odg, nodeLimit);
         if (nodesVisited > 0) {
             seg.warmedUp = true;
@@ -5234,6 +5244,63 @@ public class PersistentVectorStore extends AbstractVectorStore {
                             + "{3} nodes in {4} ms",
                     new Object[]{indexName, warmed, context, totalNodes,
                             System.currentTimeMillis() - startMs});
+        }
+    }
+
+    /**
+     * Bulk-prefetches the first {@code bytesPerSegment} bytes of the segment's
+     * graph file into the {@link herddb.remote.SegmentBlockCache} via a small
+     * number of large multipart-chunk-sized reads — issue #619.
+     *
+     * <p>This is the fast replacement for the per-node BFS reads of
+     * {@link #warmUpSegmentBfs}: instead of issuing ~{@code bytesPerSegment /
+     * 16 KiB} separate {@code readFileRange} calls, we issue one call per
+     * underlying multipart chunk (typically 4 MiB) in parallel and bulk-insert
+     * every covered cache block. The BFS that follows hits the cache for every
+     * read.
+     *
+     * <p>Best-effort: the call is a no-op when the segment's
+     * {@code onDiskReaderSupplier} does not implement
+     * {@link BulkPrefetchReaderSupplier} (e.g. local-disk suppliers used in
+     * unit tests, or in-memory readers). When the supplier supports prefetch
+     * but the read fails, the exception is logged at {@code WARNING} and
+     * swallowed — the subsequent BFS continues to load blocks one at a time
+     * via the normal path, so we never regress vs. the pre-#619 behaviour.
+     */
+    // Package-private to allow direct testing — see Issue619BulkWarmupTest.
+    void bulkPrefetchSegmentIntoCache(VectorSegment seg, long bytesPerSegment) {
+        if (bytesPerSegment <= 0) {
+            return;
+        }
+        io.github.jbellis.jvector.disk.ReaderSupplier rs = seg.onDiskReaderSupplier;
+        if (!(rs instanceof BulkPrefetchReaderSupplier)) {
+            return;
+        }
+        BulkPrefetchReaderSupplier prefetcher = (BulkPrefetchReaderSupplier) rs;
+        long startNanos = System.nanoTime();
+        try {
+            long inserted = prefetcher.bulkPrefetchIntoCache(0L, bytesPerSegment);
+            if (inserted > 0) {
+                LOGGER.log(Level.FINE,
+                        "bulkPrefetchSegmentIntoCache {0}: segment {1} prefetched "
+                                + "{2} bytes in {3} ms",
+                        new Object[]{indexName, seg.segmentId, inserted,
+                                (System.nanoTime() - startNanos) / 1_000_000L});
+            }
+        } catch (IOException e) {
+            // Best-effort: the BFS below will pull blocks on demand.
+            LOGGER.log(Level.WARNING,
+                    "bulkPrefetchSegmentIntoCache {0}: I/O error prefetching "
+                            + "segment {1}: {2} — falling back to per-node BFS",
+                    new Object[]{indexName, seg.segmentId, e.getMessage()});
+        } catch (RuntimeException e) {
+            // Narrow catch on RuntimeException only: programming errors inside the
+            // prefetcher (e.g. unaligned offset) must not abort the watermark
+            // save. Checked exceptions other than IOException are unreachable —
+            // the interface declares only IOException.
+            LOGGER.log(Level.WARNING,
+                    "bulkPrefetchSegmentIntoCache " + indexName
+                            + ": unexpected error prefetching segment " + seg.segmentId, e);
         }
     }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -771,6 +771,18 @@ public class PersistentVectorStore extends AbstractVectorStore {
      */
     final AtomicLong warmedSegmentsTotal = new AtomicLong();
 
+    /**
+     * Counter: number of segments whose warmup BFS pass was skipped because
+     * the bulk-prefetch pass (issue #619) covered the entire warmup budget.
+     * Exposed for tests (the BFS short-circuit is what the issue #619 patch
+     * delivers vs. just "BFS hits cache") and for Prometheus dashboards that
+     * track the share of warmups served by the prefetch fast path.
+     *
+     * <p>This is a strict subset of {@link #warmedSegmentsTotal}: every
+     * bulk-prefetch-only segment is also counted as a warmed segment.
+     */
+    final AtomicLong warmedSegmentsBulkPrefetchOnly = new AtomicLong();
+
     // -------------------------------------------------------------------------
     // PQ codebook cache (issue #281)
     // -------------------------------------------------------------------------
@@ -5133,6 +5145,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
+     * Number of segments whose BFS pass was skipped because the issue #619
+     * bulk-prefetch pass fully covered the warmup budget. Strict subset of
+     * {@link #getWarmedSegmentsTotal()}.
+     */
+    public long getWarmedSegmentsBulkPrefetchOnly() {
+        return warmedSegmentsBulkPrefetchOnly.get();
+    }
+
+    /**
      * Warms a single segment's block cache (issue #569), idempotently.
      *
      * <p>This is the per-segment building block called both by the
@@ -5188,8 +5209,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // The prefetch is best-effort: any I/O failure is logged and the BFS
         // path still runs as before, which means we never regress versus the
         // pre-#619 behaviour even when the remote file service is degraded.
-        bulkPrefetchSegmentIntoCache(seg, bytesPerSegment);
-        int nodesVisited = warmUpSegmentBfs(seg, odg, nodeLimit);
+        long prefetchedBytes = bulkPrefetchSegmentIntoCache(seg, bytesPerSegment);
+        // If the prefetch covered the whole warmup budget (or the whole file,
+        // if smaller) the BFS would just walk the graph in user-thread time
+        // without doing any I/O. Skip it and report nodeLimit as the visited
+        // count so the per-segment "warmed exactly once" accounting stays
+        // consistent with the BFS path. Falls through to the BFS when the
+        // prefetch is partial / failed / not applicable (local-disk supplier).
+        long expectedCoverage = Math.min(bytesPerSegment, seg.graphFileSize);
+        int nodesVisited;
+        if (prefetchedBytes >= expectedCoverage && expectedCoverage > 0) {
+            warmedSegmentsBulkPrefetchOnly.incrementAndGet();
+            nodesVisited = nodeLimit;
+        } else {
+            nodesVisited = warmUpSegmentBfs(seg, odg, nodeLimit);
+        }
         if (nodesVisited > 0) {
             seg.warmedUp = true;
             warmedSegmentsTotal.incrementAndGet();
@@ -5259,22 +5293,39 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * every covered cache block. The BFS that follows hits the cache for every
      * read.
      *
-     * <p>Best-effort: the call is a no-op when the segment's
+     * <p><b>Layout assumption.</b> The prefetch reads the file linearly from
+     * offset 0 — it assumes the bytes the warmup BFS would have visited (the
+     * HNSW entry-frontier on Layer 0) live in the prefix
+     * {@code [0, bytesPerSegment)}. This holds for the current jvector
+     * {@link io.github.jbellis.jvector.disk.OnDiskGraphIndex} layout, where
+     * Layer 0 data dominates the file from a small header onwards. If a
+     * future jvector layout change moves the entry-frontier later in the file
+     * the prefetch will still populate the cache correctly but the BFS will
+     * miss those blocks and fall back to per-node wire reads — i.e. degraded
+     * to pre-#619 performance, not broken correctness.
+     *
+     * <p>Best-effort: the call is a no-op (returns 0) when the segment's
      * {@code onDiskReaderSupplier} does not implement
      * {@link BulkPrefetchReaderSupplier} (e.g. local-disk suppliers used in
      * unit tests, or in-memory readers). When the supplier supports prefetch
-     * but the read fails, the exception is logged at {@code WARNING} and
-     * swallowed — the subsequent BFS continues to load blocks one at a time
-     * via the normal path, so we never regress vs. the pre-#619 behaviour.
+     * but the read fails, the exception is logged at {@code WARNING} and the
+     * method returns 0 — the subsequent BFS continues to load blocks one at
+     * a time via the normal path, so we never regress vs. the pre-#619
+     * behaviour.
+     *
+     * @return number of bytes actually inserted into the block cache. When
+     *     this equals {@code Math.min(bytesPerSegment, seg.graphFileSize)} the
+     *     prefetch has fully covered the warmup budget and {@link #warmUpSegment}
+     *     skips the BFS pass.
      */
     // Package-private to allow direct testing — see Issue619BulkWarmupTest.
-    void bulkPrefetchSegmentIntoCache(VectorSegment seg, long bytesPerSegment) {
+    long bulkPrefetchSegmentIntoCache(VectorSegment seg, long bytesPerSegment) {
         if (bytesPerSegment <= 0) {
-            return;
+            return 0L;
         }
         io.github.jbellis.jvector.disk.ReaderSupplier rs = seg.onDiskReaderSupplier;
         if (!(rs instanceof BulkPrefetchReaderSupplier)) {
-            return;
+            return 0L;
         }
         BulkPrefetchReaderSupplier prefetcher = (BulkPrefetchReaderSupplier) rs;
         long startNanos = System.nanoTime();
@@ -5287,12 +5338,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         new Object[]{indexName, seg.segmentId, inserted,
                                 (System.nanoTime() - startNanos) / 1_000_000L});
             }
+            return inserted;
         } catch (IOException e) {
             // Best-effort: the BFS below will pull blocks on demand.
             LOGGER.log(Level.WARNING,
                     "bulkPrefetchSegmentIntoCache {0}: I/O error prefetching "
                             + "segment {1}: {2} — falling back to per-node BFS",
                     new Object[]{indexName, seg.segmentId, e.getMessage()});
+            return 0L;
         } catch (RuntimeException e) {
             // Narrow catch on RuntimeException only: programming errors inside the
             // prefetcher (e.g. unaligned offset) must not abort the watermark
@@ -5301,6 +5354,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             LOGGER.log(Level.WARNING,
                     "bulkPrefetchSegmentIntoCache " + indexName
                             + ": unexpected error prefetching segment " + seg.segmentId, e);
+            return 0L;
         }
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/Issue619BulkWarmupTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/Issue619BulkWarmupTest.java
@@ -122,6 +122,9 @@ public class Issue619BulkWarmupTest {
     /**
      * When the supplier implements {@link BulkPrefetchReaderSupplier}, the
      * prefetch is invoked exactly once with {@code (startOffset=0, maxBytes=budget)}.
+     * Also asserts the new return-value contract introduced for issue #619
+     * review fix R3 — the bytes inserted are propagated to the caller so
+     * {@code warmUpSegment} can decide to skip the BFS.
      */
     @Test
     public void bulkPrefetchInvokedOnceWhenSupplierSupportsIt() throws Exception {
@@ -136,12 +139,50 @@ public class Issue619BulkWarmupTest {
             RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
             seg.onDiskReaderSupplier = supplier;
 
-            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+            long inserted = store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
 
             assertEquals("prefetch invoked exactly once", 1, supplier.calls.get());
             assertEquals("prefetch startOffset == 0", 0L, supplier.lastStartOffset.get());
             assertEquals("prefetch budget == warmupBytesPerSegment",
                     BUDGET_BYTES, supplier.lastBudget.get());
+            assertEquals("bytes-inserted return value flows back to caller",
+                    BUDGET_BYTES, inserted);
+        }
+    }
+
+    /**
+     * Review fix R3: when the bulk prefetch reports a successful failure
+     * (e.g. {@link IOException}) the helper returns 0 so that
+     * {@code warmUpSegment} falls back to the BFS path.
+     */
+    @Test
+    public void bulkPrefetchReturnsZeroOnIoFailure() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
+            supplier.failWith = new IOException("simulated");
+            seg.onDiskReaderSupplier = supplier;
+
+            long inserted = store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+            assertEquals("IOException is swallowed; returns 0", 0L, inserted);
+        }
+    }
+
+    /**
+     * Review fix R3: when the supplier does not implement the mixin the
+     * helper returns 0 (no prefetch attempt). Verifies the return-value
+     * contract for the local-disk fallthrough path.
+     */
+    @Test
+    public void plainSupplierReturnsZero() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            seg.onDiskReaderSupplier = new PlainSupplier();
+            assertEquals(0L, store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES));
         }
     }
 
@@ -246,6 +287,17 @@ public class Issue619BulkWarmupTest {
             store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
 
             assertEquals(3, supplier.calls.get());
+        }
+    }
+
+    /**
+     * Review fix R3: the {@code warmedSegmentsBulkPrefetchOnly} counter must
+     * still be zero before any warmup runs — sanity check the new accessor.
+     */
+    @Test
+    public void bulkPrefetchOnlyCounterStartsAtZero() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            assertEquals(0L, store.getWarmedSegmentsBulkPrefetchOnly());
         }
     }
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/Issue619BulkWarmupTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/Issue619BulkWarmupTest.java
@@ -1,0 +1,269 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.index.vector.BulkPrefetchReaderSupplier;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies the bulk-prefetch wiring introduced by issue #619:
+ * {@link PersistentVectorStore#bulkPrefetchSegmentIntoCache} only triggers when
+ * the segment's {@code onDiskReaderSupplier} implements
+ * {@link BulkPrefetchReaderSupplier}; when it does, the prefetch is invoked
+ * exactly once per segment with the configured budget; when the prefetch fails
+ * with an {@link IOException} the failure is swallowed so the BFS fallback path
+ * can run; and when the supplier does NOT implement the mixin (e.g. local-disk
+ * suppliers in unit tests) the bulk-prefetch path is skipped.
+ *
+ * <p>Uses a hand-rolled {@link ReaderSupplier} so the test does not require a
+ * running remote file server — the contract under test is "does the dispatch
+ * pick the bulk path when available", not "does the network read succeed".
+ */
+public class Issue619BulkWarmupTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    /** A budget chosen large enough that warmupBytesPerSegment > 0 always trips the prefetch. */
+    private static final long BUDGET_BYTES = 4L * 1024 * 1024;
+
+    /**
+     * Minimal {@link ReaderSupplier} that records every bulk-prefetch call and
+     * lets the test simulate success / failure paths.
+     */
+    private static final class RecordingBulkPrefetchSupplier
+            implements ReaderSupplier, BulkPrefetchReaderSupplier {
+
+        final AtomicInteger calls = new AtomicInteger();
+        final AtomicLong lastBudget = new AtomicLong(-1);
+        final AtomicLong lastStartOffset = new AtomicLong(-1);
+        volatile IOException failWith;
+
+        @Override
+        public long bulkPrefetchIntoCache(long startOffset, long maxBytes) throws IOException {
+            calls.incrementAndGet();
+            lastStartOffset.set(startOffset);
+            lastBudget.set(maxBytes);
+            if (failWith != null) {
+                throw failWith;
+            }
+            return maxBytes; // pretend we covered the full budget
+        }
+
+        @Override
+        public RandomAccessReader get() throws IOException {
+            throw new IOException("test supplier does not vend readers");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    /**
+     * A {@link ReaderSupplier} that does NOT implement
+     * {@link BulkPrefetchReaderSupplier} — used to verify the local-disk
+     * fallthrough.
+     */
+    private static final class PlainSupplier implements ReaderSupplier {
+        final AtomicInteger getCalls = new AtomicInteger();
+
+        @Override
+        public RandomAccessReader get() throws IOException {
+            getCalls.incrementAndGet();
+            throw new IOException("test supplier does not vend readers");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private PersistentVectorStore newStore(Path tmpDir) {
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore(
+                "vidx619", "vectable", "tstblspace", "vec", "uuid-619", tmpDir,
+                new MemoryDataStorageManager(), mm,
+                8, 32, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                /*compactionIntervalMs*/ Long.MAX_VALUE);
+    }
+
+    /**
+     * When the supplier implements {@link BulkPrefetchReaderSupplier}, the
+     * prefetch is invoked exactly once with {@code (startOffset=0, maxBytes=budget)}.
+     */
+    @Test
+    public void bulkPrefetchInvokedOnceWhenSupplierSupportsIt() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            // Construct a synthetic segment carrying just enough state for the
+            // dispatch helper to reach the supplier check. We don't go through
+            // warmUpSegment() proper because that path also requires a real
+            // OnDiskGraphIndex — outside the unit-test scope.
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
+            seg.onDiskReaderSupplier = supplier;
+
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+
+            assertEquals("prefetch invoked exactly once", 1, supplier.calls.get());
+            assertEquals("prefetch startOffset == 0", 0L, supplier.lastStartOffset.get());
+            assertEquals("prefetch budget == warmupBytesPerSegment",
+                    BUDGET_BYTES, supplier.lastBudget.get());
+        }
+    }
+
+    /**
+     * When the supplier does NOT implement {@link BulkPrefetchReaderSupplier}
+     * the helper must short-circuit — no prefetch attempt, no reader.get()
+     * call, no exception. Local-disk suppliers in unit tests rely on this.
+     */
+    @Test
+    public void bulkPrefetchSkippedForNonRemoteSupplier() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            PlainSupplier supplier = new PlainSupplier();
+            seg.onDiskReaderSupplier = supplier;
+
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+
+            assertEquals("plain supplier must not be invoked via get()",
+                    0, supplier.getCalls.get());
+        }
+    }
+
+    /**
+     * An {@link IOException} from the supplier must be swallowed (best-effort
+     * contract); the caller continues to the BFS fallback path. A
+     * {@link RuntimeException} from the supplier is also swallowed — see the
+     * narrow catch in {@code bulkPrefetchSegmentIntoCache}.
+     */
+    @Test
+    public void ioExceptionFromSupplierIsSwallowed() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
+            supplier.failWith = new IOException("simulated S3 fault");
+            seg.onDiskReaderSupplier = supplier;
+
+            // Must not throw — the warmup contract is best-effort.
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+            assertEquals(1, supplier.calls.get());
+        }
+    }
+
+    /**
+     * A zero (or negative) budget is a no-op: the helper does not even check
+     * the supplier type, so it never calls {@code bulkPrefetchIntoCache}.
+     */
+    @Test
+    public void zeroBudgetIsNoOp() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
+            seg.onDiskReaderSupplier = supplier;
+
+            store.bulkPrefetchSegmentIntoCache(seg, 0L);
+            store.bulkPrefetchSegmentIntoCache(seg, -1L);
+
+            assertEquals("prefetch must not run with non-positive budget", 0, supplier.calls.get());
+        }
+    }
+
+    /**
+     * The cached supplier reference is unchanged across the call — sanity
+     * check that the helper does not mutate the segment.
+     */
+    @Test
+    public void supplierReferenceIsNotMutated() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
+            seg.onDiskReaderSupplier = supplier;
+
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+
+            assertSame("supplier reference must not be mutated",
+                    supplier, seg.onDiskReaderSupplier);
+        }
+    }
+
+    /**
+     * Multiple invocations call the supplier each time — the helper is
+     * stateless and just dispatches. The caller (warmUpSegment) is responsible
+     * for the per-segment "warmedUp" idempotency guard.
+     */
+    @Test
+    public void repeatedInvocationCallsSupplierEachTime() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            RecordingBulkPrefetchSupplier supplier = new RecordingBulkPrefetchSupplier();
+            seg.onDiskReaderSupplier = supplier;
+
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+
+            assertEquals(3, supplier.calls.get());
+        }
+    }
+
+    /**
+     * A null {@code onDiskReaderSupplier} (which can happen for segments that
+     * have not been registered yet — defensive guard) must not throw.
+     */
+    @Test
+    public void nullReaderSupplierIsNoOp() throws Exception {
+        try (PersistentVectorStore store = newStore(tmpFolder.newFolder().toPath())) {
+            store.setWarmupBytesPerSegment(BUDGET_BYTES);
+            VectorSegment seg = new VectorSegment(0);
+            seg.graphFileSize = BUDGET_BYTES * 2L;
+            seg.onDiskReaderSupplier = null;
+
+            // Must not throw and must not log at SEVERE.
+            store.bulkPrefetchSegmentIntoCache(seg, BUDGET_BYTES);
+            assertTrue("null supplier path is a clean no-op", true);
+        }
+    }
+}

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -21,6 +21,7 @@
 package herddb.remote;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import herddb.index.vector.BulkPrefetchReaderSupplier;
 import herddb.index.vector.PinModeReaderSupplier;
 import herddb.utils.VectorSearchRequestContext;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
@@ -29,10 +30,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.stats.OpStatsLogger;
@@ -631,7 +636,11 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
      * that entry-frontier Layer-0 blocks survive eviction pressure from the main
      * cache.
      */
-    public static class Supplier implements ReaderSupplier, PinModeReaderSupplier {
+    public static class Supplier implements ReaderSupplier, PinModeReaderSupplier,
+            BulkPrefetchReaderSupplier {
+
+        private static final Logger SUPPLIER_LOGGER =
+                Logger.getLogger(Supplier.class.getName());
 
         private final RemoteFileServiceClient client;
         private final String path;
@@ -728,6 +737,152 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
          */
         public boolean hasFrontierCacheActive() {
             return blockCache.isFrontierCacheActive();
+        }
+
+        /**
+         * Bulk-prefetches up to {@code maxBytes} bytes starting at
+         * {@code startOffset} from the remote file into the local
+         * {@link SegmentBlockCache} (issue #619).
+         *
+         * <p>Issues one
+         * {@link RemoteFileServiceClient#readFileRangeAsByteBufAsync} call per
+         * underlying multipart chunk (chunks are {@code writeBlockSize} bytes
+         * wide) and dispatches them in parallel. Each completed chunk is fed
+         * to {@link SegmentBlockCache#bulkInsert} which slices it into
+         * {@code bufferSize}-sized cache blocks. After this method returns,
+         * subsequent reads via a normal {@link RemoteRandomAccessReader}
+         * targeting the same {@code (path, bufferSize)} key space hit the
+         * cache for every covered block — no further wire I/O.
+         *
+         * <p>If the cache is disabled
+         * ({@code blockCache.isActive() == false}) the call is a no-op:
+         * caching is off, so populating it would be pointless.
+         *
+         * <p>If the prefetch returns a {@code null} buffer for any chunk
+         * (file deleted underneath us, or not yet uploaded) the call fails
+         * with {@link IOException}; callers must treat this as best-effort
+         * and continue with the per-block fallback path. All successfully
+         * fetched buffers are released on the failure branch so no off-heap
+         * memory leaks.
+         *
+         * @param startOffset starting byte offset; must be {@code >= 0} and
+         *     aligned to {@code writeBlockSize}
+         * @param maxBytes    upper bound on the number of bytes to read;
+         *     clamped to {@code totalSize - startOffset}
+         * @return number of bytes actually inserted into the cache
+         * @throws IOException if any underlying read fails
+         */
+        @Override
+        public long bulkPrefetchIntoCache(long startOffset, long maxBytes) throws IOException {
+            if (!blockCache.isActive() || maxBytes <= 0) {
+                return 0;
+            }
+            if (startOffset < 0) {
+                throw new IllegalArgumentException(
+                        "startOffset must be >= 0, got " + startOffset);
+            }
+            if (startOffset >= totalSize) {
+                return 0;
+            }
+            if (startOffset % writeBlockSize != 0) {
+                throw new IllegalArgumentException(
+                        "startOffset must be aligned to multipart chunk size "
+                                + writeBlockSize + ", got " + startOffset);
+            }
+            long endOffset = Math.min(totalSize, startOffset + maxBytes);
+            if (endOffset <= startOffset) {
+                return 0;
+            }
+
+            // Build one per-chunk request: chunks are writeBlockSize-aligned and
+            // never span a multipart-chunk boundary (the storage backend forbids
+            // it; readFileRangeAsByteBufAsync's recursive splitter only handles
+            // a single boundary so we have to align here explicitly).
+            List<CompletableFuture<ByteBuf>> futures = new ArrayList<>();
+            List<Long> offsets = new ArrayList<>();
+            long off = startOffset;
+            while (off < endOffset) {
+                long nextBoundary = ((off / writeBlockSize) + 1L) * writeBlockSize;
+                long chunkEnd = Math.min(endOffset, nextBoundary);
+                int len = (int) (chunkEnd - off);
+                offsets.add(off);
+                futures.add(client.readFileRangeAsByteBufAsync(path, off, len, writeBlockSize));
+                off = chunkEnd;
+            }
+
+            long startNanos = System.nanoTime();
+            try {
+                // Block the calling thread (typically the checkpoint / compaction
+                // worker that owns warmUpNewSegmentsBeforePublish) until every
+                // chunk has resolved. We *want* to block: the warmup contract is
+                // synchronous and the caller is on a dedicated executor.
+                CompletableFuture.allOf(
+                                futures.toArray(new CompletableFuture[0]))
+                        .join();
+            } catch (CompletionException ce) {
+                // Drain any chunk that completed successfully before the failure.
+                releaseCompletedFutures(futures);
+                Throwable cause = ce.getCause();
+                if (cause instanceof IOException) {
+                    throw (IOException) cause;
+                }
+                throw new IOException("Bulk prefetch failed for path=" + path
+                        + " startOffset=" + startOffset, cause);
+            }
+
+            long insertedBytes = 0;
+            // Track which futures still own a buffer that we need to release on
+            // a failure mid-iteration (e.g., a null result from the server).
+            int nextToConsume = 0;
+            try {
+                for (int i = 0; i < futures.size(); i++) {
+                    ByteBuf data = futures.get(i).getNow(null);
+                    if (data == null) {
+                        // null = "block not found" — file deleted or not yet
+                        // uploaded. Surface as an IOException; the warmup path
+                        // treats it as best-effort and falls back to BFS.
+                        nextToConsume = i + 1;
+                        throw new IOException("Bulk prefetch: server returned null"
+                                + " path=" + path + " offset=" + offsets.get(i));
+                    }
+                    // bulkInsert takes ownership of `data` and releases it.
+                    long chunkOff = offsets.get(i);
+                    nextToConsume = i + 1;
+                    insertedBytes += blockCache.bulkInsert(path, chunkOff, bufferSize, data);
+                }
+                if (insertedBytes > 0) {
+                    SUPPLIER_LOGGER.log(Level.FINE,
+                            "bulkPrefetchIntoCache path={0}: inserted {1} bytes "
+                                    + "({2} chunks) in {3} ms",
+                            new Object[]{path, insertedBytes, futures.size(),
+                                    (System.nanoTime() - startNanos) / 1_000_000L});
+                }
+                return insertedBytes;
+            } catch (IOException | RuntimeException e) {
+                // Release any chunk still owned by a pending future. Anything
+                // already passed to bulkInsert has been consumed there.
+                for (int i = nextToConsume; i < futures.size(); i++) {
+                    CompletableFuture<ByteBuf> f = futures.get(i);
+                    if (f.isDone() && !f.isCompletedExceptionally() && !f.isCancelled()) {
+                        ReferenceCountUtil.safeRelease(f.getNow(null));
+                    }
+                }
+                throw e;
+            }
+        }
+
+        /**
+         * Release every successfully-completed chunk buffer in {@code futures}
+         * — used on the failure path of
+         * {@link #bulkPrefetchIntoCache(long, long)} so that buffers fetched
+         * before the failing chunk do not leak.
+         */
+        private static void releaseCompletedFutures(List<CompletableFuture<ByteBuf>> futures) {
+            for (CompletableFuture<ByteBuf> f : futures) {
+                if (f.isDone() && !f.isCompletedExceptionally() && !f.isCancelled()) {
+                    ReferenceCountUtil.safeRelease(f.getNow(null));
+                }
+            }
         }
 
         @Override

--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteRandomAccessReader.java
@@ -765,6 +765,16 @@ public class RemoteRandomAccessReader implements RandomAccessReader {
          * fetched buffers are released on the failure branch so no off-heap
          * memory leaks.
          *
+         * <p><b>Threading constraint.</b> This method blocks on
+         * {@code CompletableFuture.allOf(...).join()}, and those futures are
+         * completed on the Netty event-loop threads owned by
+         * {@code RemoteFileServiceClient}. It MUST NOT be called from one of
+         * those event-loop threads — doing so would deadlock the loop that is
+         * supposed to complete the futures. The intended caller is the
+         * indexing-service checkpoint / compaction worker, which runs on a
+         * dedicated executor thread (see
+         * {@code PersistentVectorStore.bulkPrefetchSegmentIntoCache}).
+         *
          * @param startOffset starting byte offset; must be {@code >= 0} and
          *     aligned to {@code writeBlockSize}
          * @param maxBytes    upper bound on the number of bytes to read;

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -462,6 +462,22 @@ public final class SegmentBlockCache {
                     existing.retain();
                     return existing;
                 }
+                // Issue #619 review fix: before going to the wire, check if the
+                // block is already resident in the MAIN cache (typically because
+                // a recent warmup bulk-prefetch loaded it). If so, copy its bytes
+                // into a fresh frontier-region entry — that avoids one wire read
+                // per pinned block in the warmup-followed-by-pin-BFS flow. The
+                // main and frontier ConcurrentHashMaps use independent per-key
+                // locks so this nested compute() cannot deadlock with itself.
+                ByteBuf promoted = tryPromoteFromMainCache(key, length);
+                if (promoted != null) {
+                    frontierLoadSuccess.incrementAndGet();
+                    // promoted.refCnt() == 1 (just allocated). Bump to 2: one
+                    // for the cache entry, one for the caller's distribution
+                    // ref. Mirrors the loader branch.
+                    promoted.retain();
+                    return promoted;
+                }
                 long startNanos = System.nanoTime();
                 ByteBuf loaded;
                 try {
@@ -507,18 +523,31 @@ public final class SegmentBlockCache {
      *
      * <p>The input {@code data} buffer must contain exactly the bytes located
      * at file offsets {@code [baseOffset, baseOffset + data.readableBytes())}.
-     * The method splices {@code data} into {@code blockSize}-sized retained
-     * slices (the last slice may be shorter, mirroring end-of-file blocks) and
-     * inserts each slice as a fresh cache entry keyed by
+     * The method splits {@code data} into {@code blockSize}-sized chunks (the
+     * last chunk may be shorter, mirroring end-of-file blocks) and inserts
+     * each chunk as a fresh cache entry keyed by
      * {@code (path, (baseOffset + i * blockSize) / blockSize)} — exactly the
      * key shape used by {@link #getBlock}, so subsequent reads issued by
      * {@code RemoteRandomAccessReader} on the same {@code (path, blockSize)}
      * hit the freshly-loaded blocks.
      *
+     * <p><b>Memory discipline (issue #619 review fix).</b> Each cached entry
+     * is a freshly-allocated pooled direct {@link ByteBuf} of exactly
+     * {@code blockSize} bytes — the bytes are <em>copied</em> from {@code data}
+     * into the new buffer, and {@code data} is released before the method
+     * returns. This is critical: had we stored {@code data.retainedSlice(...)},
+     * each slice would have pinned the entire parent buffer (typically a 4 MiB
+     * multipart-chunk-sized pooled allocation), so a single hot 16 KiB block
+     * surviving LRU eviction would keep the 4 MiB parent alive — making the
+     * Caffeine byte budget under-account the real off-heap footprint by up to
+     * 256×. Per-block copies eliminate that amplification at the cost of one
+     * memcpy per block, which is negligible compared to the network read that
+     * produced {@code data}.
+     *
      * <p>Insertion is non-destructive: when a cache entry already exists for a
-     * given key the existing entry is preserved and our prepared slice is
-     * released — the call never evicts an entry that another reader has just
-     * single-flighted.
+     * given key the existing entry is preserved and the per-block copy is not
+     * even attempted — the call never evicts an entry that another reader has
+     * just single-flighted.
      *
      * <p><b>Ownership</b>: this method takes ownership of {@code data}. It is
      * released exactly once before the method returns, regardless of which
@@ -583,27 +612,38 @@ public final class SegmentBlockCache {
                 BlockKey key = new BlockKey(path, blockIndex);
                 int sliceStart = dataOff;
                 int finalSliceLen = sliceLen;
-                // outcome[0] == true when we are the inserter, false when an entry
-                // already existed and we left it untouched.
-                boolean[] inserted = {false};
+                // didInsert[0] == true when we are the inserter, false when an
+                // entry already existed and we left it untouched.
+                boolean[] didInsert = {false};
                 cache.asMap().compute(key, (k, existing) -> {
                     if (existing != null) {
                         // Concurrent reader already loaded this block — keep its
                         // copy (it is fresher with respect to the LRU pass) and
-                        // skip ours. The retainedSlice we did NOT create is just
-                        // not allocated; no buffer leak.
+                        // skip ours. Because we have not allocated any per-block
+                        // buffer yet there is nothing to leak.
                         return existing;
                     }
-                    // Prepare a fresh entry: retainedSlice() returns a slice whose
-                    // own refCnt starts at 1 and which holds an additional reference
-                    // on the parent. The cache takes ownership of that single slice
-                    // reference; the slice is released by the removal listener on
-                    // eviction (parent's ref drops accordingly).
-                    ByteBuf slice = data.retainedSlice(sliceStart, finalSliceLen);
-                    inserted[0] = true;
-                    return slice;
+                    // Allocate a fresh per-block pooled direct buffer and copy
+                    // the chunk's bytes into it. Each cached entry now carries
+                    // its OWN pooled allocation matching the cache's weigher
+                    // exactly — see the javadoc memory-discipline note.
+                    // writeBytes(src, srcIndex, length) does not advance the
+                    // source buffer's reader index (absolute form).
+                    ByteBuf block = PooledByteBufAllocator.DEFAULT.directBuffer(finalSliceLen);
+                    try {
+                        block.writeBytes(data, sliceStart, finalSliceLen);
+                    } catch (RuntimeException e) {
+                        // Out-of-memory / pool exhaustion: release the allocation
+                        // and re-throw so the bulk-insert finally-block can also
+                        // release `data`. The compute() lambda must NOT return
+                        // a half-initialised buffer.
+                        block.release();
+                        throw e;
+                    }
+                    didInsert[0] = true;
+                    return block;
                 });
-                if (inserted[0]) {
+                if (didInsert[0]) {
                     bulkInsertedBlocks.incrementAndGet();
                     bulkInsertedBytes.addAndGet(sliceLen);
                     insertedBytes += sliceLen;
@@ -614,14 +654,59 @@ public final class SegmentBlockCache {
                 fileOff += sliceLen;
             }
         } finally {
-            // Release the caller-owned parent buffer. Every retained slice we
-            // handed to the cache holds its own independent reference on the
-            // underlying memory, so releasing the parent here does NOT free the
-            // bytes used by the cached entries — those are kept alive until the
-            // cache evicts them (or invalidate*/clear is called).
+            // Release the caller-owned source buffer. With per-block copy
+            // (issue #619 review fix) the cached entries hold no reference to
+            // the parent, so this release frees the multipart-chunk pooled
+            // allocation back to Netty's allocator immediately — the cache's
+            // byte budget then bounds the off-heap footprint exactly.
             ReferenceCountUtil.safeRelease(data);
         }
         return insertedBytes;
+    }
+
+    /**
+     * If the main eviction cache already holds the block at {@code key} (e.g.
+     * because the warmup bulk-prefetch loaded it), allocate a fresh pooled
+     * direct buffer for the frontier region and copy the bytes across. Returns
+     * the fresh buffer (caller-owned, {@code refCnt == 1}) or {@code null} when
+     * the main cache misses.
+     *
+     * <p>Used by {@link #pinBlock} to short-circuit a wire read in the
+     * pin-warmup BFS pass when the bulk-prefetch has already populated the
+     * main cache (issue #619 review fix). The frontier region keeps an
+     * independent copy — eviction in the much larger main cache cannot
+     * displace it.
+     *
+     * <p>Both maps' {@code asMap().compute*()} take an independent per-key
+     * lock, so this method's {@code computeIfPresent} on the main cache is
+     * safe to call from inside the frontier cache's {@code compute()} lambda
+     * (called by {@link #pinBlock}). The two locks are taken in a consistent
+     * order (frontier → main) and nothing ever inverts it, so no deadlock.
+     */
+    private ByteBuf tryPromoteFromMainCache(BlockKey key, int length) {
+        if (cache == null) {
+            return null;
+        }
+        ByteBuf[] holder = new ByteBuf[1];
+        cache.asMap().computeIfPresent(key, (k, existing) -> {
+            int readable = existing.readableBytes();
+            if (readable <= 0) {
+                // Defensive: an entry with no readable bytes is degenerate. Leave
+                // it alone and report a frontier miss so the caller goes to the
+                // loader.
+                return existing;
+            }
+            ByteBuf copy = PooledByteBufAllocator.DEFAULT.directBuffer(readable);
+            try {
+                copy.writeBytes(existing, existing.readerIndex(), readable);
+            } catch (RuntimeException e) {
+                copy.release();
+                throw e;
+            }
+            holder[0] = copy;
+            return existing;
+        });
+        return holder[0];
     }
 
     /**

--- a/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/SegmentBlockCache.java
@@ -162,6 +162,11 @@ public final class SegmentBlockCache {
     private final AtomicLong frontierLoadFailure = new AtomicLong();
     private final AtomicLong frontierLoadTimeNanos = new AtomicLong();
 
+    // --- Bulk-insert (warmup prefetch) stats — issue #619 ---
+    private final AtomicLong bulkInsertedBlocks = new AtomicLong();
+    private final AtomicLong bulkInsertedBytes = new AtomicLong();
+    private final AtomicLong bulkInsertSkipped = new AtomicLong();
+
     /**
      * Creates a cache with a main eviction region and no frontier (pinned) region.
      * Equivalent to {@code SegmentBlockCache(maxBytes, 0)}.
@@ -494,6 +499,129 @@ public final class SegmentBlockCache {
         } finally {
             retained.release();
         }
+    }
+
+    /**
+     * Bulk-inserts a contiguous range of bytes into the main eviction region as
+     * a sequence of cache-block-sized entries (issue #619).
+     *
+     * <p>The input {@code data} buffer must contain exactly the bytes located
+     * at file offsets {@code [baseOffset, baseOffset + data.readableBytes())}.
+     * The method splices {@code data} into {@code blockSize}-sized retained
+     * slices (the last slice may be shorter, mirroring end-of-file blocks) and
+     * inserts each slice as a fresh cache entry keyed by
+     * {@code (path, (baseOffset + i * blockSize) / blockSize)} — exactly the
+     * key shape used by {@link #getBlock}, so subsequent reads issued by
+     * {@code RemoteRandomAccessReader} on the same {@code (path, blockSize)}
+     * hit the freshly-loaded blocks.
+     *
+     * <p>Insertion is non-destructive: when a cache entry already exists for a
+     * given key the existing entry is preserved and our prepared slice is
+     * released — the call never evicts an entry that another reader has just
+     * single-flighted.
+     *
+     * <p><b>Ownership</b>: this method takes ownership of {@code data}. It is
+     * released exactly once before the method returns, regardless of which
+     * code path (success, no-op when the cache is disabled, or exception) is
+     * taken. Callers must not touch {@code data} after the call.
+     *
+     * <p><b>Concurrency</b>: insertion uses {@code asMap().compute()} so each
+     * per-key step is atomic with the removal listener, exactly as in
+     * {@link #getBlock}. The bulk operation as a whole is NOT a single atomic
+     * unit — a concurrent {@link #invalidatePath} call may remove some of the
+     * just-inserted blocks while others stay, which is fine: invalidation is
+     * already a best-effort coarse cleanup and never causes data corruption.
+     *
+     * @param path       logical multipart path (same path used by
+     *                   {@link #getBlock} on the read side)
+     * @param baseOffset starting file offset of the {@code data} buffer; must
+     *                   be a non-negative multiple of {@code blockSize}
+     * @param blockSize  cache-block size in bytes (must equal the read window
+     *                   used by the reader); must be {@code > 0}
+     * @param data       caller-prepared buffer containing the bytes located at
+     *                   {@code [baseOffset, baseOffset + data.readableBytes())}.
+     *                   Ownership transfers to this method.
+     * @return number of bytes actually inserted into the cache (excludes the
+     *     size of blocks that were already cached and therefore skipped)
+     * @throws IllegalArgumentException if {@code baseOffset} or
+     *     {@code blockSize} are invalid
+     */
+    public long bulkInsert(String path, long baseOffset, int blockSize, ByteBuf data) {
+        Objects.requireNonNull(path, "path");
+        Objects.requireNonNull(data, "data");
+        if (blockSize <= 0) {
+            ReferenceCountUtil.safeRelease(data);
+            throw new IllegalArgumentException("blockSize must be > 0, got " + blockSize);
+        }
+        if (baseOffset < 0) {
+            ReferenceCountUtil.safeRelease(data);
+            throw new IllegalArgumentException("baseOffset must be >= 0, got " + baseOffset);
+        }
+        if (baseOffset % blockSize != 0) {
+            ReferenceCountUtil.safeRelease(data);
+            throw new IllegalArgumentException(
+                    "baseOffset must be a multiple of blockSize, got baseOffset=" + baseOffset
+                            + " blockSize=" + blockSize);
+        }
+        // Disabled cache: nothing to insert; honour the ownership contract by releasing data.
+        if (cache == null) {
+            ReferenceCountUtil.safeRelease(data);
+            return 0;
+        }
+        int totalLen = data.readableBytes();
+        if (totalLen == 0) {
+            ReferenceCountUtil.safeRelease(data);
+            return 0;
+        }
+        long insertedBytes = 0;
+        try {
+            int dataOff = 0;
+            long fileOff = baseOffset;
+            while (dataOff < totalLen) {
+                int sliceLen = Math.min(blockSize, totalLen - dataOff);
+                long blockIndex = fileOff / blockSize;
+                BlockKey key = new BlockKey(path, blockIndex);
+                int sliceStart = dataOff;
+                int finalSliceLen = sliceLen;
+                // outcome[0] == true when we are the inserter, false when an entry
+                // already existed and we left it untouched.
+                boolean[] inserted = {false};
+                cache.asMap().compute(key, (k, existing) -> {
+                    if (existing != null) {
+                        // Concurrent reader already loaded this block — keep its
+                        // copy (it is fresher with respect to the LRU pass) and
+                        // skip ours. The retainedSlice we did NOT create is just
+                        // not allocated; no buffer leak.
+                        return existing;
+                    }
+                    // Prepare a fresh entry: retainedSlice() returns a slice whose
+                    // own refCnt starts at 1 and which holds an additional reference
+                    // on the parent. The cache takes ownership of that single slice
+                    // reference; the slice is released by the removal listener on
+                    // eviction (parent's ref drops accordingly).
+                    ByteBuf slice = data.retainedSlice(sliceStart, finalSliceLen);
+                    inserted[0] = true;
+                    return slice;
+                });
+                if (inserted[0]) {
+                    bulkInsertedBlocks.incrementAndGet();
+                    bulkInsertedBytes.addAndGet(sliceLen);
+                    insertedBytes += sliceLen;
+                } else {
+                    bulkInsertSkipped.incrementAndGet();
+                }
+                dataOff += sliceLen;
+                fileOff += sliceLen;
+            }
+        } finally {
+            // Release the caller-owned parent buffer. Every retained slice we
+            // handed to the cache holds its own independent reference on the
+            // underlying memory, so releasing the parent here does NOT free the
+            // bytes used by the cached entries — those are kept alive until the
+            // cache evicts them (or invalidate*/clear is called).
+            ReferenceCountUtil.safeRelease(data);
+        }
+        return insertedBytes;
     }
 
     /**
@@ -1004,6 +1132,37 @@ public final class SegmentBlockCache {
         return frontierCache.policy().eviction()
                 .map(e -> e.weightedSize().orElse(0L))
                 .orElse(0L);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bulk-insert (warmup prefetch) stats — issue #619.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Number of cache blocks inserted by successful {@link #bulkInsert} calls
+     * (excludes blocks skipped because the cache already held a copy).
+     */
+    public long bulkInsertedBlockCount() {
+        return bulkInsertedBlocks.get();
+    }
+
+    /**
+     * Total bytes inserted by {@link #bulkInsert} calls. Mirrors
+     * {@link #bulkInsertedBlockCount} but summed over actual slice lengths
+     * (a partial end-of-file slice contributes less than {@code blockSize}).
+     */
+    public long bulkInsertedByteCount() {
+        return bulkInsertedBytes.get();
+    }
+
+    /**
+     * Number of {@link #bulkInsert} attempts that were skipped because a
+     * concurrent reader had already cached the same {@code (path, blockIndex)}
+     * key. A high value indicates frequent overlap between bulk prefetch and
+     * single-flight loads — informational, not a fault.
+     */
+    public long bulkInsertSkippedCount() {
+        return bulkInsertSkipped.get();
     }
 
     // -------------------------------------------------------------------------

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderBulkPrefetchTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderBulkPrefetchTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -425,7 +424,6 @@ public class RemoteRandomAccessReaderBulkPrefetchTest {
                     !cache.containsBlock(PATH, (long) i * BUFFER_SIZE, BUFFER_SIZE));
         }
         // weightedSize() == 0 already implies size==0, but be explicit for readability.
-        assertNull("peekBytes returns null for evicted block",
-                cache.estimatedSize() > 0 ? "non-empty" : null);
+        assertEquals("estimatedSize() == 0 after invalidatePath", 0L, cache.estimatedSize());
     }
 }

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderBulkPrefetchTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderBulkPrefetchTest.java
@@ -20,6 +20,7 @@
 
 package herddb.remote;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -31,6 +32,7 @@ import herddb.index.vector.BulkPrefetchReaderSupplier;
 import io.github.jbellis.jvector.disk.RandomAccessReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
@@ -293,6 +295,110 @@ public class RemoteRandomAccessReaderBulkPrefetchTest {
         assertEquals(0L, supplier.bulkPrefetchIntoCache(0L, 0L));
         assertEquals(0L, supplier.bulkPrefetchIntoCache(0L, -100L));
         assertEquals(0L, cache.bulkInsertedBlockCount());
+    }
+
+    /**
+     * Review fix R5: when one chunk in the middle is missing from storage
+     * (server returns {@code null}), the prefetch must surface an
+     * {@link IOException} without leaking any buffer fetched from earlier
+     * chunks. The current implementation joins on every chunk's future before
+     * any insert, so the failed chunk causes an early bail-out and the
+     * earlier successful buffers are drained via the catch block — exercised
+     * here against a real wire.
+     */
+    @Test
+    public void prefetchFailsCleanlyWhenServerMissingTrailingChunk() {
+        // Configure the supplier to think the file is 3 chunks long, but the
+        // upload only ever wrote chunks 0 and 1 — chunk 2 will return null
+        // from the server. The Supplier's totalSize is the source of truth
+        // for how many chunks the prefetch dispatches; we set it longer than
+        // actual storage to provoke the partial-availability path.
+        int fakeTotal = WRITE_BLOCK_SIZE * (NUM_CHUNKS + 2);
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, fakeTotal,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        try {
+            supplier.bulkPrefetchIntoCache(0L, fakeTotal);
+            fail("expected IOException for trailing missing chunks");
+        } catch (IOException expected) {
+            // Either chunk 3 or chunk 4 reported missing first; both are valid.
+            assertNotNull(expected.getMessage());
+        }
+        // Critical invariant: no off-heap leak. Caffeine releases everything
+        // it holds when invalidatePath runs; if the failure branch had leaked
+        // a fetched buffer we'd observe a stale entry left in the cache. We
+        // can't probe Netty's pool directly here, but a clean invalidate +
+        // weightedSize check exercises the eviction listener for every entry
+        // we did insert before failing.
+        cache.invalidatePath(PATH);
+        cache.cleanUp();
+        assertEquals(0L, cache.weightedSize());
+    }
+
+    /**
+     * Review fix R2: after a successful bulk prefetch the main cache holds
+     * every covered block; a subsequent pin-mode reader (the warmup pin BFS)
+     * must serve those blocks from main into the frontier region WITHOUT
+     * issuing a fresh wire read. The check observes the frontier region's
+     * load_success counter increasing while {@code SegmentBlockCache.loadSuccessCount}
+     * stays at zero (no main-cache loader invocation either).
+     */
+    @Test
+    public void pinModeAfterPrefetchPromotesMainCacheWithoutWireRead() throws Exception {
+        // Need a frontier budget for the pin region to be active.
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        // 1. Prefetch fills the MAIN cache.
+        supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+        long mainLoadsAfterPrefetch = cache.loadSuccessCount();
+        // bulkInsert doesn't bump loadSuccess, so this is 0 before pin too.
+        assertEquals(0L, mainLoadsAfterPrefetch);
+
+        // 2. A pin-mode reader reads the same blocks — they must end up in
+        // the frontier region, promoted from main without a wire read.
+        try (RandomAccessReader pinReader = supplier.withPinMode().get()) {
+            pinReader.seek(0);
+            byte[] tmp = new byte[BUFFER_SIZE];
+            for (int i = 0; i < (TOTAL_SIZE / BUFFER_SIZE); i++) {
+                pinReader.readFully(tmp);
+                // bytes must match the original payload
+                int payloadOff = i * BUFFER_SIZE;
+                byte[] expected = Arrays.copyOfRange(payload, payloadOff, payloadOff + BUFFER_SIZE);
+                assertArrayEquals("block " + i + " bytes via pin reader", expected, tmp);
+            }
+        }
+
+        // 3. Frontier load_success increased — and crucially main load_success
+        // did NOT change (no extra wire read happened). This is the heart of
+        // the R2 fix.
+        assertEquals("no main-cache loader invocation after prefetch",
+                0L, cache.loadSuccessCount());
+        assertTrue("frontier loads must have run (promoted from main)",
+                cache.frontierLoadSuccessCount() > 0);
+    }
+
+    /**
+     * Sanity check for the promotion path: when the main cache is empty,
+     * pin-mode reads still work — they fall through to the loader exactly
+     * like before the R2 fix.
+     */
+    @Test
+    public void pinModeWithoutPriorPrefetchStillLoadsFromWire() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000, 200_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        // No prefetch this time — main cache stays empty.
+        try (RandomAccessReader pinReader = supplier.withPinMode().get()) {
+            pinReader.seek(0);
+            pinReader.readInt();
+        }
+        // frontier load happened via the loader because main was empty.
+        assertEquals(1L, cache.frontierLoadSuccessCount());
     }
 
     /**

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderBulkPrefetchTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteRandomAccessReaderBulkPrefetchTest.java
@@ -1,0 +1,325 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.index.vector.BulkPrefetchReaderSupplier;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end tests for the bulk warmup-prefetch path introduced by issue #619.
+ *
+ * <p>Spin up an in-process {@link RemoteFileServer} + {@link RemoteFileServiceClient},
+ * write a multipart file that spans several multipart chunks, then verify that:
+ * <ul>
+ *   <li>{@link RemoteRandomAccessReader.Supplier} implements
+ *       {@link BulkPrefetchReaderSupplier};</li>
+ *   <li>a single {@code bulkPrefetchIntoCache} call populates the
+ *       {@link SegmentBlockCache} with every covered block, in fewer wire
+ *       round-trips than the per-block path would have made;</li>
+ *   <li>a subsequent {@link RemoteRandomAccessReader} hits the cache and
+ *       returns the correct bytes;</li>
+ *   <li>argument validation rejects unaligned start offsets;</li>
+ *   <li>the disabled cache short-circuits to a no-op;</li>
+ *   <li>a non-existent path surfaces as {@link IOException}.</li>
+ * </ul>
+ */
+public class RemoteRandomAccessReaderBulkPrefetchTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private RemoteFileServer server;
+    private RemoteFileServiceClient client;
+
+    /** Multipart chunk size used by the writer. Three chunks total. */
+    private static final int WRITE_BLOCK_SIZE = 4096;
+    /** Read-side cache block size. {@code WRITE_BLOCK_SIZE % BUFFER_SIZE == 0}. */
+    private static final int BUFFER_SIZE = 256;
+    private static final int NUM_CHUNKS = 3;
+    private static final int TOTAL_SIZE = WRITE_BLOCK_SIZE * NUM_CHUNKS;
+    private static final String PATH = "ts/idx/graph.bin";
+
+    private byte[] payload;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new RemoteFileServer(0, folder.newFolder("data").toPath());
+        server.start();
+        client = new RemoteFileServiceClient(List.of("localhost:" + server.getPort()));
+
+        // Deterministic ramp so we can verify exact byte content after prefetch.
+        payload = new byte[TOTAL_SIZE];
+        for (int i = 0; i < TOTAL_SIZE; i++) {
+            payload[i] = (byte) (i & 0xFF);
+        }
+        client.writeMultipartFile(PATH, new ByteArrayInputStream(payload), WRITE_BLOCK_SIZE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        server.stop();
+    }
+
+    /**
+     * Smoke test: {@code Supplier} implements both the pin-mode mixin and the
+     * new bulk-prefetch mixin. Without this assertion the call site in
+     * {@code PersistentVectorStore.bulkPrefetchSegmentIntoCache} would silently
+     * skip the fast path for remote suppliers.
+     */
+    @Test
+    public void supplierImplementsBulkPrefetchReaderSupplier() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        assertTrue("Supplier must implement BulkPrefetchReaderSupplier",
+                supplier instanceof BulkPrefetchReaderSupplier);
+    }
+
+    /**
+     * Prefetch all 3 chunks into the cache, then verify every (path, offset)
+     * cache-block-sized key is present and a normal reader returns exact bytes
+     * without invoking the loader (no additional load_success increments).
+     */
+    @Test
+    public void prefetchAllChunksPopulatesCacheAndReadsHit() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        long inserted = supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+        assertEquals("every byte covered", TOTAL_SIZE, inserted);
+
+        int expectedBlocks = TOTAL_SIZE / BUFFER_SIZE;
+        assertEquals(expectedBlocks, cache.bulkInsertedBlockCount());
+        assertEquals(0L, cache.bulkInsertSkippedCount());
+
+        // Every cache block must report containsBlock=true.
+        for (int i = 0; i < expectedBlocks; i++) {
+            long off = (long) i * BUFFER_SIZE;
+            assertTrue("block " + i + " (" + off + ") must be cached",
+                    cache.containsBlock(PATH, off, BUFFER_SIZE));
+        }
+
+        // A normal reader reads every byte back. No additional loader call,
+        // so cache.loadSuccessCount() must stay at zero (bulk inserts never
+        // touch the loadSuccess counter — they have their own counter).
+        long loadsBefore = cache.loadSuccessCount();
+        try (RandomAccessReader reader = supplier.get()) {
+            for (int chunk = 0; chunk < NUM_CHUNKS; chunk++) {
+                reader.seek((long) chunk * WRITE_BLOCK_SIZE);
+                byte[] got = new byte[WRITE_BLOCK_SIZE];
+                reader.readFully(got);
+                for (int j = 0; j < WRITE_BLOCK_SIZE; j++) {
+                    assertEquals("byte " + (chunk * WRITE_BLOCK_SIZE + j),
+                            payload[chunk * WRITE_BLOCK_SIZE + j], got[j]);
+                }
+            }
+        }
+        assertEquals("no loader calls — every read hit the bulk-prefetched cache",
+                loadsBefore, cache.loadSuccessCount());
+        long expectedHits = (long) NUM_CHUNKS * (WRITE_BLOCK_SIZE / BUFFER_SIZE);
+        assertEquals("every reader read produced one cache hit", expectedHits, cache.hitCount());
+    }
+
+    /**
+     * Partial prefetch: only the first chunk is requested. Only the blocks in
+     * chunk 0 are cached; chunks 1 and 2 must NOT be cached after the call.
+     */
+    @Test
+    public void prefetchOfFirstChunkOnlyCachesThatChunk() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        long inserted = supplier.bulkPrefetchIntoCache(0L, WRITE_BLOCK_SIZE);
+        assertEquals(WRITE_BLOCK_SIZE, inserted);
+        int blocksPerChunk = WRITE_BLOCK_SIZE / BUFFER_SIZE;
+        assertEquals(blocksPerChunk, cache.bulkInsertedBlockCount());
+
+        for (int i = 0; i < blocksPerChunk; i++) {
+            assertTrue(cache.containsBlock(PATH, (long) i * BUFFER_SIZE, BUFFER_SIZE));
+        }
+        for (int i = blocksPerChunk; i < TOTAL_SIZE / BUFFER_SIZE; i++) {
+            assertTrue("block " + i + " must NOT be cached after partial prefetch",
+                    !cache.containsBlock(PATH, (long) i * BUFFER_SIZE, BUFFER_SIZE));
+        }
+    }
+
+    /**
+     * {@code maxBytes} is clamped to {@code totalSize - startOffset} — a
+     * request for more bytes than exist must succeed and return only the
+     * actual file size.
+     */
+    @Test
+    public void prefetchClampsToFileEnd() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+
+        long inserted = supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE * 10L);
+        assertEquals("prefetch clamped to file size", TOTAL_SIZE, inserted);
+    }
+
+    /**
+     * Unaligned start offset must be rejected — the contract requires
+     * alignment to the multipart chunk size.
+     */
+    @Test
+    public void unalignedStartOffsetRejected() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        assertThrows(IllegalArgumentException.class,
+                () -> supplier.bulkPrefetchIntoCache(WRITE_BLOCK_SIZE / 2, WRITE_BLOCK_SIZE));
+    }
+
+    /**
+     * Disabled cache: bulkPrefetchIntoCache is a no-op (no wire reads even
+     * issued, since populating an off cache would be pointless).
+     */
+    @Test
+    public void disabledCacheShortCircuits() throws Exception {
+        SegmentBlockCache cache = SegmentBlockCache.disabled();
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        long inserted = supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+        assertEquals(0L, inserted);
+        assertEquals(0L, cache.bulkInsertedBlockCount());
+    }
+
+    /**
+     * startOffset beyond EOF returns 0 without throwing.
+     */
+    @Test
+    public void startOffsetAtOrPastEofIsNoOp() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        assertEquals(0L, supplier.bulkPrefetchIntoCache(TOTAL_SIZE, WRITE_BLOCK_SIZE));
+        assertEquals(0L, supplier.bulkPrefetchIntoCache(TOTAL_SIZE * 2L, WRITE_BLOCK_SIZE));
+        assertEquals(0L, cache.bulkInsertedBlockCount());
+    }
+
+    /**
+     * Prefetching a non-existent file path must surface as an {@link IOException}
+     * and not leave any half-inserted state in the cache.
+     */
+    @Test
+    public void prefetchOfMissingPathFailsAndDoesNotPolluteCache() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, "ts/idx/does-not-exist.bin",
+                        TOTAL_SIZE, WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        try {
+            supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+            fail("expected IOException for missing file");
+        } catch (IOException expected) {
+            // Expected: server returned null for at least one chunk.
+            assertNotNull(expected.getMessage());
+        }
+        assertEquals("no blocks inserted on failure", 0L, cache.bulkInsertedBlockCount());
+    }
+
+    /**
+     * Repeated prefetch calls treat the second one as fully-cached: bytes
+     * inserted = 0, and the skip counter reflects every block.
+     */
+    @Test
+    public void repeatedPrefetchCountsSkips() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        long firstInserted = supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+        assertEquals(TOTAL_SIZE, firstInserted);
+
+        long secondInserted = supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+        assertEquals("second prefetch is fully skipped", 0L, secondInserted);
+        assertEquals(TOTAL_SIZE / BUFFER_SIZE, cache.bulkInsertSkippedCount());
+    }
+
+    /**
+     * Negative maxBytes is treated as a no-op (returns 0) — a defensive guard
+     * matching {@code bytesPerSegment <= 0} → disabled semantics.
+     */
+    @Test
+    public void nonPositiveMaxBytesIsNoOp() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        assertEquals(0L, supplier.bulkPrefetchIntoCache(0L, 0L));
+        assertEquals(0L, supplier.bulkPrefetchIntoCache(0L, -100L));
+        assertEquals(0L, cache.bulkInsertedBlockCount());
+    }
+
+    /**
+     * After a successful bulk prefetch, {@link SegmentBlockCache#invalidatePath}
+     * must drop every block (no leak from the bulk-insert path). Mirrors the
+     * regression-style assertion in {@code SegmentBlockCacheBulkInsertTest} but
+     * exercises the real wire-fed buffers.
+     */
+    @Test
+    public void invalidatePathReleasesEveryPrefetchedBlock() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        RemoteRandomAccessReader.Supplier supplier =
+                new RemoteRandomAccessReader.Supplier(client, PATH, TOTAL_SIZE,
+                        WRITE_BLOCK_SIZE, BUFFER_SIZE, NullStatsLogger.INSTANCE, cache);
+        supplier.bulkPrefetchIntoCache(0L, TOTAL_SIZE);
+        cache.cleanUp();
+        assertNotEquals(0L, cache.weightedSize());
+
+        cache.invalidatePath(PATH);
+        cache.cleanUp();
+        assertEquals(0L, cache.weightedSize());
+        for (int i = 0; i < TOTAL_SIZE / BUFFER_SIZE; i++) {
+            assertTrue("block " + i + " gone after invalidatePath",
+                    !cache.containsBlock(PATH, (long) i * BUFFER_SIZE, BUFFER_SIZE));
+        }
+        // weightedSize() == 0 already implies size==0, but be explicit for readability.
+        assertNull("peekBytes returns null for evicted block",
+                cache.estimatedSize() > 0 ? "non-empty" : null);
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheBulkInsertTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheBulkInsertTest.java
@@ -27,7 +27,12 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 /**
@@ -87,11 +92,10 @@ public class SegmentBlockCacheBulkInsertTest {
      * containing the right bytes, and the loader is never invoked when a
      * subsequent getBlock is issued.
      *
-     * <p>The parent buffer's refCnt after {@code bulkInsert} equals the number
-     * of newly-inserted slices (Netty's {@code retainedSlice} keeps an
-     * additional ref on the parent per outstanding slice); a separate test
-     * verifies that {@link SegmentBlockCache#invalidatePath} eventually drives
-     * that count back to zero — that is what "no leak" means.
+     * <p>With per-block-copy ownership (issue #619 review fix) the parent
+     * buffer is released as soon as {@code bulkInsert} returns — its refCnt
+     * is 0 immediately, not "N slices alive" — and the cache's byte budget
+     * therefore bounds the actual off-heap footprint exactly.
      */
     @Test
     public void bulkInsertCachesEveryBlock() throws Exception {
@@ -101,7 +105,7 @@ public class SegmentBlockCacheBulkInsertTest {
         assertEquals(1, data.refCnt());
 
         long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
-        assertEquals("4 cached slices keep the parent alive", 4, data.refCnt());
+        assertEquals("parent buffer released eagerly — no slice pinning", 0, data.refCnt());
         assertEquals(BLOCK * 4L, inserted);
         assertEquals(4L, cache.bulkInsertedBlockCount());
         assertEquals(BLOCK * 4L, cache.bulkInsertedByteCount());
@@ -119,10 +123,11 @@ public class SegmentBlockCacheBulkInsertTest {
         }
         assertEquals("loader never invoked after bulkInsert", 0, loaderCalls.get());
 
-        // No leak: clearing the cache must drive the parent refCnt back to 0.
+        // No leak: cached entries are independent allocations released by the
+        // eviction listener on cache.clear().
         cache.clear();
         cache.cleanUp();
-        assertEquals("parent buffer fully released after cache.clear()", 0, data.refCnt());
+        assertEquals("weighted size 0 after cache.clear()", 0L, cache.weightedSize());
     }
 
     /**
@@ -137,7 +142,7 @@ public class SegmentBlockCacheBulkInsertTest {
         ByteBuf data = directRamp(total, 0);
 
         long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
-        assertEquals("3 cached slices keep the parent alive", 3, data.refCnt());
+        assertEquals("parent released eagerly even with partial last block", 0, data.refCnt());
         assertEquals(total, inserted);
         assertEquals(3L, cache.bulkInsertedBlockCount());
 
@@ -227,9 +232,9 @@ public class SegmentBlockCacheBulkInsertTest {
         // whether block 1 was overwritten or preserved.
         ByteBuf data = directRamp(BLOCK * 4, 0);
         long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
-        // 3 slices entered the cache (blocks 0, 2, 3); the skipped block did
-        // not retain the parent, so the parent's refCnt equals 3, not 4.
-        assertEquals("only the 3 inserted slices retain the parent", 3, data.refCnt());
+        // With per-block copy (issue #619 review fix) the parent is always
+        // released eagerly — present or skipped, neither path retains it.
+        assertEquals("parent released eagerly regardless of skip count", 0, data.refCnt());
 
         // Three blocks newly inserted (0, 2, 3); block 1 already there, skipped.
         assertEquals(BLOCK * 3L, inserted);
@@ -254,8 +259,10 @@ public class SegmentBlockCacheBulkInsertTest {
 
     /**
      * After invalidatePath every block inserted by bulkInsert must be gone
-     * from the cache and the underlying parent buffer's ref-count must reach
-     * 0 — i.e. the bulk insert did not leak references.
+     * from the cache. With per-block copies (issue #619 review fix) the
+     * parent buffer is already released before {@code bulkInsert} returns
+     * — invalidate's job is to free the per-block allocations, observable
+     * via {@link SegmentBlockCache#weightedSize()} dropping to 0.
      */
     @Test
     public void invalidatePathDropsAllBulkInsertedBlocks() {
@@ -266,7 +273,11 @@ public class SegmentBlockCacheBulkInsertTest {
         cache.cleanUp();
         long weightedBefore = cache.weightedSize();
         assertTrue("cache should be non-empty after bulk insert", weightedBefore > 0);
-        assertEquals("4 slices keep the parent alive before invalidate", 4, data.refCnt());
+        assertEquals("parent released by bulkInsert — no slice pinning", 0, data.refCnt());
+        // The cache's byte budget now exactly reflects the cached bytes (no
+        // hidden multipart-chunk amplification).
+        assertEquals("cache bytes match expected per-block sum",
+                (long) BLOCK * 4L, weightedBefore);
 
         cache.invalidatePath(PATH);
         cache.cleanUp();
@@ -275,7 +286,6 @@ public class SegmentBlockCacheBulkInsertTest {
         assertFalse(cache.containsBlock(PATH, (long) BLOCK, BLOCK));
         assertFalse(cache.containsBlock(PATH, 2L * BLOCK, BLOCK));
         assertFalse(cache.containsBlock(PATH, 3L * BLOCK, BLOCK));
-        assertEquals("parent buffer fully released after invalidatePath", 0, data.refCnt());
     }
 
     /**
@@ -295,6 +305,94 @@ public class SegmentBlockCacheBulkInsertTest {
         assertEquals(2L, cache.bulkInsertedBlockCount());
         assertEquals(2L, cache.bulkInsertSkippedCount());
         assertEquals("second buffer released even on full skip", 0, second.refCnt());
+    }
+
+    /**
+     * Concurrent stress: many threads run {@code bulkInsert} against
+     * overlapping ranges while another set of threads issues {@code getBlock}
+     * calls and a third thread periodically invokes {@code invalidatePath}.
+     * The test asserts (a) no {@code IllegalReferenceCountException} or other
+     * RuntimeException escapes, (b) every {@code getBlock} returns either the
+     * correct ramp bytes from the bulk insert or freshly-loaded bytes from
+     * the loader fallback, (c) after the workload completes and the cache is
+     * cleared the byte-weighted size drops to zero.
+     */
+    @Test
+    public void concurrentBulkInsertGetBlockAndInvalidate() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(8 * 1024 * 1024);
+        final int blocks = 64; // file is 64 KiB at BLOCK==1024
+        final int total = BLOCK * blocks;
+
+        // Loader returns ramp(0) bytes — same as the bulk insert — so we can
+        // assert each retrieved block's payload regardless of which path it
+        // came from.
+        SegmentBlockCache.BlockLoader loader = (p, off, len) -> {
+            int blockIdx = (int) (off / BLOCK);
+            return directRamp(len, blockIdx * BLOCK);
+        };
+
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        final int iterations = 200;
+        final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(8);
+        try {
+            // 3 bulk-insert threads.
+            for (int t = 0; t < 3; t++) {
+                pool.submit(() -> {
+                    try {
+                        for (int i = 0; i < iterations; i++) {
+                            cache.bulkInsert(PATH, 0L, BLOCK, directRamp(total, 0));
+                        }
+                    } catch (Throwable th) {
+                        firstFailure.compareAndSet(null, th);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            // 4 read threads — assert payload correctness.
+            for (int t = 0; t < 4; t++) {
+                pool.submit(() -> {
+                    try {
+                        for (int i = 0; i < iterations * 4; i++) {
+                            int b = i % blocks;
+                            long off = (long) b * BLOCK;
+                            byte[] got = readAllAndRelease(cache.getBlock(PATH, off, BLOCK, loader));
+                            assertArrayEquals("block " + b + " bytes",
+                                    expectedSliceBytes(0, b * BLOCK, BLOCK), got);
+                        }
+                    } catch (Throwable th) {
+                        firstFailure.compareAndSet(null, th);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            // 1 invalidator thread that periodically drops everything.
+            pool.submit(() -> {
+                try {
+                    for (int i = 0; i < iterations / 4; i++) {
+                        cache.invalidatePath(PATH);
+                        Thread.sleep(1);
+                    }
+                } catch (Throwable th) {
+                    firstFailure.compareAndSet(null, th);
+                } finally {
+                    latch.countDown();
+                }
+            });
+            assertTrue("workload finished within 60s", latch.await(60, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (firstFailure.get() != null) {
+            throw new AssertionError("concurrent workload failed", firstFailure.get());
+        }
+        // Drain pending eviction work.
+        cache.clear();
+        cache.cleanUp();
+        assertEquals("weighted size 0 after final clear", 0L, cache.weightedSize());
     }
 
     /**

--- a/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheBulkInsertTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/SegmentBlockCacheBulkInsertTest.java
@@ -1,0 +1,322 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SegmentBlockCache#bulkInsert(String, long, int, ByteBuf)},
+ * the bulk warmup-prefetch API introduced in issue #619.
+ *
+ * <p>The contract under test:
+ * <ul>
+ *   <li>splits a contiguous range into block-sized cache entries keyed
+ *       identically to {@link SegmentBlockCache#getBlock};</li>
+ *   <li>handles a partial final block at end-of-file;</li>
+ *   <li>preserves existing entries (no eviction of a single-flighted block);</li>
+ *   <li>validates arguments and releases the input buffer in every branch;</li>
+ *   <li>is a no-op (still releasing the buffer) on a disabled cache;</li>
+ *   <li>tracks accurate {@code bulkInsertedBytes}/{@code bulkInsertSkipped}
+ *       counters.</li>
+ * </ul>
+ */
+public class SegmentBlockCacheBulkInsertTest {
+
+    private static final String PATH = "segments/seg-0/graph";
+    private static final int BLOCK = 1024;
+
+    /**
+     * Allocates a pooled direct buffer that increments byte values starting at
+     * {@code seed}. Lets tests verify that the right bytes end up at the right
+     * block by comparing against {@link #expectedSliceBytes}.
+     */
+    private static ByteBuf directRamp(int len, int seed) {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.directBuffer(len);
+        for (int i = 0; i < len; i++) {
+            buf.writeByte((byte) (seed + i));
+        }
+        return buf;
+    }
+
+    private static byte[] expectedSliceBytes(int seed, int sliceStart, int sliceLen) {
+        byte[] out = new byte[sliceLen];
+        for (int i = 0; i < sliceLen; i++) {
+            out[i] = (byte) (seed + sliceStart + i);
+        }
+        return out;
+    }
+
+    private static byte[] readAllAndRelease(ByteBuf buf) {
+        try {
+            byte[] out = new byte[buf.readableBytes()];
+            buf.getBytes(buf.readerIndex(), out);
+            return out;
+        } finally {
+            buf.release();
+        }
+    }
+
+    /**
+     * Sanity: a 4-block aligned prefetch results in 4 cached entries each
+     * containing the right bytes, and the loader is never invoked when a
+     * subsequent getBlock is issued.
+     *
+     * <p>The parent buffer's refCnt after {@code bulkInsert} equals the number
+     * of newly-inserted slices (Netty's {@code retainedSlice} keeps an
+     * additional ref on the parent per outstanding slice); a separate test
+     * verifies that {@link SegmentBlockCache#invalidatePath} eventually drives
+     * that count back to zero — that is what "no leak" means.
+     */
+    @Test
+    public void bulkInsertCachesEveryBlock() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ByteBuf data = directRamp(BLOCK * 4, 7);
+        // Initial refCnt is 1 (owner-only).
+        assertEquals(1, data.refCnt());
+
+        long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
+        assertEquals("4 cached slices keep the parent alive", 4, data.refCnt());
+        assertEquals(BLOCK * 4L, inserted);
+        assertEquals(4L, cache.bulkInsertedBlockCount());
+        assertEquals(BLOCK * 4L, cache.bulkInsertedByteCount());
+
+        AtomicInteger loaderCalls = new AtomicInteger();
+        SegmentBlockCache.BlockLoader failingLoader = (p, off, len) -> {
+            loaderCalls.incrementAndGet();
+            throw new IllegalStateException("loader must not be called: bulk-cached");
+        };
+        for (int i = 0; i < 4; i++) {
+            long off = (long) i * BLOCK;
+            assertTrue("block " + i + " must be cached", cache.containsBlock(PATH, off, BLOCK));
+            byte[] got = readAllAndRelease(cache.getBlock(PATH, off, BLOCK, failingLoader));
+            assertArrayEquals("block " + i + " bytes", expectedSliceBytes(7, i * BLOCK, BLOCK), got);
+        }
+        assertEquals("loader never invoked after bulkInsert", 0, loaderCalls.get());
+
+        // No leak: clearing the cache must drive the parent refCnt back to 0.
+        cache.clear();
+        cache.cleanUp();
+        assertEquals("parent buffer fully released after cache.clear()", 0, data.refCnt());
+    }
+
+    /**
+     * The final block at end-of-file may be smaller than {@code blockSize}.
+     * Verify it is cached, indexed correctly, and a subsequent getBlock
+     * returns the partial bytes.
+     */
+    @Test
+    public void bulkInsertHandlesPartialLastBlock() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        int total = BLOCK * 2 + BLOCK / 4; // 2 full blocks + 256 bytes
+        ByteBuf data = directRamp(total, 0);
+
+        long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
+        assertEquals("3 cached slices keep the parent alive", 3, data.refCnt());
+        assertEquals(total, inserted);
+        assertEquals(3L, cache.bulkInsertedBlockCount());
+
+        SegmentBlockCache.BlockLoader failingLoader = (p, off, len) -> {
+            throw new IllegalStateException("loader must not be called");
+        };
+
+        // Full block 0 and 1: full BLOCK bytes each.
+        for (int i = 0; i < 2; i++) {
+            byte[] got = readAllAndRelease(cache.getBlock(PATH, (long) i * BLOCK, BLOCK, failingLoader));
+            assertArrayEquals(expectedSliceBytes(0, i * BLOCK, BLOCK), got);
+        }
+        // Partial block 2: 256 bytes only.
+        byte[] tail = readAllAndRelease(cache.getBlock(PATH, 2L * BLOCK, BLOCK, failingLoader));
+        assertEquals(BLOCK / 4, tail.length);
+        assertArrayEquals(expectedSliceBytes(0, 2 * BLOCK, BLOCK / 4), tail);
+    }
+
+    /**
+     * An unaligned baseOffset must be rejected, and the input buffer must
+     * still be released so callers cannot leak by reusing the wrong offset.
+     */
+    @Test
+    public void unalignedBaseOffsetThrowsAndReleasesBuffer() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ByteBuf data = directRamp(BLOCK, 0);
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.bulkInsert(PATH, BLOCK / 2, BLOCK, data));
+        assertEquals("rejected buffer must be released", 0, data.refCnt());
+    }
+
+    /**
+     * A negative baseOffset is also rejected. Same release contract.
+     */
+    @Test
+    public void negativeBaseOffsetThrowsAndReleasesBuffer() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ByteBuf data = directRamp(BLOCK, 0);
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.bulkInsert(PATH, -1L, BLOCK, data));
+        assertEquals(0, data.refCnt());
+    }
+
+    /**
+     * A zero or negative blockSize is rejected. Same release contract.
+     */
+    @Test
+    public void nonPositiveBlockSizeThrowsAndReleasesBuffer() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ByteBuf data = directRamp(BLOCK, 0);
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.bulkInsert(PATH, 0L, 0, data));
+        assertEquals(0, data.refCnt());
+    }
+
+    /**
+     * The disabled cache singleton accepts bulkInsert calls (so callers don't
+     * need to special-case) but stores nothing and still releases the buffer.
+     */
+    @Test
+    public void disabledCacheIsNoOpButReleasesBuffer() {
+        SegmentBlockCache cache = SegmentBlockCache.disabled();
+        ByteBuf data = directRamp(BLOCK * 2, 0);
+        long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
+        assertEquals(0L, inserted);
+        assertEquals(0, data.refCnt());
+        assertFalse(cache.containsBlock(PATH, 0L, BLOCK));
+        assertEquals(0L, cache.bulkInsertedBlockCount());
+    }
+
+    /**
+     * If a block is already cached when bulkInsert runs, the existing entry
+     * must be preserved (single-flight is the source of truth) and the bulk
+     * slice for that block must be released without entering the cache.
+     */
+    @Test
+    public void existingEntriesArePreservedAndCountedAsSkipped() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+
+        // Pre-populate block index 1 via the normal getBlock loader so we know
+        // exactly which bytes are in the cache before the bulk insert.
+        byte[] preloaded = readAllAndRelease(
+                cache.getBlock(PATH, (long) BLOCK, BLOCK, (p, off, len) -> directRamp(BLOCK, 99)));
+        assertEquals(BLOCK, preloaded.length);
+
+        // Now bulk-insert blocks 0..3 with a *different* ramp so we can tell
+        // whether block 1 was overwritten or preserved.
+        ByteBuf data = directRamp(BLOCK * 4, 0);
+        long inserted = cache.bulkInsert(PATH, 0L, BLOCK, data);
+        // 3 slices entered the cache (blocks 0, 2, 3); the skipped block did
+        // not retain the parent, so the parent's refCnt equals 3, not 4.
+        assertEquals("only the 3 inserted slices retain the parent", 3, data.refCnt());
+
+        // Three blocks newly inserted (0, 2, 3); block 1 already there, skipped.
+        assertEquals(BLOCK * 3L, inserted);
+        assertEquals(3L, cache.bulkInsertedBlockCount());
+        assertEquals(1L, cache.bulkInsertSkippedCount());
+
+        SegmentBlockCache.BlockLoader failingLoader = (p, off, len) -> {
+            throw new IllegalStateException("loader must not be called");
+        };
+
+        // Block 0 and 2 and 3 should hold ramp-0 bytes.
+        for (int i : new int[]{0, 2, 3}) {
+            byte[] got = readAllAndRelease(cache.getBlock(PATH, (long) i * BLOCK, BLOCK, failingLoader));
+            assertArrayEquals("block " + i + " came from bulk insert",
+                    expectedSliceBytes(0, i * BLOCK, BLOCK), got);
+        }
+        // Block 1 must STILL hold the pre-loaded ramp-99 bytes.
+        byte[] got1 = readAllAndRelease(cache.getBlock(PATH, (long) BLOCK, BLOCK, failingLoader));
+        assertArrayEquals("block 1 preserved from earlier load",
+                expectedSliceBytes(99, 0, BLOCK), got1);
+    }
+
+    /**
+     * After invalidatePath every block inserted by bulkInsert must be gone
+     * from the cache and the underlying parent buffer's ref-count must reach
+     * 0 — i.e. the bulk insert did not leak references.
+     */
+    @Test
+    public void invalidatePathDropsAllBulkInsertedBlocks() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ByteBuf data = directRamp(BLOCK * 4, 0);
+
+        cache.bulkInsert(PATH, 0L, BLOCK, data);
+        cache.cleanUp();
+        long weightedBefore = cache.weightedSize();
+        assertTrue("cache should be non-empty after bulk insert", weightedBefore > 0);
+        assertEquals("4 slices keep the parent alive before invalidate", 4, data.refCnt());
+
+        cache.invalidatePath(PATH);
+        cache.cleanUp();
+        assertEquals("cache empty after invalidatePath", 0L, cache.weightedSize());
+        assertFalse(cache.containsBlock(PATH, 0L, BLOCK));
+        assertFalse(cache.containsBlock(PATH, (long) BLOCK, BLOCK));
+        assertFalse(cache.containsBlock(PATH, 2L * BLOCK, BLOCK));
+        assertFalse(cache.containsBlock(PATH, 3L * BLOCK, BLOCK));
+        assertEquals("parent buffer fully released after invalidatePath", 0, data.refCnt());
+    }
+
+    /**
+     * Two bulk inserts that target the same range should second-be-skipped
+     * (already-cached). Counters reflect that.
+     */
+    @Test
+    public void repeatedBulkInsertCountsSkips() {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        ByteBuf first = directRamp(BLOCK * 2, 0);
+        cache.bulkInsert(PATH, 0L, BLOCK, first);
+        assertEquals(2L, cache.bulkInsertedBlockCount());
+
+        ByteBuf second = directRamp(BLOCK * 2, 0);
+        long inserted2 = cache.bulkInsert(PATH, 0L, BLOCK, second);
+        assertEquals("second insert is fully skipped", 0L, inserted2);
+        assertEquals(2L, cache.bulkInsertedBlockCount());
+        assertEquals(2L, cache.bulkInsertSkippedCount());
+        assertEquals("second buffer released even on full skip", 0, second.refCnt());
+    }
+
+    /**
+     * bulkInsert at a non-zero, properly-aligned baseOffset routes to the
+     * correct block index — verifies offset arithmetic.
+     */
+    @Test
+    public void bulkInsertAtNonZeroAlignedOffset() throws Exception {
+        SegmentBlockCache cache = new SegmentBlockCache(1_000_000);
+        long base = BLOCK * 10L;
+        ByteBuf data = directRamp(BLOCK * 2, 5);
+
+        cache.bulkInsert(PATH, base, BLOCK, data);
+
+        SegmentBlockCache.BlockLoader failingLoader = (p, off, len) -> {
+            throw new IllegalStateException("loader must not be called");
+        };
+        byte[] got10 = readAllAndRelease(cache.getBlock(PATH, base, BLOCK, failingLoader));
+        byte[] got11 = readAllAndRelease(cache.getBlock(PATH, base + BLOCK, BLOCK, failingLoader));
+        assertArrayEquals(expectedSliceBytes(5, 0, BLOCK), got10);
+        assertArrayEquals(expectedSliceBytes(5, BLOCK, BLOCK), got11);
+        // Lower-index blocks must NOT be present.
+        assertFalse(cache.containsBlock(PATH, 0L, BLOCK));
+    }
+}


### PR DESCRIPTION
Fixes #619.

## What

`PersistentVectorStore.warmUpNewSegmentsBeforePublish` is the dominant cost of
checkpoint Phase C-prep and compaction publish on the indexing service —
because the warmup BFS issues one ~16 KiB `readFileRange` RPC per HNSW
Layer-0 node, ~2000 round-trips per 32 MiB-budgeted segment, against the
remote file server / S3 / GCS.

This PR replaces those many small reads with a small number of large
multipart-chunk-sized bulk reads that go straight into the
`SegmentBlockCache`. The BFS still runs afterwards — exclusively against the
hot cache — so it preserves the per-segment `warmedUp` accounting and the
pin BFS pass for the frontier region (#578), with no behaviour change for
local-file / in-memory readers.

## Changes

- **`BulkPrefetchReaderSupplier`** (new, in `herddb-core`): mixin interface
  analogous to `PinModeReaderSupplier`. Exposes
  `long bulkPrefetchIntoCache(long startOffset, long maxBytes)`.
- **`SegmentBlockCache.bulkInsert(path, baseOffset, blockSize, ByteBuf)`**:
  new API that splits a contiguous prefetched range into block-sized retained
  slices keyed identically to `getBlock`, taking ownership of the input buffer
  and never overwriting a single-flighted entry. New stats counters
  `bulkInsertedBlockCount` / `bulkInsertedByteCount` / `bulkInsertSkippedCount`.
- **`RemoteRandomAccessReader.Supplier`** now implements
  `BulkPrefetchReaderSupplier`: dispatches one
  `readFileRangeAsByteBufAsync` per multipart chunk in parallel, then
  bulk-inserts each completed chunk into the cache. Aligns to the
  `writeBlockSize` boundary because the storage backend forbids reads
  spanning more than one multipart chunk.
- **`PersistentVectorStore.bulkPrefetchSegmentIntoCache`**: invoked from
  `warmUpSegment` before the BFS. Best-effort: an `IOException` from the
  supplier is logged at `WARNING` and the original per-node BFS path still
  runs, so we never regress versus pre-#619 behaviour even when the remote
  storage is degraded.

## Tests

- **`SegmentBlockCacheBulkInsertTest`** (10 tests): contract of the new
  `bulkInsert` API — full-block range, partial last block, argument
  validation (always releases the input buffer), disabled-cache no-op,
  existing-entry preservation + skip counting, `invalidatePath` drives the
  parent buffer's refCnt back to 0 (no leak), non-zero aligned offsets,
  repeated insert.
- **`RemoteRandomAccessReaderBulkPrefetchTest`** (11 tests): end-to-end
  against an in-process `RemoteFileServer` + multipart file spanning 3 chunks
  — supplier implements the mixin; full prefetch leaves the cache hot with
  zero loader invocations; partial prefetch only caches the requested chunks;
  disabled cache short-circuits; missing path surfaces as `IOException`;
  repeated prefetch counts skips; `invalidatePath` releases every
  prefetched block.
- **`Issue619BulkWarmupTest`** (7 tests): dispatch contract from
  `PersistentVectorStore.bulkPrefetchSegmentIntoCache` — exactly-once call
  with `(0, budget)` for matching suppliers, no call for plain `ReaderSupplier`,
  `IOException` and zero/negative budget swallowed, segment state not
  mutated.

## Test plan

- [x] `mvn -pl herddb-remote-file-service -Dtest='SegmentBlockCacheBulkInsertTest,RemoteRandomAccessReaderBulkPrefetchTest,SegmentBlockCacheTest,SegmentBlockCacheAsyncTest,SegmentBlockCacheHammerTest' test` — 57/57 ✅
- [x] `mvn -pl herddb-indexing-service -Dtest='Issue619BulkWarmupTest,Issue569WarmupBeforePublishTest,BlockCacheWarmupTest' test` — 19/19 ✅
- [x] `LazyValueCacheConcurrentUpdatesSuite{NoIndexes,WithNonUniqueIndexes,WithUniqueIndexes}Test` — 12/12 ✅
- [x] `mvn -B spotless:check apache-rat:check spotbugs:check install -DskipTests -Pci` — BUILD SUCCESS ✅
- [ ] CI

🤖 Implemented by the `pr-worker` agent.