### PR TITLE
issue #632: wire BenchRuntime through GrpcBench; add query/recall phase

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingPushClient.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingPushClient.java
@@ -27,6 +27,8 @@ import herddb.indexing.proto.IndexingServiceGrpc;
 import herddb.indexing.proto.PushEntriesRequest;
 import herddb.indexing.proto.PushEntriesResponse;
 import herddb.indexing.proto.PushedLogEntry;
+import herddb.indexing.proto.SearchRequest;
+import herddb.indexing.proto.SearchResponse;
 import herddb.log.LogSequenceNumber;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -111,6 +113,34 @@ public final class IndexingPushClient implements AutoCloseable {
                 .setTable(table)
                 .setIndex(index)
                 .build());
+    }
+
+    /**
+     * Runs an ANN search via the {@code Search} RPC. Used by the
+     * {@code VectorBench} {@code --protocol grpc} query/recall phase to issue
+     * vector searches against the same indexing service the bench has just
+     * populated. The response carries each match's raw serialized
+     * {@code primary_key} bytes (no score, since {@code returnScore=false}); the
+     * caller deserializes them with {@code RecordSerializer} according to the
+     * configured table schema.
+     *
+     * @param tablespace HerdDB tablespace name
+     * @param table      table containing the vector column
+     * @param index      name of the vector index to query
+     * @param vector     query vector (dimension must match the index)
+     * @param limit      top-K — maximum number of results to return
+     */
+    public SearchResponse search(String tablespace, String table, String index, float[] vector, int limit) {
+        SearchRequest.Builder request = SearchRequest.newBuilder()
+                .setTablespace(tablespace)
+                .setTable(table)
+                .setIndex(index)
+                .setLimit(limit)
+                .setReturnScore(false);
+        for (float v : vector) {
+            request.addVector(v);
+        }
+        return stub.search(request.build());
     }
 
     @Override

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingPushClientSearchTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingPushClientSearchTest.java
@@ -1,0 +1,220 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import com.google.protobuf.ByteString;
+import herddb.codec.RecordSerializer;
+import herddb.indexing.proto.PushEntriesResponse;
+import herddb.indexing.proto.SearchResponse;
+import herddb.indexing.proto.SearchResult;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogSequenceNumber;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.utils.Bytes;
+import io.netty.buffer.ByteBuf;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+
+/**
+ * Coverage for {@link IndexingPushClient#search}: pushes a tiny dataset into
+ * an embedded push-mode indexing service, then issues {@code Search} RPCs
+ * via the new client wrapper and asserts that the returned primary keys
+ * round-trip through HerdDB's record serialization.
+ *
+ * <p>This is the {@code VectorBench} {@code --protocol grpc} query/recall
+ * phase's only contract with the indexing service — keeping a focused test
+ * here means failures are diagnosed at the gRPC boundary, not at the
+ * end-to-end bench level.
+ */
+public class IndexingPushClientSearchTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60);
+
+    private EmbeddedIndexingService service;
+    private IndexingPushClient pushClient;
+
+    @After
+    public void tearDown() throws Exception {
+        if (pushClient != null) {
+            pushClient.close();
+        }
+        if (service != null) {
+            service.close();
+        }
+    }
+
+    private static Table vectorTable() {
+        return Table.builder()
+                .name("vectable")
+                .tablespace("default")
+                .column("id", ColumnTypes.LONG)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .primaryKey("id")
+                .build();
+    }
+
+    private static Index vectorIndex() {
+        return Index.builder()
+                .name("vidx")
+                .table("vectable")
+                .tablespace("default")
+                .type(Index.TYPE_VECTOR)
+                .column("vec", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    private PushEntriesResponse push(long ledger, long firstOffset, List<LogEntry> entries) {
+        List<LogSequenceNumber> lsns = new ArrayList<>();
+        List<ByteBuf> bufs = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            lsns.add(new LogSequenceNumber(ledger, firstOffset + i));
+            bufs.add(entries.get(i).serializeAsByteBuf());
+        }
+        try {
+            return pushClient.pushEntries(lsns, bufs);
+        } finally {
+            for (ByteBuf b : bufs) {
+                b.release();
+            }
+        }
+    }
+
+    private void awaitVectorCount(long expected, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        long last = -1;
+        while (System.currentTimeMillis() < deadline) {
+            last = pushClient.getIndexStatus("default", "vectable", "vidx").getVectorCount();
+            if (last >= expected) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        throw new AssertionError("indexed vector count did not reach " + expected + " (last=" + last + ")");
+    }
+
+    private static EmbeddedIndexingService startPushService(Path logDir, Path dataDir) throws Exception {
+        Properties props = new Properties();
+        props.setProperty(IndexingServerConfiguration.PROPERTY_STORAGE_TYPE, "memory");
+        props.setProperty(IndexingServerConfiguration.PROPERTY_LOG_TYPE,
+                IndexingServerConfiguration.PROPERTY_LOG_TYPE_PUSH);
+        EmbeddedIndexingService svc = new EmbeddedIndexingService(
+                logDir, dataDir, new IndexingServerConfiguration(props));
+        svc.start();
+        return svc;
+    }
+
+    @Test
+    public void searchReturnsPrimaryKeysForPushedVectors() throws Exception {
+        service = startPushService(folder.newFolder("log").toPath(), folder.newFolder("data").toPath());
+        pushClient = new IndexingPushClient(service.getAddress());
+
+        Table table = vectorTable();
+        push(1, 1, Arrays.asList(
+                LogEntryFactory.createTable(table, null),
+                LogEntryFactory.createIndex(vectorIndex(), null)));
+
+        // Push 30 vectors with deterministic IDs 0..29 in a single batch.
+        List<LogEntry> inserts = new ArrayList<>();
+        int n = 30;
+        int dim = 8;
+        for (long id = 0; id < n; id++) {
+            float[] v = new float[dim];
+            // A simple ramp keyed by id so neighbours are predictable.
+            for (int j = 0; j < dim; j++) {
+                v[j] = id + j * 0.5f;
+            }
+            Record r = RecordSerializer.makeRecord(table, "id", id, "vec", v);
+            inserts.add(LogEntryFactory.insert(table, r.key, r.value, null));
+        }
+        push(1, 3, inserts);
+
+        awaitVectorCount(n, 40_000);
+        service.getEngine().awaitPendingWorkForTest();
+
+        // Query with the exact vector for id=10 — the nearest neighbour must be id=10.
+        float[] query = new float[dim];
+        long expectedId = 10;
+        for (int j = 0; j < dim; j++) {
+            query[j] = expectedId + j * 0.5f;
+        }
+        SearchResponse response = pushClient.search("default", "vectable", "vidx", query, 5);
+        assertNotNull(response);
+        assertTrue("expected at least one result, got " + response.getResultsCount(),
+                response.getResultsCount() > 0);
+        assertFalse("returnScore is false by default — server must not populate score",
+                anyResultHasNonZeroScore(response));
+
+        // Deserialize the top result and verify it is id=10.
+        SearchResult top = response.getResults(0);
+        Bytes pk = Bytes.from_array(toByteArray(top.getPrimaryKey()));
+        Object value = RecordSerializer.deserializePrimaryKey(pk, table);
+        assertEquals("top hit must be the exact-match id", Long.valueOf(expectedId), value);
+
+        // Verify the returned IDs are a subset of pushed IDs (sanity check on round-trip).
+        Set<Long> seen = new HashSet<>();
+        for (SearchResult r : response.getResultsList()) {
+            Bytes b = Bytes.from_array(toByteArray(r.getPrimaryKey()));
+            Long id = (Long) RecordSerializer.deserializePrimaryKey(b, table);
+            seen.add(id);
+            assertTrue("returned id must be one of the pushed ids: " + id,
+                    id >= 0 && id < n);
+        }
+        assertEquals("results must not contain duplicates",
+                response.getResultsCount(), seen.size());
+    }
+
+    private static byte[] toByteArray(ByteString bs) {
+        byte[] out = new byte[bs.size()];
+        bs.copyTo(out, 0);
+        return out;
+    }
+
+    private static boolean anyResultHasNonZeroScore(SearchResponse response) {
+        for (SearchResult r : response.getResultsList()) {
+            if (r.getScore() != 0.0f) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/vector-testings/src/main/java/herddb/vectortesting/Config.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/Config.java
@@ -92,6 +92,14 @@ public class Config {
     boolean skipIngest = false;
     boolean skipIndex = false;
     boolean skipVerify = false;
+    /**
+     * Skip the post-ingest query / recall phase. Honored only by
+     * {@code GrpcBench} ({@code --protocol grpc}); the JDBC path has its own
+     * skip semantics keyed on {@code skipIngest} / {@code skipVerify}. When
+     * {@code true}, gRPC mode exits right after count verification and emits
+     * the bench summary without any {@code Search} RPCs or recall metric.
+     */
+    boolean skipQuery = false;
     boolean dropTable = false;
     boolean checkpoint = false;
     int clientTimeoutSeconds = 7200 * 4; // 8 hours
@@ -179,6 +187,9 @@ public class Config {
         opts.addOption(null, "skip-ingest", false, "Skip ingestion phase");
         opts.addOption(null, "skip-index", false, "Skip index creation");
         opts.addOption(null, "skip-verify", false, "Skip row count verification after ingestion");
+        opts.addOption(null, "skip-query", false,
+                "Skip the post-ingest query / recall phase (--protocol grpc only). "
+                        + "Use for pure ingestion benchmarks where recall is computed separately.");
         opts.addOption(null, "drop-table", false, "Drop table before starting");
         opts.addOption(null, "checkpoint", false, "Force checkpoint after ingestion and after index creation");
         opts.addOption(null, "similarity", true, "Similarity function: euclidean, cosine, dot_product (default: from dataset)");
@@ -317,6 +328,9 @@ public class Config {
         }
         if (cmd.hasOption("skip-verify")) {
             cfg.skipVerify = true;
+        }
+        if (cmd.hasOption("skip-query")) {
+            cfg.skipQuery = true;
         }
         if (cmd.hasOption("drop-table")) {
             cfg.dropTable = true;
@@ -481,6 +495,9 @@ public class Config {
         }
         if (props.containsKey("skip-verify")) {
             skipVerify = Boolean.parseBoolean(props.getProperty("skip-verify"));
+        }
+        if (props.containsKey("skip-query")) {
+            skipQuery = Boolean.parseBoolean(props.getProperty("skip-query"));
         }
         if (props.containsKey("drop-table")) {
             dropTable = Boolean.parseBoolean(props.getProperty("drop-table"));
@@ -700,6 +717,7 @@ public class Config {
                 + ", skipIngest=" + skipIngest
                 + ", skipIndex=" + skipIndex
                 + ", skipVerify=" + skipVerify
+                + ", skipQuery=" + skipQuery
                 + ", dropTable=" + dropTable
                 + ", checkpoint=" + checkpoint
                 + ", checkpointTimeoutSeconds=" + checkpointTimeoutSeconds

--- a/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
@@ -37,6 +37,7 @@ import herddb.model.Table;
 import herddb.model.TableSpace;
 import herddb.utils.Bytes;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,6 +47,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -414,34 +417,94 @@ public final class GrpcBench {
      * computes recall@K against the dataset's ground truth. Returns
      * {@code null} if no query vectors are available (e.g. a CUSTOM dataset
      * with no query file), and the caller treats that as "phase skipped".
+     *
+     * <p>Both file loads (query vectors and ground truth) are best-effort:
+     * a missing query file skips the entire phase, a missing ground-truth
+     * file runs the queries for QPS/latency but skips recall.
      */
     static QueryPhaseResult runQueryPhase(IndexingPushClient client, Config config, BenchOutput out,
                                           DatasetLoader loader, BenchRuntime runtime,
                                           long ingestedRows) throws Exception {
-        List<float[]> queryVectors = loader.loadQueryVectors(config.queryCount);
-        if (queryVectors == null || queryVectors.isEmpty()) {
-            out.info("No query vectors available — skipping query/recall phase.");
+        List<float[]> queryVectors = tryLoadQueryVectors(
+                () -> loader.loadQueryVectors(config.queryCount), out);
+        if (queryVectors == null) {
             return null;
         }
         out.info("Loaded " + queryVectors.size() + " query vectors for the query phase");
 
-        List<int[]> groundTruth;
-        try {
-            // Recall is only meaningful when ground truth matches the
-            // baseline. Use the actual row count (resumeFrom + ingestedRows)
-            // so CUSTOM datasets with prefix checkpoints pick the right file.
-            long baseRowCount = config.resumeFrom + ingestedRows;
-            groundTruth = loader.loadGroundTruth(queryVectors.size(), baseRowCount);
+        // Recall is only meaningful when ground truth matches the baseline.
+        // Use the actual row count (resumeFrom + ingestedRows) so CUSTOM
+        // datasets with prefix checkpoints pick the right file.
+        final long baseRowCount = config.resumeFrom + ingestedRows;
+        final int querySize = queryVectors.size();
+        List<int[]> groundTruth = tryLoadGroundTruth(
+                () -> loader.loadGroundTruth(querySize, baseRowCount), out);
+        if (groundTruth != null) {
             out.info("Loaded " + groundTruth.size() + " ground-truth entries (top-K up to "
                     + (groundTruth.isEmpty() ? 0 : groundTruth.get(0).length) + ")");
-        } catch (java.io.IOException e) {
-            // Ground truth is optional — if the dataset has no file matching
-            // the row count we still run the query phase (for QPS / latency)
-            // but skip recall.
-            out.info("Ground truth unavailable: " + e.getMessage() + " — running queries without recall.");
-            groundTruth = null;
         }
+        return runQueryPhase(client, config, out, queryVectors, groundTruth, runtime);
+    }
 
+    /**
+     * Best-effort loader for query vectors. Catches {@link IOException} (e.g.
+     * dataset directory missing the query file, or a CUSTOM descriptor
+     * without {@code queryFile}) and returns {@code null} so the caller
+     * skips the phase with a clear log line instead of aborting the run
+     * after a successful ingest. Package-private so tests can inject a
+     * throwing supplier.
+     */
+    static List<float[]> tryLoadQueryVectors(IOThrowingSupplier<List<float[]>> loader, BenchOutput out) {
+        try {
+            List<float[]> v = loader.get();
+            if (v == null || v.isEmpty()) {
+                out.info("No query vectors available — skipping query/recall phase.");
+                return null;
+            }
+            return v;
+        } catch (IOException e) {
+            out.info("No query vectors available: " + e.getMessage()
+                    + " — skipping query/recall phase.");
+            return null;
+        }
+    }
+
+    /**
+     * Best-effort loader for ground truth. {@code null} means "no recall",
+     * not "no query phase" — see {@link #tryLoadQueryVectors}.
+     */
+    static List<int[]> tryLoadGroundTruth(IOThrowingSupplier<List<int[]>> loader, BenchOutput out) {
+        try {
+            return loader.get();
+        } catch (IOException e) {
+            out.info("Ground truth unavailable: " + e.getMessage()
+                    + " — running queries without recall.");
+            return null;
+        }
+    }
+
+    /**
+     * Narrow functional interface for {@link DatasetLoader} calls that throw
+     * {@link IOException}. Used by {@link #tryLoadQueryVectors} and
+     * {@link #tryLoadGroundTruth} so unit tests can inject lambdas that
+     * throw deterministically without depending on a real {@link DatasetLoader}
+     * (which is {@code final} and reads from the filesystem).
+     */
+    @FunctionalInterface
+    interface IOThrowingSupplier<T> {
+        T get() throws IOException;
+    }
+
+    /**
+     * Runs the query / recall phase given already-loaded inputs. Pure compute
+     * + gRPC — no filesystem access. Package-private so tests can drive it
+     * directly with synthetic inputs (covers {@code queryThreads > queryCount}
+     * and deterministic-recall scenarios that would otherwise require a real
+     * dataset).
+     */
+    static QueryPhaseResult runQueryPhase(IndexingPushClient client, Config config, BenchOutput out,
+                                          List<float[]> queryVectors, List<int[]> groundTruth,
+                                          BenchRuntime runtime) throws Exception {
         out.header("=== QUERY PHASE (gRPC search) ===");
         out.phaseStart("query");
         Table table = buildTable(config);
@@ -480,22 +543,61 @@ public final class GrpcBench {
             });
         }
 
-        int threads = Math.max(1, config.queryThreads);
-        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        // Clamp to the actual query count: a pool with more threads than
+        // queries would otherwise leave `chunk == 0` slices for every thread
+        // except the last, which would then process every query serially
+        // (issue #632 review item 2).
+        int requestedThreads = Math.max(1, config.queryThreads);
+        int effectiveThreads = Math.min(requestedThreads, Math.max(1, total));
+        ExecutorService pool = Executors.newFixedThreadPool(effectiveThreads);
         try {
-            List<Future<?>> futures = new ArrayList<>(threads);
-            int chunk = total / threads;
-            for (int t = 0; t < threads; t++) {
-                final int startIdx = t * chunk;
-                final int endIdx = (t == threads - 1) ? total : startIdx + chunk;
-                futures.add(pool.submit(() ->
-                        searchRange(client, config, table, queryVectors, startIdx, endIdx,
-                                rateLimiterSupplier, queryMetrics, results)));
+            ExecutorCompletionService<Void> ecs = new ExecutorCompletionService<>(pool);
+            List<Future<Void>> futures = new ArrayList<>(effectiveThreads);
+            int chunk = total / effectiveThreads;
+            int remainder = total % effectiveThreads;
+            int cursor = 0;
+            for (int t = 0; t < effectiveThreads; t++) {
+                // Distribute the remainder over the first `remainder` threads
+                // (one extra each) so partitions stay balanced even when
+                // queryCount is not divisible by effectiveThreads.
+                int size = chunk + (t < remainder ? 1 : 0);
+                final int startIdx = cursor;
+                final int endIdx = cursor + size;
+                cursor = endIdx;
+                futures.add(ecs.submit(() -> {
+                    searchRange(client, config, table, queryVectors, startIdx, endIdx,
+                            rateLimiterSupplier, queryMetrics, results);
+                    return null;
+                }));
             }
             pool.shutdown();
-            // Progress loop — same shape as VectorBench's JDBC query progress
-            // line, just emitted from this thread since there is no JDBC pool.
-            while (!pool.awaitTermination(500, TimeUnit.MILLISECONDS)) {
+            int completed = 0;
+            while (completed < futures.size()) {
+                Future<Void> next = ecs.poll(500, TimeUnit.MILLISECONDS);
+                if (next != null) {
+                    try {
+                        next.get();
+                    } catch (ExecutionException ee) {
+                        // Cancel peer workers immediately so the failure
+                        // surfaces in <1 s rather than after every peer has
+                        // drained its slice (issue #632 review item 6).
+                        for (Future<Void> f : futures) {
+                            f.cancel(true);
+                        }
+                        pool.shutdownNow();
+                        Throwable cause = ee.getCause();
+                        if (cause instanceof RuntimeException re) {
+                            throw re;
+                        }
+                        if (cause instanceof Error err) {
+                            throw err;
+                        }
+                        throw new IllegalStateException("query worker failed", cause);
+                    }
+                    completed++;
+                    continue;
+                }
+                // No worker has finished in the last 500 ms — emit a progress line.
                 double elapsed = (System.nanoTime() - queryStart) / 1e9;
                 long done = queryMetrics.getCount();
                 double qps = elapsed > 0 ? done / elapsed : 0.0;
@@ -510,10 +612,6 @@ public final class GrpcBench {
                         "queried %d/%d | %.0f qps | mean %.2f ms | p99 %.2f ms",
                         done, total, qps,
                         stats.meanNanos() / 1e6, stats.p99Nanos() / 1e6), fields);
-            }
-            for (Future<?> f : futures) {
-                // Surface any worker exception (search RPC failure, deserialization bug).
-                f.get();
             }
         } finally {
             if (!pool.isTerminated()) {
@@ -572,10 +670,17 @@ public final class GrpcBench {
                 Bytes pk = Bytes.from_array(r.getPrimaryKey().toByteArray());
                 Object idValue = RecordSerializer.deserializePrimaryKey(pk, table);
                 // Single-column LONG PK: idValue is a Long. Recall arithmetic
-                // works on int ids (ground truth is int[]); a bench with more
-                // than 2^31 rows would need int64 recall comparisons too — far
-                // beyond what fits in a single IS today.
+                // works on int ids (ground truth files are int[]); a bench with
+                // more than 2^31 rows would need int64 recall comparisons too
+                // — far beyond what fits in a single IS today. Fail loudly if
+                // a future regression overflows the int cast, rather than
+                // wrapping to a negative id that silently corrupts recall.
                 long id = ((Number) idValue).longValue();
+                if (id < 0 || id > Integer.MAX_VALUE) {
+                    throw new IllegalStateException("returned primary key id=" + id
+                            + " does not fit in the int recall arithmetic; "
+                            + "the gRPC recall path is bounded to 2^31 rows");
+                }
                 ids.add((int) id);
             }
             results.set(i, ids);

--- a/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/GrpcBench.java
@@ -19,10 +19,13 @@
  */
 package herddb.vectortesting;
 
+import com.google.common.util.concurrent.RateLimiter;
 import herddb.codec.RecordSerializer;
 import herddb.index.vector.VectorIndexManager;
 import herddb.indexing.IndexingPushClient;
 import herddb.indexing.proto.PushEntriesResponse;
+import herddb.indexing.proto.SearchResponse;
+import herddb.indexing.proto.SearchResult;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
 import herddb.log.LogEntryType;
@@ -32,13 +35,25 @@ import herddb.model.Index;
 import herddb.model.Record;
 import herddb.model.Table;
 import herddb.model.TableSpace;
+import herddb.utils.Bytes;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 /**
  * The {@code --protocol grpc} ingestion path of VectorBench.
@@ -50,26 +65,53 @@ import java.util.function.Function;
  * them over the {@code PushEntries} gRPC RPC. No HerdDB server, BookKeeper or
  * commit log is involved.
  *
- * <p>It is ingestion-only: a transaction wraps each batch of inserts, the
- * entries are serialized into pooled direct {@link ByteBuf}s to keep the
- * client's memory footprint low, and a single thread issues every push so the
- * indexing service sees a strictly increasing LSN stream. Verification polls
- * the index status over gRPC and checks the indexed vector count.
+ * <p>It is ingestion + optional recall: a transaction wraps each batch of
+ * inserts, the entries are serialized into pooled direct {@link ByteBuf}s to
+ * keep the client's memory footprint low, and a single thread issues every
+ * push so the indexing service sees a strictly increasing LSN stream.
+ * Verification polls the index status over gRPC and checks the indexed
+ * vector count; the query phase (when enabled) drives {@code Search} RPCs
+ * against the same service and computes recall@K against the dataset's
+ * ground truth.
  */
 public final class GrpcBench {
 
     /** Name of the vector index this mode creates, populates and verifies. */
     private static final String INDEX_NAME = "vidx";
 
+    /**
+     * Maximum time to wait for the indexing service's tailer to apply every
+     * pushed entry once {@link #ingest} has finished pushing.
+     *
+     * <p>The {@code PushEntries} RPC only guarantees that entries have been
+     * <em>accepted into the bounded push buffer</em> by the time it returns —
+     * the IS tailer thread applies them asynchronously. In push mode the IS
+     * does not lag a real commit log, so once the last buffered entry has been
+     * accepted the apply loop typically finishes within milliseconds. A short
+     * fixed cap is enough to absorb that lag without pretending we need an
+     * open-ended wait.
+     *
+     * <p>Deliberately not driven by {@code --wait-for-indexes-timeout}: that
+     * flag is a JDBC-only concept (server-side {@code WAITFORINDEXES}) and is
+     * meaningless for push mode, where there is no external tailer to wait
+     * for. Promoting this to a CLI flag is intentionally avoided so the
+     * "always up-to-date" contract of push mode stays visible.
+     */
+    private static final long VERIFY_CATCHUP_TIMEOUT_MS = 30_000L;
+
+    /** Poll interval used while waiting for the tailer to apply the last buffered entries. */
+    private static final long VERIFY_POLL_INTERVAL_MS = 200L;
+
     private GrpcBench() {
     }
 
     /**
      * Entry point for {@code --protocol grpc}. Loads the dataset, opens the
-     * gRPC client and drives ingestion, then exits the JVM (mirroring the JDBC
+     * gRPC client and drives ingestion, optionally followed by verification
+     * and a query / recall phase, then exits the JVM (mirroring the JDBC
      * path's terminal {@code System.exit(0)}).
      */
-    static void run(Config config, BenchOutput out, long benchmarkStartNs) throws Exception {
+    static void run(Config config, BenchOutput out, long benchmarkStartNs, BenchRuntime runtime) throws Exception {
         out.header("=== gRPC PUSH MODE (indexing service " + config.grpcEndpoint + ") ===");
         if (config.resumeFromAuto) {
             out.info("WARNING: --resume-from auto is not supported with --protocol grpc; "
@@ -80,17 +122,50 @@ public final class GrpcBench {
         loader.ensureDataset();
 
         long toIngest = Math.max(0L, config.numRows - config.resumeFrom);
+        long pushed;
+        double recall = -1.0;
+        long recallQueries = 0;
+        long queriesRun = 0;
+        double queryWallSecs = -1.0;
         try (IndexingPushClient client = new IndexingPushClient(config.grpcEndpoint);
                 DatasetLoader.VectorStream stream = loader.streamBaseVectors(config.resumeFrom, toIngest)) {
-            long pushed = ingest(client, config, out, stream.iterator(), config.resumeFrom, toIngest);
-            double totalSecs = (System.nanoTime() - benchmarkStartNs) / 1e9;
-            LinkedHashMap<String, Object> summary = new LinkedHashMap<>();
-            summary.put("protocol", "grpc");
-            summary.put("endpoint", config.grpcEndpoint);
-            summary.put("dataset", config.dataset.name());
-            summary.put("rows", pushed);
-            summary.put("total_wall_time_s", Math.round(totalSecs * 10.0) / 10.0);
-            out.summary(summary);
+            pushed = ingest(client, config, out, stream.iterator(), config.resumeFrom, toIngest, runtime);
+
+            if (!config.skipQuery) {
+                QueryPhaseResult q = runQueryPhase(client, config, out, loader, runtime, pushed);
+                if (q != null) {
+                    recall = q.recall;
+                    recallQueries = q.recallQueries;
+                    queriesRun = q.queries;
+                    queryWallSecs = q.wallSecs;
+                }
+            } else {
+                out.info("Skipping query/recall phase (--skip-query).");
+            }
+        }
+        double totalSecs = (System.nanoTime() - benchmarkStartNs) / 1e9;
+        LinkedHashMap<String, Object> summary = new LinkedHashMap<>();
+        summary.put("protocol", "grpc");
+        summary.put("endpoint", config.grpcEndpoint);
+        summary.put("dataset", config.dataset.name());
+        summary.put("rows", pushed);
+        if (queriesRun > 0) {
+            summary.put("queries", queriesRun);
+            summary.put("query_wall_s", Math.round(queryWallSecs * 10.0) / 10.0);
+            summary.put("qps", queryWallSecs > 0
+                    ? Math.round((queriesRun / queryWallSecs) * 10.0) / 10.0 : 0.0);
+        }
+        if (recall >= 0.0) {
+            summary.put("recall_at_k", Math.round(recall * 10000.0) / 10000.0);
+            summary.put("recall_queries", recallQueries);
+            summary.put("top_k", config.topK);
+        }
+        summary.put("total_wall_time_s", Math.round(totalSecs * 10.0) / 10.0);
+        out.summary(summary);
+        // Final status: indicate we are done so the admin API stops reporting
+        // an in-progress phase after run() has returned.
+        if (runtime != null) {
+            runtime.setStatusSupplier(() -> Collections.singletonMap("phase", "done"));
         }
         out.done();
         System.exit(0);
@@ -103,12 +178,26 @@ public final class GrpcBench {
      * count over gRPC.
      *
      * <p>Package-private and free of {@code System.exit} so integration tests
-     * can drive it directly with a synthetic vector source.
+     * can drive it directly with a synthetic vector source. The {@code runtime}
+     * argument is optional ({@code null} permitted): when present, per-phase
+     * status fields are published to the admin HTTP API as the bench moves
+     * through {@code schema} → {@code ingest} → {@code verification}.
      *
      * @return the number of vector rows pushed
      */
     static long ingest(IndexingPushClient client, Config config, BenchOutput out,
                        Iterator<float[]> vectors, long firstRowId, long totalRows) throws Exception {
+        return ingest(client, config, out, vectors, firstRowId, totalRows, null);
+    }
+
+    /**
+     * Same as {@link #ingest(IndexingPushClient, Config, BenchOutput, Iterator, long, long)}
+     * but accepts a {@link BenchRuntime} so the admin HTTP API can observe
+     * each phase transition (issue #632).
+     */
+    static long ingest(IndexingPushClient client, Config config, BenchOutput out,
+                       Iterator<float[]> vectors, long firstRowId, long totalRows,
+                       BenchRuntime runtime) throws Exception {
         Table table = buildTable(config);
         Index index = buildIndex(config);
 
@@ -119,6 +208,7 @@ public final class GrpcBench {
         long[] offset = {1L};
 
         out.phaseStart("schema");
+        setSimpleStatus(runtime, "schema");
         out.info("Pushing CREATE TABLE " + config.tableName + " + CREATE VECTOR INDEX " + INDEX_NAME);
         PushEntriesResponse schemaResp = pushBatch(client, ledgerId, offset, Arrays.asList(
                 LogEntryFactory.createTable(table, null),
@@ -135,6 +225,29 @@ public final class GrpcBench {
         out.header("=== INGESTION PHASE (gRPC push) ===");
         out.phaseStart("ingest");
         long ingestStart = System.nanoTime();
+        // AtomicLongs so the status supplier (read concurrently from Jetty
+        // threads in BenchRuntime) sees a coherent snapshot rather than a
+        // half-updated long.
+        AtomicLong pushedRows = new AtomicLong(0);
+        AtomicLong pushCallsCounter = new AtomicLong(0);
+        if (runtime != null) {
+            final long ingestStartNs = ingestStart;
+            runtime.setStatusSupplier(() -> {
+                Runtime rt = Runtime.getRuntime();
+                long rows = pushedRows.get();
+                double elapsed = (System.nanoTime() - ingestStartNs) / 1e9;
+                double opsPerSec = elapsed > 0 ? rows / elapsed : 0.0;
+                LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+                m.put("phase", "ingest");
+                m.put("rows", rows);
+                m.put("total", totalRows);
+                m.put("ops_per_sec", opsPerSec);
+                m.put("push_calls", pushCallsCounter.get());
+                m.put("heap_used_mb", (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024));
+                m.put("heap_max_mb", rt.maxMemory() / (1024 * 1024));
+                return m;
+            });
+        }
         long rowId = firstRowId;
         long pushed = 0;
         long pushCalls = 0;
@@ -160,6 +273,8 @@ public final class GrpcBench {
             PushEntriesResponse resp = pushBatch(client, ledgerId, offset, batch);
             pushed += n;
             pushCalls++;
+            pushedRows.set(pushed);
+            pushCallsCounter.set(pushCalls);
             if (resp.getAcceptedCount() != batch.size()) {
                 throw new IllegalStateException("indexing service accepted "
                         + resp.getAcceptedCount() + " of " + batch.size() + " pushed entries");
@@ -189,41 +304,322 @@ public final class GrpcBench {
         if (config.skipVerify) {
             out.info("Skipping vector-count verification (--skip-verify).");
         } else {
-            verifyVectorCount(client, config, out, baseline + pushed);
+            verifyVectorCount(client, config, out, baseline + pushed, runtime);
         }
         return pushed;
     }
 
     /**
      * Polls {@code GetIndexStatus} until the indexed vector count reaches
-     * {@code expected}. The indexing service applies pushed entries
-     * asynchronously and may pause for a checkpoint/compaction, so this waits
-     * with a generous deadline rather than asserting immediately.
+     * {@code expected}. {@code PushEntries} only guarantees buffer-accept,
+     * not apply, so a tiny lag is possible right after the last batch
+     * returns — but in push mode the IS is "always up to date" and the
+     * tailer drains in milliseconds, so we bound the wait at
+     * {@link #VERIFY_CATCHUP_TIMEOUT_MS} (deliberately short, and explicitly
+     * <em>not</em> driven by {@code --wait-for-indexes-timeout}, which is a
+     * JDBC concept).
      */
     private static void verifyVectorCount(IndexingPushClient client, Config config,
-                                          BenchOutput out, long expected) throws InterruptedException {
+                                          BenchOutput out, long expected,
+                                          BenchRuntime runtime) throws InterruptedException {
+        LongSupplier counter = () -> client.getIndexStatus(TableSpace.DEFAULT, config.tableName, INDEX_NAME)
+                .getVectorCount();
+        verifyVectorCount(counter, out, expected, runtime, VERIFY_CATCHUP_TIMEOUT_MS, VERIFY_POLL_INTERVAL_MS);
+    }
+
+    /**
+     * Polling-loop core, factored out so unit tests can drive it with a
+     * synthetic counter (no live gRPC server) and pin the timing contract:
+     * the deadline is the {@code timeoutMs} value passed in, NOT
+     * {@code config.waitForIndexesTimeoutSeconds}.
+     *
+     * <p>Package-private for {@link GrpcBenchTest}.
+     */
+    static void verifyVectorCount(LongSupplier currentCount, BenchOutput out, long expected,
+                                  BenchRuntime runtime, long timeoutMs, long pollIntervalMs)
+            throws InterruptedException {
         out.phaseStart("verification");
         long verifyStart = System.nanoTime();
-        long deadlineMs = System.currentTimeMillis() + 3_600_000L;
+        AtomicLong lastObserved = new AtomicLong(-1);
+        if (runtime != null) {
+            final long expectedFinal = expected;
+            runtime.setStatusSupplier(() -> {
+                LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+                m.put("phase", "verification");
+                m.put("vector_count", lastObserved.get());
+                m.put("expected", expectedFinal);
+                return m;
+            });
+        }
+        long deadlineMs = System.currentTimeMillis() + timeoutMs;
         long last = -1;
-        while (System.currentTimeMillis() < deadlineMs) {
-            last = client.getIndexStatus(TableSpace.DEFAULT, config.tableName, INDEX_NAME)
-                    .getVectorCount();
+        boolean firstAttempt = true;
+        while (true) {
+            last = currentCount.getAsLong();
+            lastObserved.set(last);
             if (last >= expected) {
                 out.phaseDone("verification", (System.nanoTime() - verifyStart) / 1e9);
                 out.info("Verification OK: index '" + INDEX_NAME + "' reports " + last + " vectors");
                 return;
             }
-            double elapsed = (System.nanoTime() - verifyStart) / 1e9;
-            LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
-            fields.put("vector_count", last);
-            fields.put("expected", expected);
-            out.progress("verification", elapsed,
-                    "indexed " + last + "/" + expected + " vectors", fields);
-            Thread.sleep(1000);
+            if (firstAttempt) {
+                // Only log a verification "progress" line when we actually had
+                // to wait — the steady-state push-mode case is a single
+                // sub-millisecond status call.
+                double elapsed = (System.nanoTime() - verifyStart) / 1e9;
+                LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+                fields.put("vector_count", last);
+                fields.put("expected", expected);
+                out.progress("verification", elapsed,
+                        "indexed " + last + "/" + expected + " vectors — waiting for tailer to apply last batch",
+                        fields);
+                firstAttempt = false;
+            }
+            if (System.currentTimeMillis() >= deadlineMs) {
+                break;
+            }
+            Thread.sleep(pollIntervalMs);
         }
         throw new IllegalStateException("index vector count reached only " + last
-                + " of the expected " + expected + " within the verification timeout");
+                + " of the expected " + expected + " within " + timeoutMs
+                + " ms — the indexing-service tailer has not applied every pushed entry."
+                + " In push mode this is expected to take milliseconds; a longer lag indicates"
+                + " a stalled tailer (a long-running checkpoint/compaction or a bug)");
+    }
+
+    /**
+     * Result of {@link #runQueryPhase}: aggregate counts and the computed recall.
+     * Returned by the query phase so the bench summary can include the same
+     * fields the JDBC path reports.
+     */
+    static final class QueryPhaseResult {
+        final long queries;
+        final double wallSecs;
+        final double recall;
+        final long recallQueries;
+
+        QueryPhaseResult(long queries, double wallSecs, double recall, long recallQueries) {
+            this.queries = queries;
+            this.wallSecs = wallSecs;
+            this.recall = recall;
+            this.recallQueries = recallQueries;
+        }
+    }
+
+    /**
+     * Runs the query / recall phase over gRPC. Loads {@code config.queryCount}
+     * query vectors and ground-truth records from {@code loader}, drives
+     * {@code Search} RPCs in parallel across {@code config.queryThreads}
+     * threads at {@code config.queryMaxOpsPerSecond} aggregate rate, then
+     * computes recall@K against the dataset's ground truth. Returns
+     * {@code null} if no query vectors are available (e.g. a CUSTOM dataset
+     * with no query file), and the caller treats that as "phase skipped".
+     */
+    static QueryPhaseResult runQueryPhase(IndexingPushClient client, Config config, BenchOutput out,
+                                          DatasetLoader loader, BenchRuntime runtime,
+                                          long ingestedRows) throws Exception {
+        List<float[]> queryVectors = loader.loadQueryVectors(config.queryCount);
+        if (queryVectors == null || queryVectors.isEmpty()) {
+            out.info("No query vectors available — skipping query/recall phase.");
+            return null;
+        }
+        out.info("Loaded " + queryVectors.size() + " query vectors for the query phase");
+
+        List<int[]> groundTruth;
+        try {
+            // Recall is only meaningful when ground truth matches the
+            // baseline. Use the actual row count (resumeFrom + ingestedRows)
+            // so CUSTOM datasets with prefix checkpoints pick the right file.
+            long baseRowCount = config.resumeFrom + ingestedRows;
+            groundTruth = loader.loadGroundTruth(queryVectors.size(), baseRowCount);
+            out.info("Loaded " + groundTruth.size() + " ground-truth entries (top-K up to "
+                    + (groundTruth.isEmpty() ? 0 : groundTruth.get(0).length) + ")");
+        } catch (java.io.IOException e) {
+            // Ground truth is optional — if the dataset has no file matching
+            // the row count we still run the query phase (for QPS / latency)
+            // but skip recall.
+            out.info("Ground truth unavailable: " + e.getMessage() + " — running queries without recall.");
+            groundTruth = null;
+        }
+
+        out.header("=== QUERY PHASE (gRPC search) ===");
+        out.phaseStart("query");
+        Table table = buildTable(config);
+        int total = queryVectors.size();
+        List<List<Integer>> results = new ArrayList<>(Collections.nCopies(total, null));
+        MetricsCollector queryMetrics = new MetricsCollector();
+        long queryStart = System.nanoTime();
+        // Per-iteration re-read so an admin-issued query-rate change takes
+        // effect on the next query, matching the JDBC QueryWorker behaviour.
+        Supplier<RateLimiter> rateLimiterSupplier = runtime != null
+                ? runtime::queryRateLimiter
+                : () -> RateLimiter.create(config.queryMaxOpsPerSecond > 0
+                        ? config.queryMaxOpsPerSecond : BenchRuntime.UNLIMITED_RATE);
+
+        if (runtime != null) {
+            final long queryStartNs = queryStart;
+            runtime.setStatusSupplier(() -> {
+                LinkedHashMap<String, Object> m = new LinkedHashMap<>();
+                double elapsed = (System.nanoTime() - queryStartNs) / 1e9;
+                long done = queryMetrics.getCount();
+                double qps = elapsed > 0 ? done / elapsed : 0.0;
+                m.put("phase", "query");
+                m.put("queries_done", done);
+                m.put("total", (long) total);
+                m.put("qps", qps);
+                m.put("top_k", config.topK);
+                MetricsCollector.Stats s = queryMetrics.computeStats();
+                LinkedHashMap<String, Object> latency = new LinkedHashMap<>();
+                latency.put("mean_ms", s.meanNanos() / 1e6);
+                latency.put("p50_ms", s.p50Nanos() / 1e6);
+                latency.put("p95_ms", s.p95Nanos() / 1e6);
+                latency.put("p99_ms", s.p99Nanos() / 1e6);
+                latency.put("max_ms", s.maxNanos() / 1e6);
+                m.put("latency", latency);
+                return m;
+            });
+        }
+
+        int threads = Math.max(1, config.queryThreads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new ArrayList<>(threads);
+            int chunk = total / threads;
+            for (int t = 0; t < threads; t++) {
+                final int startIdx = t * chunk;
+                final int endIdx = (t == threads - 1) ? total : startIdx + chunk;
+                futures.add(pool.submit(() ->
+                        searchRange(client, config, table, queryVectors, startIdx, endIdx,
+                                rateLimiterSupplier, queryMetrics, results)));
+            }
+            pool.shutdown();
+            // Progress loop — same shape as VectorBench's JDBC query progress
+            // line, just emitted from this thread since there is no JDBC pool.
+            while (!pool.awaitTermination(500, TimeUnit.MILLISECONDS)) {
+                double elapsed = (System.nanoTime() - queryStart) / 1e9;
+                long done = queryMetrics.getCount();
+                double qps = elapsed > 0 ? done / elapsed : 0.0;
+                LinkedHashMap<String, Object> fields = new LinkedHashMap<>();
+                fields.put("queries_done", done);
+                fields.put("total", (long) total);
+                fields.put("qps", qps);
+                MetricsCollector.Stats stats = queryMetrics.computeStats();
+                fields.put("latency_mean_ms", stats.meanNanos() / 1e6);
+                fields.put("latency_p99_ms", stats.p99Nanos() / 1e6);
+                out.progress("query", elapsed, String.format(
+                        "queried %d/%d | %.0f qps | mean %.2f ms | p99 %.2f ms",
+                        done, total, qps,
+                        stats.meanNanos() / 1e6, stats.p99Nanos() / 1e6), fields);
+            }
+            for (Future<?> f : futures) {
+                // Surface any worker exception (search RPC failure, deserialization bug).
+                f.get();
+            }
+        } finally {
+            if (!pool.isTerminated()) {
+                pool.shutdownNow();
+            }
+        }
+        double querySecs = (System.nanoTime() - queryStart) / 1e9;
+        out.phaseDone("query", querySecs);
+
+        long queriesRun = queryMetrics.getCount();
+        double qps = querySecs > 0 ? queriesRun / querySecs : 0.0;
+        out.info(String.format("Ran %d searches in %.1fs (%.0f qps), top-K=%d",
+                queriesRun, querySecs, qps, config.topK));
+
+        double recall = -1.0;
+        long recallQueries = 0;
+        if (groundTruth != null && !groundTruth.isEmpty()) {
+            // Match the JDBC path's recall semantics: compare only the prefix
+            // of result rows that have ground truth.
+            List<List<Integer>> recallResults = results.subList(0, Math.min(results.size(), groundTruth.size()));
+            recall = computeRecall(recallResults, groundTruth, config.topK);
+            recallQueries = recallResults.size();
+            out.info(String.format("Recall@%d: %.4f (computed on %d queries)",
+                    config.topK, recall, recallQueries));
+        } else {
+            out.info("Recall@" + config.topK + ": not computed (no ground truth available)");
+        }
+        return new QueryPhaseResult(queriesRun, querySecs, recall, recallQueries);
+    }
+
+    /**
+     * Runs the {@code Search} RPC for {@code queryVectors[startIdx..endIdx)},
+     * deserializing each result's serialized primary key into the row's
+     * integer id (single-column LONG PK — fits in int while the bench's row
+     * count stays below 2^31). Populates {@code results[i]} with the list of
+     * matched ids in rank order so the caller can compute recall.
+     */
+    private static void searchRange(IndexingPushClient client, Config config, Table table,
+                                    List<float[]> queryVectors, int startIdx, int endIdx,
+                                    Supplier<RateLimiter> rateLimiterSupplier,
+                                    MetricsCollector metrics, List<List<Integer>> results) {
+        for (int i = startIdx; i < endIdx; i++) {
+            int k = config.topK;
+            RateLimiter rl = rateLimiterSupplier.get();
+            if (rl != null) {
+                rl.acquire(1);
+            }
+            long start = System.nanoTime();
+            SearchResponse response = client.search(TableSpace.DEFAULT, config.tableName,
+                    INDEX_NAME, queryVectors.get(i), k);
+            long elapsed = System.nanoTime() - start;
+            metrics.record(elapsed);
+
+            List<Integer> ids = new ArrayList<>(response.getResultsCount());
+            for (SearchResult r : response.getResultsList()) {
+                Bytes pk = Bytes.from_array(r.getPrimaryKey().toByteArray());
+                Object idValue = RecordSerializer.deserializePrimaryKey(pk, table);
+                // Single-column LONG PK: idValue is a Long. Recall arithmetic
+                // works on int ids (ground truth is int[]); a bench with more
+                // than 2^31 rows would need int64 recall comparisons too — far
+                // beyond what fits in a single IS today.
+                long id = ((Number) idValue).longValue();
+                ids.add((int) id);
+            }
+            results.set(i, ids);
+        }
+    }
+
+    /**
+     * Recall@K: fraction of ground-truth-top-K ids that appear in the result
+     * top-K. Identical semantics to {@code VectorBench.computeRecall} so the
+     * gRPC and JDBC paths report the same metric.
+     */
+    private static double computeRecall(List<List<Integer>> results, List<int[]> groundTruth, int k) {
+        int totalRelevant = 0;
+        int totalFound = 0;
+        int count = Math.min(results.size(), groundTruth.size());
+        for (int i = 0; i < count; i++) {
+            List<Integer> result = results.get(i);
+            if (result == null) {
+                continue;
+            }
+            int[] truth = groundTruth.get(i);
+            Set<Integer> truthSet = new HashSet<>();
+            for (int j = 0; j < Math.min(k, truth.length); j++) {
+                truthSet.add(truth[j]);
+            }
+            totalRelevant += truthSet.size();
+            for (int id : result) {
+                if (truthSet.contains(id)) {
+                    totalFound++;
+                }
+            }
+        }
+        return totalRelevant == 0 ? 0.0 : (double) totalFound / totalRelevant;
+    }
+
+    private static void setSimpleStatus(BenchRuntime runtime, String phase) {
+        if (runtime == null) {
+            return;
+        }
+        runtime.setStatusSupplier(() -> {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("phase", phase);
+            return m;
+        });
     }
 
     /**

--- a/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
+++ b/vector-testings/src/main/java/herddb/vectortesting/VectorBench.java
@@ -189,7 +189,7 @@ public class VectorBench {
         // gRPC push mode: ingestion straight into a single indexing service,
         // with no HerdDB server. Entirely separate from the JDBC path below.
         if (config.protocol == Config.Protocol.GRPC) {
-            GrpcBench.run(config, out, benchmarkStartNs);
+            GrpcBench.run(config, out, benchmarkStartNs, runtime);
             return;
         }
 

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
@@ -28,8 +28,10 @@ import herddb.indexing.IndexingServerConfiguration;
 import herddb.model.TableSpace;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
@@ -243,54 +245,93 @@ class GrpcBenchIntegrationTest {
     }
 
     /**
-     * Issue #632 (3): the new query / recall phase runs gRPC {@code Search}
-     * calls against the same IS the bench has just populated. With a tiny
-     * deterministic dataset (200 dim-8 vectors built from a coordinate ramp)
-     * the query for the exact vector at row K must rank K first — so
-     * recall@1 = 1.0 across every probe. This pins both the
-     * {@link IndexingPushClient#search} round-trip and the primary-key
-     * deserialization in {@code GrpcBench.searchRange}.
+     * Issue #632 (3): the new query / recall phase end-to-end. Ingest a
+     * deterministic dataset (300 dim-8 ramp vectors), then drive the
+     * package-private {@link GrpcBench#runQueryPhase(IndexingPushClient,
+     * Config, BenchOutput, List, List, BenchRuntime)} with hand-built
+     * query vectors and ground truth. Asserts on the returned
+     * {@code QueryPhaseResult} — exercising the parallel search pool,
+     * primary-key deserialization, recall computation, and the
+     * {@code phase=query} status supplier all at once.
      */
     @Test
     @Timeout(120)
-    void grpcQueryPhaseProducesPerfectRecallOnDeterministicData() throws Exception {
+    void grpcQueryPhaseEndToEndProducesPerfectRecall() throws Exception {
         EmbeddedIndexingService service = startPushService();
         try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
             Config config = grpcConfig("grpc_recall");
-            int rows = 200;
+            config.topK = 1;
+            int rows = 300;
+            int dim = 8;
+            BenchRuntime runtime = new BenchRuntime(config);
+            long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
+                    rampVectors(rows, dim), 0L, rows, runtime);
+            assertEquals(rows, pushed);
+
+            // Build query vectors that are exact replicas of 10 known rows,
+            // so the nearest-neighbour at top-1 is always the matching id.
+            int probes = 10;
+            List<float[]> queryVectors = new ArrayList<>(probes);
+            List<int[]> groundTruth = new ArrayList<>(probes);
+            for (int k = 0; k < probes; k++) {
+                int probeId = k * (rows / probes);
+                queryVectors.add(rampVector(probeId, dim));
+                groundTruth.add(new int[]{probeId});
+            }
+
+            GrpcBench.QueryPhaseResult result = GrpcBench.runQueryPhase(
+                    client, config, BenchOutput.create(config),
+                    queryVectors, groundTruth, runtime);
+
+            assertNotNull(result);
+            assertEquals(probes, result.queries, "every probe must have been searched");
+            assertEquals(probes, result.recallQueries);
+            assertTrue(result.recall >= 0.9,
+                    "deterministic ramp dataset must produce near-perfect recall@1, got " + result.recall);
+            // Phase supplier should have been left on `query` (final transition
+            // back to `done` happens in GrpcBench.run, not runQueryPhase).
+            Map<String, Object> status = runtime.getStatusSupplier().get();
+            assertEquals("query", status.get("phase"));
+            assertEquals((long) probes, status.get("total"));
+        } finally {
+            service.close();
+        }
+    }
+
+    /**
+     * Issue #632 review item 2: when {@code queryThreads > queryCount} the
+     * old work-partitioning collapsed every query onto the last thread.
+     * After the fix every query must still be executed exactly once and the
+     * returned {@code QueryPhaseResult.queries} must equal the input size.
+     */
+    @Test
+    @Timeout(60)
+    void grpcQueryPhaseHandlesMoreThreadsThanQueries() throws Exception {
+        EmbeddedIndexingService service = startPushService();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = grpcConfig("grpc_threads_over_queries");
+            config.topK = 1;
+            config.queryThreads = 8;
+            int rows = 64;
             int dim = 8;
             long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
                     rampVectors(rows, dim), 0L, rows);
             assertEquals(rows, pushed);
 
-            // Issue Search RPCs for the exact vectors at K=10 known positions.
-            // Each must rank its own id first (recall@1 = 1).
-            int hits = 0;
-            int probes = 10;
-            for (int k = 0; k < probes; k++) {
-                int probeId = k * (rows / probes);
-                float[] query = rampVector(probeId, dim);
-                var resp = client.search(TableSpace.DEFAULT, "grpc_recall", "vidx", query, 5);
-                assertNotNull(resp);
-                assertTrue(resp.getResultsCount() > 0,
-                        "search must return at least one hit for id=" + probeId);
-                // Decode the top result's primary key (single-column LONG id).
-                herddb.utils.Bytes pk = herddb.utils.Bytes.from_array(
-                        resp.getResults(0).getPrimaryKey().toByteArray());
-                herddb.model.Table table = herddb.model.Table.builder()
-                        .name("grpc_recall")
-                        .tablespace(TableSpace.DEFAULT)
-                        .column("id", herddb.model.ColumnTypes.LONG)
-                        .column("vec", herddb.model.ColumnTypes.FLOATARRAY)
-                        .primaryKey("id")
-                        .build();
-                long topId = ((Number) herddb.codec.RecordSerializer.deserializePrimaryKey(pk, table)).longValue();
-                if (topId == probeId) {
-                    hits++;
-                }
-            }
-            assertTrue(hits >= probes - 1,
-                    "expected at least " + (probes - 1) + " exact-match top hits, got " + hits);
+            // Two queries, eight pool threads — every query must still be
+            // executed.
+            List<float[]> queryVectors = new ArrayList<>();
+            queryVectors.add(rampVector(0, dim));
+            queryVectors.add(rampVector(1, dim));
+
+            GrpcBench.QueryPhaseResult result = GrpcBench.runQueryPhase(
+                    client, config, BenchOutput.create(config),
+                    queryVectors, null, null);
+
+            assertNotNull(result);
+            assertEquals(2L, result.queries,
+                    "every query must be executed even when queryThreads > queryCount");
+            assertEquals(-1.0, result.recall, "recall is -1 when no ground truth was passed");
         } finally {
             service.close();
         }

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchIntegrationTest.java
@@ -20,6 +20,8 @@
 package herddb.vectortesting;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import herddb.indexing.EmbeddedIndexingService;
 import herddb.indexing.IndexingPushClient;
 import herddb.indexing.IndexingServerConfiguration;
@@ -28,8 +30,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -143,5 +148,184 @@ class GrpcBenchIntegrationTest {
         } finally {
             service.close();
         }
+    }
+
+    /**
+     * Issue #632 (1): the gRPC ingest path must thread {@link BenchRuntime}
+     * status through each phase (schema → ingest → verification) so the admin
+     * {@code /status} endpoint stops permanently reporting {@code idle}.
+     * Sample the runtime supplier from a background thread while ingestion
+     * is in progress and assert we observe at least one non-{@code idle}
+     * phase before the bench finishes.
+     */
+    @Test
+    @Timeout(60)
+    void grpcIngestWiresPhaseToBenchRuntime() throws Exception {
+        EmbeddedIndexingService service = startPushService();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = grpcConfig("grpc_runtime_phase");
+            // Keep the ingest large enough that the sampler runs while we're
+            // still pushing — 2000 vectors at batchSize=64 is ~30 push calls,
+            // each with a sub-millisecond gRPC round-trip, so the sampler will
+            // see the ingest phase mid-loop on any sane CI host.
+            int rows = 2000;
+            BenchRuntime runtime = new BenchRuntime(config);
+            assertEquals("idle", runtime.getStatusSupplier().get().get("phase"),
+                    "fresh BenchRuntime must default to phase=idle");
+
+            Set<String> observedPhases = ConcurrentHashMap.newKeySet();
+            Thread sampler = new Thread(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    Map<String, Object> snapshot = runtime.getStatusSupplier().get();
+                    Object phase = snapshot.get("phase");
+                    if (phase != null) {
+                        observedPhases.add(phase.toString());
+                    }
+                    try {
+                        // 1 ms is aggressive enough to catch sub-second phase transitions.
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }, "phase-sampler");
+            sampler.setDaemon(true);
+            sampler.start();
+            try {
+                long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
+                        syntheticVectors(rows, 16), 0L, rows, runtime);
+                assertEquals(rows, pushed);
+            } finally {
+                sampler.interrupt();
+                sampler.join();
+            }
+
+            // We must have observed the ingest phase (or schema, or verification) —
+            // i.e. the supplier was swapped away from the default "idle".
+            assertTrue(observedPhases.contains("ingest") || observedPhases.contains("schema")
+                            || observedPhases.contains("verification"),
+                    "expected to observe at least one non-idle phase during ingest, got: " + observedPhases);
+        } finally {
+            service.close();
+        }
+    }
+
+    /**
+     * Issue #632 (2): the verification phase must complete quickly in push
+     * mode — the IS is "always up to date" once the bounded push buffer
+     * drains, so the wait is bounded by milliseconds in practice, not by
+     * {@code --wait-for-indexes-timeout}. We set that JDBC flag to 1 second
+     * to prove it is ignored (the old 1-hour hard-coded deadline would also
+     * be ignored, and a regression that re-introduced it would still fall
+     * within the test timeout — the strong tripwire is the unit test
+     * {@code GrpcBenchTest#verifyVectorCountFailsFastWhenIndexFallsShort}).
+     */
+    @Test
+    @Timeout(30)
+    void grpcVerifyReturnsImmediatelyWhenIndexIsUpToDate() throws Exception {
+        EmbeddedIndexingService service = startPushService();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = grpcConfig("grpc_verify_fast");
+            // Tiny value, would block a JDBC WAITFORINDEXES — must be ignored
+            // by the push-mode verification.
+            config.waitForIndexesTimeoutSeconds = 1;
+            long start = System.nanoTime();
+            long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
+                    syntheticVectors(200, 16), 0L, 200);
+            double elapsedSecs = (System.nanoTime() - start) / 1e9;
+            assertEquals(200, pushed);
+            assertTrue(elapsedSecs < 20.0,
+                    "push-mode verification must be near-instant, elapsed=" + elapsedSecs + " s");
+        } finally {
+            service.close();
+        }
+    }
+
+    /**
+     * Issue #632 (3): the new query / recall phase runs gRPC {@code Search}
+     * calls against the same IS the bench has just populated. With a tiny
+     * deterministic dataset (200 dim-8 vectors built from a coordinate ramp)
+     * the query for the exact vector at row K must rank K first — so
+     * recall@1 = 1.0 across every probe. This pins both the
+     * {@link IndexingPushClient#search} round-trip and the primary-key
+     * deserialization in {@code GrpcBench.searchRange}.
+     */
+    @Test
+    @Timeout(120)
+    void grpcQueryPhaseProducesPerfectRecallOnDeterministicData() throws Exception {
+        EmbeddedIndexingService service = startPushService();
+        try (IndexingPushClient client = new IndexingPushClient(service.getAddress())) {
+            Config config = grpcConfig("grpc_recall");
+            int rows = 200;
+            int dim = 8;
+            long pushed = GrpcBench.ingest(client, config, BenchOutput.create(config),
+                    rampVectors(rows, dim), 0L, rows);
+            assertEquals(rows, pushed);
+
+            // Issue Search RPCs for the exact vectors at K=10 known positions.
+            // Each must rank its own id first (recall@1 = 1).
+            int hits = 0;
+            int probes = 10;
+            for (int k = 0; k < probes; k++) {
+                int probeId = k * (rows / probes);
+                float[] query = rampVector(probeId, dim);
+                var resp = client.search(TableSpace.DEFAULT, "grpc_recall", "vidx", query, 5);
+                assertNotNull(resp);
+                assertTrue(resp.getResultsCount() > 0,
+                        "search must return at least one hit for id=" + probeId);
+                // Decode the top result's primary key (single-column LONG id).
+                herddb.utils.Bytes pk = herddb.utils.Bytes.from_array(
+                        resp.getResults(0).getPrimaryKey().toByteArray());
+                herddb.model.Table table = herddb.model.Table.builder()
+                        .name("grpc_recall")
+                        .tablespace(TableSpace.DEFAULT)
+                        .column("id", herddb.model.ColumnTypes.LONG)
+                        .column("vec", herddb.model.ColumnTypes.FLOATARRAY)
+                        .primaryKey("id")
+                        .build();
+                long topId = ((Number) herddb.codec.RecordSerializer.deserializePrimaryKey(pk, table)).longValue();
+                if (topId == probeId) {
+                    hits++;
+                }
+            }
+            assertTrue(hits >= probes - 1,
+                    "expected at least " + (probes - 1) + " exact-match top hits, got " + hits);
+        } finally {
+            service.close();
+        }
+    }
+
+    /** Same deterministic ramp as {@link #syntheticVectors} but exposed as a single vector. */
+    private static float[] rampVector(int id, int dim) {
+        float[] v = new float[dim];
+        for (int j = 0; j < dim; j++) {
+            // Make every id a distinct point — no modulo. Recall semantics
+            // for the integration test rely on per-id uniqueness.
+            v[j] = id + j * 0.5f;
+        }
+        return v;
+    }
+
+    /** Per-id-distinct ramp iterator — used so the recall test has unambiguous nearest neighbours. */
+    private static Iterator<float[]> rampVectors(int count, int dim) {
+        return new Iterator<>() {
+            private int produced;
+
+            @Override
+            public boolean hasNext() {
+                return produced < count;
+            }
+
+            @Override
+            public float[] next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                float[] v = rampVector(produced, dim);
+                produced++;
+                return v;
+            }
+        };
     }
 }

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchTest.java
@@ -21,14 +21,17 @@ package herddb.vectortesting;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -147,6 +150,48 @@ class GrpcBenchTest {
      * {@code expected} fields — so the supervision loop can observe the
      * phase even while waiting for the tailer to apply the last batch.
      */
+    /**
+     * Issue #632 review item 1: when {@code DatasetLoader.loadQueryVectors}
+     * throws {@link IOException} (e.g. dataset directory is missing the
+     * query file), the query phase must be skipped cleanly — the bench
+     * must not crash <em>after</em> a successful ingest. We exercise the
+     * dedicated seam {@link GrpcBench#tryLoadQueryVectors} so the test does
+     * not need a live filesystem.
+     */
+    @Test
+    void tryLoadQueryVectorsReturnsNullOnIOException() {
+        Config config = new Config();
+        BenchOutput out = BenchOutput.create(config);
+        List<float[]> queries = GrpcBench.tryLoadQueryVectors(
+                () -> {
+                    throw new IOException("dataset has no query file");
+                },
+                out);
+        assertNull(queries, "IOException must be converted to a null skip, not propagated");
+    }
+
+    @Test
+    void tryLoadQueryVectorsReturnsNullOnEmpty() {
+        Config config = new Config();
+        BenchOutput out = BenchOutput.create(config);
+        List<float[]> queries = GrpcBench.tryLoadQueryVectors(
+                () -> Collections.emptyList(),
+                out);
+        assertNull(queries, "empty result must be treated the same as no query file");
+    }
+
+    @Test
+    void tryLoadGroundTruthReturnsNullOnIOException() {
+        Config config = new Config();
+        BenchOutput out = BenchOutput.create(config);
+        List<int[]> gt = GrpcBench.tryLoadGroundTruth(
+                () -> {
+                    throw new IOException("no ground truth checkpoint matches baseVectorCount");
+                },
+                out);
+        assertNull(gt, "missing ground truth must surface as null (recall skipped)");
+    }
+
     @Test
     void verifyVectorCountPublishesPhaseToBenchRuntime() throws Exception {
         Config config = new Config();

--- a/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchTest.java
+++ b/vector-testings/src/test/java/herddb/vectortesting/GrpcBenchTest.java
@@ -20,7 +20,9 @@
 package herddb.vectortesting;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;
 import io.netty.buffer.ByteBuf;
@@ -28,6 +30,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -62,5 +65,100 @@ class GrpcBenchTest {
             assertEquals(0, buf.refCnt(),
                     "every allocated buffer must be released after a mid-batch failure");
         }
+    }
+
+    /**
+     * Issue #632: the admin {@code /status} endpoint must reflect the bench's
+     * current phase rather than always reporting {@code idle}. The default
+     * supplier installed on a fresh {@link BenchRuntime} returns
+     * {@code phase=idle} — verify that {@link BenchRuntime#setStatusSupplier}
+     * does swap it out for the supplier {@code GrpcBench} would install during
+     * ingestion, and that the supplier carries the documented numeric fields.
+     */
+    @Test
+    void benchRuntimeStatusSupplierIsSwappable() {
+        Config config = new Config();
+        BenchRuntime runtime = new BenchRuntime(config);
+
+        // Default — what /status used to permanently report for grpc mode.
+        Map<String, Object> initial = runtime.getStatusSupplier().get();
+        assertEquals("idle", initial.get("phase"));
+
+        runtime.setStatusSupplier(() -> Map.of(
+                "phase", "ingest",
+                "rows", 42L,
+                "total", 100L,
+                "ops_per_sec", 13.5,
+                "push_calls", 7L));
+
+        Map<String, Object> updated = runtime.getStatusSupplier().get();
+        assertEquals("ingest", updated.get("phase"));
+        assertEquals(42L, updated.get("rows"));
+        assertEquals(100L, updated.get("total"));
+        assertEquals(7L, updated.get("push_calls"));
+        assertNotNull(updated.get("ops_per_sec"));
+    }
+
+    /**
+     * Issue #632: in push mode the verification phase must <em>not</em> wait
+     * on {@code --wait-for-indexes-timeout} (a JDBC-only flag) and must not
+     * inherit the previous hard-coded 1-hour deadline. It returns immediately
+     * the moment the indexed count reaches the expected value.
+     */
+    @Test
+    void verifyVectorCountReturnsImmediatelyOnHit() throws Exception {
+        Config config = new Config();
+        BenchOutput out = BenchOutput.create(config);
+        long start = System.nanoTime();
+        // Counter already at the expected value — happy path: zero waits.
+        GrpcBench.verifyVectorCount(() -> 100L, out, 100L, null, 60_000L, 50L);
+        double elapsedMs = (System.nanoTime() - start) / 1e6;
+        assertTrue(elapsedMs < 1_000.0,
+                "verification must return immediately when the index is already up to date,"
+                        + " elapsed=" + elapsedMs + " ms");
+    }
+
+    /**
+     * Issue #632: when the indexing service never catches up, verification
+     * must fail within the (short) push-mode timeout — proving the new bound
+     * replaces the old 1-hour wait and is not driven by the JDBC
+     * {@code --wait-for-indexes-timeout} flag. We pass a 2-second cap to keep
+     * the test fast; the production constant is 30 s.
+     */
+    @Test
+    void verifyVectorCountFailsFastWhenIndexFallsShort() {
+        Config config = new Config();
+        // Deliberately set the JDBC flag to something huge to prove it is not consulted.
+        config.waitForIndexesTimeoutSeconds = 86_400;
+        BenchOutput out = BenchOutput.create(config);
+        long start = System.nanoTime();
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+                GrpcBench.verifyVectorCount(() -> 5L, out, 100L, null, 2_000L, 50L));
+        double elapsedMs = (System.nanoTime() - start) / 1e6;
+        assertTrue(elapsedMs >= 1_900.0 && elapsedMs < 4_000.0,
+                "verification must fail close to the provided timeoutMs (2000), elapsed=" + elapsedMs + " ms");
+        assertTrue(ex.getMessage().contains("reached only 5"), "expected message to report the last observed count, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("within 2000 ms"), "expected message to report the bound, got: " + ex.getMessage());
+    }
+
+    /**
+     * Issue #632: the verification phase must update the admin status supplier
+     * to {@code phase=verification} with {@code vector_count} and
+     * {@code expected} fields — so the supervision loop can observe the
+     * phase even while waiting for the tailer to apply the last batch.
+     */
+    @Test
+    void verifyVectorCountPublishesPhaseToBenchRuntime() throws Exception {
+        Config config = new Config();
+        BenchRuntime runtime = new BenchRuntime(config);
+        BenchOutput out = BenchOutput.create(config);
+        // Counter at expected → returns immediately, but must have installed
+        // the verification supplier before returning. We capture the supplier
+        // by inspecting the runtime state.
+        GrpcBench.verifyVectorCount(() -> 50L, out, 50L, runtime, 60_000L, 50L);
+        Map<String, Object> status = runtime.getStatusSupplier().get();
+        assertEquals("verification", status.get("phase"));
+        assertEquals(50L, status.get("vector_count"));
+        assertEquals(50L, status.get("expected"));
     }
 }


### PR DESCRIPTION
Fixes #632.

## Changes

- **`GrpcBench.java`**: now accepts `BenchRuntime` and publishes a
  per-phase `statusSupplier` for each transition (`schema` → `ingest` →
  `verification` → `query` → `done`), with the documented numeric
  fields (`rows`, `total`, `ops_per_sec`, `push_calls`, `vector_count`,
  `expected`, `queries_done`, `qps`, `top_k`, etc.). The admin
  `/status` endpoint stops permanently reporting `idle` for
  `--protocol grpc` runs.
- **Verification**: the hard-coded 1-hour deadline is replaced by a
  short `30 s` push-mode cap. `PushEntries` blocks until entries are
  *accepted into the bounded push buffer*, not until they are applied;
  the tailer drains buffered entries in milliseconds in push mode, so
  the cap is generous. **`--wait-for-indexes-timeout` is a JDBC-only
  flag and is explicitly ignored** in gRPC mode (the IS in push mode
  does not tail an external commit log). The new bound is factored
  into a package-private helper so unit tests can pin the timing.
- **Query / recall phase (new)**: `IndexingPushClient.search()` wraps
  the existing `Search` RPC; `GrpcBench.runQueryPhase` loads
  `--queries` query vectors and the matching ground-truth file from
  the dataset, drives `Search` RPCs in parallel (`--query-threads`,
  `--query-max-ops`), deserializes each result's serialized primary
  key into the row's integer id, and computes `recall@K`. The bench
  summary now includes `queries`, `qps`, `recall_at_k`, and
  `recall_queries`. Recall is skipped (with a clear log message) when
  ground truth is unavailable.
- **CLI**: new `--skip-query` / `skip-query` config flag to opt out
  of the new phase for pure-ingestion benchmarks (mirrors `--skip-verify`).
- **`VectorBench.runBenchmark`**: pass `runtime` to `GrpcBench.run`.

## Tests

- `IndexingPushClientSearchTest`: round-trips the `Search` RPC against
  an embedded push IS — pushes 30 LONG-keyed vectors, queries with the
  exact vector of id=10, asserts the top hit deserializes to id=10 and
  that `returnScore=false` is honored.
- `GrpcBenchTest#benchRuntimeStatusSupplierIsSwappable`: pins that the
  default `phase=idle` is swappable to the supplier `GrpcBench` installs.
- `GrpcBenchTest#verifyVectorCountReturnsImmediatelyOnHit`: happy-path
  verification returns in ≪ 1 s when the index is already at the
  expected count.
- `GrpcBenchTest#verifyVectorCountFailsFastWhenIndexFallsShort`:
  verification fails within the configured push-mode cap (the test
  passes `2_000 ms`) and the failure message reports the bound and
  the last observed count. Sets `waitForIndexesTimeoutSeconds=86400`
  to prove the JDBC flag is ignored.
- `GrpcBenchTest#verifyVectorCountPublishesPhaseToBenchRuntime`: the
  verification phase installs `phase=verification` with the documented
  `vector_count` / `expected` fields.
- `GrpcBenchIntegrationTest#grpcIngestWiresPhaseToBenchRuntime`:
  end-to-end against an embedded push IS — a background sampler thread
  observes at least one non-`idle` phase during ingestion.
- `GrpcBenchIntegrationTest#grpcVerifyReturnsImmediatelyWhenIndexIsUpToDate`:
  verification completes in well under 20 s for a 200-vector ingest
  even with `--wait-for-indexes-timeout=1` set (proves the flag is
  ignored).
- `GrpcBenchIntegrationTest#grpcQueryPhaseProducesPerfectRecallOnDeterministicData`:
  ingests 200 dim-8 ramp vectors, runs 10 exact-match `Search` RPCs,
  asserts the top hit equals the probed id for at least 9 of 10
  probes (recall@1 ≈ 1).

🤖 Implemented by the `pr-worker` agent.