### PR TITLE
issue #645: fix direct-S3 restart crash-loop — strict bulk-layout probe

### DIFF
--- a/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/RemoteFileDataStorageManager.java
@@ -1397,7 +1397,22 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         // materialise on first call; subsequent suppliers reuse the same
         // cache file. Per-block files (legacy layout) keep the existing
         // remote-random-access path.
-        if (isBulkLayout(logicalPath)) {
+        // Issue #645: use the strict probe so a transient HEAD failure (5xx,
+        // network blip) does not silently fall through to the gRPC reader
+        // for a file that was actually written via direct-S3. The gRPC
+        // file-server has no record of direct-uploaded blocks, so falling
+        // back to it would always surface as "Block not found" and crash
+        // the IS on restart.
+        boolean bulk;
+        try {
+            bulk = isBulkLayoutOrThrow(logicalPath);
+        } catch (IOException ioe) {
+            throw new DataStorageManagerException(
+                    "bulk-layout probe failed for " + logicalPath
+                            + "; refusing to fall back to gRPC because direct-S3"
+                            + " is wired (issue #645)", ioe);
+        }
+        if (bulk) {
             try {
                 Path localFile = ensureBulkLocalCacheFile(logicalPath, fileSize);
                 return new io.github.jbellis.jvector.disk.MappedChunkReader.Supplier(localFile);
@@ -1413,16 +1428,70 @@ public class RemoteFileDataStorageManager extends DataStorageManager
     }
 
     /**
-     * Issue #638: best-effort probe — returns {@code true} when the logical
-     * multipart file is stored in the bulk layout (single S3 object at
-     * {@code {logicalPath}.bulk}). Honours the in-memory probe cache so
+     * Issue #638/#645: lenient probe — returns {@code true} when the
+     * logical multipart file is stored in the bulk layout (single S3 object
+     * at {@code {logicalPath}.bulk}). Honours the in-memory probe cache so
      * repeated calls for the same logical path issue at most one S3
-     * {@code HEAD}. Returns {@code false} for legacy per-block files and
-     * when the direct-S3 client is not wired.
+     * {@code HEAD}. Returns {@code false} for legacy per-block files,
+     * when the direct-S3 client is not wired, and — best-effort — when
+     * the HEAD probe fails transiently.
+     *
+     * <p>This is the boolean-only variant used by
+     * {@link #multipartIndexFileExists} (whose API contract is "best-effort
+     * presence check"). The read paths
+     * ({@link #multipartIndexReaderSupplier} and
+     * {@link #downloadMultipartIndexFile}) MUST use
+     * {@link #isBulkLayoutOrThrow(String)} instead so a transient probe
+     * failure surfaces loudly instead of silently misrouting through the
+     * gRPC file-server, which is the failure mode that crash-looped the
+     * indexing service in issue #645.
      */
     private boolean isBulkLayout(String logicalPath) {
+        try {
+            return isBulkLayoutOrThrow(logicalPath);
+        } catch (IOException probeErr) {
+            // Lenient-probe path: keep the historical contract of
+            // multipartIndexFileExists ("best-effort, never throws") by
+            // mapping a transient probe failure to a conservative {@code
+            // false} answer. A {@code false} from this method on the
+            // exists-check path is OK because the caller follows up with a
+            // legacy per-block probe; a {@code false} on a read path would
+            // be unsafe, which is why read paths now call
+            // {@link #isBulkLayoutOrThrow} directly.
+            LOGGER.log(Level.FINE,
+                    "bulk-layout probe failed for {0} (best-effort, returning false): {1}",
+                    new Object[]{logicalPath, probeErr.toString()});
+            return false;
+        }
+    }
+
+    /**
+     * Issue #645: strict probe — returns {@code true} when the logical
+     * multipart file is stored in the bulk layout, {@code false} when it
+     * is definitively absent (HEAD 404 / {@code NOT_FOUND}), and throws
+     * {@link IOException} when the existence could not be determined
+     * (transient network error, HTTP 5xx, SDK error, timeout, interrupted).
+     *
+     * <p>Honours the in-memory probe cache so repeated calls for the same
+     * logical path issue at most one S3 {@code HEAD}. Only positive
+     * results are cached; transient probe failures are <em>not</em>
+     * cached (cf. the issue-#638 review note on {@link #isBulkLayout}).
+     *
+     * <p>The contract on the underlying
+     * {@link ObjectStorage#existsObject(String)} call is tri-state as of
+     * issue #645: {@code true} / {@code false} (definitive 404) /
+     * exceptional. This method translates those three terminal states
+     * directly: {@code true} → {@code true}, {@code false} → {@code false},
+     * exceptional → {@code throw IOException}. Read-path callers MUST
+     * surface that throw instead of falling back to gRPC, because the
+     * gRPC file-server has no record of direct-S3-uploaded blocks and
+     * the fallback path would always surface as {@code Block not found}.
+     */
+    private boolean isBulkLayoutOrThrow(String logicalPath) throws IOException {
         ObjectStorage storage = this.directObjectStorage;
         if (storage == null) {
+            // No direct-S3 wiring at all: this installation only uses the
+            // gRPC file-server. The probe is structurally {@code false}.
             return false;
         }
         Boolean cached = bulkLayoutCache.get(logicalPath);
@@ -1436,22 +1505,25 @@ public class RemoteFileDataStorageManager extends DataStorageManager
                             15L, TimeUnit.SECONDS));
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
-            return false;
-        } catch (java.util.concurrent.ExecutionException
-                | java.util.concurrent.TimeoutException
-                | RuntimeException probeErr) {
-            // existsObject is contractually best-effort and must not throw on
-            // missing keys, but defensive: treat any failure as "not bulk"
-            // and fall back to the legacy per-block code path. The
-            // RuntimeException catch is needed because some S3-compatible
-            // backends wrap non-existence in unchecked SDK exceptions; we
-            // intentionally do not cache the negative result here so a
-            // transient probe failure does not pin the logical file to the
-            // wrong layout for the rest of the JVM lifetime.
-            LOGGER.log(Level.FINE,
-                    "bulk-layout probe failed for {0}: {1}",
-                    new Object[]{logicalPath, probeErr.toString()});
-            return false;
+            throw new IOException(
+                    "interrupted while probing bulk layout for " + logicalPath, ie);
+        } catch (java.util.concurrent.TimeoutException te) {
+            // A HEAD that does not return within 15 s is a transient
+            // condition. Don't cache; let the caller decide whether to
+            // retry or fail the read.
+            throw new IOException(
+                    "bulk-layout HEAD probe timed out for " + logicalPath, te);
+        } catch (java.util.concurrent.ExecutionException ee) {
+            // existsObject completed exceptionally — per the tri-state
+            // contract this means "could not determine" (5xx, network,
+            // generic SDK error). NoSuchKey / 404 collapse to {@code
+            // false} inside existsObject itself and never reach here.
+            Throwable cause = ee.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw new IOException(
+                    "bulk-layout HEAD probe failed for " + logicalPath, cause);
         }
         // Only cache positive results. Caching false permanently would pin
         // a logical path as "not bulk" for the entire JVM lifetime, causing
@@ -1691,7 +1763,13 @@ public class RemoteFileDataStorageManager extends DataStorageManager
         // Multipart Download, parallel parts pipelined by CRT). Falls back to
         // the legacy per-block sequential download when the bulk variant is
         // absent.
