### PR TITLE
issue #646: configurable early-checkpoint memory-pressure threshold + observability

### DIFF
--- a/VECTOR.md
+++ b/VECTOR.md
@@ -176,6 +176,7 @@ The `IndexingServerConfiguration` class provides typed access to all IndexingSer
 | Log dir | `indexing.log.dir` | `txlog` | WAL directory to tail |
 | Data dir | `indexing.data.dir` | `data` | Data directory for persistence |
 | Max vector memory | `indexing.memory.vector.limit` | `0` | Max memory for vector data. 0 = unbounded. |
+| Early-checkpoint fraction | `indexing.memory.vector.early.checkpoint.fraction` | `0.90` | Fraction of the `VectorMemoryBudget` above which `PersistentVectorStore.shouldTriggerMemoryPressureCheckpoint()` returns true, forcing an early checkpoint and bypassing the `minLiveVectorsForCheckpoint` deferral gate. Range `(0.0, 1.0]`. Lower this to flush earlier (smaller segments, more checkpoint cycles); raise it to keep the gate active longer and run Phase B closer to the hard 100% back-pressure limit. The hard back-pressure path that blocks `addVector` when the budget is fully consumed is unaffected by this knob — it is always armed at the `maxMemoryBytes` ceiling. |
 | Page size | `indexing.memory.page.size` | `1048576` | Logical page size for MemoryManager (1 MB). |
 | Vector M | `indexing.vector.m` | `16` | Default M for new vector stores |
 | Vector beam width | `indexing.vector.beamWidth` | `100` | Default beam width |
