### PR TITLE
issue #640: expose real-time compaction progress via describe-index / engine-stats

### DIFF
--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -1665,6 +1665,23 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         return vectorStores.size();
     }
 
+    /**
+     * Snapshot of every loaded {@link PersistentVectorStore}. Used by
+     * {@code GetEngineStats} (issue #640) to aggregate compaction state
+     * across all indexes without holding the {@code vectorStores} map
+     * lock. The returned list is a defensive copy: it is safe to iterate
+     * concurrently with engine mutations.
+     */
+    public java.util.List<PersistentVectorStore> getPersistentVectorStoresSnapshot() {
+        java.util.List<PersistentVectorStore> out = new java.util.ArrayList<>(vectorStores.size());
+        for (AbstractVectorStore s : vectorStores.values()) {
+            if (s instanceof PersistentVectorStore) {
+                out.add((PersistentVectorStore) s);
+            }
+        }
+        return out;
+    }
+
     public int getApplyQueueSize() {
         ExecutorService[] workers = this.applyWorkers;
         if (workers == null) {
@@ -4239,6 +4256,15 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.compactionNodesTotal = pvs.getCompactionNodesTotal();
             d.uploadBytesDone = pvs.getUploadBytesDone();
             d.uploadBytesTotal = pvs.getUploadBytesTotal();
+            // Issue #640: real-time compaction observability fields.
+            d.compactionBatchesDone = pvs.getCompactionBatchesDone();
+            d.compactionBatchesTotal = pvs.getCompactionBatchesTotal();
+            d.compactionCycleId = pvs.getCompactionCycleId();
+            d.compactionInputSegmentCount = (int) Math.min(Integer.MAX_VALUE,
+                    pvs.getCompactionInputSegmentCount());
+            d.compactionInputVectorCount = pvs.getCompactionInputVectorCount();
+            d.compactionElapsedMs = pvs.getCompactionElapsedMs();
+            d.compactionRunning = pvs.isCompactionRunning();
             d.nextNodeId = pvs.getNextNodeId();
             if (!"idle".equals(d.compactionPhase)) {
                 d.status = d.compactionPhase;
@@ -5783,6 +5809,14 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         public long compactionNodesTotal;
         public long uploadBytesDone;
         public long uploadBytesTotal;
+        // Real-time compaction observability (issue #640).
+        public long compactionBatchesDone;
+        public long compactionBatchesTotal;
+        public long compactionCycleId;
+        public int compactionInputSegmentCount;
+        public long compactionInputVectorCount;
+        public long compactionElapsedMs;
+        public boolean compactionRunning;
         // Global monotonic node-id counter (issue #256). Widened to long end-to-end;
         // surfaced so clients and dashboards can observe the burn rate.
         public long nextNodeId;

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -375,7 +375,15 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setUploadBytesDone(details.uploadBytesDone)
                     .setUploadBytesTotal(details.uploadBytesTotal)
                     .setNextNodeId(details.nextNodeId)
-                    .setNumShards(details.numShards);
+                    .setNumShards(details.numShards)
+                    // Issue #640: real-time compaction observability fields.
+                    .setCompactionBatchesDone(details.compactionBatchesDone)
+                    .setCompactionBatchesTotal(details.compactionBatchesTotal)
+                    .setCompactionCycleId(details.compactionCycleId)
+                    .setCompactionInputSegmentCount(details.compactionInputSegmentCount)
+                    .setCompactionInputVectorCount(details.compactionInputVectorCount)
+                    .setCompactionElapsedMs(details.compactionElapsedMs)
+                    .setCompactionRunning(details.compactionRunning);
             responseObserver.onNext(builder.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
@@ -480,6 +488,36 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
             addInt64(b, "jvm_heap_max_bytes", heapMax);
             addInt64(b, "jvm_heap_used_pct", heapPct);
 
+            // Issue #640: aggregate compaction state across all loaded
+            // PersistentVectorStores so a single top-level engine-stats call
+            // reveals whether any index is currently compacting, without
+            // requiring a describe-index per index.
+            //
+            //   compaction_running : true iff at least one PVS has an active
+            //                        cycle (started-nanos != 0).
+            //   compaction_phase   : the most advanced phase string observed
+            //                        across all PVSs (priority:
+            //                        uploading-segment > compacting-graph >
+            //                        writing-graph > idle). "idle" when no
+            //                        store reports any activity.
+            boolean anyRunning = false;
+            String aggregatePhase = "idle";
+            int aggregateRank = 0;
+            for (herddb.indexing.vector.PersistentVectorStore pvs
+                    : engine.getPersistentVectorStoresSnapshot()) {
+                if (pvs.isCompactionRunning()) {
+                    anyRunning = true;
+                }
+                String ph = pvs.getCompactionPhase();
+                int rank = phaseRank(ph);
+                if (rank > aggregateRank) {
+                    aggregateRank = rank;
+                    aggregatePhase = ph;
+                }
+            }
+            addBool(b, "compaction_running", anyRunning);
+            addString(b, "compaction_phase", aggregatePhase);
+
             responseObserver.onNext(b.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {
@@ -503,6 +541,37 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                 .setKey(key)
                 .setValue(MetricValue.newBuilder().setBoolValue(value).build())
                 .build());
+    }
+
+    // Issue #640: string-valued engine-stats metric helper. Mirrors
+    // addInt64/addBool — used so the aggregated `compaction_phase` can be
+    // surfaced as a human-readable string rather than an opaque integer
+    // rank.
+    private static void addString(GetEngineStatsResponse.Builder b, String key, String value) {
+        b.addMetrics(MetricEntry.newBuilder()
+                .setKey(key)
+                .setValue(MetricValue.newBuilder()
+                        .setStringValue(value == null ? "" : value)
+                        .build())
+                .build());
+    }
+
+    /**
+     * Rank used to pick the "most advanced" compaction phase across all
+     * loaded stores in {@link #getEngineStats}. Matches the priority order
+     * of {@link herddb.indexing.vector.PersistentVectorStore#getCompactionPhase}.
+     */
+    private static int phaseRank(String phase) {
+        if (phase == null) {
+            return 0;
+        }
+        switch (phase) {
+            case "uploading-segment": return 3;
+            case "compacting-graph":  return 2;
+            case "writing-graph":     return 1;
+            case "idle":
+            default:                  return 0;
+        }
     }
 
     @Override

--- a/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/admin/IndexingAdminCli.java
@@ -538,6 +538,14 @@ public final class IndexingAdminCli {
         m.put("compaction_nodes_total", r.getCompactionNodesTotal());
         m.put("upload_bytes_done", r.getUploadBytesDone());
         m.put("upload_bytes_total", r.getUploadBytesTotal());
+        // Issue #640: real-time compaction observability fields.
+        m.put("compaction_batches_done", r.getCompactionBatchesDone());
+        m.put("compaction_batches_total", r.getCompactionBatchesTotal());
+        m.put("compaction_cycle_id", r.getCompactionCycleId());
+        m.put("compaction_input_segment_count", r.getCompactionInputSegmentCount());
+        m.put("compaction_input_vector_count", r.getCompactionInputVectorCount());
+        m.put("compaction_elapsed_ms", r.getCompactionElapsedMs());
+        m.put("compaction_running", r.getCompactionRunning());
         m.put("num_shards", r.getNumShards());
         return m;
     }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -6418,7 +6418,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // cycle-id / elapsed-ms / input-shape bookkeeping the runCompactionCycle
         // path uses. inputSegmentCount=0 because this is the live-shard fold,
         // not an on-disk segment merge; inputVectorCount is the snapshot size.
+        //
+        // The whole post-Phase-A body runs inside the single try/finally
+        // below so a throw from ANY point — Phase B, Phase C-prep,
+        // warmUpNewSegmentsBeforePublish, the Stage-1 deletes apply,
+        // phaseCPostDeletesApplyHook, or Stage 2 — always clears the
+        // running flag. Pre-#640-review the cleanup was scattered across
+        // three open-coded catch arms, which left the running flag stuck
+        // on the catch-less "happy-path" Stage 1 / hook / warmup throws.
         beginCompactionCycle(0, totalSnapshotSize);
+        try {
         List<SegmentWriteResult> newSegmentResults;
         try {
             newSegmentResults = doCheckpointFusedPQPhaseB(
@@ -6457,10 +6466,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             consecutiveCheckpointFailures.incrementAndGet();
             totalCheckpointFailures.incrementAndGet();
             recoverFromPhaseBFailure(snapshotShards);
-            // Issue #640: the cycle is over, even on failure — clear the
-            // running flag so describe-index does not show a stale "in
-            // progress" state until the next cycle begins.
-            endCompactionCycle();
             throw e;
         }
 
@@ -6534,9 +6539,6 @@ public class PersistentVectorStore extends AbstractVectorStore {
             consecutiveCheckpointFailures.incrementAndGet();
             totalCheckpointFailures.incrementAndGet();
             recoverFromPhaseBFailure(snapshotShards);
-            // Issue #640: clear the cycle running flag on the Phase C-prep
-            // failure path too.
-            endCompactionCycle();
             throw e;
         }
 
@@ -6789,16 +6791,24 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.checkpointPhaseComplete = null;
             stateLock.writeLock().unlock();
             lastPhaseCWriteLockNanos.set(System.nanoTime() - stage2Start);
-            // Issue #640: terminate the cycle (clear running flag) on the
-            // happy path. Idempotent w.r.t. the catch-side endCompactionCycle
-            // calls above — a double-clear is just a no-op set(0).
-            endCompactionCycle();
             if (latch != null) {
                 latch.countDown();
             }
             synchronized (memoryPressureMonitor) {
                 memoryPressureMonitor.notifyAll();
             }
+        }
+        } finally {
+            // Issue #640: top-level cycle-clear so a throw from ANY point in
+            // the post-Phase-A body — Phase B, Phase C-prep,
+            // warmUpNewSegmentsBeforePublish, the Stage-1 deletes apply,
+            // phaseCPostDeletesApplyHook, or Stage 2 — always clears the
+            // running flag. Per the pr-reviewer pass on #640, the previous
+            // three open-coded calls left a coverage hole for the
+            // unprotected stretch between Phase C-prep success and the
+            // Stage 2 try block. A single finally here makes that category
+            // impossible to forget.
+            endCompactionCycle();
         }
     }
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -1063,6 +1063,36 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private final AtomicLong uploadBytesDone = new AtomicLong();
     private final AtomicLong uploadBytesTotal = new AtomicLong();
 
+    // Real-time streaming-compaction observability (issue #640).
+    //
+    // Until this issue, describe-index showed the previous compaction
+    // cycle's terminal state for the entire duration of the next cycle,
+    // because:
+    //   - Phase tracking was blind during OnDiskGraphIndexCompactor.compact()
+    //     (writingGraphActive / uploadingActive were only flipped by the
+    //     surrounding writeStreamingCompactedSegment, which runs AFTER the
+    //     batch loop), and
+    //   - the four legacy counters above were never reset on the streaming
+    //     compaction path — only the legacy doCheckpointFusedPQThreePhase
+    //     reset them.
+    //
+    // The new state below closes both gaps. `compactionStreamingActive`
+    // is a counter (not a bool) so overlapping streaming cycles are
+    // representable in principle, even though runCompactionCycle's
+    // compactionLock serialises them today. `compactionBatchesDone/Total`
+    // are fed by a CompactionProgressListener that jvector calls every 10
+    // batches from runBatchesWithBackpressure. `compactionCycleId` is the
+    // generation token consumers can use to detect a new cycle even when
+    // the per-cycle counters happen to be at 100% from the previous one.
+    private final AtomicInteger compactionStreamingActive = new AtomicInteger();
+    private final AtomicLong compactionBatchesDone = new AtomicLong();
+    private final AtomicLong compactionBatchesTotal = new AtomicLong();
+    private final AtomicLong compactionCycleId = new AtomicLong();
+    private final AtomicLong compactionInputSegmentCount = new AtomicLong();
+    private final AtomicLong compactionInputVectorCount = new AtomicLong();
+    /** Nanos when the current compaction cycle started, or 0 when idle. */
+    private final AtomicLong compactionStartedNanos = new AtomicLong();
+
     // Deferred shard metrics (issue #107).
     //
     // Track shard deferral due to Phase A byte-cap logic, for visibility into
@@ -1363,18 +1393,37 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     /**
      * Returns the current compaction phase: {@code "idle"},
-     * {@code "writing-graph"}, or {@code "uploading-segment"}. Priority is
-     * upload &gt; graph-write, so when segment writes overlap (Phase B
-     * parallelism) the most advanced phase wins.
+     * {@code "writing-graph"}, {@code "compacting-graph"}, or
+     * {@code "uploading-segment"}. Priority is
+     * upload &gt; compacting-graph &gt; writing-graph, so the most advanced
+     * phase wins when multiple sub-phases overlap.
+     *
+     * <p>{@code "compacting-graph"} (issue #640) covers the streaming
+     * Phase B I/O loop driven by jvector's {@code
+     * OnDiskGraphIndexCompactor.runBatchesWithBackpressure}; before #640
+     * this multi-minute interval was reported as {@code "idle"} because
+     * nothing surrounding it flipped a phase flag.
      */
     public String getCompactionPhase() {
         if (uploadingActive.get() > 0) {
             return "uploading-segment";
         }
+        if (compactionStreamingActive.get() > 0) {
+            return "compacting-graph";
+        }
         if (writingGraphActive.get() > 0) {
             return "writing-graph";
         }
         return "idle";
+    }
+
+    /**
+     * Whether a compaction or checkpoint Phase B cycle is currently
+     * in flight (issue #640). True from {@link #beginCompactionCycle}
+     * until the matching {@link #endCompactionCycle}.
+     */
+    public boolean isCompactionRunning() {
+        return compactionStartedNanos.get() != 0L;
     }
 
     public int getWritingGraphActiveCount() {
@@ -1401,16 +1450,65 @@ public class PersistentVectorStore extends AbstractVectorStore {
         return uploadBytesTotal.get();
     }
 
+    // -------------------------------------------------------------------------
+    // Issue #640: real-time compaction observability accessors.
+    // -------------------------------------------------------------------------
+
+    public long getCompactionBatchesDone() {
+        return compactionBatchesDone.get();
+    }
+
+    public long getCompactionBatchesTotal() {
+        return compactionBatchesTotal.get();
+    }
+
+    /**
+     * Monotonic cycle id bumped on every {@link #beginCompactionCycle} call.
+     * Consumers polling {@code describe-index} can use the change in this
+     * value to detect that a new compaction cycle has begun even when the
+     * other progress counters happen to be at 100% from the previous one.
+     */
+    public long getCompactionCycleId() {
+        return compactionCycleId.get();
+    }
+
+    public long getCompactionInputSegmentCount() {
+        return compactionInputSegmentCount.get();
+    }
+
+    public long getCompactionInputVectorCount() {
+        return compactionInputVectorCount.get();
+    }
+
+    /**
+     * Wall-clock milliseconds since the current compaction cycle started,
+     * or 0 when no cycle is in flight.
+     */
+    public long getCompactionElapsedMs() {
+        long startedNanos = compactionStartedNanos.get();
+        if (startedNanos == 0L) {
+            return 0L;
+        }
+        long elapsed = System.nanoTime() - startedNanos;
+        return elapsed < 0L ? 0L : elapsed / 1_000_000L;
+    }
+
     /**
      * Returns the progress percentage of whichever phase is currently
      * active, or {@code -1} when idle. During {@code uploading-segment} it
-     * reflects bytes-based progress; during {@code writing-graph} it
-     * reflects node-count progress.
+     * reflects bytes-based progress; during {@code compacting-graph} it
+     * reflects batch-based progress (issue #640); during
+     * {@code writing-graph} it reflects node-count progress.
      */
     public int getCompactionProgressPercent() {
         if (uploadingActive.get() > 0) {
             long total = uploadBytesTotal.get();
             long done = uploadBytesDone.get();
+            return total > 0 ? (int) Math.min(100L, (100L * done) / total) : 0;
+        }
+        if (compactionStreamingActive.get() > 0) {
+            long total = compactionBatchesTotal.get();
+            long done = compactionBatchesDone.get();
             return total > 0 ? (int) Math.min(100L, (100L * done) / total) : 0;
         }
         if (writingGraphActive.get() > 0) {
@@ -1419,6 +1517,90 @@ public class PersistentVectorStore extends AbstractVectorStore {
             return total > 0 ? (int) Math.min(100L, (100L * done) / total) : 0;
         }
         return -1;
+    }
+
+    /**
+     * Marks the start of a compaction or checkpoint Phase B cycle
+     * (issue #640). Zeroes every per-cycle progress counter
+     * ({@code compactionNodesDone/Total}, {@code uploadBytesDone/Total},
+     * {@code compactionBatchesDone/Total}), records the input shape and
+     * the wall-clock start, and bumps {@link #compactionCycleId} so
+     * external observers can see the cycle change.
+     *
+     * <p>Must be paired with exactly one {@link #endCompactionCycle} in
+     * a {@code finally} block. Calls are serialised by
+     * {@code compactionLock} (for runCompactionCycle) and by
+     * {@code stateLock.writeLock()} (for checkpoint Phase B), so there
+     * is no concurrency exposure on the reset itself.
+     *
+     * @param inputSegmentCount how many on-disk segments are being merged
+     *                          in this cycle; 0 on the checkpoint Phase B
+     *                          path which folds live shards instead of
+     *                          merging on-disk segments
+     * @param inputVectorCount  total vector count across the input set
+     */
+    public void beginCompactionCycle(int inputSegmentCount, long inputVectorCount) {
+        compactionNodesDone.set(0);
+        compactionNodesTotal.set(0);
+        uploadBytesDone.set(0);
+        uploadBytesTotal.set(0);
+        compactionBatchesDone.set(0);
+        compactionBatchesTotal.set(0);
+        compactionInputSegmentCount.set(Math.max(0, inputSegmentCount));
+        compactionInputVectorCount.set(Math.max(0L, inputVectorCount));
+        compactionCycleId.incrementAndGet();
+        // Set started-nanos last so a reader that sees a non-zero
+        // started-nanos also sees the freshly-bumped cycle id and the
+        // freshly-zeroed counters.
+        long now = System.nanoTime();
+        // Guard against the (theoretical) System.nanoTime() == 0 reading
+        // which would be indistinguishable from "idle".
+        compactionStartedNanos.set(now == 0L ? 1L : now);
+    }
+
+    /**
+     * Marks the end of the cycle started by {@link #beginCompactionCycle}.
+     * The progress counters are left populated so a post-hoc
+     * {@code describe-index} still shows the final totals of the last
+     * compaction; only the running flag (started-nanos) is cleared.
+     */
+    public void endCompactionCycle() {
+        compactionStartedNanos.set(0L);
+    }
+
+    /**
+     * Increments the streaming-active counter (issue #640) — flips
+     * {@link #getCompactionPhase()} to {@code "compacting-graph"} while
+     * jvector's {@code OnDiskGraphIndexCompactor.compact()} runs.
+     * Must be balanced by {@link #decrementCompactionStreamingActive()}
+     * in a {@code finally} block.
+     */
+    public void incrementCompactionStreamingActive() {
+        compactionStreamingActive.incrementAndGet();
+    }
+
+    public void decrementCompactionStreamingActive() {
+        compactionStreamingActive.decrementAndGet();
+    }
+
+    /**
+     * Sets the batch total reported by jvector's
+     * {@code CompactionProgressListener.onProgress(completed, total)}.
+     * Issue #640.
+     */
+    public void setCompactionBatchesTotal(long total) {
+        compactionBatchesTotal.set(Math.max(0L, total));
+    }
+
+    /**
+     * Sets the running batch count reported by jvector's
+     * {@code CompactionProgressListener.onProgress(completed, total)}.
+     * The listener fires every 10 batches with a strictly non-decreasing
+     * {@code completed} value within a level, so a {@code set} (not an
+     * {@code addAndGet}) is the right idiom. Issue #640.
+     */
+    public void setCompactionBatchesDone(long done) {
+        compactionBatchesDone.set(Math.max(0L, done));
     }
 
     public int getDeferralEvents() {
@@ -2808,6 +2990,21 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
             compactionActive.set(1);
 
+            // Issue #640: open a new compaction cycle in the progress
+            // counters. Resets compaction_batches_done/total,
+            // compaction_nodes_done/total, upload_bytes_done/total to 0,
+            // bumps compaction_cycle_id, records inputSegmentCount +
+            // inputVectorCount, and starts the elapsed-ms clock — so a
+            // describe-index sampled during this cycle reflects this
+            // cycle's progress instead of the previous cycle's terminal
+            // state. Paired with endCompactionCycle() in the outer finally
+            // below.
+            long inputVectorCount = 0L;
+            for (VectorSegment seg : candidates) {
+                inputVectorCount += Math.max(0, seg.liveCount.get());
+            }
+            beginCompactionCycle(candidates.size(), inputVectorCount);
+
             // Allocate the BLink-backed pendingCompactionDeletes set + the
             // BLink-backed authority map (issue #290): both replace the prior
             // unbounded HashMap/HashSet structures so memory stays bounded by
@@ -3055,6 +3252,15 @@ public class PersistentVectorStore extends AbstractVectorStore {
             }
         } finally {
             compactionActive.set(0);
+            // Issue #640: clear the cycle's running flag here regardless of
+            // outcome. Per-cycle progress counters are left at their final
+            // values so a post-hoc describe-index still shows the totals of
+            // the last cycle (mirrors the legacy checkpoint Phase B
+            // behaviour the issue called out as desirable). Idempotent if
+            // beginCompactionCycle was never called on this path (early
+            // returns before candidate selection): endCompactionCycle just
+            // sets started-nanos to 0, which was already 0.
+            endCompactionCycle();
             // Issue #535: drain segments queued for close by any concurrent
             // dropSegmentByUuid that landed during this cycle. Doing this
             // BEFORE releasing compactionLock guarantees the close cannot
@@ -6078,6 +6284,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
         List<VectorSegment> sealedSegments;
         List<VectorSegment> mergeableSegments;
         int snapshotDimension;
+        // Hoisted out of the Phase A writeLock scope (issue #640) so the
+        // beginCompactionCycle(...) call below — which runs without the
+        // writeLock — can still see this checkpoint's input vector count.
+        int totalSnapshotSize;
 
         stateLock.writeLock().lock();
         try {
@@ -6160,7 +6370,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.pendingCheckpointDeletes = createTempPagedPkSet(
                     "ckpdel_" + totalCheckpointCount.get());
             this.checkpointPhaseComplete = new CountDownLatch(1);
-            int totalSnapshotSize = 0;
+            totalSnapshotSize = 0;
             for (LiveGraphShard shard : snapshotShards) {
                 totalSnapshotSize += shard.nodeToPk.size();
             }
@@ -6203,12 +6413,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // checkpoint.
         this.provisionalPageIds = Collections.synchronizedList(new ArrayList<>());
         this.provisionalMultipartFiles = Collections.synchronizedList(new ArrayList<>());
-        // Reset compaction progress counters so a describe-index sampled
-        // mid-Phase-B reflects this checkpoint's totals, not the previous one.
-        compactionNodesDone.set(0);
-        compactionNodesTotal.set(0);
-        uploadBytesDone.set(0);
-        uploadBytesTotal.set(0);
+        // Issue #640: replace the four ad-hoc counter resets with a single
+        // beginCompactionCycle call so the checkpoint path shares the same
+        // cycle-id / elapsed-ms / input-shape bookkeeping the runCompactionCycle
+        // path uses. inputSegmentCount=0 because this is the live-shard fold,
+        // not an on-disk segment merge; inputVectorCount is the snapshot size.
+        beginCompactionCycle(0, totalSnapshotSize);
         List<SegmentWriteResult> newSegmentResults;
         try {
             newSegmentResults = doCheckpointFusedPQPhaseB(
@@ -6247,6 +6457,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             consecutiveCheckpointFailures.incrementAndGet();
             totalCheckpointFailures.incrementAndGet();
             recoverFromPhaseBFailure(snapshotShards);
+            // Issue #640: the cycle is over, even on failure — clear the
+            // running flag so describe-index does not show a stale "in
+            // progress" state until the next cycle begins.
+            endCompactionCycle();
             throw e;
         }
 
@@ -6320,6 +6534,9 @@ public class PersistentVectorStore extends AbstractVectorStore {
             consecutiveCheckpointFailures.incrementAndGet();
             totalCheckpointFailures.incrementAndGet();
             recoverFromPhaseBFailure(snapshotShards);
+            // Issue #640: clear the cycle running flag on the Phase C-prep
+            // failure path too.
+            endCompactionCycle();
             throw e;
         }
 
@@ -6572,6 +6789,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             this.checkpointPhaseComplete = null;
             stateLock.writeLock().unlock();
             lastPhaseCWriteLockNanos.set(System.nanoTime() - stage2Start);
+            // Issue #640: terminate the cycle (clear running flag) on the
+            // happy path. Idempotent w.r.t. the catch-side endCompactionCycle
+            // calls above — a double-clear is just a no-op set(0).
+            endCompactionCycle();
             if (latch != null) {
                 latch.countDown();
             }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorIndexCompactor.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorIndexCompactor.java
@@ -27,6 +27,7 @@ import io.github.jbellis.jvector.disk.RandomAccessReader;
 import io.github.jbellis.jvector.disk.ReaderSupplier;
 import io.github.jbellis.jvector.disk.ReaderSupplierFactory;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
+import io.github.jbellis.jvector.graph.disk.CompactionProgressListener;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexCompactor;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
@@ -1483,7 +1484,33 @@ final class VectorIndexCompactor {
                             localSources, liveBitsets, mappers, store.compactionSimilarity(),
                             PhysicalCoreExecutor.pool(),
                             pqReaderFactory);
-                    compactor.compact(graphTemp);
+                    // Issue #640: wire a CompactionProgressListener so the
+                    // IS gRPC describe-index API reflects real-time
+                    // Phase B I/O progress. The listener fires every 10
+                    // batches from jvector's runBatchesWithBackpressure
+                    // with (completed, total) — exactly the numbers the
+                    // IS log already prints as "Compaction I/O progress:
+                    // X/Y batches written to disk". Push them straight
+                    // into the store's atomic batch counters; describe-index
+                    // / engine-stats read them every tick.
+                    //
+                    // We also flip the streaming-active flag around the
+                    // call so getCompactionPhase() returns
+                    // "compacting-graph" while the batch loop runs
+                    // (previously "idle" for the entire multi-minute
+                    // jvector run — the central symptom of issue #640).
+                    final PersistentVectorStore storeRef = store;
+                    CompactionProgressListener progressListener =
+                            (completed, total) -> {
+                                storeRef.setCompactionBatchesTotal(total);
+                                storeRef.setCompactionBatchesDone(completed);
+                            };
+                    store.incrementCompactionStreamingActive();
+                    try {
+                        compactor.compact(graphTemp, progressListener);
+                    } finally {
+                        store.decrementCompactionStreamingActive();
+                    }
                 } catch (java.io.FileNotFoundException | RuntimeException | Error e) {
                     // jvector boundary — wrap unchecked OR FileNotFoundException
                     // (declared on compact()) failures so they never reach the

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorIndexCompactor.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorIndexCompactor.java
@@ -1499,11 +1499,21 @@ final class VectorIndexCompactor {
                     // "compacting-graph" while the batch loop runs
                     // (previously "idle" for the entire multi-minute
                     // jvector run — the central symptom of issue #640).
-                    final PersistentVectorStore storeRef = store;
+                    //
+                    // Order matters: set `done` BEFORE `total` so a racing
+                    // describe-index reader that observes the new `done`
+                    // alongside the still-old `total` sees a strictly
+                    // non-decreasing perceived progress. Setting `total`
+                    // first would briefly expose `done > total` on a new
+                    // level (jvector internally resets `total` per level
+                    // and ramps `done` from 0); `Math.min(100, ...)` in
+                    // getCompactionProgressPercent() keeps the visible
+                    // percent bounded, but the swap is cheap insurance
+                    // for monotonic perception.
                     CompactionProgressListener progressListener =
                             (completed, total) -> {
-                                storeRef.setCompactionBatchesTotal(total);
-                                storeRef.setCompactionBatchesDone(completed);
+                                store.setCompactionBatchesDone(completed);
+                                store.setCompactionBatchesTotal(total);
                             };
                     store.incrementCompactionStreamingActive();
                     try {

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -195,7 +195,11 @@ message DescribeIndexResponse {
     bool persistent = 17;
     string store_class = 18;
     // Compaction progress (issue #80). compaction_phase is one of
-    // "idle", "writing-graph", "uploading-segment". compaction_progress
+    // "idle", "writing-graph", "compacting-graph", "uploading-segment".
+    // "compacting-graph" (issue #640) covers the streaming-compaction
+    // Phase B I/O loop driven by jvector's OnDiskGraphIndexCompactor —
+    // a busy phase that used to read as "idle" because nothing surrounding
+    // it flipped writingGraphActive/uploadingActive. compaction_progress
     // is an integer 0..100, or -1 when idle.
     string compaction_phase = 19;
     int32 compaction_progress = 20;
@@ -231,6 +235,36 @@ message DescribeIndexResponse {
     // genuine live-vector heap from on-disk segment overhead — the latter
     // grows with segment_count and does not shrink on checkpoint.
     int64 ondisk_segment_memory_bytes = 31;
+
+    // Real-time compaction observability (issue #640). These fields are
+    // updated continuously while a compaction cycle is active so the
+    // describe-index API reflects the *current* cycle's I/O progress
+    // instead of the stale terminal state of the previous one.
+    //
+    //  - compaction_batches_done / compaction_batches_total reflect the
+    //    OnDiskGraphIndexCompactor.runBatchesWithBackpressure counter that
+    //    the IS log prints as "Compaction I/O progress: X/Y batches".
+    //  - compaction_cycle_id is a monotonic counter that bumps once per
+    //    runCompactionCycle / checkpoint Phase B call; consumers can use
+    //    it to detect that a new cycle has begun even if the other
+    //    counters were still at 100% from the previous cycle.
+    //  - compaction_input_segment_count is how many segments are being
+    //    merged in the active cycle (0 on the checkpoint Phase B path,
+    //    which folds live shards rather than merging on-disk segments).
+    //  - compaction_input_vector_count is the total vector count of the
+    //    input set.
+    //  - compaction_elapsed_ms is the wall-clock milliseconds since the
+    //    current cycle started (0 when idle).
+    //  - compaction_running is true while a cycle holds the compaction
+    //    or checkpoint Phase B lock. Mirrors what GetEngineStats now
+    //    surfaces aggregated across all loaded stores.
+    int64 compaction_batches_done = 32;
+    int64 compaction_batches_total = 33;
+    int64 compaction_cycle_id = 34;
+    int32 compaction_input_segment_count = 35;
+    int64 compaction_input_vector_count = 36;
+    int64 compaction_elapsed_ms = 37;
+    bool compaction_running = 38;
 }
 
 message ListPrimaryKeysRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcCompactionFieldsTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcCompactionFieldsTest.java
@@ -1,0 +1,203 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.indexing.admin.IndexingAdminClient;
+import herddb.indexing.proto.DescribeIndexResponse;
+import herddb.indexing.proto.GetEngineStatsResponse;
+import herddb.indexing.proto.MetricEntry;
+import herddb.indexing.proto.MetricValue;
+import herddb.indexing.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #640 — gRPC-level verification that the new real-time compaction
+ * fields ({@code compaction_batches_done/total}, {@code compaction_cycle_id},
+ * {@code compaction_input_segment_count/vector_count},
+ * {@code compaction_elapsed_ms}, {@code compaction_running}) flow end-to-end
+ * from {@link PersistentVectorStore} through
+ * {@link herddb.indexing.IndexingServiceImpl#describeIndex} and
+ * {@link herddb.indexing.IndexingServiceImpl#getEngineStats} into the
+ * proto response, and that the aggregate {@code compaction_phase} on
+ * engine-stats reflects the per-store state correctly.
+ */
+public class IndexingServiceDiagnosticsGrpcCompactionFieldsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+    private IndexingAdminClient client;
+    private int savedMinLiveVectors;
+
+    @Before
+    public void setUp() throws Exception {
+        savedMinLiveVectors = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+        client = new IndexingAdminClient(service.getAddress(), 10);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (service != null) {
+            service.close();
+        }
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectors;
+    }
+
+    private Index vectorIndex(String indexName, String table, String tablespace) {
+        return Index.builder()
+                .name(indexName)
+                .table(table)
+                .tablespace(tablespace)
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private static Map<String, MetricValue> indexMetricsByKey(GetEngineStatsResponse r) {
+        Map<String, MetricValue> m = new HashMap<>();
+        for (MetricEntry e : r.getMetricsList()) {
+            m.put(e.getKey(), e.getValue());
+        }
+        return m;
+    }
+
+    @Test
+    public void compactionFieldsPropagateAfterStreamingCycle() throws Exception {
+        // Build a real PersistentVectorStore in a temp dir and register it
+        // through registerIndexForTest so describe-index / engine-stats see
+        // it. We drive the compaction directly on the store (the engine's
+        // own compaction loop isn't started here).
+        Path tmpDir = folder.newFolder("pvs-data").toPath();
+        int dim = 16;
+        int numSegments = 3;
+        int perSegment = 200;
+        Random rng = new Random(640L);
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore pvs = new PersistentVectorStore(
+                "default", "tbl_640", "tsuuid-640", "embedding",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+        pvs.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                Integer.MAX_VALUE, 0);
+        pvs.start();
+        try {
+            // Register through the engine's test seam so the gRPC layer
+            // resolves this PVS for describe-index lookups.
+            service.getEngine().registerIndexForTest(
+                    vectorIndex("idx_640", "tbl_640", "default"), pvs);
+
+            // Build numSegments on-disk segments.
+            for (int c = 0; c < numSegments; c++) {
+                for (int i = 0; i < perSegment; i++) {
+                    pvs.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                pvs.checkpoint();
+            }
+            assertEquals(numSegments, pvs.getSegmentCount());
+
+            // Pre-cycle describe-index: compaction_running=false, cycleId
+            // captures whatever the checkpoints already drove (each one
+            // bumps cycleId since checkpoint Phase B now uses
+            // beginCompactionCycle).
+            DescribeIndexResponse pre = client.describeIndex(
+                    "default", "tbl_640", "idx_640");
+            assertEquals("PersistentVectorStore", pre.getStoreClass());
+            assertEquals(false, pre.getCompactionRunning());
+            long preCycleId = pre.getCompactionCycleId();
+            assertTrue("checkpoint Phase B must have bumped cycleId at least once",
+                    preCycleId >= 1L);
+
+            // Drive a streaming compaction cycle.
+            pvs.runCompactionCycle();
+
+            // Post-cycle describe-index: cycleId bumped, running=false,
+            // counters left populated (final totals of the last cycle).
+            DescribeIndexResponse post = client.describeIndex(
+                    "default", "tbl_640", "idx_640");
+            assertEquals(false, post.getCompactionRunning());
+            assertTrue("cycleId must strictly increase after runCompactionCycle:"
+                            + " pre=" + preCycleId + " post=" + post.getCompactionCycleId(),
+                    post.getCompactionCycleId() > preCycleId);
+            assertTrue("compaction_batches_total left populated after the cycle: "
+                            + post.getCompactionBatchesTotal(),
+                    post.getCompactionBatchesTotal() > 0L);
+            assertTrue("compaction_batches_done left populated after the cycle: "
+                            + post.getCompactionBatchesDone(),
+                    post.getCompactionBatchesDone() > 0L);
+            assertEquals("input_segment_count reflects the merged candidates",
+                    numSegments, post.getCompactionInputSegmentCount());
+            assertTrue("input_vector_count is positive after a successful cycle: "
+                            + post.getCompactionInputVectorCount(),
+                    post.getCompactionInputVectorCount() > 0L);
+            // elapsed_ms reads 0 once the cycle ends (started_nanos cleared).
+            assertEquals("compaction_elapsed_ms reads 0 when idle",
+                    0L, post.getCompactionElapsedMs());
+
+            // engine-stats reflects the same idle state.
+            GetEngineStatsResponse stats = client.getEngineStats();
+            Map<String, MetricValue> metrics = indexMetricsByKey(stats);
+            assertTrue("compaction_running key present in engine-stats",
+                    metrics.containsKey("compaction_running"));
+            assertEquals("compaction_running is false once the cycle ends",
+                    false, metrics.get("compaction_running").getBoolValue());
+            assertEquals("compaction_phase aggregates to 'idle' once the cycle ends",
+                    "idle", metrics.get("compaction_phase").getStringValue());
+        } finally {
+            pvs.close();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceDiagnosticsGrpcTest.java
@@ -147,6 +147,15 @@ public class IndexingServiceDiagnosticsGrpcTest {
         assertEquals(0L, response.getCompactionNodesTotal());
         assertEquals(0L, response.getUploadBytesDone());
         assertEquals(0L, response.getUploadBytesTotal());
+        // Issue #640: new real-time compaction observability fields default
+        // to zero / false for any non-PersistentVectorStore.
+        assertEquals(0L, response.getCompactionBatchesDone());
+        assertEquals(0L, response.getCompactionBatchesTotal());
+        assertEquals(0L, response.getCompactionCycleId());
+        assertEquals(0, response.getCompactionInputSegmentCount());
+        assertEquals(0L, response.getCompactionInputVectorCount());
+        assertEquals(0L, response.getCompactionElapsedMs());
+        assertEquals(false, response.getCompactionRunning());
     }
 
     @Test
@@ -249,6 +258,17 @@ public class IndexingServiceDiagnosticsGrpcTest {
                 metrics.containsKey("tailer_entries_shard_filtered"));
         assertEquals("tailer_entries_shard_filtered", 0L,
                 metrics.get("tailer_entries_shard_filtered").getInt64Value());
+        // Issue #640: aggregate compaction state — for an idle in-memory
+        // setup with no PersistentVectorStores loaded, compaction_running
+        // is false and compaction_phase is "idle".
+        assertTrue("compaction_running must be present",
+                metrics.containsKey("compaction_running"));
+        assertEquals("compaction_running default is false on an idle service",
+                false, metrics.get("compaction_running").getBoolValue());
+        assertTrue("compaction_phase must be present",
+                metrics.containsKey("compaction_phase"));
+        assertEquals("compaction_phase default is 'idle' on an idle service",
+                "idle", metrics.get("compaction_phase").getStringValue());
     }
 
     private static Map<String, MetricValue> indexMetricsByKey(GetEngineStatsResponse r) {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineStatsCompactionTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineStatsCompactionTest.java
@@ -1,0 +1,219 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.indexing.admin.IndexingAdminClient;
+import herddb.indexing.proto.GetEngineStatsResponse;
+import herddb.indexing.proto.MetricEntry;
+import herddb.indexing.proto.MetricValue;
+import herddb.indexing.vector.PersistentVectorStore;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Index;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #640 — verifies that {@code GetEngineStats} surfaces a top-level
+ * {@code compaction_running} flag and an aggregated {@code compaction_phase}
+ * derived from every loaded {@link PersistentVectorStore}, so an operator
+ * can answer "is any index on this IS currently compacting?" with a
+ * single RPC.
+ */
+public class IndexingServiceEngineStatsCompactionTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private EmbeddedIndexingService service;
+    private IndexingAdminClient client;
+    private int savedMinLiveVectors;
+
+    @Before
+    public void setUp() throws Exception {
+        savedMinLiveVectors = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+        service = new EmbeddedIndexingService(
+                folder.newFolder("log").toPath(),
+                folder.newFolder("data").toPath());
+        service.start();
+        client = new IndexingAdminClient(service.getAddress(), 10);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (service != null) {
+            service.close();
+        }
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectors;
+    }
+
+    private Index vectorIndex(String indexName, String table, String tablespace) {
+        return Index.builder()
+                .name(indexName)
+                .table(table)
+                .tablespace(tablespace)
+                .type(Index.TYPE_VECTOR)
+                .column("embedding", ColumnTypes.FLOATARRAY)
+                .build();
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    private static Map<String, MetricValue> indexMetricsByKey(GetEngineStatsResponse r) {
+        Map<String, MetricValue> m = new HashMap<>();
+        for (MetricEntry e : r.getMetricsList()) {
+            m.put(e.getKey(), e.getValue());
+        }
+        return m;
+    }
+
+    @Test
+    public void engineStatsAggregatesCompactionState() throws Exception {
+        // Baseline: an idle service reports compaction_running=false /
+        // compaction_phase="idle". This is also covered by
+        // IndexingServiceDiagnosticsGrpcTest#testGetEngineStats; we
+        // re-assert here so this test is self-contained.
+        GetEngineStatsResponse idleStats = client.getEngineStats();
+        Map<String, MetricValue> idleMetrics = indexMetricsByKey(idleStats);
+        assertEquals(false, idleMetrics.get("compaction_running").getBoolValue());
+        assertEquals("idle", idleMetrics.get("compaction_phase").getStringValue());
+
+        Path tmpDir = folder.newFolder("pvs-data").toPath();
+        int dim = 16;
+        int numSegments = 3;
+        int perSegment = 200;
+        Random rng = new Random(640L);
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        PersistentVectorStore pvs = new PersistentVectorStore(
+                "default", "tbl_640", "tsuuid-640", "embedding",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+        pvs.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                Integer.MAX_VALUE, 0);
+        pvs.start();
+        try {
+            service.getEngine().registerIndexForTest(
+                    vectorIndex("idx_640", "tbl_640", "default"), pvs);
+
+            for (int c = 0; c < numSegments; c++) {
+                for (int i = 0; i < perSegment; i++) {
+                    pvs.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                pvs.checkpoint();
+            }
+            assertEquals(numSegments, pvs.getSegmentCount());
+
+            // Poll engine-stats while a compaction is in flight on a
+            // background thread. The watcher tracks both whether the
+            // aggregate `compaction_running` flag ever flipped to true
+            // and whether the aggregate `compaction_phase` ever reported
+            // a non-idle value.
+            //
+            // Note: there is a narrow window at the very start of a cycle
+            // where `compaction_running=true` (beginCompactionCycle has
+            // fired) but `compaction_phase` still reads as "idle" — the
+            // streaming-active counter only flips inside
+            // VectorIndexCompactor.rebuildSegmentStreaming around the
+            // jvector compact() call, AFTER candidate selection + eager
+            // download. So the two booleans are tracked independently.
+            AtomicBoolean watcherStop = new AtomicBoolean();
+            AtomicBoolean sawRunningTrue = new AtomicBoolean();
+            AtomicBoolean sawNonIdlePhase = new AtomicBoolean();
+            AtomicReference<String> lastNonIdlePhase = new AtomicReference<>(null);
+            Thread watcher = new Thread(() -> {
+                while (!watcherStop.get()) {
+                    GetEngineStatsResponse r = client.getEngineStats();
+                    Map<String, MetricValue> m = indexMetricsByKey(r);
+                    if (m.get("compaction_running").getBoolValue()) {
+                        sawRunningTrue.set(true);
+                    }
+                    String phase = m.get("compaction_phase").getStringValue();
+                    if (!"idle".equals(phase)) {
+                        sawNonIdlePhase.set(true);
+                        lastNonIdlePhase.set(phase);
+                    }
+                }
+            }, "engine-stats-watcher");
+            watcher.setDaemon(true);
+            watcher.start();
+
+            pvs.runCompactionCycle();
+
+            watcherStop.set(true);
+            watcher.join(10_000);
+
+            assertTrue("watcher must have observed compaction_running=true during"
+                            + " the cycle (issue #640: aggregate flag must reflect"
+                            + " in-flight compaction across all stores)",
+                    sawRunningTrue.get());
+            // The non-idle-phase observation is best-effort: on a very fast
+            // machine the watcher may miss every sub-phase entirely. When
+            // it DID see one, it must be one of the recognised values.
+            if (sawNonIdlePhase.get()) {
+                String observed = lastNonIdlePhase.get();
+                assertTrue("non-idle phase must be one of"
+                                + " {compacting-graph, writing-graph, uploading-segment};"
+                                + " observed=" + observed,
+                        "compacting-graph".equals(observed)
+                                || "writing-graph".equals(observed)
+                                || "uploading-segment".equals(observed));
+            }
+
+            // Post-cycle: the aggregate flag must flip back to false and
+            // the phase aggregator must read as "idle".
+            GetEngineStatsResponse post = client.getEngineStats();
+            Map<String, MetricValue> postMetrics = indexMetricsByKey(post);
+            assertEquals("compaction_running false after the cycle ends",
+                    false, postMetrics.get("compaction_running").getBoolValue());
+            assertEquals("compaction_phase aggregates back to 'idle' after the cycle",
+                    "idle", postMetrics.get("compaction_phase").getStringValue());
+        } finally {
+            pvs.close();
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineStatsCompactionTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/IndexingServiceEngineStatsCompactionTest.java
@@ -177,6 +177,17 @@ public class IndexingServiceEngineStatsCompactionTest {
                         sawNonIdlePhase.set(true);
                         lastNonIdlePhase.set(phase);
                     }
+                    // Throttle the polling loop: every iteration issues an
+                    // RPC, which at full spin produces tens of thousands of
+                    // calls per cycle. On a single-vCPU CI runner that
+                    // starves the cycle thread and amplifies flake risk
+                    // (pr-reviewer pass #640).
+                    try {
+                        Thread.sleep(2);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
                 }
             }, "engine-stats-watcher");
             watcher.setDaemon(true);

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCompactionCycleResetTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCompactionCycleResetTest.java
@@ -1,0 +1,200 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #640 — unit-level coverage of the per-cycle reset semantics added to
+ * {@link PersistentVectorStore}.
+ *
+ * <p>Verifies that:
+ * <ol>
+ *   <li>{@link PersistentVectorStore#beginCompactionCycle(int, long)} zeroes
+ *       every per-cycle progress counter ({@code compactionNodesDone/Total},
+ *       {@code uploadBytesDone/Total}, {@code compactionBatchesDone/Total}),
+ *       even when the store was left at non-zero "previous-cycle terminal"
+ *       values — exactly the staleness symptom described in the issue.</li>
+ *   <li>{@code compactionCycleId} is strictly monotonic across {@code begin}
+ *       calls so consumers can detect a new cycle even if the per-cycle
+ *       counters happen to be at 100% from the previous one.</li>
+ *   <li>{@code compactionStartedNanos} (read via
+ *       {@link PersistentVectorStore#getCompactionElapsedMs()} /
+ *       {@link PersistentVectorStore#isCompactionRunning()}) is set on
+ *       begin and cleared on end.</li>
+ *   <li>{@code compactionInputSegmentCount} and
+ *       {@code compactionInputVectorCount} record the shape supplied at
+ *       begin.</li>
+ *   <li>End-of-cycle leaves the per-cycle counters populated so a post-hoc
+ *       describe-index still shows the last cycle's totals — matches the
+ *       legacy Phase B behaviour the issue called out as desirable.</li>
+ * </ol>
+ */
+public class PersistentVectorStoreCompactionCycleResetTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        return new PersistentVectorStore("idx-cyclereset", "tbl-cyclereset",
+                "ts-cyclereset", "vec_col", tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    @Test
+    public void beginResetsAllPerCycleCounters() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("reset").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+
+            // Simulate the "previous cycle terminal state" from the issue's
+            // describe-index evidence: nodes_done == nodes_total != 0,
+            // upload_bytes_done == upload_bytes_total != 0, batches_done
+            // == batches_total != 0.
+            store.setCompactionBatchesTotal(13_479L);
+            store.setCompactionBatchesDone(13_479L);
+            // We don't have direct setters for the legacy counters because
+            // they're updated by Phase B internals; use beginCompactionCycle
+            // followed by a synthetic Phase-B-like nudge through the only
+            // public knob we have. We instead just call begin twice — the
+            // first call gives us a clean baseline, then assert begin always
+            // zeroes the streaming-batch counters.
+            store.beginCompactionCycle(7, 874_105L);
+            // Fake some progress within the first cycle.
+            store.setCompactionBatchesTotal(13_479L);
+            store.setCompactionBatchesDone(13_479L);
+            assertEquals(13_479L, store.getCompactionBatchesDone());
+            assertEquals(13_479L, store.getCompactionBatchesTotal());
+            long firstCycleId = store.getCompactionCycleId();
+            assertTrue("first cycle started", store.isCompactionRunning());
+            store.endCompactionCycle();
+            assertFalse("end clears running flag", store.isCompactionRunning());
+            // End-of-cycle keeps the terminal values so a post-hoc poll
+            // still shows the last cycle's totals.
+            assertEquals(13_479L, store.getCompactionBatchesDone());
+
+            // The user's complaint: the NEXT cycle starts but describe-index
+            // still shows the PREVIOUS cycle's 13_479/13_479 — until begin
+            // resets it.
+            store.beginCompactionCycle(128, 10_912_000L);
+            assertEquals("compactionBatchesDone must reset to 0 on begin",
+                    0L, store.getCompactionBatchesDone());
+            assertEquals("compactionBatchesTotal must reset to 0 on begin",
+                    0L, store.getCompactionBatchesTotal());
+            assertEquals("compactionNodesDone must reset to 0 on begin",
+                    0L, store.getCompactionNodesDone());
+            assertEquals("compactionNodesTotal must reset to 0 on begin",
+                    0L, store.getCompactionNodesTotal());
+            assertEquals("uploadBytesDone must reset to 0 on begin",
+                    0L, store.getUploadBytesDone());
+            assertEquals("uploadBytesTotal must reset to 0 on begin",
+                    0L, store.getUploadBytesTotal());
+
+            // Input metadata reflects the cycle shape supplied at begin.
+            assertEquals(128L, store.getCompactionInputSegmentCount());
+            assertEquals(10_912_000L, store.getCompactionInputVectorCount());
+
+            // CycleId is monotonic across begins.
+            long secondCycleId = store.getCompactionCycleId();
+            assertTrue("cycleId is strictly monotonic across begins",
+                    secondCycleId > firstCycleId);
+
+            // Running flag is set, elapsed is non-negative (could be 0 if
+            // nanos happens to read identically on a very fast machine, so
+            // we only assert >= 0).
+            assertTrue("isCompactionRunning after begin", store.isCompactionRunning());
+            assertTrue("elapsedMs is non-negative", store.getCompactionElapsedMs() >= 0L);
+
+            store.endCompactionCycle();
+            assertFalse("isCompactionRunning false after end", store.isCompactionRunning());
+            assertEquals("elapsedMs returns 0 when idle",
+                    0L, store.getCompactionElapsedMs());
+        }
+    }
+
+    @Test
+    public void inputArgumentsAreClampedNonNegative() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("clamp").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            // Defence in depth: clamp negatives so a downstream consumer of
+            // the gRPC int32 / int64 fields never sees a negative magnitude
+            // from a buggy caller.
+            store.beginCompactionCycle(-3, -1_000L);
+            assertEquals(0L, store.getCompactionInputSegmentCount());
+            assertEquals(0L, store.getCompactionInputVectorCount());
+            store.endCompactionCycle();
+        }
+    }
+
+    @Test
+    public void endIsIdempotent() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("end-idem").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            assertFalse(store.isCompactionRunning());
+            // Double end without begin must be a safe no-op.
+            store.endCompactionCycle();
+            store.endCompactionCycle();
+            assertFalse(store.isCompactionRunning());
+            // Begin → end → end is also safe.
+            store.beginCompactionCycle(2, 100L);
+            store.endCompactionCycle();
+            store.endCompactionCycle();
+            assertFalse(store.isCompactionRunning());
+        }
+    }
+
+    @Test
+    public void streamingActiveCounterFlipsPhase() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("streaming-phase").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            assertEquals("idle", store.getCompactionPhase());
+
+            store.incrementCompactionStreamingActive();
+            try {
+                assertEquals("compacting-graph", store.getCompactionPhase());
+                // Progress percent during streaming reflects batches when
+                // the counters are populated.
+                store.setCompactionBatchesTotal(100L);
+                store.setCompactionBatchesDone(25L);
+                assertEquals(25, store.getCompactionProgressPercent());
+            } finally {
+                store.decrementCompactionStreamingActive();
+            }
+
+            assertEquals("idle", store.getCompactionPhase());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCompactionCycleResetTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/PersistentVectorStoreCompactionCycleResetTest.java
@@ -175,6 +175,67 @@ public class PersistentVectorStoreCompactionCycleResetTest {
         }
     }
 
+    /**
+     * pr-reviewer pass #640 follow-up: a throw from the window between
+     * Phase B success and Stage 2 (specifically:
+     * {@code warmUpNewSegmentsBeforePublish}, the Stage-1 deletes apply,
+     * or {@code phaseCPostDeletesApplyHook}) was previously uncovered by
+     * an {@code endCompactionCycle()} call — the running flag would stay
+     * stuck at {@code true} until the next cycle began. With the
+     * top-level try/finally introduced by the review fix, ANY throw from
+     * the checkpoint body must clear the flag.
+     *
+     * <p>This test injects a {@link RuntimeException} via
+     * {@link PersistentVectorStore#setPhaseCPostDeletesApplyHookForTest},
+     * confirms it escapes {@code checkpoint()}, and asserts that
+     * {@link PersistentVectorStore#isCompactionRunning()} is {@code false}
+     * afterwards — i.e. the cycle running flag was cleared by the
+     * top-level finally, not by a path-specific catch arm.
+     */
+    @Test
+    public void runningFlagClearsOnPhaseCHookThrow() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("phasec-throw").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.start();
+            // Add a vector so the checkpoint actually does Phase B work.
+            store.addVector(herddb.utils.Bytes.from_int(1), new float[16]);
+
+            // Pre-checkpoint sanity.
+            assertFalse(store.isCompactionRunning());
+            long preCycleId = store.getCompactionCycleId();
+
+            // Force a RuntimeException from the post-deletes-apply hook,
+            // which runs AFTER Phase B success and BEFORE the Stage 2
+            // try/finally — the unprotected window the review flagged.
+            store.setPhaseCPostDeletesApplyHookForTest(() -> {
+                throw new RuntimeException("forced phase-C throw (issue #640 review)");
+            });
+
+            Throwable caught = null;
+            try {
+                store.checkpoint();
+            } catch (Throwable t) {
+                caught = t;
+            }
+            assertTrue("checkpoint must surface the hook's RuntimeException",
+                    caught instanceof RuntimeException);
+
+            // Headline assertion: even though the throw bypassed every
+            // path-specific catch arm, the top-level finally cleared the
+            // running flag. Pre-fix this would have stayed `true` forever.
+            assertFalse("isCompactionRunning() must be false after a Phase-C"
+                            + " hook throw (issue #640 review)",
+                    store.isCompactionRunning());
+            assertEquals("getCompactionElapsedMs() reads 0 once the cycle ends",
+                    0L, store.getCompactionElapsedMs());
+            // The cycle id must still have been bumped by beginCompactionCycle
+            // even though the cycle failed — observers can still detect that
+            // a cycle attempt occurred.
+            assertTrue("compactionCycleId must have bumped on the failed cycle",
+                    store.getCompactionCycleId() > preCycleId);
+        }
+    }
+
     @Test
     public void streamingActiveCounterFlipsPhase() throws Exception {
         Path tmpDir = tmpFolder.newFolder("streaming-phase").toPath();

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/StreamingCompactionISLiveProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/StreamingCompactionISLiveProgressTest.java
@@ -1,0 +1,211 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #640 — end-to-end test that {@link PersistentVectorStore#runCompactionCycle}
+ * surfaces real-time streaming-compaction progress on the IS side:
+ * <ol>
+ *   <li>While {@link io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexCompactor#compact}
+ *       runs, {@link PersistentVectorStore#getCompactionPhase} returns
+ *       {@code "compacting-graph"} (NOT {@code "idle"} as it did pre-fix —
+ *       the central symptom in the issue's evidence).</li>
+ *   <li>{@link PersistentVectorStore#getCompactionBatchesDone()} /
+ *       {@link PersistentVectorStore#getCompactionBatchesTotal()} move from
+ *       0 to non-zero during the run (instead of staying at the previous
+ *       cycle's terminal values).</li>
+ *   <li>{@link PersistentVectorStore#getCompactionCycleId()} bumps every
+ *       cycle so external pollers can detect a new cycle even when the per-cycle
+ *       counters happen to be at 100% from the previous one.</li>
+ *   <li>{@link PersistentVectorStore#isCompactionRunning()} is true during
+ *       the cycle and false after it ends.</li>
+ *   <li>After the cycle ends, the per-cycle counters are LEFT POPULATED so a
+ *       post-hoc describe-index still sees the totals — and the NEXT cycle
+ *       resets them on begin (not on end).</li>
+ * </ol>
+ */
+public class StreamingCompactionISLiveProgressTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private int savedMinLiveVectors;
+
+    @org.junit.Before
+    public void setUp() {
+        savedMinLiveVectors = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @org.junit.After
+    public void tearDown() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectors;
+    }
+
+    private static float[] vec(Random rng, int dim) {
+        float[] v = new float[dim];
+        for (int i = 0; i < dim; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test
+    public void streamingCompactionExposesLiveProgress() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("is-live-progress").toPath();
+        int dim = 16;
+        int numSegments = 3;
+        int perSegment = 200;
+        Random rng = new Random(640L);
+
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+
+        try (PersistentVectorStore store = new PersistentVectorStore(
+                "ts-640", "tbl-640", "tsuuid-640", "vec_col",
+                tmpDir, dsm, mm,
+                16, 100, 1.2f, 1.4f, true, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN)) {
+            // Aggressive compaction: any 2+ segments merge in the next cycle.
+            store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 2,
+                    Integer.MAX_VALUE, 0);
+            store.start();
+
+            // Build numSegments on-disk segments via checkpoint.
+            for (int c = 0; c < numSegments; c++) {
+                for (int i = 0; i < perSegment; i++) {
+                    store.addVector(Bytes.from_int(c * 10_000 + i), vec(rng, dim));
+                }
+                store.checkpoint();
+            }
+            assertEquals(numSegments, store.getSegmentCount());
+
+            // Pre-cycle state: counters are at whatever the last checkpoint
+            // left them at, but no cycle is running.
+            assertEquals("compaction must not be running before runCompactionCycle",
+                    false, store.isCompactionRunning());
+            long preCycleId = store.getCompactionCycleId();
+
+            // Sample the live state from a watcher thread while the cycle
+            // runs. Use CAS to capture the max done/total observed and the
+            // set of phases seen.
+            AtomicBoolean watcherStop = new AtomicBoolean();
+            AtomicLong maxBatchesDone = new AtomicLong();
+            AtomicLong maxBatchesTotal = new AtomicLong();
+            AtomicBoolean sawCompactingPhase = new AtomicBoolean();
+            AtomicBoolean sawRunning = new AtomicBoolean();
+            AtomicLong observedCycleId = new AtomicLong(-1L);
+            Thread watcher = new Thread(() -> {
+                while (!watcherStop.get()) {
+                    if (store.isCompactionRunning()) {
+                        sawRunning.set(true);
+                    }
+                    String phase = store.getCompactionPhase();
+                    if ("compacting-graph".equals(phase)) {
+                        sawCompactingPhase.set(true);
+                    }
+                    long d = store.getCompactionBatchesDone();
+                    long t = store.getCompactionBatchesTotal();
+                    if (d > maxBatchesDone.get()) {
+                        maxBatchesDone.set(d);
+                    }
+                    if (t > maxBatchesTotal.get()) {
+                        maxBatchesTotal.set(t);
+                    }
+                    long cid = store.getCompactionCycleId();
+                    if (cid != observedCycleId.get()) {
+                        observedCycleId.set(cid);
+                    }
+                }
+            }, "is-live-progress-watcher");
+            watcher.setDaemon(true);
+            watcher.start();
+
+            store.runCompactionCycle();
+
+            watcherStop.set(true);
+            watcher.join(5_000);
+
+            // Cycle id strictly bumped — even if the watcher never saw the
+            // "running" window (very fast machine), this assertion fails the
+            // user's "stale counters" scenario where two cycles look identical.
+            long postCycleId = store.getCompactionCycleId();
+            assertNotEquals("compactionCycleId must bump on a run",
+                    preCycleId, postCycleId);
+            assertTrue("compactionCycleId is strictly monotonic",
+                    postCycleId > preCycleId);
+
+            // The watcher should have observed the cycle: running flag true at
+            // some sample, "compacting-graph" phase at some sample, and the
+            // batch counters non-zero by the time the listener fires.
+            assertTrue("watcher must have observed isCompactionRunning=true at some point",
+                    sawRunning.get());
+            assertTrue("watcher must have observed compaction_phase=compacting-graph"
+                            + " (was 'idle' pre-fix — the central issue #640 symptom)",
+                    sawCompactingPhase.get());
+            assertTrue("compactionBatchesTotal must reach non-zero during the cycle",
+                    maxBatchesTotal.get() > 0L);
+            assertTrue("compactionBatchesDone must reach non-zero during the cycle",
+                    maxBatchesDone.get() > 0L);
+
+            // Post-cycle: running flag clear, elapsed reads as 0 (idle).
+            assertEquals("compaction_running false after cycle",
+                    false, store.isCompactionRunning());
+            assertEquals("elapsed_ms reads 0 when idle",
+                    0L, store.getCompactionElapsedMs());
+
+            // Counters are LEFT POPULATED so a post-hoc describe-index sees
+            // the cycle totals — exactly the legacy Phase B contract from
+            // issue #80 that the issue #640 fix preserves.
+            assertTrue("compactionBatchesDone left populated after end",
+                    store.getCompactionBatchesDone() > 0L);
+            assertTrue("compactionBatchesTotal left populated after end",
+                    store.getCompactionBatchesTotal() > 0L);
+
+            // Input metadata captured at begin reflects the cycle shape.
+            assertEquals("input segment count reflects the candidates merged",
+                    (long) numSegments, store.getCompactionInputSegmentCount());
+            // We don't pin an exact vector count (segment.liveCount depends
+            // on jvector internals); the lower bound is the perSegment we
+            // wrote and the upper bound is the total — accept anything in
+            // that range to keep the test stable.
+            long vecs = store.getCompactionInputVectorCount();
+            assertTrue("input vector count is positive: " + vecs, vecs > 0L);
+            assertTrue("input vector count is at most numSegments*perSegment: " + vecs,
+                    vecs <= (long) numSegments * perSegment);
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/StreamingCompactionISLiveProgressTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/StreamingCompactionISLiveProgressTest.java
@@ -149,6 +149,17 @@ public class StreamingCompactionISLiveProgressTest {
                     if (cid != observedCycleId.get()) {
                         observedCycleId.set(cid);
                     }
+                    // Throttle the polling loop: this is a sampler, not an
+                    // event-wait. An unthrottled spin on a single-vCPU CI
+                    // runner can starve the thread that drives the cycle,
+                    // slowing the test and increasing the flake surface
+                    // (pr-reviewer pass #640).
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
                 }
             }, "is-live-progress-watcher");
             watcher.setDaemon(true);


### PR DESCRIPTION
Fixes #640.

## Root cause

Streaming compactions on the IS side ran for minutes without surfacing any
progress: `describe-index --json` showed the *previous* cycle's terminal
"100% done" values for the whole new cycle, and `compaction_phase` read as
`"idle"` even while jvector's `OnDiskGraphIndexCompactor` was writing 13k+
batches to S3.

Two gaps in the IS code path were responsible:

1. `VectorIndexCompactor.rebuildSegmentStreaming` called
   `compactor.compact(graphTemp)` *without* a `CompactionProgressListener`,
   so jvector's `runBatchesWithBackpressure` counter (the one that the IS
   log already prints as `"Compaction I/O progress: X/Y batches written to
   disk"`) never reached the IS counters.
2. Phase tracking was blind during the batch loop &mdash;
   `writingGraphActive` / `uploadingActive` were only flipped by the
   surrounding `writeStreamingCompactedSegment`, which runs AFTER the
   batch loop &mdash; and the four legacy compaction counters were reset
   only inside `doCheckpointFusedPQThreePhase`, never on the streaming
   compaction path.

## Changes

- New atomic counters on `PersistentVectorStore`: `compactionBatchesDone`,
  `compactionBatchesTotal`, `compactionCycleId`,
  `compactionInputSegmentCount`, `compactionInputVectorCount`,
  `compactionStartedNanos`, plus a `compactionStreamingActive` flag for
  phase tracking.
- `beginCompactionCycle(inputSegmentCount, inputVectorCount)` /
  `endCompactionCycle()` helpers that own per-cycle reset semantics,
  cycle-id bump and elapsed-ms tracking. Both `runCompactionCycle` and
  the checkpoint Phase B path now go through these helpers; the legacy
  in-line counter reset in `doCheckpointFusedPQThreePhase` is gone.
- `VectorIndexCompactor.rebuildSegmentStreaming` now wraps the
  `compactor.compact(...)` call in `incrementCompactionStreamingActive()`
  / `decrementCompactionStreamingActive()` and passes a
  `CompactionProgressListener` that pushes `(completed, total)` from
  every `runBatchesWithBackpressure` tick into the new batch counters.
- `getCompactionPhase()` returns a new `"compacting-graph"` value while
  streaming-active is non-zero (priority: `uploading-segment` &gt;
  `compacting-graph` &gt; `writing-graph` &gt; `idle`). The progress
  percent falls back to batch-based progress in this phase.
- 7 new fields on `DescribeIndexResponse` (tags 32&ndash;38):
  `compaction_batches_done/total`, `compaction_cycle_id`,
  `compaction_input_segment_count/vector_count`,
  `compaction_elapsed_ms`, `compaction_running`.
- `GetEngineStats` aggregates `compaction_running` (any) and
  `compaction_phase` (most advanced) across all loaded
  `PersistentVectorStore`s, so a single top-level call reveals whether
  any index on the IS is currently compacting.
- `indexing-admin describe-index --json` emits the seven new fields.

## Tests

- `PersistentVectorStoreCompactionCycleResetTest` &mdash; unit-level
  coverage of `beginCompactionCycle`'s per-cycle reset, monotonic cycle
  id, idempotent `endCompactionCycle`, negative-clamp, and the new
  `compacting-graph` phase string.
- `StreamingCompactionISLiveProgressTest` &mdash; drives a real
  `runCompactionCycle()` through `VectorIndexCompactor.rebuildSegmentStreaming`;
  a watcher thread asserts that `getCompactionPhase()` reports
  `compacting-graph` (NOT `idle` &mdash; the issue's central symptom),
  batches counters move from 0 to non-zero, cycle id bumps and elapsed-ms
  reads 0 once the cycle ends.
- `IndexingServiceDiagnosticsGrpcCompactionFieldsTest` &mdash; gRPC-level
  round-trip: registers a real PVS, runs a streaming cycle, asserts the
  new seven fields propagate end-to-end through
  `IndexingServiceImpl.describeIndex` to the proto response and that
  `engine-stats` reflects the post-cycle idle state.
- `IndexingServiceEngineStatsCompactionTest` &mdash; verifies the
  aggregated `compaction_running=true` flips during a cycle and back to
  `false` afterwards, and that any non-idle `compaction_phase` observed
  is one of the recognised values.
- `IndexingServiceDiagnosticsGrpcTest` augmented with assertions for the
  new defaults (0/false) on an in-memory store and for the new
  `compaction_running`/`compaction_phase` keys on engine-stats.

All 44 compaction-related tests in `herddb-indexing-service` pass
locally. Pre-PR validation (`mvn spotless:check apache-rat:check
spotbugs:check install -Pci -DskipTests`) is green.

🤖 Implemented by the \`pr-worker\` agent.