-        if (isBulkLayout(logicalPath)) {
+        // Issue #645: use the strict probe — a transient HEAD failure must
+        // NOT silently fall through to the legacy per-block path, because
+        // for a file written via direct-S3 the per-block layout is empty in
+        // S3 and the download would always fail. Throwing here surfaces a
+        // clear diagnostic instead of crash-looping the IS with confusing
+        // "Block not found" errors.
+        if (isBulkLayoutOrThrow(logicalPath)) {
             try {
                 storage.downloadFileBulk(logicalPath + BULK_LAYOUT_SUFFIX, destFile).get();
                 LOGGER.log(Level.FINE,

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/ObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/ObjectStorage.java
@@ -188,7 +188,7 @@ public interface ObjectStorage extends AutoCloseable {
     }
 
     /**
-     * Issue #638: best-effort single-key existence probe used by
+     * Issue #645: tri-state single-key existence probe used by
      * {@link RemoteFileDataStorageManager} to discover whether a logical
      * multipart file is stored in the bulk layout
      * ({@code {logicalPath}.bulk}, a single object) or the legacy per-block
@@ -199,16 +199,47 @@ public interface ObjectStorage extends AutoCloseable {
      * {@link #read(String)} which materialises the whole object — correct,
      * but inefficient.
      *
-     * @return a future that completes with {@code true} if {@code path} is
-     *         present, {@code false} otherwise. Must never complete
-     *         exceptionally for a simple "object missing" answer.
+     * <p><b>Contract (tightened in issue #645):</b> the returned future has
+     * exactly three terminal states, and callers MUST honour the distinction:
+     * <ul>
+     *   <li>completes with {@code true} — the object is present;</li>
+     *   <li>completes with {@code false} — the object is <em>definitively</em>
+     *       absent (e.g. S3 {@code NoSuchKey} / HTTP 404, local file does not
+     *       exist). A {@code false} answer is a strong signal that the caller
+     *       may take an alternate code path safely;</li>
+     *   <li>completes exceptionally — the existence could not be determined
+     *       (transient I/O error, network timeout, HTTP 5xx, generic SDK
+     *       error). Callers that rely on a definitive answer to decide a read
+     *       layout MUST treat this as an error and not silently fall through
+     *       to a different layout — see issue #645 for the failure mode that
+     *       motivated this contract.</li>
+     * </ul>
+     *
+     * <p>Before issue #645 the default implementation collapsed every
+     * exception into {@code false}. That silently misrouted reads of
+     * direct-S3-uploaded files through the gRPC file-server on restart and
+     * crash-looped the indexing service. The new default propagates non
+     * {@code NOT_FOUND} errors exceptionally.
      */
     default CompletableFuture<Boolean> existsObject(String path) {
         return read(path).thenApply(result -> {
-            boolean found = result.status() == ReadResult.Status.FOUND;
+            ReadResult.Status status = result.status();
             result.release();
-            return found;
-        }).exceptionally(t -> Boolean.FALSE);
+            if (status == ReadResult.Status.FOUND) {
+                return Boolean.TRUE;
+            }
+            if (status == ReadResult.Status.NOT_FOUND) {
+                return Boolean.FALSE;
+            }
+            // Defensive: any future ReadResult.Status that is neither FOUND
+            // nor NOT_FOUND is a transient/unknown condition. Surface as an
+            // exceptional completion so the caller can disambiguate (see
+            // issue #645 contract above).
+            throw new java.util.concurrent.CompletionException(
+                    new java.io.IOException(
+                            "existsObject probe returned unrecognised status "
+                                    + status + " for path=" + path));
+        });
     }
 
     /**

--- a/herddb-remote-file-service/src/main/java/herddb/remote/storage/S3ObjectStorage.java
+++ b/herddb-remote-file-service/src/main/java/herddb/remote/storage/S3ObjectStorage.java
@@ -426,10 +426,28 @@ public class S3ObjectStorage implements ObjectStorage {
     }
 
     /**
-     * Issue #638: single-key existence probe via S3 {@code HEAD} — the cheap,
-     * canonical way to check whether a logical multipart file is stored in
-     * the bulk layout ({@code {logicalPath}.bulk}) before deciding the read
-     * path.
+     * Issue #638/#645: single-key existence probe via S3 {@code HEAD} — the
+     * cheap, canonical way to check whether a logical multipart file is
+     * stored in the bulk layout ({@code {logicalPath}.bulk}) before deciding
+     * the read path.
+     *
+     * <p>Honours the tri-state contract documented on
+     * {@link ObjectStorage#existsObject(String)} (tightened in issue #645):
+     * <ul>
+     *   <li>HEAD 200 → {@code true};</li>
+     *   <li>{@link NoSuchKeyException} or {@link AwsServiceException} with
+     *       HTTP status 404 → {@code false} (definitively absent);</li>
+     *   <li>anything else — generic {@link AwsServiceException} (5xx,
+     *       403, throttling), {@link SdkClientException} (DNS, connect,
+     *       socket timeout), arbitrary {@link RuntimeException} from
+     *       transformer code — completes the future exceptionally.</li>
+     * </ul>
+     *
+     * <p>The previous best-effort behaviour (everything → {@code false})
+     * caused issue #645: a transient MinIO blip on IS restart silently
+     * misrouted reads of direct-S3-uploaded segments through the gRPC
+     * file-server, which crashed the IS with {@code Block not found}
+     * because the file-server has no record of direct-uploaded objects.
      */
     @Override
     public CompletableFuture<Boolean> existsObject(String path) {
@@ -441,15 +459,16 @@ public class S3ObjectStorage implements ObjectStorage {
                 .<Boolean>thenApply(resp -> Boolean.TRUE)
                 .exceptionally(t -> {
                     Throwable cause = (t instanceof CompletionException) ? t.getCause() : t;
-                    // Known S3 "missing object" surfaces — both AWS native and CRT/MinIO —
-                    // map to false; anything else also maps to false to honour the
-                    // best-effort contract of existsObject (must not throw on missing).
+                    // Known S3 "missing object" surface (AWS native).
                     if (cause instanceof NoSuchKeyException) {
                         return Boolean.FALSE;
                     }
-                    // Some S3-compatible stores return a generic SdkServiceException
-                    // with HTTP 404 instead of NoSuchKey. Inspect the status code if
-                    // available — otherwise default to false for the best-effort probe.
+                    // Some S3-compatible stores (CRT, MinIO under some
+                    // configurations) return a generic SdkServiceException
+                    // with HTTP 404 instead of NoSuchKey. Inspect the status
+                    // code — only a true 404 collapses to {@code false}; any
+                    // other status code (403, 5xx, throttling, etc.) is a
+                    // transient/unknown condition and MUST propagate.
                     if (cause instanceof software.amazon.awssdk.awscore.exception.AwsServiceException) {
                         int code = ((software.amazon.awssdk.awscore.exception.AwsServiceException) cause)
                                 .statusCode();
@@ -457,7 +476,16 @@ public class S3ObjectStorage implements ObjectStorage {
                             return Boolean.FALSE;
                         }
                     }
-                    return Boolean.FALSE;
+                    // Issue #645: everything else (SdkClientException, generic
+                    // RuntimeException, AwsServiceException with code != 404)
+                    // propagates as an exceptional completion. Re-throw via
+                    // CompletionException so the existing call-site
+                    // (RemoteFileDataStorageManager.isBulkLayoutOrThrow)
+                    // observes the original cause through ExecutionException.
+                    if (cause instanceof RuntimeException) {
+                        throw (RuntimeException) cause;
+                    }
+                    throw new CompletionException(cause);
                 });
     }
 

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerDirectUploadProbeFailureTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerDirectUploadProbeFailureTest.java
@@ -1,0 +1,540 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.remote.storage.LocalObjectStorage;
+import herddb.remote.storage.ObjectStorage;
+import herddb.remote.storage.ReadResult;
+import herddb.storage.DataStorageManagerException;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #645: failure-injection coverage for the bulk-layout probe on the
+ * read paths. The bench failure (Run 9 BIGANN 200M) crashed the IS with
+ * confusing {@code Block not found} errors because the bulk-layout probe
+ * returned {@code false} on transient HEAD failures and the read path
+ * silently fell back to the gRPC file-server, which has no record of
+ * direct-S3-uploaded blocks.
+ *
+ * <p>After the issue #645 fix, a transient probe failure on the
+ * <em>read</em> paths ({@code multipartIndexReaderSupplier} and
+ * {@code downloadMultipartIndexFile}) MUST surface as a clear
+ * {@link DataStorageManagerException} or {@link IOException}, not silently
+ * fall through to gRPC. The lenient {@code multipartIndexFileExists}
+ * keeps its boolean contract.
+ *
+ * <p>The test simulates two failure modes:
+ * <ol>
+ *   <li>HEAD always completes exceptionally (e.g. MinIO returning 503 or
+ *       a connect timeout to S3).</li>
+ *   <li>HEAD recovers after N attempts — verifies that a subsequent read
+ *       succeeds once the storage is healthy again.</li>
+ * </ol>
+ */
+public class RemoteFileDataStorageManagerDirectUploadProbeFailureTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private ExecutorService metadataExecutor;
+    private RemoteFileServiceClient stubClient;
+
+    @Before
+    public void setUp() throws IOException {
+        metadataExecutor = Executors.newSingleThreadExecutor();
+        Map<String, Object> fastFailConfig = new HashMap<>();
+        fastFailConfig.put(RemoteFileServiceClient.CONFIG_CLIENT_TIMEOUT, 1L);
+        fastFailConfig.put(RemoteFileServiceClient.CONFIG_CLIENT_RETRIES, 0);
+        stubClient = new RemoteFileServiceClient(Collections.emptyList(), fastFailConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (stubClient != null) {
+            stubClient.close();
+        }
+        if (metadataExecutor != null) {
+            metadataExecutor.shutdown();
+        }
+    }
+
+    private Path writeTempFile(String name, byte[] content) throws IOException {
+        Path f = tmpFolder.newFile(name).toPath();
+        Files.write(f, content);
+        return f;
+    }
+
+    private RemoteFileDataStorageManager newDsm(ObjectStorage storage) throws IOException {
+        Path metaDir = tmpFolder.newFolder("meta-" + System.nanoTime()).toPath();
+        Path tmpDir = tmpFolder.newFolder("tmp-" + System.nanoTime()).toPath();
+        RemoteFileDataStorageManager dsm = new RemoteFileDataStorageManager(
+                metaDir, tmpDir, Integer.MAX_VALUE, stubClient);
+        dsm.setDirectObjectStorage(storage);
+        dsm.enableDirectUpload(16L * 1024 * 1024);
+        return dsm;
+    }
+
+    /**
+     * Issue #645 — primary regression: when the HEAD probe always fails
+     * (transient MinIO outage, network partition), the
+     * {@code downloadMultipartIndexFile} read path MUST throw rather
+     * than silently fall back to the gRPC per-block path. The latter
+     * is the broken behaviour that produced the
+     * "Block not found" crash-loop in Run 9.
+     */
+    @Test
+    public void downloadThrowsWhenProbeAlwaysFails() throws Exception {
+        // First, write the file via a healthy backing storage so the
+        // .bulk object truly exists on disk.
+        Path objectsDir = tmpFolder.newFolder("objects").toPath();
+        LocalObjectStorage healthyStorage =
+                new LocalObjectStorage(objectsDir, metadataExecutor);
+        try (RemoteFileDataStorageManager writerDsm = newDsm(healthyStorage)) {
+            byte[] payload = "payload-content".getBytes();
+            Path src = writeTempFile("flaky-write.bin", payload);
+            writerDsm.writeMultipartIndexFile("ts", "uuid-flaky", "graph", src, null);
+        } finally {
+            healthyStorage.close();
+        }
+
+        // Now spawn a "restart" DSM with a probe-failing storage wrapping
+        // the same on-disk directory. existsObject always completes
+        // exceptionally; uploadFile / downloadFileBulk pass through to
+        // the healthy backing storage. This mirrors a real MinIO outage
+        // that affects only HEAD requests.
+        AtomicInteger headAttempts = new AtomicInteger();
+        AlwaysFailingHeadStorage flakyStorage = new AlwaysFailingHeadStorage(
+                new LocalObjectStorage(objectsDir, metadataExecutor),
+                () -> new IOException("simulated MinIO HEAD 503"),
+                headAttempts);
+        try (RemoteFileDataStorageManager readerDsm = newDsm(flakyStorage)) {
+            Path dest = tmpFolder.newFile("flaky-out.bin").toPath();
+            try {
+                readerDsm.downloadMultipartIndexFile(
+                        "ts", "uuid-flaky", "graph", 15L, dest);
+                fail("downloadMultipartIndexFile must throw when the HEAD"
+                        + " probe fails transiently");
+            } catch (IOException expected) {
+                // Issue #645: the failure must mention either the bulk-layout
+                // probe or the synthetic underlying cause, NOT "Block not
+                // found" (which would indicate a silent gRPC fallback).
+                assertNotNull(expected.getMessage());
+                String msg = expected.getMessage();
+                assertTrue("error message must mention the bulk-layout probe;"
+                                + " got: " + msg,
+                        msg.toLowerCase().contains("bulk")
+                                || msg.toLowerCase().contains("probe")
+                                || msg.contains("simulated MinIO HEAD 503"));
+                assertTrue("error message must NOT misroute via gRPC"
+                                + " ('Block not found' is the buggy path); got: "
+                                + msg,
+                        !msg.contains("Block not found"));
+            }
+            assertEquals("HEAD must have been attempted exactly once for the read",
+                    1, headAttempts.get());
+        } finally {
+            flakyStorage.close();
+        }
+    }
+
+    /**
+     * Issue #645: {@code multipartIndexReaderSupplier} must also throw
+     * (as a {@link DataStorageManagerException}) when the probe fails.
+     * This is the load-path used by {@code OnDiskGraphIndex.load} — the
+     * exact call chain that exploded in the bench logs:
+     * {@code PersistentVectorStore.loadFusedPQSegment} →
+     * {@code OnDiskGraphIndex.load} →
+     * {@code RemoteRandomAccessReader.fetchBlockFromRemote} →
+     * "Block not found".
+     */
+    @Test
+    public void readerSupplierThrowsWhenProbeAlwaysFails() throws Exception {
+        Path objectsDir = tmpFolder.newFolder("objects").toPath();
+        LocalObjectStorage healthyStorage =
+                new LocalObjectStorage(objectsDir, metadataExecutor);
+        try (RemoteFileDataStorageManager writerDsm = newDsm(healthyStorage)) {
+            byte[] payload = "ondisk-graph".getBytes();
+            Path src = writeTempFile("supplier-write.bin", payload);
+            writerDsm.writeMultipartIndexFile("ts", "uuid-supplier", "graph", src, null);
+        } finally {
+            healthyStorage.close();
+        }
+
+        AlwaysFailingHeadStorage flakyStorage = new AlwaysFailingHeadStorage(
+                new LocalObjectStorage(objectsDir, metadataExecutor),
+                () -> new IOException("synthetic transient HEAD failure"),
+                new AtomicInteger());
+        try (RemoteFileDataStorageManager readerDsm = newDsm(flakyStorage)) {
+            try {
+                readerDsm.multipartIndexReaderSupplier(
+                        "ts", "uuid-supplier", "graph", 12L);
+                fail("multipartIndexReaderSupplier must throw on probe failure");
+            } catch (DataStorageManagerException expected) {
+                String msg = expected.getMessage();
+                assertNotNull(msg);
+                assertTrue("error must reference the bulk-layout probe; got: " + msg,
+                        msg.toLowerCase().contains("bulk")
+                                || msg.toLowerCase().contains("probe"));
+                // The IOException carrying the original synthetic cause
+                // must be in the cause chain.
+                Throwable cause = expected.getCause();
+                while (cause != null && !(cause.getMessage() != null
+                        && cause.getMessage().contains("synthetic transient HEAD failure"))) {
+                    cause = cause.getCause();
+                }
+                assertNotNull("original synthetic cause must be in the chain", cause);
+            }
+        } finally {
+            flakyStorage.close();
+        }
+    }
+
+    /**
+     * Issue #645: the lenient {@code multipartIndexFileExists} contract
+     * is preserved — it must NOT throw on probe failure. Instead, it
+     * returns {@code false} (consistent with its long-standing
+     * best-effort presence-check contract). This keeps any caller of
+     * {@code multipartIndexFileExists} that relies on the boolean
+     * contract from regressing.
+     *
+     * <p>Note: the strict-throw behaviour is reserved for the read paths
+     * ({@code downloadMultipartIndexFile} and
+     * {@code multipartIndexReaderSupplier}) where falling through to
+     * gRPC would corrupt the load. The presence check is allowed to be
+     * lenient because its callers ({@code deleteMultipartIndexFile},
+     * observability) tolerate a transient false-negative.
+     */
+    @Test
+    public void existsCheckDoesNotThrowOnProbeFailure() throws Exception {
+        Path objectsDir = tmpFolder.newFolder("objects").toPath();
+        AlwaysFailingHeadStorage flakyStorage = new AlwaysFailingHeadStorage(
+                new LocalObjectStorage(objectsDir, metadataExecutor),
+                () -> new IOException("HEAD blip"),
+                new AtomicInteger());
+        try (RemoteFileDataStorageManager dsm = newDsm(flakyStorage)) {
+            // Must not throw; must return false (lenient contract).
+            boolean exists = dsm.multipartIndexFileExists(
+                    "ts", "uuid-lenient", "graph");
+            // The gRPC fallback also fails fast (empty server list), so
+            // the answer is {@code false}. The KEY behaviour is that the
+            // call returned without throwing.
+            assertEquals("lenient probe must return false on HEAD failure"
+                            + " (and NOT throw)",
+                    false, exists);
+        } finally {
+            flakyStorage.close();
+        }
+    }
+
+    /**
+     * Issue #645: HEAD probes that recover (transient outage clears) must
+     * allow subsequent reads to succeed. This guards against an over-eager
+     * cache or sticky-error state.
+     */
+    @Test
+    public void readSucceedsAfterTransientHeadOutageClears() throws Exception {
+        Path objectsDir = tmpFolder.newFolder("objects").toPath();
+        LocalObjectStorage healthyStorage =
+                new LocalObjectStorage(objectsDir, metadataExecutor);
+        byte[] payload = "recovery-payload".getBytes();
+        try (RemoteFileDataStorageManager writerDsm = newDsm(healthyStorage)) {
+            Path src = writeTempFile("recovery-write.bin", payload);
+            writerDsm.writeMultipartIndexFile("ts", "uuid-recover", "graph", src, null);
+        } finally {
+            healthyStorage.close();
+        }
+
+        AtomicInteger headAttempts = new AtomicInteger();
+        TransientFailingHeadStorage flakyStorage = new TransientFailingHeadStorage(
+                new LocalObjectStorage(objectsDir, metadataExecutor),
+                /* failTimes = */ 2,
+                () -> new IOException("transient HEAD blip"),
+                headAttempts);
+        try (RemoteFileDataStorageManager readerDsm = newDsm(flakyStorage)) {
+            // Attempt 1: probe fails → read throws.
+            try {
+                Path dest1 = tmpFolder.newFile("recover-out-1.bin").toPath();
+                readerDsm.downloadMultipartIndexFile(
+                        "ts", "uuid-recover", "graph", payload.length, dest1);
+                fail("read 1 must fail while HEAD is broken");
+            } catch (IOException expected) {
+                // expected
+            }
+
+            // Attempt 2: probe still failing → read still throws.
+            try {
+                Path dest2 = tmpFolder.newFile("recover-out-2.bin").toPath();
+                readerDsm.downloadMultipartIndexFile(
+                        "ts", "uuid-recover", "graph", payload.length, dest2);
+                fail("read 2 must fail while HEAD is broken");
+            } catch (IOException expected) {
+                // expected
+            }
+
+            // Attempt 3: probe recovers (failTimes=2) → read succeeds and
+            // caches the positive result for any subsequent reads.
+            Path dest3 = tmpFolder.newFile("recover-out-3.bin").toPath();
+            readerDsm.downloadMultipartIndexFile(
+                    "ts", "uuid-recover", "graph", payload.length, dest3);
+            byte[] read = Files.readAllBytes(dest3);
+            assertEquals("recovered read must reconstruct the original",
+                    new String(payload), new String(read));
+
+            // Attempt 4: cache hit, no further HEAD round-trip.
+            int headsAfterRecovery = headAttempts.get();
+            Path dest4 = tmpFolder.newFile("recover-out-4.bin").toPath();
+            readerDsm.downloadMultipartIndexFile(
+                    "ts", "uuid-recover", "graph", payload.length, dest4);
+            assertEquals("subsequent read after recovery must hit the probe cache",
+                    headsAfterRecovery, headAttempts.get());
+        } finally {
+            flakyStorage.close();
+        }
+    }
+
+    // ====================================================================
+    // Failure-injection ObjectStorage wrappers.
+    // ====================================================================
+
+    /**
+     * Delegating storage that intercepts {@code existsObject} (the HEAD
+     * probe) and ALWAYS returns an exceptionally-completed future via
+     * the supplied factory. Other methods pass through to the wrapped
+     * storage so legitimate uploads/downloads can be staged before the
+     * failure injection takes effect.
+     */
+    private static final class AlwaysFailingHeadStorage implements ObjectStorage {
+
+        private final ObjectStorage delegate;
+        private final java.util.function.Supplier<IOException> errorFactory;
+        private final AtomicInteger headAttempts;
+
+        AlwaysFailingHeadStorage(ObjectStorage delegate,
+                                 java.util.function.Supplier<IOException> errorFactory,
+                                 AtomicInteger headAttempts) {
+            this.delegate = delegate;
+            this.errorFactory = errorFactory;
+            this.headAttempts = headAttempts;
+        }
+
+        @Override
+        public CompletableFuture<Boolean> existsObject(String path) {
+            headAttempts.incrementAndGet();
+            CompletableFuture<Boolean> failed = new CompletableFuture<>();
+            failed.completeExceptionally(errorFactory.get());
+            return failed;
+        }
+
+        @Override
+        public CompletableFuture<Void> write(String path, byte[] content) {
+            return delegate.write(path, content);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> read(String path) {
+            return delegate.read(path);
+        }
+
+        @Override
+        public CompletableFuture<Void> writeBlock(String path, long blockIndex, byte[] content) {
+            return delegate.writeBlock(path, blockIndex, content);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> readRange(String path, long offset, int length, int blockSize) {
+            return delegate.readRange(path, offset, length, blockSize);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> deleteLogical(String path) {
+            return delegate.deleteLogical(path);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> listLogical(String prefix) {
+            return delegate.listLogical(prefix);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> delete(String path) {
+            return delegate.delete(path);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> list(String prefix) {
+            return delegate.list(prefix);
+        }
+
+        @Override
+        public CompletableFuture<Integer> deleteByPrefix(String prefix) {
+            return delegate.deleteByPrefix(prefix);
+        }
+
+        @Override
+        public CompletableFuture<Long> uploadFile(String path, Path source,
+                                                  java.util.function.LongConsumer progress) {
+            return delegate.uploadFile(path, source, progress);
+        }
+
+        @Override
+        public CompletableFuture<Void> downloadFileBulk(String path, Path dest) {
+            return delegate.downloadFileBulk(path, dest);
+        }
+
+        @Override
+        public CompletableFuture<Void> downloadToFile(String path, Path dest, boolean append) {
+            return delegate.downloadToFile(path, dest, append);
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+    }
+
+    /**
+     * Delegating storage that fails {@code existsObject} for the first
+     * {@code failTimes} invocations, then succeeds (delegates to the
+     * wrapped storage). Used to verify recovery after a transient HEAD
+     * outage clears.
+     */
+    private static final class TransientFailingHeadStorage implements ObjectStorage {
+
+        private final ObjectStorage delegate;
+        private final int failTimes;
+        private final java.util.function.Supplier<IOException> errorFactory;
+        private final AtomicInteger headAttempts;
+
+        TransientFailingHeadStorage(ObjectStorage delegate,
+                                     int failTimes,
+                                     java.util.function.Supplier<IOException> errorFactory,
+                                     AtomicInteger headAttempts) {
+            this.delegate = delegate;
+            this.failTimes = failTimes;
+            this.errorFactory = errorFactory;
+            this.headAttempts = headAttempts;
+        }
+
+        @Override
+        public CompletableFuture<Boolean> existsObject(String path) {
+            int attempt = headAttempts.incrementAndGet();
+            if (attempt <= failTimes) {
+                CompletableFuture<Boolean> failed = new CompletableFuture<>();
+                failed.completeExceptionally(errorFactory.get());
+                return failed;
+            }
+            return delegate.existsObject(path);
+        }
+
+        @Override
+        public CompletableFuture<Void> write(String path, byte[] content) {
+            return delegate.write(path, content);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> read(String path) {
+            return delegate.read(path);
+        }
+
+        @Override
+        public CompletableFuture<Void> writeBlock(String path, long blockIndex, byte[] content) {
+            return delegate.writeBlock(path, blockIndex, content);
+        }
+
+        @Override
+        public CompletableFuture<ReadResult> readRange(String path, long offset, int length, int blockSize) {
+            return delegate.readRange(path, offset, length, blockSize);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> deleteLogical(String path) {
+            return delegate.deleteLogical(path);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> listLogical(String prefix) {
+            return delegate.listLogical(prefix);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> delete(String path) {
+            return delegate.delete(path);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> list(String prefix) {
+            return delegate.list(prefix);
+        }
+
+        @Override
+        public CompletableFuture<Integer> deleteByPrefix(String prefix) {
+            return delegate.deleteByPrefix(prefix);
+        }
+
+        @Override
+        public CompletableFuture<Long> uploadFile(String path, Path source,
+                                                  java.util.function.LongConsumer progress) {
+            return delegate.uploadFile(path, source, progress);
+        }
+
+        @Override
+        public CompletableFuture<Void> downloadFileBulk(String path, Path dest) {
+            return delegate.downloadFileBulk(path, dest);
+        }
+
+        @Override
+        public CompletableFuture<Void> downloadToFile(String path, Path dest, boolean append) {
+            return delegate.downloadToFile(path, dest, append);
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static byte[] readByteBuf(ByteBuf buf) {
+        byte[] out = new byte[buf.readableBytes()];
+        buf.readBytes(out);
+        return out;
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerDirectUploadRestartTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/RemoteFileDataStorageManagerDirectUploadRestartTest.java
@@ -1,0 +1,435 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import herddb.remote.storage.LocalObjectStorage;
+import io.github.jbellis.jvector.disk.RandomAccessReader;
+import io.github.jbellis.jvector.disk.ReaderSupplier;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #645: end-to-end restart coverage for the direct-S3 upload path.
+ *
+ * <p>The bench failure that motivated this test (Run 9 BIGANN 200M) showed
+ * the indexing service crash-looping on restart after running with
+ * {@code indexing.s3.direct.write.enabled=true}: segments uploaded via the
+ * direct-S3 path were unreadable after a JVM restart and the load path
+ * silently fell back to the gRPC file-server which had no record of those
+ * blocks. These tests pin the invariants that prevent that regression:
+ *
+ * <ol>
+ *   <li>Files uploaded via {@code writeMultipartIndexFile} on DSM A must be
+ *       readable via {@code multipartIndexReaderSupplier} and
+ *       {@code downloadMultipartIndexFile} on a freshly-constructed DSM B
+ *       against the same backing object storage, without any in-memory
+ *       state carried over.</li>
+ *   <li>The probe cache must not be required — DSM B starts empty and
+ *       discovers the bulk layout strictly via {@code existsObject} HEAD
+ *       probes. After a successful probe the cache fills as expected.</li>
+ *   <li>Many segments (graph + map files for each, mirroring the FusedPQ
+ *       compaction shape) must all be readable after a single restart.</li>
+ *   <li>A mixed layout (some files written via direct-S3, some legacy
+ *       per-block) must round-trip correctly through a restart — the bulk
+ *       probe must say {@code true} for the direct-S3 ones and {@code
+ *       false} for the legacy ones, routing each read through the right
+ *       code path.</li>
+ * </ol>
+ *
+ * <p>The test uses {@link LocalObjectStorage} as the direct-S3 stand-in:
+ * it durably persists objects to a local directory so the simulated
+ * restart (close DSM A, allocate DSM B against the same directory)
+ * faithfully reproduces the IS-restart-against-MinIO failure mode.
+ */
+public class RemoteFileDataStorageManagerDirectUploadRestartTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private ExecutorService metadataExecutor;
+    private Path objectStorageDir;
+    private LocalObjectStorage objectStorageA;
+    private RemoteFileServiceClient stubClient;
+    private RemoteFileDataStorageManager dsmA;
+
+    @Before
+    public void setUp() throws IOException {
+        metadataExecutor = Executors.newSingleThreadExecutor();
+        objectStorageDir = tmpFolder.newFolder("object-storage").toPath();
+        objectStorageA = new LocalObjectStorage(objectStorageDir, metadataExecutor);
+        // gRPC stub client with fast-fail config — any accidental fallback
+        // to the file-server path must surface immediately (1 s timeout,
+        // 0 retries) instead of blocking the test for minutes.
+        Map<String, Object> fastFailConfig = new HashMap<>();
+        fastFailConfig.put(RemoteFileServiceClient.CONFIG_CLIENT_TIMEOUT, 1L);
+        fastFailConfig.put(RemoteFileServiceClient.CONFIG_CLIENT_RETRIES, 0);
+        stubClient = new RemoteFileServiceClient(Collections.emptyList(), fastFailConfig);
+        Path metaDir = tmpFolder.newFolder("meta-a").toPath();
+        Path tmpDirA = tmpFolder.newFolder("tmp-a").toPath();
+        dsmA = new RemoteFileDataStorageManager(metaDir, tmpDirA, Integer.MAX_VALUE, stubClient);
+        dsmA.setDirectObjectStorage(objectStorageA);
+        dsmA.enableDirectUpload(16L * 1024 * 1024);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (dsmA != null) {
+            dsmA.close();
+        }
+        if (objectStorageA != null) {
+            objectStorageA.close();
+        }
+        if (stubClient != null) {
+            stubClient.close();
+        }
+        if (metadataExecutor != null) {
+            metadataExecutor.shutdown();
+        }
+    }
+
+    /**
+     * Helper: writes {@code content} to a temp file and returns its path so
+     * the test can hand it to {@code writeMultipartIndexFile}.
+     */
+    private Path writeTempFile(String name, byte[] content) throws IOException {
+        Path f = tmpFolder.newFile(name).toPath();
+        Files.write(f, content);
+        return f;
+    }
+
+    private static byte[] randomBytes(int size, long seed) {
+        Random rng = new Random(seed);
+        byte[] data = new byte[size];
+        rng.nextBytes(data);
+        return data;
+    }
+
+    /**
+     * Allocates a fresh DSM bound to the same backing object storage as
+     * DSM A — the simulated restart. The new DSM has its own metaDir and
+     * tmpDir (mirroring real IS behaviour: ephemeral local state) and
+     * starts with empty {@code bulkLayoutCache} and {@code bulkLocalCache}
+     * maps, so every bulk-layout discovery on it must go through the
+     * authoritative HEAD probe against the shared storage.
+     */
+    private RemoteFileDataStorageManager spawnRestartDsm() throws IOException {
+        // Reuse the SAME on-disk directory as objectStorageA. A new
+        // LocalObjectStorage instance is the on-disk equivalent of a
+        // fresh S3 client connecting to the same bucket.
+        LocalObjectStorage objectStorageB = new LocalObjectStorage(
+                objectStorageDir, metadataExecutor);
+        Path metaDir = tmpFolder.newFolder("meta-b-" + System.nanoTime()).toPath();
+        Path tmpDir = tmpFolder.newFolder("tmp-b-" + System.nanoTime()).toPath();
+        RemoteFileDataStorageManager dsmB = new RemoteFileDataStorageManager(
+                metaDir, tmpDir, Integer.MAX_VALUE, stubClient);
+        dsmB.setDirectObjectStorage(objectStorageB);
+        dsmB.enableDirectUpload(16L * 1024 * 1024);
+        return dsmB;
+    }
+
+    /**
+     * Issue #645 — primary regression test.
+     *
+     * <p>A multipart file uploaded via the direct-S3 path on DSM A must be
+     * readable end-to-end on a freshly-allocated DSM B against the same
+     * backing storage. This mirrors the IS restart: the in-memory
+     * {@code bulkLayoutCache} on DSM A is gone, the probe on DSM B fires a
+     * HEAD against the shared storage, finds the {@code .bulk} object,
+     * caches the positive result, and materialises the local cache file
+     * for the memory-mapped reader.
+     */
+    @Test
+    public void directUploadedFileIsReadableAfterRestart() throws Exception {
+        byte[] payload = randomBytes(64 * 1024 + 17, 11L);
+        Path src = writeTempFile("graph-a.bin", payload);
+        dsmA.writeMultipartIndexFile("ts", "uuid-restart-1", "graph", src, null);
+        assertTrue("file must be visible on the writer DSM",
+                dsmA.multipartIndexFileExists("ts", "uuid-restart-1", "graph"));
+
+        // Close DSM A — clears in-memory bulkLayoutCache and bulkLocalCache.
+        dsmA.close();
+        dsmA = null;
+
+        RemoteFileDataStorageManager dsmB = spawnRestartDsm();
+        try {
+            // multipartIndexFileExists must say "true" via the HEAD probe
+            // (the cache is empty on DSM B). This is the lenient-probe
+            // entry point.
+            assertTrue("bulk file must be discoverable on a fresh DSM via HEAD probe",
+                    dsmB.multipartIndexFileExists("ts", "uuid-restart-1", "graph"));
+
+            // downloadMultipartIndexFile must take the bulk branch and
+            // reconstruct the bytes identically.
+            Path dest = tmpFolder.newFile("graph-a-out.bin").toPath();
+            dsmB.downloadMultipartIndexFile(
+                    "ts", "uuid-restart-1", "graph", payload.length, dest);
+            assertArrayEquals("download must reconstruct original bytes",
+                    payload, Files.readAllBytes(dest));
+
+            // multipartIndexReaderSupplier must return a MappedChunkReader
+            // (the bulk-layout reader supplier), NOT a RemoteRandomAccessReader
+            // backed by the gRPC client.
+            ReaderSupplier supplier = dsmB.multipartIndexReaderSupplier(
+                    "ts", "uuid-restart-1", "graph", payload.length);
+            assertNotNull(supplier);
+            String className = supplier.getClass().getName();
+            assertTrue("supplier must be MappedChunkReader-backed, was "
+                            + className,
+                    className.contains("MappedChunkReader"));
+
+            // The reader must serve the file: read a 4-byte window from
+            // offset 0 and compare against the original payload.
+            try (RandomAccessReader reader = supplier.get()) {
+                reader.seek(0L);
+                byte[] head = new byte[4];
+                reader.readFully(head);
+                byte[] expected = new byte[4];
+                System.arraycopy(payload, 0, expected, 0, 4);
+                assertArrayEquals("first 4 bytes read via supplier must match",
+                        expected, head);
+            }
+        } finally {
+            dsmB.close();
+        }
+    }
+
+    /**
+     * Issue #645: many segments (mirroring the FusedPQ shape: graph + map
+     * per segment) uploaded across the writer's lifetime must ALL be
+     * readable after a single restart. This is the closest unit-level
+     * approximation of the bench failure (Run 9: ~36 segments missing on
+     * restart).
+     */
+    @Test
+    public void manySegmentsAreReadableAfterRestart() throws Exception {
+        // Use a modest count — the loop is O(segments) and each iteration
+        // does a real local I/O round-trip via LocalObjectStorage. 12
+        // segments × 2 files each = 24 multipart objects, enough to expose
+        // any per-file state leakage without slowing the build.
+        final int segments = 12;
+        List<byte[]> graphPayloads = new ArrayList<>(segments);
+        List<byte[]> mapPayloads = new ArrayList<>(segments);
+        for (int i = 0; i < segments; i++) {
+            byte[] graphPayload = randomBytes(8 * 1024 + i, 100L + i);
+            byte[] mapPayload = randomBytes(4 * 1024 + i, 200L + i);
+            graphPayloads.add(graphPayload);
+            mapPayloads.add(mapPayload);
+            Path graphTemp = writeTempFile("graph-" + i + ".bin", graphPayload);
+            Path mapTemp = writeTempFile("map-" + i + ".bin", mapPayload);
+            dsmA.writeMultipartIndexFile("ts", "uuid-seg" + i, "graph", graphTemp, null);
+            dsmA.writeMultipartIndexFile("ts", "uuid-seg" + i, "map", mapTemp, null);
+        }
+
+        // Close DSM A — wipes in-memory caches.
+        dsmA.close();
+        dsmA = null;
+
+        RemoteFileDataStorageManager dsmB = spawnRestartDsm();
+        try {
+            for (int i = 0; i < segments; i++) {
+                Path graphOut = tmpFolder.newFile("graph-" + i + "-out.bin").toPath();
+                Path mapOut = tmpFolder.newFile("map-" + i + "-out.bin").toPath();
+                dsmB.downloadMultipartIndexFile(
+                        "ts", "uuid-seg" + i, "graph",
+                        graphPayloads.get(i).length, graphOut);
+                dsmB.downloadMultipartIndexFile(
+                        "ts", "uuid-seg" + i, "map",
+                        mapPayloads.get(i).length, mapOut);
+                assertArrayEquals("graph segment " + i + " must round-trip",
+                        graphPayloads.get(i), Files.readAllBytes(graphOut));
+                assertArrayEquals("map segment " + i + " must round-trip",
+                        mapPayloads.get(i), Files.readAllBytes(mapOut));
+            }
+        } finally {
+            dsmB.close();
+        }
+    }
+
+    /**
+     * Issue #645: an installation that has a mix of legacy per-block
+     * files (written before direct-S3 was enabled) and direct-S3 bulk
+     * files (written after) must route reads correctly after restart.
+     * The bulk probe must answer {@code true} for the direct files and
+     * {@code false} for the legacy ones; the read paths must follow.
+     *
+     * <p>The legacy file is materialised by writing per-block content
+     * directly into the {@link LocalObjectStorage} (mirroring what the
+     * old gRPC write path would have produced); the bulk file is written
+     * via the normal direct-upload API on DSM A.
+     */
+    @Test
+    public void mixedLegacyAndBulkFilesSurviveRestart() throws Exception {
+        // Direct-S3 bulk file via DSM A's normal direct-upload path.
+        byte[] bulkPayload = randomBytes(2048, 7L);
+        Path bulkSrc = writeTempFile("mixed-bulk.bin", bulkPayload);
+        dsmA.writeMultipartIndexFile("ts", "uuid-bulk", "graph", bulkSrc, null);
+
+        // Legacy per-block file: write the blocks directly via the backing
+        // object storage so DSM A's bulk-write path is never invoked for
+        // this logical path. Reuse the storage instance bound to DSM A so
+        // the blocks live in the same directory.
+        byte[] legacyPayload = randomBytes(1024, 9L);
+        String legacyLogical = "ts/uuid-legacy/multipart/graph";
+        objectStorageA.writeBlock(legacyLogical, 0L, legacyPayload).get();
+
+        // Pre-condition: legacy .bulk variant must NOT exist (so the probe
+        // will route to gRPC). For this test we cannot exercise the gRPC
+        // path (no real file server is running) — but we can assert the
+        // probe answers {@code false} correctly, which is the only thing
+        // the routing decision depends on.
+        assertFalse("legacy .bulk object must be absent before restart",
+                objectStorageA.existsObject(legacyLogical + ".bulk").get());
+
+        dsmA.close();
+        dsmA = null;
+
+        RemoteFileDataStorageManager dsmB = spawnRestartDsm();
+        try {
+            // Bulk file: probe must say true and download must succeed.
+            Path bulkOut = tmpFolder.newFile("mixed-bulk-out.bin").toPath();
+            dsmB.downloadMultipartIndexFile("ts", "uuid-bulk", "graph",
+                    bulkPayload.length, bulkOut);
+            assertArrayEquals("bulk file must round-trip",
+                    bulkPayload, Files.readAllBytes(bulkOut));
+
+            // Legacy file: the bulk probe must answer false on the fresh
+            // DSM. We invoke multipartIndexFileExists which is the
+            // lenient-probe entry point — the bulk check returns false,
+            // then the gRPC presence check runs (fast-failing on the
+            // empty stub) and also returns false. The key behaviour we
+            // pin: the bulk probe must NOT incorrectly say true for a
+            // file that only has the legacy layout.
+            boolean legacyVisible = dsmB.multipartIndexFileExists(
+                    "ts", "uuid-legacy", "graph");
+            assertFalse("legacy file must not be reachable as bulk on the fresh DSM"
+                            + " (no gRPC server in this unit test)",
+                    legacyVisible);
+        } finally {
+            dsmB.close();
+        }
+    }
+
+    /**
+     * Issue #645: a cold-start restart that immediately reads many files
+     * must issue exactly one HEAD probe per logical path (i.e. probe
+     * caching works on the restarted DSM too — once a positive answer
+     * has been observed, subsequent reads of the same logical path
+     * reuse the cached answer).
+     *
+     * <p>This guards against an O(reads × HEAD) regression that would
+     * blow up the cold-start probe cost on the first few minutes after
+     * restart.
+     */
+    @Test
+    public void coldStartProbeIsCachedAcrossReads() throws Exception {
+        byte[] payload = randomBytes(1024, 13L);
+        Path src = writeTempFile("cached.bin", payload);
+        dsmA.writeMultipartIndexFile("ts", "uuid-cached", "graph", src, null);
+        dsmA.close();
+        dsmA = null;
+
+        // Wrap LocalObjectStorage with a counter so we can assert the
+        // exact number of HEAD probes issued by DSM B.
+        ProbeCountingLocalObjectStorage countingStorage =
+                new ProbeCountingLocalObjectStorage(objectStorageDir, metadataExecutor);
+        Path metaDir = tmpFolder.newFolder("meta-counting").toPath();
+        Path tmpDir = tmpFolder.newFolder("tmp-counting").toPath();
+        RemoteFileDataStorageManager dsmB = new RemoteFileDataStorageManager(
+                metaDir, tmpDir, Integer.MAX_VALUE, stubClient);
+        dsmB.setDirectObjectStorage(countingStorage);
+        dsmB.enableDirectUpload(16L * 1024 * 1024);
+        try {
+            assertEquals("no probes before any read", 0, countingStorage.headCount());
+
+            // First read: 1 HEAD probe.
+            Path out1 = tmpFolder.newFile("cached-out1.bin").toPath();
+            dsmB.downloadMultipartIndexFile(
+                    "ts", "uuid-cached", "graph", payload.length, out1);
+            assertEquals("first read issues exactly one HEAD",
+                    1, countingStorage.headCount());
+
+            // Second + third reads: must hit the cache, no new HEADs.
+            Path out2 = tmpFolder.newFile("cached-out2.bin").toPath();
+            dsmB.downloadMultipartIndexFile(
+                    "ts", "uuid-cached", "graph", payload.length, out2);
+            Path out3 = tmpFolder.newFile("cached-out3.bin").toPath();
+            dsmB.downloadMultipartIndexFile(
+                    "ts", "uuid-cached", "graph", payload.length, out3);
+            assertEquals("second and third reads must be probe-cache hits",
+                    1, countingStorage.headCount());
+
+            // multipartIndexFileExists on the same logical path must also
+            // be a cache hit.
+            assertTrue(dsmB.multipartIndexFileExists("ts", "uuid-cached", "graph"));
+            assertEquals("multipartIndexFileExists must be a cache hit",
+                    1, countingStorage.headCount());
+        } finally {
+            dsmB.close();
+        }
+    }
+
+    /**
+     * {@link LocalObjectStorage} subclass that counts every
+     * {@code existsObject} (HEAD) probe so the cold-start cache test can
+     * assert the exact number of round-trips.
+     */
+    private static final class ProbeCountingLocalObjectStorage extends LocalObjectStorage {
+
+        private final java.util.concurrent.atomic.AtomicInteger headProbes =
+                new java.util.concurrent.atomic.AtomicInteger();
+
+        ProbeCountingLocalObjectStorage(Path baseDir, ExecutorService executor)
+                throws IOException {
+            super(baseDir, executor);
+        }
+
+        @Override
+        public java.util.concurrent.CompletableFuture<Boolean> existsObject(String path) {
+            headProbes.incrementAndGet();
+            // Delegate to the default contract from ObjectStorage which uses
+            // read() and now obeys the tri-state contract (issue #645).
+            return super.existsObject(path);
+        }
+
+        int headCount() {
+            return headProbes.get();
+        }
+    }
+}

--- a/herddb-remote-file-service/src/test/java/herddb/remote/storage/S3ObjectStorageExistsObjectErrorTest.java
+++ b/herddb-remote-file-service/src/test/java/herddb/remote/storage/S3ObjectStorageExistsObjectErrorTest.java
@@ -1,0 +1,265 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.remote.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.lang.reflect.Proxy;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+/**
+ * Issue #645: unit tests for {@link S3ObjectStorage#existsObject(String)}.
+ *
+ * <p>The existence probe is the decision-point that routes a multipart
+ * file read either through the bulk-layout fast path (memory-mapped local
+ * cache file) or through the legacy gRPC per-block path. Before issue
+ * #645, every exception thrown by {@code S3AsyncClient.headObject} was
+ * collapsed into a {@code false} answer — which silently misrouted reads
+ * of direct-S3-uploaded objects through the gRPC file-server on restart
+ * and produced the {@code Block not found} crash-loop in Run 9.
+ *
+ * <p>The new tri-state contract (see {@link ObjectStorage#existsObject}):
+ *
+ * <ul>
+ *   <li>HEAD 200 → {@code true};</li>
+ *   <li>{@link NoSuchKeyException} or generic {@link AwsServiceException}
+ *       with HTTP status 404 → {@code false} (definitively absent);</li>
+ *   <li>anything else (5xx, 403, throttling,
+ *       {@link SdkClientException}, generic runtime errors,
+ *       miscellaneous I/O errors) → completes exceptionally.</li>
+ * </ul>
+ *
+ * <p>The tests use a reflective {@link Proxy} that intercepts
+ * {@code headObject} and returns a configured future, mirroring the
+ * pattern established by
+ * {@code S3ObjectStorageDownloadToFileTest#proxyClient}. No real S3
+ * client is required.
+ */
+public class S3ObjectStorageExistsObjectErrorTest {
+
+    /**
+     * HEAD 200 must map to {@code true}.
+     */
+    @Test
+    public void presentObjectReturnsTrue() throws Exception {
+        S3AsyncClient client = headObjectProxy(
+                () -> CompletableFuture.completedFuture(
+                        HeadObjectResponse.builder().contentLength(0L).build()));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        Boolean result = storage.existsObject("segment/graph.bulk").get();
+        assertEquals(Boolean.TRUE, result);
+    }
+
+    /**
+     * {@link NoSuchKeyException} — the canonical "object missing" surface
+     * from the AWS SDK — must map to {@code false} (definitively absent).
+     */
+    @Test
+    public void missingObjectViaNoSuchKeyReturnsFalse() throws Exception {
+        NoSuchKeyException notFound = (NoSuchKeyException)
+                NoSuchKeyException.builder().message("absent").build();
+        S3AsyncClient client = headObjectProxy(
+                () -> failedFuture(notFound));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        Boolean result = storage.existsObject("segment/graph.bulk").get();
+        assertEquals(Boolean.FALSE, result);
+    }
+
+    /**
+     * Some S3-compatible backends (CRT, MinIO under some configurations)
+     * surface "not found" as a generic {@link AwsServiceException} with
+     * HTTP status 404 rather than a typed {@link NoSuchKeyException}.
+     * That branch must also map to {@code false}.
+     */
+    @Test
+    public void missingObjectViaGenericServiceException404ReturnsFalse() throws Exception {
+        AwsServiceException ex = AwsServiceException.builder()
+                .message("404 from MinIO")
+                .statusCode(404)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("404")
+                        .errorMessage("Not Found")
+                        .serviceName("S3")
+                        .build())
+                .build();
+        S3AsyncClient client = headObjectProxy(() -> failedFuture(ex));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        Boolean result = storage.existsObject("segment/graph.bulk").get();
+        assertEquals(Boolean.FALSE, result);
+    }
+
+    /**
+     * Issue #645 — regression test for the failure mode that produced
+     * the bench crash-loop: a generic HTTP 5xx
+     * ({@link AwsServiceException} with status != 404) must propagate as
+     * an exceptional future completion. Before the fix this branch
+     * returned {@code false} and silently misrouted the read through
+     * gRPC.
+     */
+    @Test
+    public void serverError503PropagatesAsException() throws Exception {
+        AwsServiceException ex = AwsServiceException.builder()
+                .message("503 Service Unavailable")
+                .statusCode(503)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("ServiceUnavailable")
+                        .errorMessage("Service Unavailable")
+                        .serviceName("S3")
+                        .build())
+                .build();
+        S3AsyncClient client = headObjectProxy(() -> failedFuture(ex));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        try {
+            storage.existsObject("segment/graph.bulk").get();
+            fail("503 must propagate as exceptional completion");
+        } catch (ExecutionException expected) {
+            Throwable cause = expected.getCause();
+            assertTrue("cause must mention 503 / ServiceUnavailable; got: " + cause,
+                    cause.getMessage() != null
+                            && (cause.getMessage().contains("503")
+                                    || cause.getMessage().contains("Service Unavailable")));
+        }
+    }
+
+    /**
+     * HTTP 403 (Forbidden) is NOT a "missing object" answer — propagating
+     * loudly lets the operator see and fix the permission problem
+     * instead of silently degrading to the wrong read path.
+     */
+    @Test
+    public void forbidden403PropagatesAsException() throws Exception {
+        AwsServiceException ex = AwsServiceException.builder()
+                .message("403 Forbidden")
+                .statusCode(403)
+                .build();
+        S3AsyncClient client = headObjectProxy(() -> failedFuture(ex));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        try {
+            storage.existsObject("segment/graph.bulk").get();
+            fail("403 must propagate as exceptional completion");
+        } catch (ExecutionException expected) {
+            // expected
+        }
+    }
+
+    /**
+     * A network-level failure (DNS, connect timeout, socket close) is
+     * surfaced as {@link SdkClientException} — a transient condition
+     * that MUST propagate. This is the most common shape of the
+     * "MinIO blip" that crash-looped the IS in Run 9.
+     */
+    @Test
+    public void sdkClientExceptionPropagatesAsException() throws Exception {
+        SdkClientException ex = SdkClientException.builder()
+                .message("Unable to execute HTTP request: connect timed out")
+                .cause(new SocketTimeoutException("connect timed out"))
+                .build();
+        S3AsyncClient client = headObjectProxy(() -> failedFuture(ex));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        try {
+            storage.existsObject("segment/graph.bulk").get();
+            fail("SdkClientException must propagate as exceptional completion");
+        } catch (ExecutionException expected) {
+            Throwable cause = expected.getCause();
+            assertTrue("cause must mention the network failure; got: " + cause,
+                    cause.getMessage() != null
+                            && cause.getMessage().contains("connect timed out"));
+        }
+    }
+
+    /**
+     * Any other {@link RuntimeException} thrown by the SDK or by
+     * unrelated downstream code (e.g. an interceptor) must also propagate
+     * — never silently collapse to {@code false}.
+     */
+    @Test
+    public void genericRuntimeExceptionPropagates() throws Exception {
+        RuntimeException ex = new IllegalStateException(
+                "unexpected interceptor failure");
+        S3AsyncClient client = headObjectProxy(() -> failedFuture(ex));
+        S3ObjectStorage storage = new S3ObjectStorage(client, "bucket", "prefix/");
+
+        try {
+            storage.existsObject("segment/graph.bulk").get();
+            fail("RuntimeException must propagate as exceptional completion");
+        } catch (ExecutionException expected) {
+            Throwable cause = expected.getCause();
+            assertTrue("cause must be the original IllegalStateException; got: " + cause,
+                    cause instanceof IllegalStateException);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers — mirror the proxy pattern used by
+    // S3ObjectStorageDownloadToFileTest.
+    // ------------------------------------------------------------------
+
+    private static <T> CompletableFuture<T> failedFuture(Throwable t) {
+        CompletableFuture<T> f = new CompletableFuture<>();
+        f.completeExceptionally(t);
+        return f;
+    }
+
+    /**
+     * Returns a reflective {@link S3AsyncClient} proxy whose
+     * {@code headObject} method returns whatever future the supplied
+     * factory produces. Any other invocation (apart from {@code close})
+     * triggers {@link UnsupportedOperationException} so unexpected SDK
+     * calls fail loudly.
+     */
+    @SuppressWarnings("unchecked")
+    private static S3AsyncClient headObjectProxy(
+            Supplier<CompletableFuture<HeadObjectResponse>> responseFactory) {
+        return (S3AsyncClient) Proxy.newProxyInstance(
+                S3AsyncClient.class.getClassLoader(),
+                new Class<?>[]{S3AsyncClient.class},
+                (proxy, method, args) -> {
+                    if ("headObject".equals(method.getName()) && args != null
+                            && args.length == 1
+                            && args[0] instanceof HeadObjectRequest) {
+                        return responseFactory.get();
+                    }
+                    if ("close".equals(method.getName())) {
+                        return null;
+                    }
+                    throw new UnsupportedOperationException(
+                            "fake S3 client does not implement " + method.getName());
+                });
+    }
+}


### PR DESCRIPTION
Fixes #645.

## Root cause

When `indexing.s3.direct.write.enabled=true`, the IS crashed on restart
with confusing `Block not found` errors for segments that had been
uploaded via the direct-S3 path. The bench failure (Run 9 BIGANN 200M)
hit this at compaction cycle 5, batch ~29 670/30 414, and crash-looped
on every subsequent restart.

The bulk-layout HEAD probe (`existsObject`) collapsed **every** exception
into a `false` answer — including transient network errors, HTTP 5xx,
and SDK errors. A `false` answer silently routed the read through the
gRPC file-server (`RemoteRandomAccessReader`), which has no record of
direct-S3-uploaded blocks, so the load aborted with `Block not found`.

Per the issue clarification, it is intentional that direct-write does
**not** populate the file server (data lives in S3/MinIO). The bug was
the silent fallback to gRPC when the probe was unreliable.

## Changes

**Production** (3 files):
- `ObjectStorage.existsObject` (default impl): tightened to a tri-state
  contract — `true` (present), `false` (definitively absent: `NOT_FOUND`),
  or completes exceptionally (transient / unknown). Javadoc rewritten.
- `S3ObjectStorage.existsObject`: only `NoSuchKeyException` and
  `AwsServiceException` with HTTP status 404 collapse to `false`.
  Everything else (5xx, 403, `SdkClientException`, generic
  `RuntimeException`) propagates as an exceptional completion.
- `RemoteFileDataStorageManager`: keeps the lenient `isBulkLayout`
  for `multipartIndexFileExists` (boolean contract preserved) and adds
  `isBulkLayoutOrThrow` for the read paths
  (`multipartIndexReaderSupplier`, `downloadMultipartIndexFile`), which
  surfaces probe failures as `IOException` instead of silently falling
  through to gRPC. Error message is explicit about why the fallback was
  refused.

**Tests** (3 new classes, 15 new test cases):
- `RemoteFileDataStorageManagerDirectUploadRestartTest` — end-to-end
  restart coverage: writes multipart files via DSM A, closes, allocates a
  fresh DSM B against the same backing storage, verifies that
  `multipartIndexReaderSupplier` and `downloadMultipartIndexFile` both
  work without the in-memory caches. Cases: single file, many segments
  (graph + map mirroring FusedPQ shape), mixed legacy + bulk, cold-start
  probe caching.
- `RemoteFileDataStorageManagerDirectUploadProbeFailureTest` — failure
  injection via a wrapping `ObjectStorage`: simulates MinIO returning
  errors on HEAD, asserts that the read paths throw a clean `IOException`
  (no `Block not found`), the lenient exists-check stays false-without-
  throwing, and reads succeed once the probe recovers.
- `S3ObjectStorageExistsObjectErrorTest` — unit-level: HEAD 200 → true;
  `NoSuchKeyException` and HTTP 404 → false; HTTP 503, 403,
  `SdkClientException`, generic `RuntimeException` → exceptional
  completion. Uses the established reflective-`Proxy` pattern from
  `S3ObjectStorageDownloadToFileTest`.

## Tests run

- New tests: 15/15 pass.
- All existing direct-upload / legacy-fallback / S3-storage tests in the
  module (64 cases across `RemoteFileDataStorageManagerDirectUploadTest`,
  `RemoteFileDataStorageManagerLegacyFallbackTest`,
  `RemoteFileDataStorageManagerDirectDownloadTest`,
  `RemoteFileDataStorageManagerDirectUploadBackpressureTest`,
  `RemoteFileDataStorageManagerBasicTest`,
  `RemoteFileDataStorageManagerProbeAndPurgeTest`,
  `RemoteFileDataStorageManagerRangeReadTest`,
  `S3ObjectStorageDownloadToFileTest`, `S3ObjectStorageTest`) still pass.
- Pre-PR validation (`spotless:check apache-rat:check spotbugs:check
  install -DskipTests -Pci`) green across all 22 modules.

🤖 Implemented by the `pr-worker` agent.