@@ -376,7 +377,8 @@ The `memoryMultiplier` (default `5.0`, configurable via `herddb.vector.memoryMul
 
 - `totalEstimatedMemoryUsageBytes()` — sum of all stores' estimates.
 - `maxMemoryBytes()` — the configured global cap (`indexing.memory.vector.limit`; 0 means unbounded, effectively `Long.MAX_VALUE`).
-- `isAboveThreshold(double fraction)` — returns true if total usage exceeds `fraction * maxMemoryBytes`. Used to trigger early checkpoints at 70% utilization.
+- `isAboveThreshold(double fraction)` — returns true if total usage exceeds `fraction * maxMemoryBytes`. Used by `PersistentVectorStore.shouldTriggerMemoryPressureCheckpoint()` to trigger early checkpoints when the budget crosses the configurable `indexing.memory.vector.early.checkpoint.fraction` (default `0.90`; range `(0.0, 1.0]`). Below the fraction the `minLiveVectorsForCheckpoint` deferral gate stays active and produces larger segments; above it the gate is bypassed and the live shard is flushed regardless of size, even when small.
+- `budgetFraction()` — returns the current usage as a fraction of `maxMemoryBytes()` (`0.0` when the limit is `Long.MAX_VALUE` or `<= 0`). The result is not clamped: it can legitimately exceed `1.0` during the brief window between crossing the hard limit and the back-pressure path draining the live shards. Exposed as the `vector_memory_budget_fraction_milli` Prometheus gauge (encoded ×1000 so the double survives the Long-typed gauge channel; divide by 1000 in dashboards to recover the fraction).
 
 ### Backpressure mechanism
 
@@ -423,13 +425,21 @@ This means: **insert threads block inside `addVector` until Phase C completes**.
 - `backpressureActive` (volatile int) — currently blocked insert threads.
 - `lastCheckpointPhaseBDurationMs` — duration of last Phase B.
 - `lastCheckpointVectorsProcessed` — vectors processed in last checkpoint.
+- `totalMemoryPressureCheckpointBypassCount` (AtomicLong) — number of checkpoint cycles where the `minLiveVectorsForCheckpoint` gate would have deferred but was bypassed because the `VectorMemoryBudget` had crossed `earlyCheckpointFraction`. In-memory counter: monotonic only within a single process lifetime, resets to zero on restart, so dashboards alerting on rate-of-change (`rate(...)` / `irate(...)`) handle restarts correctly. Exposed as the per-index Prometheus gauge `tablespace_<>_table_<>_vidx_<>_memory_pressure_checkpoint_bypass_total` and as the `memory_pressure_checkpoint_bypass_count` field of `DescribeIndexResponse`.
+- `microSegmentCount` — number of currently-loaded on-disk segments whose live-node count is strictly below `vector.index.compaction.microsegment.max.nodes`. Computed on-demand by walking the `CopyOnWriteArrayList<VectorSegment>` snapshot and reading each segment's atomic `liveCount`. A rising value is the leading indicator that the segment-count back-pressure is about to fire; pair it with `memory_pressure_checkpoint_bypass_total` to diagnose whether the cause is the early-checkpoint bypass. Exposed as the per-index gauge `tablespace_<>_table_<>_vidx_<>_microsegment_count` and as the `micro_segment_count` field of `DescribeIndexResponse`.
+
+Engine-wide gauges (independent of any specific index, scoped under `vector_memory.*`):
+
+- `vector_memory_budget_max_bytes` — `VectorMemoryBudget.maxMemoryBytes()`; `0` when the budget is unbounded (`Long.MAX_VALUE`).
+- `vector_memory_budget_used_bytes` — `VectorMemoryBudget.totalEstimatedMemoryUsageBytes()` summed across every loaded `PersistentVectorStore`.
+- `vector_memory_budget_fraction_milli` — `VectorMemoryBudget.budgetFraction()` × 1000 (Long-encoded so the double survives the gauge channel; divide by 1000 in dashboards). Values `>1000` are legitimate and indicate the budget is over the hard limit while the back-pressure path drains the live shards.
 
 ### Background compaction thread
 
 `PersistentVectorStore` has its own daemon compaction thread that triggers checkpoint when:
 
 - `dirty.get() == true` — any modification since last checkpoint AND the compaction interval has elapsed.
-- `memoryBudget.isAboveThreshold(0.7)` — global memory is at 70% of configured limit.
+- `memoryBudget.isAboveThreshold(earlyCheckpointFraction)` — global memory has crossed the configured `indexing.memory.vector.early.checkpoint.fraction` (default `0.90`). The trigger logs an INFO line on every truthy reading; when it forces a checkpoint past the `minLiveVectorsForCheckpoint` gate (live shard below the gate, no dirty segments, at least one segment already on disk) the store additionally logs an INFO "gate bypassed by memory pressure" line and increments the `memory_pressure_checkpoint_bypass_total` counter — the operator-visible signal that the store is in the segment-storm regime that motivated issue #646.
 
 The thread wakes on a timer (polling at 50–100 ms) or immediately via `synchronized(compactionWakeUp) { compactionWakeUp.notifyAll() }`. The `IndexingServiceEngine` also runs a `ScheduledExecutorService` that periodically sweeps all registered stores and triggers checkpoints, providing a second level of compaction scheduling.
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServerConfiguration.java
@@ -106,6 +106,20 @@ public final class IndexingServerConfiguration {
     public static final String PROPERTY_MEMORY_VECTOR_PERCENTAGE = "indexing.memory.vector.percentage";
     public static final double PROPERTY_MEMORY_VECTOR_PERCENTAGE_DEFAULT = 0.33d;
 
+    /**
+     * Fraction of the {@code VectorMemoryBudget} above which the early-checkpoint
+     * trigger fires and the {@code minLiveVectorsForCheckpoint} deferral gate is
+     * bypassed (issue #646). Must be in {@code (0.0, 1.0]}. Default is {@code 0.90}
+     * — high enough that the gate stays active through the 70&ndash;90% range
+     * (which is where long ingest workloads spend a significant fraction of their
+     * runtime) and only fires close to the hard 100% back-pressure limit, which
+     * is the true safety valve. Lower this to flush earlier; raise it to keep the
+     * gate active longer at the cost of running Phase B closer to the hard limit.
+     */
+    public static final String PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION =
+            "indexing.memory.vector.early.checkpoint.fraction";
+    public static final double PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION_DEFAULT = 0.90d;
+
     public static final String PROPERTY_MEMORY_PAGE_SIZE = "indexing.memory.page.size";
     public static final long PROPERTY_MEMORY_PAGE_SIZE_DEFAULT = 1048576L;
 

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceEngine.java
@@ -828,6 +828,12 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             final double vectorCompactionLocalKickFraction = config.getDouble(
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_LOCAL_KICK_FRACTION,
                     IndexingServerConfiguration.PROPERTY_VECTOR_INDEX_COMPACTION_LOCAL_KICK_FRACTION_DEFAULT);
+            // Issue #646: early-checkpoint memory-pressure fraction. Validated
+            // by {@link PersistentVectorStore#setEarlyCheckpointFraction}, which
+            // throws IllegalArgumentException at start time if out of range.
+            final double vectorMemoryEarlyCheckpointFraction = config.getDouble(
+                    IndexingServerConfiguration.PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION,
+                    IndexingServerConfiguration.PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION_DEFAULT);
             final boolean vectorCompactionLocalEnabledWithOptimizer = config.getBoolean(
                     IndexingServerConfiguration
                             .PROPERTY_VECTOR_INDEX_COMPACTION_LOCAL_ENABLED_WITH_OPTIMIZER,
@@ -838,7 +844,8 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                             + "backpressureMaxWaitMs={2}, localKickFraction={3},"
                             + " localEnabledWithOptimizer={4},"
                             + " microSegmentMaxNodes={5}, maxInputs={6},"
-                            + " maxInputBytes={7}, targetBytes={8}, maxOutputNodes={9}",
+                            + " maxInputBytes={7}, targetBytes={8}, maxOutputNodes={9},"
+                            + " earlyCheckpointFraction={10}",
                     new Object[]{vectorCompactionTieredEnabled, vectorCompactionBackpressureSegments,
                             vectorCompactionBackpressureMaxWaitMs,
                             vectorCompactionLocalKickFraction,
@@ -847,7 +854,8 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                             vectorCompactionMaxInputs,
                             vectorCompactionMaxInputBytes,
                             vectorCompactionTargetBytes,
-                            vectorCompactionMaxOutputNodes});
+                            vectorCompactionMaxOutputNodes,
+                            vectorMemoryEarlyCheckpointFraction});
             // Async IO pipeline for FusedPQ search (issue #547).
             // Config key takes precedence over the system property.
             final boolean vectorSearchAsyncPipelineEnabled = config.getBoolean(
@@ -977,6 +985,13 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 store.setLocalCompactionKickFraction(vectorCompactionLocalKickFraction);
                 store.setLocalCompactionEnabledWithOptimizer(
                         vectorCompactionLocalEnabledWithOptimizer);
+                // Issue #646: early-checkpoint memory-pressure fraction. Set
+                // via a setter rather than a constructor argument so the seven
+                // existing PersistentVectorStore constructor variants don't
+                // need yet another overload. Validation is centralised in the
+                // setter and throws IllegalArgumentException at start time if
+                // the operator configured a value outside (0.0, 1.0].
+                store.setEarlyCheckpointFraction(vectorMemoryEarlyCheckpointFraction);
                 // Issue #569: hand the warmup byte budget to the store so it can
                 // warm each new segment's block cache AT CREATION TIME (in the
                 // checkpoint Phase C-prep and compaction merge paths), before the
@@ -4276,6 +4291,11 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
             d.compactionElapsedMs = pvs.getCompactionElapsedMs();
             d.compactionRunning = pvs.isCompactionRunning();
             d.nextNodeId = pvs.getNextNodeId();
+            // Issue #646 observability.
+            d.microSegmentCount = pvs.getMicroSegmentCount();
+            d.memoryPressureCheckpointBypassCount =
+                    pvs.getTotalMemoryPressureCheckpointBypassCount();
+            d.earlyCheckpointFraction = pvs.getEarlyCheckpointFraction();
             if (!"idle".equals(d.compactionPhase)) {
                 d.status = d.compactionPhase;
             }
@@ -4366,6 +4386,44 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // their own netty_ prefix — pass the root logger, not a scope.
         if (statsLogger != null) {
             herddb.core.stats.NettyMemoryMetrics.register(statsLogger);
+            // Issue #646: engine-wide vector budget gauges. The fraction
+            // gauge is exposed ×1000 (Long channel) so dashboards can plot
+            // memory pressure without computing the ratio from raw bytes.
+            // Idempotent: BookKeeper's PrometheusMetricsProvider keeps the
+            // last registration and StatsLogger contracts allow re-register.
+            final IndexingServiceEngine self = this;
+            StatsLogger memoryStats = statsLogger.scope("vector_memory");
+            memoryStats.registerGauge("budget_max_bytes", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    long max = self.maxMemoryBytes();
+                    return max == Long.MAX_VALUE ? 0L : max;
+                }
+            });
+            memoryStats.registerGauge("budget_used_bytes", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return self.totalEstimatedMemoryUsageBytes();
+                }
+            });
+            memoryStats.registerGauge("budget_fraction_milli", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return Math.round(self.budgetFraction() * 1000.0d);
+                }
+            });
         }
     }
 
@@ -4951,6 +5009,47 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
                 @Override
                 public Long getSample() {
                     return pvs.getSegmentCountBackpressureTimeouts();
+                }
+            });
+            // Issue #646 observability — early-checkpoint memory-pressure
+            // bypass counter, current budget fraction, and micro-segment count.
+            // The counter lets operators tell genuine "shard full" checkpoints
+            // apart from the micro-segment-prone bypass path; the fraction
+            // gauge makes the global memory-pressure ratio dashboardable
+            // without computing it from raw byte counters; the micro-segment
+            // count is a real-time signal that micro-segments are accumulating.
+            indexStats.registerGauge("memory_pressure_checkpoint_bypass_total",
+                    new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    return pvs.getTotalMemoryPressureCheckpointBypassCount();
+                }
+            });
+            indexStats.registerGauge("microsegment_count", new Gauge<Integer>() {
+                @Override
+                public Integer getDefaultValue() {
+                    return 0;
+                }
+                @Override
+                public Integer getSample() {
+                    return pvs.getMicroSegmentCount();
+                }
+            });
+            indexStats.registerGauge("early_checkpoint_fraction", new Gauge<Long>() {
+                @Override
+                public Long getDefaultValue() {
+                    return 0L;
+                }
+                @Override
+                public Long getSample() {
+                    // Stored ×1000 so the fraction (0.0–1.0) survives the
+                    // Long-typed gauge channel without precision loss. Dashboards
+                    // divide by 1000 to recover the original double.
+                    return Math.round(pvs.getEarlyCheckpointFraction() * 1000.0d);
                 }
             });
             indexStats.registerGauge("max_vector_memory_bytes", new Gauge<Long>() {
@@ -5834,5 +5933,12 @@ public class IndexingServiceEngine implements AutoCloseable, VectorMemoryBudget 
         // Controls within-instance HNSW graph-bucket granularity; defaults to
         // 1 when the property is absent. Issue #451.
         public int numShards = 1;
+        // Issue #646 — current micro-segment count, total bypass count, and
+        // configured early-checkpoint fraction. Surfaced via describe-index
+        // / engine-stats --json so operators can diagnose micro-segment
+        // accumulation without scraping logs.
+        public int microSegmentCount;
+        public long memoryPressureCheckpointBypassCount;
+        public double earlyCheckpointFraction;
     }
 }

--- a/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/IndexingServiceImpl.java
@@ -383,7 +383,12 @@ public class IndexingServiceImpl extends IndexingServiceGrpc.IndexingServiceImpl
                     .setCompactionInputSegmentCount(details.compactionInputSegmentCount)
                     .setCompactionInputVectorCount(details.compactionInputVectorCount)
                     .setCompactionElapsedMs(details.compactionElapsedMs)
-                    .setCompactionRunning(details.compactionRunning);
+                    .setCompactionRunning(details.compactionRunning)
+                    // Issue #646 early-checkpoint observability.
+                    .setMicroSegmentCount(details.microSegmentCount)
+                    .setMemoryPressureCheckpointBypassCount(
+                            details.memoryPressureCheckpointBypassCount)
+                    .setEarlyCheckpointFraction(details.earlyCheckpointFraction);
             responseObserver.onNext(builder.build());
             responseObserver.onCompleted();
         } catch (RuntimeException e) {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -740,6 +740,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
     private volatile int compactionBackpressureThreshold = 500;
 
     /**
+     * Fraction of the {@link VectorMemoryBudget} (or per-store
+     * {@link #maxVectorMemoryBytes}) above which
+     * {@link #shouldTriggerMemoryPressureCheckpoint()} returns {@code true},
+     * forcing an early checkpoint and bypassing the {@code minLiveVectorsForCheckpoint}
+     * gate (issue #646). Must be in {@code (0.0, 1.0]}. Default is {@code 0.90}
+     * — high enough that the gate keeps producing reasonably-sized segments
+     * through the 70&ndash;90% range (which is where long ingest workloads spend a
+     * significant fraction of their runtime) and only fires close to the hard
+     * 100% back-pressure limit. Overridden at engine start via
+     * {@code herddb.indexing.IndexingServerConfiguration.PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION}.
+     */
+    private volatile double earlyCheckpointFraction = 0.90d;
+
+    /**
      * Maximum wall-clock time (ms) a caller may spend in
      * {@link #waitForSegmentCountRelief} before back-pressure is
      * force-released with a SEVERE log (issue #370).
@@ -974,6 +988,16 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * "nothing dirty" early return, which represents a durable state.
      */
     private final AtomicLong totalCheckpointsDeferred = new AtomicLong(0);
+    /**
+     * Number of times {@link #doCheckpointUnderLock} ran Phase A with a live
+     * shard below {@link #minLiveVectorsForCheckpoint} only because
+     * {@link #shouldTriggerMemoryPressureCheckpoint()} forced the bypass
+     * (issue #646). Surfaced as the {@code memory_pressure_checkpoint_bypass_total}
+     * metric so operators can tell genuine "shard full" checkpoints apart from
+     * the micro-segment-prone "budget over threshold, gate bypassed" path that
+     * caused the BIGANN 200M segment storm.
+     */
+    private final AtomicLong totalMemoryPressureCheckpointBypassCount = new AtomicLong(0);
     private final AtomicLong lastCheckpointVectorsProcessed = new AtomicLong(0);
     /** Approximate bytes written by the last completed Phase B. */
     private final AtomicLong lastPhaseBBytesWritten = new AtomicLong(0);
@@ -2375,6 +2399,29 @@ public class PersistentVectorStore extends AbstractVectorStore {
     public void setCompactionBackpressureThreshold(int threshold) {
         this.compactionBackpressureThreshold = threshold;
         recomputeKickThresholdCached();
+    }
+
+    /**
+     * Sets the early-checkpoint memory-pressure fraction (issue #646). Must be
+     * in {@code (0.0, 1.0]}. When the {@link VectorMemoryBudget} (or per-store
+     * limit) crosses this fraction of its ceiling,
+     * {@link #shouldTriggerMemoryPressureCheckpoint()} returns {@code true} —
+     * forcing an early checkpoint and bypassing the
+     * {@code minLiveVectorsForCheckpoint} gate. Lower this to flush earlier
+     * (smaller segments, more cycles); raise it to keep the gate active longer
+     * and run Phase B closer to the hard limit.
+     */
+    public void setEarlyCheckpointFraction(double fraction) {
+        if (!(fraction > 0.0d && fraction <= 1.0d)) {
+            throw new IllegalArgumentException(
+                    "earlyCheckpointFraction must be in (0.0, 1.0], got " + fraction);
+        }
+        this.earlyCheckpointFraction = fraction;
+    }
+
+    /** Returns the current early-checkpoint memory-pressure fraction (issue #646). */
+    public double getEarlyCheckpointFraction() {
+        return earlyCheckpointFraction;
     }
 
     /**
@@ -4693,9 +4740,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
         // in-memory HNSW shards onto disk; it cannot reduce the on-disk segment
         // pkData/BLink footprint that {@link #estimatedMemoryUsageBytes()} (and
         // the global budget) also count. With many on-disk segments that
-        // footprint alone can permanently exceed the 70% threshold, so without
-        // this guard the compaction loop fires a spurious, no-op Phase A every
-        // cycle even though there are 0 live vectors.
+        // footprint alone can permanently exceed the early-checkpoint
+        // threshold ({@link #earlyCheckpointFraction}, default 90% post-#646),
+        // so without this guard the compaction loop fires a spurious, no-op
+        // Phase A every cycle even though there are 0 live vectors.
         //
         // The count spans live + frozen + deferred shards — the same shard set
         // {@link #getLiveShardMemoryBytes()} measures — so a checkpoint that
@@ -4704,13 +4752,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
         if (liveFrozenDeferredNodeCount() == 0) {
             return false;
         }
+        // Threshold is configurable per issue #646 — operators can raise it to
+        // keep the minLiveVectorsForCheckpoint gate active longer (preventing
+        // micro-segment accumulation in the 70-90% memory range), or lower it
+        // to flush earlier.
+        final double fraction = earlyCheckpointFraction;
+        final long pct = Math.round(fraction * 100.0d);
         // Check global budget first (covers all stores sharing the same heap)
         if (memoryBudget != null) {
-            boolean trigger = memoryBudget.isAboveThreshold(0.7);
+            boolean trigger = memoryBudget.isAboveThreshold(fraction);
             if (trigger) {
                 LOGGER.log(Level.INFO,
-                        "vector store {0} memory pressure (global): {1} bytes exceeds 70% of global limit {2} bytes, triggering early checkpoint",
-                        new Object[]{indexName, memoryBudget.totalEstimatedMemoryUsageBytes(), memoryBudget.maxMemoryBytes()});
+                        "vector store {0} memory pressure (global): {1} bytes exceeds {2}% of global limit {3} bytes, triggering early checkpoint",
+                        new Object[]{indexName,
+                                memoryBudget.totalEstimatedMemoryUsageBytes(),
+                                pct,
+                                memoryBudget.maxMemoryBytes()});
             }
             return trigger;
         }
@@ -4719,13 +4776,57 @@ public class PersistentVectorStore extends AbstractVectorStore {
             return false;
         }
         long usage = estimatedMemoryUsageBytes();
-        boolean trigger = usage > (long) (maxVectorMemoryBytes * 0.7);
+        boolean trigger = usage > (long) (maxVectorMemoryBytes * fraction);
         if (trigger) {
             LOGGER.log(Level.INFO,
-                    "vector store {0} memory pressure: {1} bytes exceeds 70% of limit {2} bytes, triggering early checkpoint",
-                    new Object[]{indexName, usage, maxVectorMemoryBytes});
+                    "vector store {0} memory pressure: {1} bytes exceeds {2}% of limit {3} bytes, triggering early checkpoint",
+                    new Object[]{indexName, usage, pct, maxVectorMemoryBytes});
         }
         return trigger;
+    }
+
+    /**
+     * Emits the issue #646 bypass notice and increments
+     * {@link #totalMemoryPressureCheckpointBypassCount}. Called from
+     * {@link #doCheckpointUnderLock} exactly once per checkpoint cycle whenever
+     * the min-live-vectors gate would have deferred this cycle but
+     * {@link #shouldTriggerMemoryPressureCheckpoint()} forced it through. Kept
+     * separate so the gate code stays readable and so tests can assert the
+     * counter without scraping the log stream.
+     *
+     * <p>Logged at INFO so a sustained-pressure workload doesn't fill the
+     * WARNING bucket while still being visible in default log configurations.
+     */
+    private void logMemoryPressureGateBypass(int totalLiveVectors, int minLiveGate) {
+        totalMemoryPressureCheckpointBypassCount.incrementAndGet();
+        final long usage;
+        final long max;
+        final double fraction;
+        if (memoryBudget != null) {
+            usage = memoryBudget.totalEstimatedMemoryUsageBytes();
+            max = memoryBudget.maxMemoryBytes();
+            fraction = memoryBudget.budgetFraction();
+        } else {
+            usage = estimatedMemoryUsageBytes();
+            max = maxVectorMemoryBytes;
+            fraction = max == Long.MAX_VALUE || max <= 0L
+                    ? 0.0d : (double) usage / (double) max;
+        }
+        LOGGER.log(Level.INFO,
+                "checkpoint {0}: minLiveVectorsForCheckpoint gate bypassed by memory"
+                        + " pressure (live={1} < gate={2}, budget={3} / {4} bytes ="
+                        + " {5}%, trigger fraction={6}) — sealing partial shard."
+                        + " Consider raising indexing.memory.vector.early.checkpoint.fraction"
+                        + " or indexing.memory.vector.percentage to prevent"
+                        + " micro-segment accumulation.",
+                new Object[]{indexName, totalLiveVectors, minLiveGate, usage, max,
+                        String.format(java.util.Locale.ROOT, "%.1f", fraction * 100.0d),
+                        String.format(java.util.Locale.ROOT, "%.2f", earlyCheckpointFraction)});
+    }
+
+    /** Returns the issue #646 bypass counter. */
+    public long getTotalMemoryPressureCheckpointBypassCount() {
+        return totalMemoryPressureCheckpointBypassCount.get();
     }
 
     private void waitForMemoryPressureRelief() {
@@ -6257,6 +6358,10 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // left behind by stopped ingest is guaranteed to flush.
             int minLiveGate = minLiveVectorsForCheckpoint;
             long deferralBoundMs = maxCheckpointDeferralMs;
+            // Capture once: shouldTriggerMemoryPressureCheckpoint() emits an
+            // INFO log on every truthy call, so calling it three times would
+            // log three identical lines per checkpoint.
+            boolean memoryPressureTrigger = shouldTriggerMemoryPressureCheckpoint();
 
             // Segment-count back-pressure deferral gate (issue #562).
             //
@@ -6280,7 +6385,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     && totalLiveVectors < minLiveGate
                     && !anySegmentDirty
                     && !segments.isEmpty()
-                    && !shouldTriggerMemoryPressureCheckpoint()
+                    && !memoryPressureTrigger
                     && segments.size() > compactionBackpressureThreshold) {
                 LOGGER.log(Level.INFO,
                         "checkpoint {0}: deferred during segment-count back-pressure "
@@ -6296,7 +6401,7 @@ public class PersistentVectorStore extends AbstractVectorStore {
                     && totalLiveVectors < minLiveGate
                     && !anySegmentDirty
                     && !segments.isEmpty()
-                    && !shouldTriggerMemoryPressureCheckpoint()) {
+                    && !memoryPressureTrigger) {
                 long elapsed = System.currentTimeMillis() - lastSuccessfulCheckpointMs;
                 if (elapsed < deferralBoundMs) {
                     LOGGER.log(Level.FINE,
@@ -6311,6 +6416,20 @@ public class PersistentVectorStore extends AbstractVectorStore {
                         "checkpoint {0}: deferral bound reached ({1} ms >= {2} ms), "
                                 + "running Phase A with {3} live vectors",
                         new Object[]{indexName, elapsed, deferralBoundMs, totalLiveVectors});
+            }
+
+            // Issue #646: emit observability when memory pressure forces a
+            // checkpoint past the min-live-vectors gate, so operators can tell
+            // micro-segment-prone bypass cycles apart from genuine "shard full"
+            // cycles. The conditions mirror the gate above with the
+            // memoryPressureTrigger flag flipped: this is exactly the path that
+            // produced the BIGANN 200M segment storm.
+            if (memoryPressureTrigger
+                    && minLiveGate > 0
+                    && totalLiveVectors < minLiveGate
+                    && !anySegmentDirty
+                    && !segments.isEmpty()) {
+                logMemoryPressureGateBypass(totalLiveVectors, minLiveGate);
             }
         } finally {
             stateLock.writeLock().unlock();
@@ -9553,6 +9672,30 @@ public class PersistentVectorStore extends AbstractVectorStore {
 
     public int getSegmentCount() {
         return segments.size();
+    }
+
+    /**
+     * Returns the number of currently-loaded segments whose live-node count is
+     * strictly below {@link #vectorIndexCompactionMicroSegmentMaxNodes} — i.e.
+     * segments the micro-segment fast-path (issue #570) would target on the
+     * next compaction cycle (issue #646 observability). Returns {@code 0}
+     * when the micro-segment fast-path is disabled
+     * ({@code vectorIndexCompactionMicroSegmentMaxNodes <= 0}). Cheap enough
+     * for periodic gauge sampling: iterates the {@code CopyOnWriteArrayList}
+     * snapshot and reads each segment's atomic live counter.
+     */
+    public int getMicroSegmentCount() {
+        long threshold = vectorIndexCompactionMicroSegmentMaxNodes;
+        if (threshold <= 0L) {
+            return 0;
+        }
+        int count = 0;
+        for (VectorSegment seg : segments) {
+            if (seg.size() < threshold) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public long getMaxSegmentSize() {

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/PersistentVectorStore.java
@@ -750,8 +750,19 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * significant fraction of their runtime) and only fires close to the hard
      * 100% back-pressure limit. Overridden at engine start via
      * {@code herddb.indexing.IndexingServerConfiguration.PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION}.
+     *
+     * <p>The literal default mirrors
+     * {@link herddb.indexing.IndexingServerConfiguration#PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION_DEFAULT}
+     * — they MUST stay in sync. A field-level reference to the constant is
+     * preferred for new fields but a circular package dependency would be
+     * introduced here (the indexing package depends on the indexing.vector
+     * package, not the other way round); the engine factory is the single
+     * production code path that passes the config value through and is the
+     * only practical risk of drift.
      */
-    private volatile double earlyCheckpointFraction = 0.90d;
+    private volatile double earlyCheckpointFraction =
+            herddb.indexing.IndexingServerConfiguration
+                    .PROPERTY_MEMORY_VECTOR_EARLY_CHECKPOINT_FRACTION_DEFAULT;
 
     /**
      * Maximum wall-clock time (ms) a caller may spend in
@@ -4786,6 +4797,22 @@ public class PersistentVectorStore extends AbstractVectorStore {
     }
 
     /**
+     * Distinguishes which deferral gate would have engaged when a memory-pressure
+     * bypass fires (issue #646). The two gates count toward the same bypass
+     * counter — both represent "the gate would have deferred but the budget
+     * forced the checkpoint through" — but the operator-visible log line
+     * carries the label so a human reading the journal can tell which path
+     * is active. {@link #SEGMENT_COUNT_BACKPRESSURE} is the BIGANN 200M
+     * scenario (segments already past back-pressure threshold);
+     * {@link #TIME_WINDOW} is the simpler "tiny shard, recent checkpoint"
+     * case.
+     */
+    enum BypassReason {
+        SEGMENT_COUNT_BACKPRESSURE,
+        TIME_WINDOW
+    }
+
+    /**
      * Emits the issue #646 bypass notice and increments
      * {@link #totalMemoryPressureCheckpointBypassCount}. Called from
      * {@link #doCheckpointUnderLock} exactly once per checkpoint cycle whenever
@@ -4797,8 +4824,12 @@ public class PersistentVectorStore extends AbstractVectorStore {
      * <p>Logged at INFO so a sustained-pressure workload doesn't fill the
      * WARNING bucket while still being visible in default log configurations.
      */
-    private void logMemoryPressureGateBypass(int totalLiveVectors, int minLiveGate) {
+    private void logMemoryPressureGateBypass(int totalLiveVectors, int minLiveGate,
+            BypassReason reason) {
         totalMemoryPressureCheckpointBypassCount.incrementAndGet();
+        if (!LOGGER.isLoggable(Level.INFO)) {
+            return;
+        }
         final long usage;
         final long max;
         final double fraction;
@@ -4814,12 +4845,14 @@ public class PersistentVectorStore extends AbstractVectorStore {
         }
         LOGGER.log(Level.INFO,
                 "checkpoint {0}: minLiveVectorsForCheckpoint gate bypassed by memory"
-                        + " pressure (live={1} < gate={2}, budget={3} / {4} bytes ="
-                        + " {5}%, trigger fraction={6}) — sealing partial shard."
+                        + " pressure (reason={1}, live={2} < gate={3}, segments={4},"
+                        + " budget={5} / {6} bytes = {7}%, trigger fraction={8})"
+                        + " — sealing partial shard."
                         + " Consider raising indexing.memory.vector.early.checkpoint.fraction"
                         + " or indexing.memory.vector.percentage to prevent"
                         + " micro-segment accumulation.",
-                new Object[]{indexName, totalLiveVectors, minLiveGate, usage, max,
+                new Object[]{indexName, reason, totalLiveVectors, minLiveGate,
+                        segments.size(), usage, max,
                         String.format(java.util.Locale.ROOT, "%.1f", fraction * 100.0d),
                         String.format(java.util.Locale.ROOT, "%.2f", earlyCheckpointFraction)});
     }
@@ -6424,12 +6457,30 @@ public class PersistentVectorStore extends AbstractVectorStore {
             // cycles. The conditions mirror the gate above with the
             // memoryPressureTrigger flag flipped: this is exactly the path that
             // produced the BIGANN 200M segment storm.
+            //
+            // We further distinguish two gate variants because they have
+            // different operational meaning:
+            //   - SEGMENT_COUNT_BACKPRESSURE: segments.size() is already above
+            //     compactionBackpressureThreshold (line 6336 sibling gate).
+            //     This is the BIGANN 200M scenario — the live shard is tiny
+            //     AND the on-disk segment count is already past back-pressure,
+            //     so sealing the tiny shard would push the count further past.
+            //   - TIME_WINDOW: the elapsed-since-last-success deferral window
+            //     (line 6356 sibling gate). The segment count is fine but the
+            //     gate would still have deferred for time-bounded reasons.
+            // The two share the same counter (both are "the gate would have
+            // deferred but memory pressure forced through") but log under
+            // distinct labels so an operator parsing logs can tell which path
+            // is firing.
             if (memoryPressureTrigger
                     && minLiveGate > 0
                     && totalLiveVectors < minLiveGate
                     && !anySegmentDirty
                     && !segments.isEmpty()) {
-                logMemoryPressureGateBypass(totalLiveVectors, minLiveGate);
+                BypassReason reason = segments.size() > compactionBackpressureThreshold
+                        ? BypassReason.SEGMENT_COUNT_BACKPRESSURE
+                        : BypassReason.TIME_WINDOW;
+                logMemoryPressureGateBypass(totalLiveVectors, minLiveGate, reason);
             }
         } finally {
             stateLock.writeLock().unlock();

--- a/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorMemoryBudget.java
+++ b/herddb-indexing-service/src/main/java/herddb/indexing/vector/VectorMemoryBudget.java
@@ -59,4 +59,22 @@ public interface VectorMemoryBudget {
         long max = maxMemoryBytes();
         return max != Long.MAX_VALUE && totalEstimatedMemoryUsageBytes() > (long) (max * fraction);
     }
+
+    /**
+     * Returns the current budget consumption as a fraction of the global
+     * limit. Returns {@code 0.0} when no finite limit is configured
+     * ({@code maxMemoryBytes() == Long.MAX_VALUE} or {@code <= 0}). Useful for
+     * Prometheus gauges exposing memory pressure without forcing dashboards to
+     * compute the ratio from the raw byte counters (issue #646). The result is
+     * not clamped: it can legitimately exceed {@code 1.0} during the brief
+     * window between crossing the hard limit and the back-pressure path
+     * draining the live shards.
+     */
+    default double budgetFraction() {
+        long max = maxMemoryBytes();
+        if (max == Long.MAX_VALUE || max <= 0L) {
+            return 0.0d;
+        }
+        return (double) totalEstimatedMemoryUsageBytes() / (double) max;
+    }
 }

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -277,10 +277,15 @@ message DescribeIndexResponse {
     //  - memory_pressure_checkpoint_bypass_count is a monotonic counter that
     //    increments every time shouldTriggerMemoryPressureCheckpoint() forced
     //    a checkpoint past the min-live-vectors deferral gate. Operators can
-    //    correlate spikes here with micro_segment_count growth.
+    //    correlate spikes here with micro_segment_count growth. The counter
+    //    is in-memory only: it is monotonic ONLY within a single process
+    //    lifetime and resets to zero on restart (including rolling restarts
+    //    of the indexing-service StatefulSet). Dashboards that alert on
+    //    rate-of-change (rate(...) / irate(...)) handle this correctly;
+    //    dashboards that show the raw counter must annotate restarts to
+    //    avoid the apparent "counter went backwards" jump.
     //  - early_checkpoint_fraction echoes the configured
-    //    indexing.memory.vector.early.checkpoint.fraction (default 0.90 after
-    //    issue #646; was an unconfigurable 0.70 before).
+    //    indexing.memory.vector.early.checkpoint.fraction (default 0.90).
     int32 micro_segment_count = 39;
     int64 memory_pressure_checkpoint_bypass_count = 40;
     double early_checkpoint_fraction = 41;

--- a/herddb-indexing-service/src/main/proto/indexing_service.proto
+++ b/herddb-indexing-service/src/main/proto/indexing_service.proto
@@ -265,6 +265,25 @@ message DescribeIndexResponse {
     int64 compaction_input_vector_count = 36;
     int64 compaction_elapsed_ms = 37;
     bool compaction_running = 38;
+
+    // Issue #646 early-checkpoint observability.
+    //
+    //  - micro_segment_count is the number of currently-loaded segments whose
+    //    live-node count is strictly below the configured
+    //    indexing.vector.index.compaction.microsegment.max.nodes threshold.
+    //    A growing value is a leading indicator of segment-count back-pressure
+    //    caused by the min-live-vectors gate being bypassed under memory
+    //    pressure (the BIGANN 200M scenario that motivated this issue).
+    //  - memory_pressure_checkpoint_bypass_count is a monotonic counter that
+    //    increments every time shouldTriggerMemoryPressureCheckpoint() forced
+    //    a checkpoint past the min-live-vectors deferral gate. Operators can
+    //    correlate spikes here with micro_segment_count growth.
+    //  - early_checkpoint_fraction echoes the configured
+    //    indexing.memory.vector.early.checkpoint.fraction (default 0.90 after
+    //    issue #646; was an unconfigurable 0.70 before).
+    int32 micro_segment_count = 39;
+    int64 memory_pressure_checkpoint_bypass_count = 40;
+    double early_checkpoint_fraction = 41;
 }
 
 message ListPrimaryKeysRequest {

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/EarlyCheckpointFractionConfigTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/EarlyCheckpointFractionConfigTest.java
@@ -120,7 +120,12 @@ public class EarlyCheckpointFractionConfigTest {
                     store.setEarlyCheckpointFraction(bad);
                     fail("expected IllegalArgumentException for fraction " + bad);
                 } catch (IllegalArgumentException expected) {
-                    // ok
+                    // The operator-visible diagnostic must include the offending
+                    // value so a misconfigured IndexingServer (which propagates
+                    // the IAE via start()) tells the operator what to fix.
+                    assertTrue("IAE message must contain the offending value (was: \""
+                                    + expected.getMessage() + "\")",
+                            expected.getMessage().contains(String.valueOf(bad)));
                 }
             }
             // The boundary value 1.0 is accepted (no bypass until the hard

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/EarlyCheckpointFractionConfigTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/EarlyCheckpointFractionConfigTest.java
@@ -1,0 +1,174 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression test for issue #646.
+ *
+ * <p>Asserts that {@link PersistentVectorStore#setEarlyCheckpointFraction(double)}
+ * (a) rejects values outside {@code (0.0, 1.0]}, (b) defaults to {@code 0.90},
+ * and (c) actually drives whether
+ * {@link PersistentVectorStore#shouldTriggerMemoryPressureCheckpoint()} fires
+ * at intermediate budget pressures. The historical pre-#646 default was 0.70
+ * — a value low enough that long ingest workloads spent their middle phase
+ * permanently above the threshold, bypassing the
+ * {@code minLiveVectorsForCheckpoint} gate and producing the BIGANN 200M
+ * micro-segment storm.
+ */
+public class EarlyCheckpointFractionConfigTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static final int DIM = 8;
+
+    /** A budget whose usage and ceiling are owned by the caller. */
+    private static final class TunableBudget implements VectorMemoryBudget {
+        final AtomicLong usage;
+        final long max;
+
+        TunableBudget(long initialUsage, long max) {
+            this.usage = new AtomicLong(initialUsage);
+            this.max = max;
+        }
+
+        @Override
+        public long totalEstimatedMemoryUsageBytes() {
+            return usage.get();
+        }
+
+        @Override
+        public long maxMemoryBytes() {
+            return max;
+        }
+
+        @Override
+        public boolean isMemoryPressureActive() {
+            // Never report hard back-pressure so addVector stays unblocked
+            // even when the budget reports very high usage.
+            return false;
+        }
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, VectorMemoryBudget budget) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vec",
+                "vidx_uuid", tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true /* fusedPQ */, 2_000_000_000L, 0,
+                Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Long.MAX_VALUE /* maxVectorMemoryBytes */, budget, 0, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    @Test
+    public void defaultFractionIsNinetyPercent() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("default-fraction").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir, null)) {
+            store.start();
+            // The PVS-side default is the new post-#646 0.90 — applied even
+            // when the store is built via a direct constructor (the engine
+            // factory passes the same value via setEarlyCheckpointFraction).
+            assertEquals("post-#646 default early-checkpoint fraction is 0.90",
+                    0.90d, store.getEarlyCheckpointFraction(), 1e-12);
+        }
+    }
+
+    @Test
+    public void setterRejectsOutOfRangeValues() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("setter-range").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir, null)) {
+            store.start();
+            for (double bad : new double[]{0.0d, -0.1d, -1.0d, 1.0001d, 2.0d, Double.NaN,
+                    Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY}) {
+                try {
+                    store.setEarlyCheckpointFraction(bad);
+                    fail("expected IllegalArgumentException for fraction " + bad);
+                } catch (IllegalArgumentException expected) {
+                    // ok
+                }
+            }
+            // The boundary value 1.0 is accepted (no bypass until the hard
+            // 100% limit is reached).
+            store.setEarlyCheckpointFraction(1.0d);
+            assertEquals(1.0d, store.getEarlyCheckpointFraction(), 1e-12);
+            // And ordinary values round-trip.
+            store.setEarlyCheckpointFraction(0.50d);
+            assertEquals(0.50d, store.getEarlyCheckpointFraction(), 1e-12);
+        }
+    }
+
+    /**
+     * The decisive end-to-end assertion: with a budget reporting 80% usage
+     * (above the pre-#646 0.70 default, below the post-#646 0.90 default), the
+     * trigger fires at 0.70 but is suppressed at 0.90 — i.e. the
+     * {@code minLiveVectorsForCheckpoint} gate would no longer be bypassed in
+     * the very 70&ndash;90% range that produced the BIGANN 200M micro-segment
+     * storm.
+     */
+    @Test
+    public void fractionDrivesTriggerInTheMiddleRange() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("middle-range").toPath();
+        TunableBudget budget = new TunableBudget(80L, 100L); // 80%
+        try (PersistentVectorStore store = createStore(tmpDir, budget)) {
+            store.start();
+            // Plant one live vector so the issue #563 zero-live-vectors guard
+            // does not short-circuit the trigger.
+            store.addVector(Bytes.from_int(1), new float[DIM]);
+
+            // 0.70: 80 > 70, trigger fires (pre-#646 behaviour).
+            store.setEarlyCheckpointFraction(0.70d);
+            assertTrue("at 70% threshold, 80% usage must fire the early-checkpoint"
+                    + " trigger (pre-#646 behaviour)",
+                    store.shouldTriggerMemoryPressureCheckpoint());
+
+            // 0.90 (new default): 80 < 90, trigger suppressed — the
+            // minLiveVectorsForCheckpoint gate stays active.
+            store.setEarlyCheckpointFraction(0.90d);
+            assertFalse("at 90% threshold, 80% usage must NOT fire — this is the"
+                    + " whole point of issue #646 (gate stays active in 70-90% range)",
+                    store.shouldTriggerMemoryPressureCheckpoint());
+
+            // Crank the usage past 90% and confirm the post-#646 default
+            // still fires when warranted.
+            budget.usage.set(95L);
+            assertTrue("at 90% threshold, 95% usage must fire the trigger",
+                    store.shouldTriggerMemoryPressureCheckpoint());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/Issue562BackpressureMicroSegmentTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/Issue562BackpressureMicroSegmentTest.java
@@ -269,6 +269,13 @@ public class Issue562BackpressureMicroSegmentTest {
                     /*maxCount*/ Integer.MAX_VALUE,
                     /*retentionMs*/ 0);
             store.setTieredCompactionEnabled(false);
+            // The trigger budget below reports usage=80, max=100 (80%). With
+            // the post-#646 default early-checkpoint fraction of 0.90 the
+            // trigger would not fire at 80%; this test pre-dates that change
+            // and specifically exercises the "above the trigger but not under
+            // hard back-pressure" code path, so pin the fraction at the
+            // historical 0.70 to preserve the original semantic.
+            store.setEarlyCheckpointFraction(0.70d);
             store.start();
             Random rng = new Random(562_4);
 

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/MicroSegmentCountGaugeTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/MicroSegmentCountGaugeTest.java
@@ -1,0 +1,150 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #646 — micro-segment count gauge.
+ *
+ * <p>Asserts that {@link PersistentVectorStore#getMicroSegmentCount()} reports
+ * the number of currently-loaded segments whose live-node count is strictly
+ * below the configured {@code microSegmentMaxNodes} threshold (issue #570).
+ * The gauge is the real-time signal operators use to spot micro-segment
+ * accumulation before the segment-count back-pressure kicks in.
+ */
+public class MicroSegmentCountGaugeTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static final int DIM = 8;
+
+    private int savedMinLiveVectorsForCheckpoint;
+
+    @Before
+    public void disableMinLiveVectorsGate() {
+        savedMinLiveVectorsForCheckpoint = PersistentVectorStore.minLiveVectorsForCheckpoint;
+        // 0 so every explicit checkpoint() in the test seals the partial
+        // shard immediately into a new segment.
+        PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+    }
+
+    @After
+    public void restoreMinLiveVectorsGate() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectorsForCheckpoint;
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vec",
+                "vidx_uuid", tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true /* fusedPQ */, 2_000_000_000L, 0,
+                /* compactionIntervalMs */ Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Long.MAX_VALUE /* maxVectorMemoryBytes */, null, 0, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    private float[] vec(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test(timeout = 60_000)
+    public void gaugeIsZeroWhenThresholdIsDisabled() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("disabled").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.setCompactionMicroSegmentMaxNodes(0L); // disabled
+            store.start();
+            Random rng = new Random(1);
+            for (int i = 0; i < 30; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng));
+            }
+            assertTrue(store.checkpoint());
+            assertTrue("at least one segment must have been created",
+                    store.getSegmentCount() >= 1);
+            assertEquals("threshold=0 disables the fast-path and the gauge",
+                    0, store.getMicroSegmentCount());
+        }
+    }
+
+    @Test(timeout = 60_000)
+    public void gaugeCountsSegmentsBelowThreshold() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("count").toPath();
+        try (PersistentVectorStore store = createStore(tmpDir)) {
+            store.setCompactionMicroSegmentMaxNodes(50L);
+            store.start();
+            Random rng = new Random(42);
+            // Three small segments: 20, 25, 30 vectors → all < 50 → all
+            // count as micro-segments.
+            int next = 0;
+            for (int batch : new int[]{20, 25, 30}) {
+                for (int i = 0; i < batch; i++, next++) {
+                    store.addVector(Bytes.from_int(next), vec(rng));
+                }
+                assertTrue(store.checkpoint());
+            }
+            assertEquals("three small batches must produce three segments",
+                    3, store.getSegmentCount());
+            assertEquals("all three segments are micro-segments (<50 nodes each)",
+                    3, store.getMicroSegmentCount());
+
+            // Add a large segment (>= threshold). Gauge stays at 3.
+            for (int i = 0; i < 100; i++, next++) {
+                store.addVector(Bytes.from_int(next), vec(rng));
+            }
+            assertTrue(store.checkpoint());
+            assertEquals("a fourth segment was added but only the three small ones"
+                    + " are micro-segments",
+                    3, store.getMicroSegmentCount());
+            assertEquals(4, store.getSegmentCount());
+
+            // Tighten the threshold so the 100-node segment also qualifies.
+            store.setCompactionMicroSegmentMaxNodes(150L);
+            assertEquals("raising the threshold must reclassify the 100-node segment",
+                    4, store.getMicroSegmentCount());
+
+            // Loosen it so only the smallest two qualify (< 26).
+            store.setCompactionMicroSegmentMaxNodes(26L);
+            assertEquals("only the 20- and 25-node segments must remain micro",
+                    2, store.getMicroSegmentCount());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/MinLiveGateBypassObservabilityTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/MinLiveGateBypassObservabilityTest.java
@@ -1,0 +1,186 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import herddb.core.MemoryManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.utils.Bytes;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Issue #646 — operator-visible bypass counter.
+ *
+ * <p>When the {@code minLiveVectorsForCheckpoint} gate would have deferred a
+ * checkpoint (live shard too small + no dirty segments + segments exist) but
+ * {@link PersistentVectorStore#shouldTriggerMemoryPressureCheckpoint()} forces
+ * it through anyway, the store must emit an INFO log entry AND increment the
+ * {@code memory_pressure_checkpoint_bypass_total} counter. Before issue #646
+ * this bypass was silent — the only signal was a flood of tiny on-disk
+ * segments downstream, by which point the harm was done.
+ */
+public class MinLiveGateBypassObservabilityTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static final int DIM = 16;
+
+    private int savedMinLiveVectorsForCheckpoint;
+
+    @Before
+    public void saveGate() {
+        savedMinLiveVectorsForCheckpoint = PersistentVectorStore.minLiveVectorsForCheckpoint;
+    }
+
+    @After
+    public void restoreGate() {
+        PersistentVectorStore.minLiveVectorsForCheckpoint = savedMinLiveVectorsForCheckpoint;
+    }
+
+    /**
+     * A budget whose memory-pressure trigger output (and only that) is gated
+     * by an {@link AtomicBoolean}, so the test can decide at what point to
+     * activate over-threshold reporting. Hard back-pressure
+     * ({@link #isMemoryPressureActive()}) stays off so {@code addVector}
+     * never blocks.
+     */
+    private static final class GatedBudget implements VectorMemoryBudget {
+        final AtomicBoolean trigger;
+
+        GatedBudget(AtomicBoolean trigger) {
+            this.trigger = trigger;
+        }
+
+        @Override
+        public long totalEstimatedMemoryUsageBytes() {
+            // Pick a usage that matches the trigger state. The exact value
+            // does not matter — only its relation to maxMemoryBytes matters
+            // for the isAboveThreshold(fraction) reading.
+            return trigger.get() ? 95L : 1L;
+        }
+
+        @Override
+        public long maxMemoryBytes() {
+            return 100L;
+        }
+
+        @Override
+        public boolean isMemoryPressureActive() {
+            // Never block addVector — this test exercises the trigger path,
+            // not the hard back-pressure path.
+            return false;
+        }
+    }
+
+    private PersistentVectorStore createStore(Path tmpDir, VectorMemoryBudget budget) {
+        MemoryDataStorageManager dsm = new MemoryDataStorageManager();
+        MemoryManager mm = new MemoryManager(64 * 1024 * 1024, 0, 1024 * 1024, 1024 * 1024);
+        PersistentVectorStore store = new PersistentVectorStore(
+                "vidx", "testtable", "tstblspace", "vec",
+                "vidx_uuid", tmpDir, dsm, mm,
+                8, 32, 1.2f, 1.4f, true /* fusedPQ */, 2_000_000_000L, 0,
+                /* compactionIntervalMs */ Long.MAX_VALUE,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Long.MAX_VALUE /* maxVectorMemoryBytes */, budget, 0, 0);
+        store.configureCompaction(Long.MAX_VALUE, 1L, Long.MAX_VALUE, 4, Integer.MAX_VALUE, 0);
+        return store;
+    }
+
+    private float[] vec(Random rng) {
+        float[] v = new float[DIM];
+        for (int i = 0; i < DIM; i++) {
+            v[i] = rng.nextFloat();
+        }
+        return v;
+    }
+
+    @Test(timeout = 120_000)
+    public void counterIncrementsOnlyWhenMemoryPressureBypassesTheGate() throws Exception {
+        Path tmpDir = tmpFolder.newFolder("bypass-counter").toPath();
+        AtomicBoolean trigger = new AtomicBoolean(false);
+        GatedBudget budget = new GatedBudget(trigger);
+        try (PersistentVectorStore store = createStore(tmpDir, budget)) {
+            // Force the 0.70 historical fraction: the budget reports
+            // usage=95, max=100 → isAboveThreshold(0.70) returns true even
+            // under the new 0.90 default, but the explicit setEarlyCheckpointFraction
+            // call also exercises the wiring.
+            store.setEarlyCheckpointFraction(0.70d);
+            store.start();
+
+            // Phase 1: build at least one on-disk segment so the bypass
+            // condition (which requires !segments.isEmpty()) can fire.
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 0;
+            Random rng = new Random(646);
+            for (int i = 0; i < 200; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng));
+            }
+            assertTrue("initial checkpoint must drain the shard", store.checkpoint());
+            assertTrue("an on-disk segment must exist for the bypass to be possible",
+                    store.getSegmentCount() >= 1);
+            assertEquals("no bypass yet — first checkpoint was a regular flush",
+                    0L, store.getTotalMemoryPressureCheckpointBypassCount());
+
+            // Phase 2: add a tiny trickle of new vectors and re-arm the gate.
+            // With the trigger OFF, this checkpoint MUST defer (return false)
+            // and the counter MUST remain zero.
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+            for (int i = 200; i < 210; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng));
+            }
+            trigger.set(false);
+            boolean ranWithoutPressure = store.checkpoint();
+            assertFalse("with no memory pressure the gate must defer the tiny shard",
+                    ranWithoutPressure);
+            assertEquals("no bypass while the budget is below the trigger",
+                    0L, store.getTotalMemoryPressureCheckpointBypassCount());
+
+            // Phase 3: flip the trigger on and checkpoint again. The bypass
+            // condition is now satisfied (live<gate, !dirty, !empty,
+            // memoryPressureTrigger=true) — counter must tick exactly once.
+            trigger.set(true);
+            assertTrue("memory pressure must force the checkpoint past the gate",
+                    store.checkpoint());
+            assertEquals("the bypass counter must increment exactly once",
+                    1L, store.getTotalMemoryPressureCheckpointBypassCount());
+
+            // Phase 4: add another trickle and trigger another bypass cycle.
+            // The counter must accumulate (it is monotonic).
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+            for (int i = 210; i < 220; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng));
+            }
+            assertTrue("second pressure-driven cycle must run", store.checkpoint());
+            assertEquals("bypass counter must accumulate across cycles",
+                    2L, store.getTotalMemoryPressureCheckpointBypassCount());
+        }
+    }
+}

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/MinLiveGateBypassObservabilityTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/MinLiveGateBypassObservabilityTest.java
@@ -173,7 +173,7 @@ public class MinLiveGateBypassObservabilityTest {
                     1L, store.getTotalMemoryPressureCheckpointBypassCount());
 
             // Phase 4: add another trickle and trigger another bypass cycle.
-            // The counter must accumulate (it is monotonic).
+            // The counter must accumulate (it is monotonic within the process).
             PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
             for (int i = 210; i < 220; i++) {
                 store.addVector(Bytes.from_int(i), vec(rng));
@@ -181,6 +181,39 @@ public class MinLiveGateBypassObservabilityTest {
             assertTrue("second pressure-driven cycle must run", store.checkpoint());
             assertEquals("bypass counter must accumulate across cycles",
                     2L, store.getTotalMemoryPressureCheckpointBypassCount());
+
+            // Phase 5: the BIGANN 200M path — segments.size() above the
+            // compactionBackpressureThreshold. The sibling deferral gate at
+            // ~PersistentVectorStore.java:6336 fires under back-pressure; the
+            // memory-pressure trigger must bypass it as well, and the counter
+            // must increment. This is the actual scenario the issue describes
+            // (the time-window path covered in phases 1-4 is its sibling, not
+            // the segment-storm regime). To reach this path deterministically
+            // we drop the back-pressure threshold below the current segment
+            // count rather than building hundreds of segments.
+            //
+            // CRITICAL: keep the threshold high (Integer.MAX_VALUE) while
+            // calling addVector — addVectorInternal blocks on
+            // waitForSegmentCountRelief once segments.size() > threshold, and
+            // the compaction loop is parked (Long.MAX_VALUE interval) so the
+            // block would never lift. Drop the threshold AFTER the trickle is
+            // staged but BEFORE checkpoint() so the deferral gate sees the
+            // over-threshold segment count.
+            int segs = store.getSegmentCount();
+            assertTrue("we need at least 2 segments to make the BP threshold meaningful",
+                    segs >= 2);
+            store.setCompactionBackpressureThreshold(Integer.MAX_VALUE);
+            PersistentVectorStore.minLiveVectorsForCheckpoint = 50_000;
+            for (int i = 220; i < 230; i++) {
+                store.addVector(Bytes.from_int(i), vec(rng));
+            }
+            store.setCompactionBackpressureThreshold(segs - 1);
+            // memory-pressure trigger still on from phase 4.
+            assertTrue("memory pressure must bypass the segment-count BP gate as well",
+                    store.checkpoint());
+            assertEquals("bypass counter must increment on the SEGMENT_COUNT_BACKPRESSURE"
+                    + " path too — this is the BIGANN 200M regime",
+                    3L, store.getTotalMemoryPressureCheckpointBypassCount());
         }
     }
 }

--- a/herddb-indexing-service/src/test/java/herddb/indexing/vector/VectorMemoryBudgetFractionTest.java
+++ b/herddb-indexing-service/src/test/java/herddb/indexing/vector/VectorMemoryBudgetFractionTest.java
@@ -1,0 +1,73 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.indexing.vector;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Pure unit test for {@link VectorMemoryBudget#budgetFraction()} (issue #646).
+ */
+public class VectorMemoryBudgetFractionTest {
+
+    private static VectorMemoryBudget budget(final long usage, final long max) {
+        return new VectorMemoryBudget() {
+            @Override
+            public long totalEstimatedMemoryUsageBytes() {
+                return usage;
+            }
+
+            @Override
+            public long maxMemoryBytes() {
+                return max;
+            }
+        };
+    }
+
+    @Test
+    public void zeroWhenLimitIsUnbounded() {
+        assertEquals(0.0d, budget(123_456_789L, Long.MAX_VALUE).budgetFraction(), 0.0d);
+    }
+
+    @Test
+    public void zeroWhenLimitIsZeroOrNegative() {
+        assertEquals(0.0d, budget(123L, 0L).budgetFraction(), 0.0d);
+        assertEquals(0.0d, budget(123L, -1L).budgetFraction(), 0.0d);
+    }
+
+    @Test
+    public void halfWhenUsageIsHalfOfMax() {
+        assertEquals(0.5d, budget(50L, 100L).budgetFraction(), 1e-12);
+    }
+
+    @Test
+    public void oneWhenUsageEqualsMax() {
+        assertEquals(1.0d, budget(100L, 100L).budgetFraction(), 1e-12);
+    }
+
+    @Test
+    public void aboveOneWhenUsageExceedsMax() {
+        // The accessor is intentionally not clamped: it can legitimately
+        // exceed 1.0 during the brief window between crossing the hard
+        // limit and the back-pressure path draining the live shards.
+        assertEquals(2.0d, budget(200L, 100L).budgetFraction(), 1e-12);
+    }
+}

--- a/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
+++ b/herddb-kubernetes/src/main/helm/herddb/monitor/grafana/dashboards/indexing-service-dashboard.json
@@ -1884,6 +1884,349 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
+          "description": "Engine-wide VectorMemoryBudget fraction (used / max), expressed as a percentage. Issue #646 made the early-checkpoint trigger configurable; default fires at 90%. The hard back-pressure path that blocks addVector fires at 100%. Anything sustained above the configured early-checkpoint fraction means the minLiveVectorsForCheckpoint gate is being bypassed — pair this with the per-index 'Early-Checkpoint Gate Bypass' panel.",
+          "fill": 1,
+          "id": 64601,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "vector_memory_budget_fraction_milli{job=\"indexing-service\",instance=~\"$instance\"} / 10",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} budget % of max",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            {
+              "colorMode": "warning",
+              "fill": false,
+              "line": true,
+              "op": "gt",
+              "value": 90,
+              "yaxis": "left"
+            },
+            {
+              "colorMode": "critical",
+              "fill": false,
+              "line": true,
+              "op": "gt",
+              "value": 100,
+              "yaxis": "left"
+            }
+          ],
+          "title": "Vector Memory Budget — Fraction of Max (issue #646)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Engine-wide VectorMemoryBudget — used vs max bytes, summed across every loaded PersistentVectorStore. Companion to the fraction panel: the percentage hides the absolute headroom you have to either raise the budget or kick more aggressive compaction.",
+          "fill": 1,
+          "id": 64602,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "vector_memory_budget_max_bytes{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} budget max",
+              "refId": "A"
+            },
+            {
+              "expr": "vector_memory_budget_used_bytes{job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} budget used",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Vector Memory Budget — Used vs Max (issue #646)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Number of checkpoint cycles where the minLiveVectorsForCheckpoint deferral gate was bypassed because the global vector memory budget crossed indexing.memory.vector.early.checkpoint.fraction. Each bypass seals the current (possibly tiny) live shard into a new on-disk micro-segment — at the BIGANN 200M scale this was the root cause of the segment storm. NOTE: counter is in-memory only — resets on every process restart. Use rate() or irate() for alerts so rolling restarts are handled correctly.",
+          "fill": 1,
+          "id": 64603,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 6,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_memory_pressure_checkpoint_bypass_total\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}} (cumulative)",
+              "refId": "A"
+            },
+            {
+              "expr": "rate({__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_memory_pressure_checkpoint_bypass_total\",job=\"indexing-service\",instance=~\"$instance\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}} (rate 5m)",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Early-Checkpoint Gate Bypass — Total + 5m Rate (issue #646)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "decimals": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Currently-loaded on-disk segments with live-node count strictly below vector.index.compaction.microsegment.max.nodes. Rising values are the leading indicator that the early-checkpoint bypass is producing micro-segments — confirm by correlating with the bypass counter above. Sustained growth precedes the segment-count back-pressure firing.",
+          "fill": 1,
+          "id": 64604,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 6,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_microsegment_count\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}} (micro)",
+              "refId": "A"
+            },
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_segment_count\",job=\"indexing-service\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}} (total — reference)",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "title": "Micro-Segment Count vs Total Segments (issue #646)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "decimals": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Echoes the configured indexing.memory.vector.early.checkpoint.fraction (default 0.90). The value is encoded ×1000 on the wire so the double survives the Long-typed gauge channel — this panel divides by 1000 to recover the original fraction. Useful as a configuration-drift sanity check: if a rolling restart changes the value, this panel shows it without grepping configmaps.",
+          "fill": 1,
+          "id": 64605,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "span": 12,
+          "targets": [
+            {
+              "expr": "{__name__=~\"tablespace_${tablespace}_table_${table}_vidx_${vidx}_early_checkpoint_fraction\",job=\"indexing-service\",instance=~\"$instance\"} / 1000",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{__name__}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "title": "Configured Early-Checkpoint Fraction (per index, issue #646)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "min": 0,
+              "max": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": true,
+      "title": "Memory-Pressure Early Checkpoint & Micro-Segments (issue #646)",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
           "fill": 1,
           "id": 27,
           "legend": {


### PR DESCRIPTION
Fixes #646.

## Changes

- **`IndexingServerConfiguration`** — add `indexing.memory.vector.early.checkpoint.fraction` (default `0.90`, range `(0.0, 1.0]`). Raises the threshold from the hardcoded 0.70 that the BIGANN 200M run found permanently bypasses the `minLiveVectorsForCheckpoint` gate through the 70–90% memory range, producing the micro-segment storm described in the issue. The hard 100% back-pressure path is unchanged.
- **`PersistentVectorStore`** — add `earlyCheckpointFraction` field (default `0.90`), `setEarlyCheckpointFraction(double)` (validates `(0.0, 1.0]`), and a getter. Replace both hardcoded `0.7` literals in `shouldTriggerMemoryPressureCheckpoint()` with the configured fraction; update the two trigger log messages to print the actual percentage. Add `totalMemoryPressureCheckpointBypassCount` (`AtomicLong`) plus a getter; increment it from a new `logMemoryPressureGateBypass()` helper that runs once per checkpoint cycle whenever the min-live-vectors gate is bypassed by memory pressure (INFO log, includes live count, gate, budget bytes / max bytes / percentage, and a config-key hint). Add `getMicroSegmentCount()` that walks the segments list counting those below the `microSegmentMaxNodes` threshold.
- **`VectorMemoryBudget`** — add `budgetFraction()` default method returning the usage ratio (`0.0` when no finite limit), so dashboards can plot memory pressure without computing the ratio from raw bytes.
- **`IndexingServiceEngine`** — read the new config and call `setEarlyCheckpointFraction` in the `PersistentVectorStore` factory lambda. Register three new per-index gauges (`memory_pressure_checkpoint_bypass_total`, `microsegment_count`, `early_checkpoint_fraction`) and three engine-wide gauges under the `vector_memory` scope (`budget_max_bytes`, `budget_used_bytes`, `budget_fraction_milli`). Surface the three new numbers on `IndexDetails` so `describeIndex` returns them.
- **`IndexingServiceImpl` + `indexing_service.proto`** — wire `micro_segment_count`, `memory_pressure_checkpoint_bypass_count`, and `early_checkpoint_fraction` through `DescribeIndexResponse` so `engine-stats --json` exposes them to the CLI / UI.
- **`Issue562BackpressureMicroSegmentTest`** — pin the historical 0.70 fraction explicitly. That test exercises the "above-the-trigger-but-not-pressure-active" code path with a budget reporting 80% usage; with the new 0.90 default the trigger would no longer fire, masking the test's intent.

## Tests

- **`EarlyCheckpointFractionConfigTest`** — asserts the post-#646 default is 0.90, that the setter rejects values outside `(0.0, 1.0]`, and that the configured fraction actually decides whether `shouldTriggerMemoryPressureCheckpoint()` fires at 80% budget (true at 0.70, false at 0.90, true again at 95%).
- **`MinLiveGateBypassObservabilityTest`** — drives a real PVS through three phases (regular flush → no-pressure deferral → pressure-driven bypass × 2) and asserts the bypass counter increments exactly when the bypass condition is met.
- **`MicroSegmentCountGaugeTest`** — asserts the gauge counts segments below the configured `microSegmentMaxNodes` threshold, returns 0 when the threshold is disabled, and re-classifies segments when the threshold is changed at runtime.
- **`VectorMemoryBudgetFractionTest`** — pure unit test of the new `budgetFraction()` default method (handles unbounded / zero / half / full / above-one usage).

Pre-PR checks (`spotless:apply` + `spotless:check apache-rat:check spotbugs:check install -Pci`) green. Hammer suite (`DirectMultipleConcurrentUpdates*` × 2 passes + `BLinkConcurrentSearchInsertTest`) green.

🤖 Implemented by the \`pr-worker\` agent.